### PR TITLE
[Luxon] Add invalid return types. Allow opt out. Breaking Change

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 3.2
+// Type definitions for luxon 3.3
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Hyeonseok Yang <https://github.com/FourwingsY>
 //                 Jonathan Siebern <https://github.com/jsiebern>

--- a/types/luxon/src/_util.d.ts
+++ b/types/luxon/src/_util.d.ts
@@ -1,2 +1,4 @@
-export type CanBeInvalid = false;
-export type IfInvalid<T> = never;
+import { TSSettings } from './settings';
+
+export type CanBeInvalid = TSSettings extends { throwOnInvalid: true } ? false : true;
+export type IfInvalid<T> = CanBeInvalid extends true ? T : never;

--- a/types/luxon/src/_util.d.ts
+++ b/types/luxon/src/_util.d.ts
@@ -1,0 +1,2 @@
+export type CanBeInvalid = false;
+export type IfInvalid<T> = never;

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -10,6 +10,7 @@ import {
 import { Zone } from './zone';
 import { Duration, DurationLike, DurationUnits } from './duration';
 import { Interval } from './interval';
+import { CanBeInvalid, IfInvalid } from './_util';
 
 export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
 export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
@@ -201,7 +202,12 @@ export type PossibleDaysInMonth = 28 | 29 | 30 | 31;
 export type PossibleDaysInYear = 365 | 366;
 export type PossibleWeeksInYear = 52 | 53;
 
-export type ToObjectOutput<IncludeConfig extends boolean | undefined = true> =
+export type ToObjectOutput<IncludeConfig extends boolean | undefined = undefined> =
+    CanBeInvalid extends true
+        ? Partial<_ToObjectOutput<IncludeConfig>>
+        : _ToObjectOutput<IncludeConfig>;
+/** @internal */
+export type _ToObjectOutput<IncludeConfig extends boolean | undefined = undefined> =
     & Record<Exclude<DateTimeUnit, 'quarter' | 'week'>, number>
     & (IncludeConfig extends true ? LocaleOptions : unknown);
 
@@ -799,17 +805,17 @@ export class DateTime {
     /**
      * Get the locale of a DateTime, such as 'en-GB'. The locale is used when formatting the DateTime
      */
-    get locale(): string;
+    get locale(): string | IfInvalid<null>;
 
     /**
      * Get the numbering system of a DateTime, such as 'beng'. The numbering system is used when formatting the DateTime
      */
-    get numberingSystem(): string;
+    get numberingSystem(): string | IfInvalid<null>;
 
     /**
      * Get the output calendar of a DateTime, such as 'islamic'. The output calendar is used when formatting the DateTime
      */
-    get outputCalendar(): string;
+    get outputCalendar(): string | IfInvalid<null>;
 
     /**
      * Get the time zone associated with this DateTime.
@@ -819,42 +825,42 @@ export class DateTime {
     /**
      * Get the name of the time zone.
      */
-    get zoneName(): string;
+    get zoneName(): string | IfInvalid<null>;
 
     /**
      * Get the year
      *
      * @example DateTime.local(2017, 5, 25).year //=> 2017
      */
-    get year(): number;
+    get year(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the quarter
      *
      * @example DateTime.local(2017, 5, 25).quarter //=> 2
      */
-    get quarter(): QuarterNumbers;
+    get quarter(): QuarterNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the month (1-12).
      *
      * @example DateTime.local(2017, 5, 25).month //=> 5
      */
-    get month(): MonthNumbers;
+    get month(): MonthNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the day of the month (1-30ish).
      *
      * @example DateTime.local(2017, 5, 25).day //=> 25
      */
-    get day(): DayNumbers;
+    get day(): DayNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the hour of the day (0-23).
      *
      * @example DateTime.local(2017, 5, 25, 9).hour //=> 9
      */
-    get hour(): HourNumbers;
+    get hour(): HourNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the minute of the hour (0-59).
@@ -862,7 +868,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25, 9, 30).minute //=> 30
      */
-    get minute(): MinuteNumbers;
+    get minute(): MinuteNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the second of the minute (0-59).
@@ -870,7 +876,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25, 9, 30, 52).second //=> 52
      */
-    get second(): SecondNumbers;
+    get second(): SecondNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the millisecond of the second (0-999).
@@ -878,7 +884,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25, 9, 30, 52, 654).millisecond //=> 654
      */
-    get millisecond(): number;
+    get millisecond(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the week year
@@ -887,7 +893,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 12, 31).weekYear //=> 2015
      */
-    get weekYear(): number;
+    get weekYear(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the week number of the week year (1-52ish).
@@ -896,7 +902,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).weekNumber //=> 21
      */
-    get weekNumber(): WeekNumbers;
+    get weekNumber(): WeekNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the day of the week.
@@ -906,7 +912,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 11, 31).weekday //=> 4
      */
-    get weekday(): WeekdayNumbers;
+    get weekday(): WeekdayNumbers | IfInvalid<typeof NaN>;
 
     /**
      * Get the ordinal (meaning the day of the year)
@@ -914,7 +920,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).ordinal //=> 145
      */
-    get ordinal(): number;
+    get ordinal(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the human readable short month name, such as 'Oct'.
@@ -923,7 +929,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 10, 30).monthShort //=> Oct
      */
-    get monthShort(): string;
+    get monthShort(): string | IfInvalid<null>;
 
     /**
      * Get the human readable long month name, such as 'October'.
@@ -932,7 +938,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 10, 30).monthLong //=> October
      */
-    get monthLong(): string;
+    get monthLong(): string | IfInvalid<null>;
 
     /**
      * Get the human readable short weekday, such as 'Mon'.
@@ -941,7 +947,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 10, 30).weekdayShort //=> Mon
      */
-    get weekdayShort(): string;
+    get weekdayShort(): string | IfInvalid<null>;
 
     /**
      * Get the human readable long weekday, such as 'Monday'.
@@ -950,7 +956,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 10, 30).weekdayLong //=> Monday
      */
-    get weekdayLong(): string;
+    get weekdayLong(): string | IfInvalid<null>;
 
     /**
      * Get the UTC offset of this DateTime in minutes
@@ -960,29 +966,29 @@ export class DateTime {
      * @example
      * DateTime.utc().offset //=> 0
      */
-    get offset(): number;
+    get offset(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the short human name for the zone's current offset, for example "EST" or "EDT".
      * Defaults to the system's locale if no locale has been specified
      */
-    get offsetNameShort(): string;
+    get offsetNameShort(): string | IfInvalid<null>;
 
     /**
      * Get the long human name for the zone's current offset, for example "Eastern Standard Time" or "Eastern Daylight Time".
      * Defaults to the system's locale if no locale has been specified
      */
-    get offsetNameLong(): string;
+    get offsetNameLong(): string | IfInvalid<null>;
 
     /**
      * Get whether this zone's offset ever changes, as in a DST.
      */
-    get isOffsetFixed(): boolean;
+    get isOffsetFixed(): boolean | IfInvalid<null>;
 
     /**
      * Get whether the DateTime is in a DST.
      */
-    get isInDST(): boolean;
+    get isInDST(): boolean | IfInvalid<false>;
 
     /**
      * Returns true if this DateTime is in a leap year, false otherwise
@@ -1002,7 +1008,7 @@ export class DateTime {
      * @example
      * DateTime.local(2016, 3).daysInMonth //=> 31
      */
-    get daysInMonth(): PossibleDaysInMonth;
+    get daysInMonth(): PossibleDaysInMonth | IfInvalid<undefined>;
 
     /**
      * Returns the number of days in this DateTime's year
@@ -1012,7 +1018,7 @@ export class DateTime {
      * @example
      * DateTime.local(2013).daysInYear //=> 365
      */
-    get daysInYear(): PossibleDaysInYear;
+    get daysInYear(): PossibleDaysInYear | IfInvalid<typeof NaN>;
 
     /**
      * Returns the number of weeks in this DateTime's year
@@ -1023,7 +1029,7 @@ export class DateTime {
      * @example
      * DateTime.local(2013).weeksInWeekYear //=> 52
      */
-    get weeksInWeekYear(): PossibleWeeksInYear;
+    get weeksInWeekYear(): PossibleWeeksInYear | IfInvalid<typeof NaN>;
 
     /**
      * Returns the resolved Intl options for this DateTime.
@@ -1185,7 +1191,7 @@ export class DateTime {
      * @example
      * DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
      */
-    toFormat(fmt: string, opts?: LocaleOptions): string;
+    toFormat(fmt: string, opts?: LocaleOptions): string | IfInvalid<'Invalid DateTime'>;
 
     /**
      * Returns a localized string representing this date. Accepts the same options as the Intl.DateTimeFormat constructor and any presets defined by Luxon,
@@ -1215,7 +1221,7 @@ export class DateTime {
      * @example
      * DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }); //=> '11:32'
      */
-    toLocaleString(formatOpts?: DateTimeFormatOptions, opts?: LocaleOptions): string;
+    toLocaleString(formatOpts?: DateTimeFormatOptions, opts?: LocaleOptions): string | IfInvalid<'Invalid DateTime'>;
 
     /**
      * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
@@ -1231,7 +1237,7 @@ export class DateTime {
      *                                 //=>   { type: 'year', value: '1982' }
      *                                 //=> ]
      */
-    toLocaleParts(opts?: DateTimeFormatOptions): Intl.DateTimeFormatPart[];
+    toLocaleParts(opts?: DateTimeFormatOptions): Intl.DateTimeFormatPart[] | IfInvalid<[]>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime
@@ -1245,7 +1251,7 @@ export class DateTime {
      * @example
      * DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
      */
-    toISO(opts?: ToISOTimeOptions): string;
+    toISO(opts?: ToISOTimeOptions): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's date component
@@ -1258,7 +1264,7 @@ export class DateTime {
      * @example
      * DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
      */
-    toISODate(opts?: ToISODateOptions): string;
+    toISODate(opts?: ToISODateOptions): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's week date
@@ -1266,7 +1272,7 @@ export class DateTime {
      * @example
      * DateTime.utc(1982, 5, 25).toISOWeekDate() //=> '1982-W21-2'
      */
-    toISOWeekDate(): string;
+    toISOWeekDate(): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's time component
@@ -1287,7 +1293,7 @@ export class DateTime {
      * @example
      * DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
      */
-    toISOTime(ops?: ToISOTimeOptions): string;
+    toISOTime(opts?: ToISOTimeOptions): string | IfInvalid<null>;
 
     /**
      * Returns an RFC 2822-compatible string representation of this DateTime, always in UTC
@@ -1297,7 +1303,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 -0400'
      */
-    toRFC2822(): string;
+    toRFC2822(): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in HTTP headers.
@@ -1309,7 +1315,7 @@ export class DateTime {
      * @example
      * DateTime.utc(2014, 7, 13, 19).toHTTP() //=> 'Sun, 13 Jul 2014 19:00:00 GMT'
      */
-    toHTTP(): string;
+    toHTTP(): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL Date
@@ -1317,7 +1323,7 @@ export class DateTime {
      * @example
      * DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
      */
-    toSQLDate(): string;
+    toSQLDate(): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL Time
@@ -1331,7 +1337,7 @@ export class DateTime {
      * @example
      * DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
      */
-    toSQLTime(opts?: ToSQLOptions): string;
+    toSQLTime(opts?: ToSQLOptions): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this DateTime for use in SQL DateTime
@@ -1345,37 +1351,37 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
      */
-    toSQL(opts?: ToSQLOptions): string;
+    toSQL(opts?: ToSQLOptions): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this DateTime appropriate for debugging
      */
-    toString(): string;
+    toString(): string | IfInvalid<'Invalid DateTime'>;
 
     /**
      * Returns the epoch milliseconds of this DateTime. Alias of {@link DateTime.toMillis}
      */
-    valueOf(): number;
+    valueOf(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns the epoch milliseconds of this DateTime.
      */
-    toMillis(): number;
+    toMillis(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns the epoch seconds of this DateTime.
      */
-    toSeconds(): number;
+    toSeconds(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns the epoch seconds (as a whole number) of this DateTime.
      */
-    toUnixInteger(): number;
+    toUnixInteger(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
      */
-    toJSON(): string;
+    toJSON(): string | IfInvalid<null>;
 
     /**
      * Returns a BSON-serializable equivalent to this DateTime.
@@ -1453,7 +1459,7 @@ export class DateTime {
      * @example
      * DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
      */
-    hasSame(otherDateTime: DateTime, unit: DateTimeUnit): boolean;
+    hasSame(otherDateTime: DateTime, unit: DateTimeUnit): boolean | IfInvalid<false>;
 
     /**
      * An equality check.
@@ -1462,7 +1468,7 @@ export class DateTime {
      *
      * @param other - the other DateTime
      */
-    equals(other: DateTime): boolean;
+    equals(other: DateTime): boolean | IfInvalid<false>;
 
     /**
      * Returns a string representation of this time relative to now, such as "in two days".
@@ -1482,7 +1488,7 @@ export class DateTime {
      * @example
      * DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
      */
-    toRelative(options?: ToRelativeOptions): string | null;
+    toRelative(options?: ToRelativeOptions): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
@@ -1497,7 +1503,7 @@ export class DateTime {
      * @example
      * DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
      */
-    toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
+    toRelativeCalendar(options?: ToRelativeCalendarOptions): string | IfInvalid<null>;
 
     /**
      * Return the min of several date times

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -1,5 +1,6 @@
 import { NumberingSystem } from './misc';
 import { ConversionAccuracy } from './datetime';
+import { IfInvalid } from './_util';
 
 export interface DurationOptions {
     locale?: string | undefined;
@@ -195,12 +196,12 @@ export class Duration {
     /**
      * Get the locale of a Duration, such as 'en-GB'
      */
-    get locale(): string;
+    get locale(): string | IfInvalid<null>;
 
     /**
      * Get the numbering system of a Duration, such as 'beng'. The numbering system is used when formatting the Duration
      */
-    get numberingSystem(): string;
+    get numberingSystem(): string | IfInvalid<null>;
 
     /**
      * Returns a string representation of this Duration formatted according to the specified format string. You may use these tokens:
@@ -226,7 +227,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("M S") //=> "12 518402000"
      */
-    toFormat(fmt: string, opts?: { floor?: boolean | undefined }): string;
+    toFormat(fmt: string, opts?: { floor?: boolean | undefined }): string | IfInvalid<'Invalid Duration'>;
 
     /**
      * Returns a string representation of a Duration with all units included
@@ -265,7 +266,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
      */
-    toISO(): string;
+    toISO(): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
@@ -288,27 +289,27 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
      */
-    toISOTime(opts?: ToISOTimeDurationOptions): string;
+    toISOTime(opts?: ToISOTimeDurationOptions): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
      */
-    toJSON(): string;
+    toJSON(): string | IfInvalid<null>;
 
     /**
      * Returns an ISO 8601 representation of this Duration appropriate for use in debugging.
      */
-    toString(): string;
+    toString(): string | IfInvalid<null>;
 
     /**
      * Returns a millisecond value of this Duration.
      */
-    toMillis(): number;
+    toMillis(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns a millisecond value of this Duration. Alias of {@link toMillis}
      */
-    valueOf(): number;
+    valueOf(): number | IfInvalid<typeof NaN>;
 
     /**
      * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
@@ -346,7 +347,7 @@ export class Duration {
      * @example
      * Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
      */
-    get(unit: DurationUnit): number;
+    get(unit: DurationUnit): number | IfInvalid<typeof NaN>;
 
     /**
      * "Set" the values of specified units. Return a newly-constructed Duration.
@@ -380,7 +381,7 @@ export class Duration {
      * @example
      * Duration.fromObject({hours: 60}).as('days') //=> 2.5
      */
-    as(unit: DurationUnit): number;
+    as(unit: DurationUnit): number | IfInvalid<typeof NaN>;
 
     /**
      * Reduce this Duration to its canonical representation in its current units.
@@ -425,47 +426,47 @@ export class Duration {
     /**
      * Get the years.
      */
-    get years(): number;
+    get years(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the quarters.
      */
-    get quarters(): number;
+    get quarters(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the months.
      */
-    get months(): number;
+    get months(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the weeks
      */
-    get weeks(): number;
+    get weeks(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the days.
      */
-    get days(): number;
+    get days(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the hours.
      */
-    get hours(): number;
+    get hours(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the minutes.
      */
-    get minutes(): number;
+    get minutes(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the seconds.
      */
-    get seconds(): number;
+    get seconds(): number | IfInvalid<typeof NaN>;
 
     /**
      * Get the milliseconds.
      */
-    get milliseconds(): number;
+    get milliseconds(): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns whether the Duration is invalid.
@@ -487,5 +488,5 @@ export class Duration {
      * Equality check
      * Two Durations are equal iff they have the same units and the same values for each unit.
      */
-    equals(other: Duration): boolean;
+    equals(other: Duration): boolean | IfInvalid<false>;
 }

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -1,5 +1,6 @@
 import { DateObjectUnits, DateTime, DateTimeOptions, DiffOptions, LocaleOptions, ToISOTimeOptions } from './datetime';
 import { Duration, DurationLike, DurationUnit } from './duration';
+import { IfInvalid } from './_util';
 
 export interface IntervalObject {
     start?: DateTime | undefined;
@@ -80,12 +81,12 @@ export class Interval {
     /**
      * Returns the start of the Interval
      */
-    get start(): DateTime;
+    get start(): DateTime | IfInvalid<null>;
 
     /**
      * Returns the end of the Interval
      */
-    get end(): DateTime;
+    get end(): DateTime | IfInvalid<null>;
 
     /**
      * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.
@@ -107,7 +108,7 @@ export class Interval {
      *
      * @param unit - the unit (such as 'hours' or 'days') to return the length in.
      */
-    length(unit?: DurationUnit): number;
+    length(unit?: DurationUnit): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns the count of minutes, hours, days, months, or years included in the Interval, even in part.
@@ -116,14 +117,14 @@ export class Interval {
      *
      * @param unit - the unit of time to count. Defaults to 'milliseconds'.
      */
-    count(unit?: DurationUnit): number;
+    count(unit?: DurationUnit): number | IfInvalid<typeof NaN>;
 
     /**
      * Returns whether this Interval's start and end are both in the same unit of time
      *
      * @param unit - the unit of time to check sameness on
      */
-    hasSame(unit: DurationUnit): boolean;
+    hasSame(unit: DurationUnit): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval has the same start and end DateTimes.
@@ -135,21 +136,21 @@ export class Interval {
      *
      * @param dateTime
      */
-    isAfter(dateTime: DateTime): boolean;
+    isAfter(dateTime: DateTime): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval's end is before the specified DateTime.
      *
      * @param dateTime
      */
-    isBefore(dateTime: DateTime): boolean;
+    isBefore(dateTime: DateTime): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval contains the specified DateTime.
      *
      * @param dateTime
      */
-    contains(dateTime: DateTime): boolean;
+    contains(dateTime: DateTime): boolean | IfInvalid<false>;
 
     /**
      * "Sets" the start and/or end dates. Returns a newly-constructed Interval.
@@ -165,7 +166,7 @@ export class Interval {
      *
      * @param dateTimes - the unit of time to count.
      */
-    splitAt(...dateTimes: DateTime[]): Interval[];
+    splitAt(...dateTimes: DateTime[]): Interval[] | IfInvalid<[]>;
 
     /**
      * Split this Interval into smaller Intervals, each of the specified length.
@@ -173,14 +174,14 @@ export class Interval {
      *
      * @param duration - The length of each resulting interval.
      */
-    splitBy(duration: DurationLike): Interval[];
+    splitBy(duration: DurationLike): Interval[] | IfInvalid<[]>;
 
     /**
      * Split this Interval into the specified number of smaller intervals.
      *
      * @param numberOfParts - The number of Intervals to divide the Interval into.
      */
-    divideEqually(numberOfParts: number): Interval[];
+    divideEqually(numberOfParts: number): Interval[] | IfInvalid<[]>;
 
     /**
      * Return whether this Interval overlaps with the specified Interval
@@ -190,22 +191,22 @@ export class Interval {
     /**
      * Return whether this Interval's end is adjacent to the specified Interval's start.
      */
-    abutsStart(other: Interval): boolean;
+    abutsStart(other: Interval): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval's start is adjacent to the specified Interval's end.
      */
-    abutsEnd(other: Interval): boolean;
+    abutsEnd(other: Interval): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval engulfs the start and end of the specified Interval.
      */
-    engulfs(other: Interval): boolean;
+    engulfs(other: Interval): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Interval has the same start and end as the specified Interval.
      */
-    equals(other: Interval): boolean;
+    equals(other: Interval): boolean | IfInvalid<false>;
 
     /**
      * Return an Interval representing the intersection of this Interval and the specified Interval.
@@ -221,7 +222,7 @@ export class Interval {
     union(other: Interval): Interval;
 
     /**
-     * Merge an array of Intervals into a equivalent minimal set of Intervals.
+     * Merge an array of Intervals into an equivalent minimal set of Intervals.
      * Combines overlapping and adjacent Intervals.
      */
     static merge(intervals: Interval[]): Interval[];
@@ -239,7 +240,7 @@ export class Interval {
     /**
      * Returns a string representation of this Interval appropriate for debugging.
      */
-    toString(): string;
+    toString(): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Returns a localized string representing this Interval. Accepts the same options as the
@@ -269,7 +270,7 @@ export class Interval {
      *   minute: "2-digit",
      * }); //=> Mon, Nov 07, 6:00 – 8:00 p
      */
-    toLocaleString(formatOpts?: Intl.DateTimeFormatOptions, opts?: LocaleOptions): string;
+    toLocaleString(formatOpts?: Intl.DateTimeFormatOptions, opts?: LocaleOptions): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this Interval.
@@ -277,14 +278,14 @@ export class Interval {
      *
      * @param opts - The same options as {@link DateTime#toISO}
      */
-    toISO(opts?: ToISOTimeOptions): string;
+    toISO(opts?: ToISOTimeOptions): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Returns an ISO 8601-compliant string representation of the dates in this Interval.
      * The time components are ignored.
      * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
      */
-    toISODate(): string;
+    toISODate(): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Returns an ISO 8601-compliant string representation of the times in this Interval.
@@ -293,7 +294,7 @@ export class Interval {
      *
      * @param opts - The same options as {@link DateTime.toISO}
      */
-    toISOTime(opts?: ToISOTimeOptions): string;
+    toISOTime(opts?: ToISOTimeOptions): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Returns a string representation of this Interval formatted according to the specified format string.
@@ -307,7 +308,7 @@ export class Interval {
         opts?: {
             separator?: string | undefined;
         },
-    ): string;
+    ): string | IfInvalid<'Invalid Interval'>;
 
     /**
      * Return a Duration representing the time spanned by this interval.

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -44,6 +44,15 @@ export class Settings {
 
     /**
      * Whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
+     *
+     * If setting this to true, be sure to opt-out of Luxon's invalid return types.
+     * @example
+     * Settings.throwOnInvalid = true;
+     * declare module 'luxon' {
+     *   interface TSSettings {
+     *     throwOnInvalid: true;
+     *   }
+     * }
      */
     static throwOnInvalid: boolean;
 
@@ -52,3 +61,11 @@ export class Settings {
      */
     static resetCaches(): void;
 }
+
+/**
+ * TS only settings. Consumers can declaration merge this interface to change TS options.
+ *
+ * @see Settings.throwOnInvalid
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface TSSettings {}

--- a/types/luxon/src/zone.d.ts
+++ b/types/luxon/src/zone.d.ts
@@ -1,3 +1,5 @@
+import { IfInvalid } from './_util';
+
 export interface ZoneOffsetOptions {
     /**
      * What style of offset to return.
@@ -19,7 +21,7 @@ export abstract class Zone {
     /**
      * The type of zone
      */
-    get type(): string;
+    get type(): string | IfInvalid<'invalid'>;
 
     /**
      * The name of this zone.
@@ -29,7 +31,7 @@ export abstract class Zone {
     /**
      * Returns whether the offset is known to be fixed for the whole year.
      */
-    get isUniversal(): boolean;
+    get isUniversal(): boolean | IfInvalid<false>;
 
     /**
      * Returns the offset's common name (such as EST) at the specified timestamp
@@ -39,7 +41,7 @@ export abstract class Zone {
      * @param options.format - What style of offset to return.
      * @param options.locale - What locale to return the offset name in.
      */
-    offsetName(ts: number, options: ZoneOffsetOptions): string;
+    offsetName(ts: number, options: ZoneOffsetOptions): string | IfInvalid<null>;
 
     /**
      * Returns the offset's value as a string
@@ -48,26 +50,26 @@ export abstract class Zone {
      * @param format - What style of offset to return.
      *                 Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
      */
-    formatOffset(ts: number, format: ZoneOffsetFormat): string;
+    formatOffset(ts: number, format: ZoneOffsetFormat): string | IfInvalid<''>;
 
     /**
      * Return the offset in minutes for this zone at the specified timestamp.
      *
      * @param ts - Epoch milliseconds for which to compute the offset
      */
-    offset(ts: number): number;
+    offset(ts: number): number | IfInvalid<typeof NaN>;
 
     /**
      * Return whether this Zone is equal to another zone
      *
      * @param other - the zone to compare
      */
-    equals(other: Zone): boolean;
+    equals(other: Zone): boolean | IfInvalid<false>;
 
     /**
      * Return whether this Zone is valid.
      */
-    get isValid(): boolean;
+    get isValid(): boolean | IfInvalid<false>;
 }
 
 /**
@@ -115,6 +117,8 @@ export class IANAZone extends Zone {
     static isValidZone(zone: string): boolean;
 
     constructor(name: string);
+
+    get isValid(): true;
 }
 
 /**
@@ -146,12 +150,19 @@ export class FixedOffsetZone extends Zone {
      * FixedOffsetZone.parseSpecifier("UTC-6:00")
      */
     static parseSpecifier(s: string): FixedOffsetZone;
+
+    get isValid(): true;
 }
 
 /**
  * A zone that failed to parse. You should never need to instantiate this.
  */
-export class InvalidZone extends Zone {}
+export class InvalidZone extends Zone {
+    get type(): 'invalid';
+    get isUniversal(): false;
+    get offsetFormat(): '';
+    get isValid(): false;
+}
 
 /**
  * Represents the system zone for this JavaScript environment.
@@ -161,4 +172,6 @@ export class SystemZone extends Zone {
      * Get a singleton instance of the system zone
      */
     static get instance(): SystemZone;
+
+    get isValid(): true;
 }

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -13,6 +13,12 @@ import {
     ZoneOffsetOptions,
 } from 'luxon';
 
+declare module 'luxon' {
+    interface TSSettings {
+        throwOnInvalid: true;
+    }
+}
+
 /* VERSION */
 VERSION; // $ExpectType string
 
@@ -126,8 +132,8 @@ dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string
 dt.toLocaleString(DateTime.DATE_MED, {}); // $ExpectType string
 dt.toMillis(); // $ExpectType number
 dt.toMillis(); // $ExpectType number
-dt.toRelative(); // $ExpectType string | null
-dt.toRelativeCalendar(); // $ExpectType string | null
+dt.toRelative(); // $ExpectType string
+dt.toRelativeCalendar(); // $ExpectType string
 dt.toRFC2822(); // $ExpectType string
 dt.toSeconds(); // $ExpectType number
 dt.toSQL(); // $ExpectType string
@@ -144,7 +150,7 @@ dt.toObject({ includeConfig: true }); // $ExpectType _ToObjectOutput<true>
 dt.toObject({ includeConfig: true }).locale; // $ExpectType string | undefined
 dt.toUnixInteger(); // $ExpectType number
 
-// $ExpectType string | null
+// $ExpectType string
 dt.toRelative({
     base: DateTime.local(),
     locale: 'fr',
@@ -155,7 +161,7 @@ dt.toRelative({
     numberingSystem: 'bali',
 });
 
-// $ExpectType string | null
+// $ExpectType string
 dt.toRelative({
     base: DateTime.local(),
     locale: 'fr',
@@ -166,7 +172,7 @@ dt.toRelative({
     numberingSystem: 'bali',
 });
 
-// $ExpectType string | null
+// $ExpectType string
 dt.toRelativeCalendar({
     base: DateTime.local(),
     locale: 'fr',

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -140,7 +140,7 @@ dt.valueOf(); // $ExpectType number
 dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number>
 // @ts-expect-error
 dt.toObject().locale;
-dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput<true>
+dt.toObject({ includeConfig: true }); // $ExpectType _ToObjectOutput<true>
 dt.toObject({ includeConfig: true }).locale; // $ExpectType string | undefined
 dt.toUnixInteger(); // $ExpectType number
 


### PR DESCRIPTION
It's been requested several times to add the invalid return types to this library. I've always pushed back against it because these output types can be disabled with a setting and I didn't want to pollute my codebases with all these useless null checks. However, via declaration merging we can make these invalid return types optional.

Since luxon requires you to opt-in to throwing on errors, I believe it makes sense to opt-out of these invalid return types here. Regrettably this is a breaking change.

To restore the previous functionality you'd inform typescript of your setting. This should probably be done right next to your luxon runtime setting.
```ts
Settings.throwOnInvalid = true;

declare module 'luxon' {
  interface TSSettings {
    throwOnInvalid: true;
  }
}
```

There are several places where I added the invalid return type even if it does not change the output type. For example,
```ts
number | typeof NaN
string | 'Invalid DateTime'
boolean | false
```
This is just for DX so the type can quickly be checked and you can see what will happen with invalid objects without having to comb through the src code.

I left the test suite using the strict types as it was easier, but another version could be created.