### PR TITLE
[Luxon] Correct Settings.defaultZone getter

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -13,6 +13,8 @@
 //                 Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// Minimum TypeScript Version: 4.3
+
 export * from './src/luxon';
 
 export as namespace luxon;

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -23,9 +23,9 @@ export class Settings {
     /**
      * The default time zone object currently used to create DateTimes. Does not affect existing instances.
      * The default value is the system's time zone (the one set on the machine that runs this code).
-     * Getting this property always returns a Zone object.
      */
-    static defaultZone: Zone | string;
+    static get defaultZone(): Zone;
+    static set defaultZone(zone: Zone | string);
 
     /**
      * The default locale to create DateTimes with. Does not affect existing instances.

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -28,44 +28,24 @@ export class Settings {
     static defaultZone: Zone | string;
 
     /**
-     * Get the default locale to create DateTimes with. Does not affect existing instances.
+     * The default locale to create DateTimes with. Does not affect existing instances.
      */
-    static get defaultLocale(): string;
+    static defaultLocale: string;
 
     /**
-     * Set the default locale to create DateTimes with. Does not affect existing instances.
+     * The default numbering system to create DateTimes with. Does not affect existing instances.
      */
-    static set defaultLocale(locale: string);
+    static defaultNumberingSystem: string;
 
     /**
-     * Get the default numbering system to create DateTimes with. Does not affect existing instances.
+     * The default output calendar to create DateTimes with. Does not affect existing instances.
      */
-    static get defaultNumberingSystem(): string;
+    static defaultOutputCalendar: string;
 
     /**
-     * Set the default numbering system to create DateTimes with. Does not affect existing instances.
+     * Whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
      */
-    static set defaultNumberingSystem(numberingSystem: string);
-
-    /**
-     * Get the default output calendar to create DateTimes with. Does not affect existing instances.
-     */
-    static get defaultOutputCalendar(): string;
-
-    /**
-     * Set the default output calendar to create DateTimes with. Does not affect existing instances.
-     */
-    static set defaultOutputCalendar(outputCalendar: string);
-
-    /**
-     * Get whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
-     */
-    static get throwOnInvalid(): boolean;
-
-    /**
-     * Set whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
-     */
-    static set throwOnInvalid(t: boolean);
+    static throwOnInvalid: boolean;
 
     /**
      * Reset Luxon's global caches. Should only be necessary in testing scenarios.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -304,6 +304,7 @@ Settings.resetCaches();
 Settings.defaultZone = ianaZone;
 Settings.defaultZone = 'America/Los_Angeles';
 Settings.defaultZone = Settings.defaultZone;
+Settings.defaultZone; // $ExpectType Zone
 
 // The following tests were coped from the docs
 // http://moment.github.io/luxon/docs/manual/


### PR DESCRIPTION
Now that TS 4.3 allows it, the getter is always a Zone instance even though setter can use a string.

Simplified other settings properties that used getter/setters instead of properties.