### PR TITLE
Fix Callsite.getFileName return type in `@types/node`

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -158,7 +158,7 @@ declare namespace NodeJS {
         /**
          * Name of the script [if this function was defined in a script]
          */
-        getFileName(): string | null;
+        getFileName(): string | undefined;
 
         /**
          * Current line number [if this function was defined in a script]

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -163,7 +163,7 @@ import * as trace_events from 'node:trace_events';
         const func: Function | undefined  = frame.getFunction();
         const funcName: string | null = frame.getFunctionName();
         const meth: string | null  = frame.getMethodName();
-        const fname: string | null  = frame.getFileName();
+        const fname: string | undefined  = frame.getFileName();
         const lineno: number | null  = frame.getLineNumber();
         const colno: number | null  = frame.getColumnNumber();
         const evalOrigin: string | undefined  = frame.getEvalOrigin();

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -528,7 +528,7 @@ declare namespace NodeJS {
         /**
          * Name of the script [if this function was defined in a script]
          */
-        getFileName(): string | null;
+        getFileName(): string | undefined;
 
         /**
          * Current line number [if this function was defined in a script]

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -224,7 +224,7 @@ import * as trace_events from 'trace_events';
         const func: Function | undefined  = frame.getFunction();
         const funcName: string | null = frame.getFunctionName();
         const meth: string | null  = frame.getMethodName();
-        const fname: string | null  = frame.getFileName();
+        const fname: string | undefined  = frame.getFileName();
         const lineno: number | null  = frame.getLineNumber();
         const colno: number | null  = frame.getColumnNumber();
         const evalOrigin: string | undefined  = frame.getEvalOrigin();

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -144,7 +144,7 @@ declare namespace NodeJS {
         /**
          * Name of the script [if this function was defined in a script]
          */
-        getFileName(): string | null;
+        getFileName(): string | undefined;
 
         /**
          * Current line number [if this function was defined in a script]

--- a/types/node/v16/node-tests.ts
+++ b/types/node/v16/node-tests.ts
@@ -162,7 +162,7 @@ import * as trace_events from 'node:trace_events';
         const func: Function | undefined  = frame.getFunction();
         const funcName: string | null = frame.getFunctionName();
         const meth: string | null  = frame.getMethodName();
-        const fname: string | null  = frame.getFileName();
+        const fname: string | undefined  = frame.getFileName();
         const lineno: number | null  = frame.getLineNumber();
         const colno: number | null  = frame.getColumnNumber();
         const evalOrigin: string | undefined  = frame.getEvalOrigin();


### PR DESCRIPTION
Based on Node.js' usage here: https://github.com/nodejs/node/blob/cd36f6eeff56aa5b1529d2d5e6e387f5a5ba57e8/lib/internal/source_map/prepare_stack_trace.js#L62-L67 this typing is incorrect and should be `undefined` instead of `null`. Others may also need to be changed, but I haven't found definitive proof

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

