### PR TITLE
blueimp-load-image: add types for replaceHead and writeExifData methods

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -21,6 +21,7 @@ const b64DataJPEG =
   'h4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ' +
   '2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/v4ooooA/9k=';
 const imageUrlJPEG = 'data:image/jpeg;base64,' + b64DataJPEG;
+const imageBlob = new Blob([imageUrlJPEG]);
 
 // Callback style
 loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
@@ -53,3 +54,29 @@ loadImage.parseMetaData(imageUrlJPEG).then((metadata) => {
   console.log(metadata.exif && metadata.exif.get('Orientation'));
   console.log(metadata.exif && metadata.exif[0x0112]);
 });
+
+// Replace image head, using callback
+loadImage(imageUrlJPEG, (_: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
+  if (data?.imageHead) {
+    loadImage.replaceHead(imageBlob, data.imageHead, (blob) => {
+      console.log(blob?.size);
+    });
+  }
+}, {});
+
+// Replace image head, using promise
+loadImage(imageUrlJPEG, (_: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
+  if (data?.imageHead) {
+    loadImage.replaceHead(imageBlob, data.imageHead).then((blob) => {
+      console.log(blob?.size);
+    });
+  }
+}, {});
+
+// Write Exif data
+loadImage(imageUrlJPEG, (_: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
+  if (data?.imageHead) {
+    const newBuffer: ArrayBuffer | Uint8Array = loadImage.writeExifData(data.imageHead, data, 'Orientation', 1);
+    console.log(newBuffer.byteLength);
+  }
+}, {});

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -121,6 +121,18 @@ interface ParseMetadata {
     ): Promise<loadImage.MetaData>;
 }
 
+interface ReplaceHead {
+    (
+        blob: Blob,
+        head: ArrayBuffer | Uint8Array,
+        callback: (blob: Blob|null) => void
+    ): void;
+    (
+        blob: Blob,
+        head: ArrayBuffer | Uint8Array,
+    ): Promise<Blob|null>;
+}
+
 // loadImage is implemented as a callable object.
 interface LoadImage {
     (file: File | Blob | string, callback: loadImage.LoadImageCallback, options: loadImage.LoadImageOptions):
@@ -133,6 +145,11 @@ interface LoadImage {
 
     // Parses image meta data and calls the callback/returns the promise with the image head
     blobSlice: (this: Blob, start?: number, end?: number) => Blob;
+
+    // Replaces the image head of a JPEG blob with the given one
+    replaceHead: ReplaceHead;
+
+    writeExifData: (buffer: ArrayBuffer | Uint8Array, data: loadImage.MetaData, id: number | string, value: loadImage.ExifTagValue) => ArrayBuffer | Uint8Array;
 }
 
 declare const loadImage: LoadImage;


### PR DESCRIPTION
Add types for the `replaceHead` and `writeExifData` method  

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [replaceHead method](https://github.com/blueimp/JavaScript-Load-Image/blob/5d34ed4ce3472ecb22d920c66cc4d7604526ff24/js/load-image-meta.js#L201) and [writeExifData method](https://github.com/blueimp/JavaScript-Load-Image/blob/5d34ed4ce3472ecb22d920c66cc4d7604526ff24/js/load-image-exif.js#L443)

