### PR TITLE
[itemsjs] Fix incorrect key type on buckets

### DIFF
--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -6,19 +6,19 @@
 export as namespace itemsjs;
 
 declare namespace itemsjs {
-    interface Bucket<I extends {}> {
-        key: keyof I & string;
+    interface Bucket<K> {
+        key: K;
         doc_count: number;
         selected: boolean;
     }
 
-    type Buckets<I extends {}> = Array<Bucket<I>>;
+    type Buckets<K> = Array<Bucket<K>>;
 
-    interface SearchAggregation<I extends {}, A extends string> {
+    interface SearchAggregation<I extends {}, A extends keyof I & string> {
         name: A;
         title: string;
         position: number;
-        buckets: Buckets<I>;
+        buckets: Buckets<I[A]>;
     }
 
     interface Pagination {
@@ -27,7 +27,7 @@ declare namespace itemsjs {
         total: number;
     }
 
-    interface SearchOptions<I extends {}, S extends string, A extends string> {
+    interface SearchOptions<I extends {}, S extends string, A extends keyof I & string> {
         query?: string | undefined;
         /** @default 1 */
         page?: number | undefined;
@@ -66,7 +66,7 @@ declare namespace itemsjs {
         per_page?: number | undefined;
     }
 
-    interface ItemsJs<I extends {}, S extends string, A extends string> {
+    interface ItemsJs<I extends {}, S extends string, A extends keyof I & string> {
         /** Search items */
         search(options?: SearchOptions<I, S, A>): {
             data: {
@@ -85,7 +85,7 @@ declare namespace itemsjs {
 
         /** Get data for aggregation */
         aggregation(options: AggregationOptions<A>): {
-            data: { buckets: Buckets<I> };
+            data: { buckets: Buckets<I[A]> };
             pagination: Pagination;
         };
 
@@ -130,7 +130,7 @@ declare namespace itemsjs {
     }
 
     /** Configuration for itemsjs */
-    interface Configuration<I extends {}, S extends string, A extends string> {
+    interface Configuration<I extends {}, S extends string, A extends keyof I & string> {
         sortings?: Record<S, Sorting<I>> | undefined;
         aggregations?: Record<A, Aggregation> | undefined;
         /** @default [] */
@@ -146,9 +146,10 @@ declare namespace itemsjs {
  * @param configuration itemsjs
  * @template I The type of items being indexed
  */
-declare function itemsjs<I extends {} = Record<any, unknown>, S extends string = string, A extends string = string>(
-    items: I[],
-    configuration?: itemsjs.Configuration<I, S, A>,
-): itemsjs.ItemsJs<I, S, A>;
+declare function itemsjs<
+    I extends {} = Record<any, unknown>,
+    S extends string = string,
+    A extends keyof I & string = keyof I & string,
+>(items: I[], configuration?: itemsjs.Configuration<I, S, A>): itemsjs.ItemsJs<I, S, A>;
 
 export = itemsjs;

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -27,11 +27,15 @@ const items = itemsjs(myitems, {
         },
     },
     aggregations: {
-        anAggregation: {
+        anumber: {
             title: 'A Number',
             hide_zero_doc_count: true,
             conjunction: false,
             chosen_filters_on_top: false,
+        },
+        // @ts-expect-error `someKey` doesn't exist on the object
+        someKey: {
+            title: 'Some Key',
         },
     },
 });
@@ -68,16 +72,23 @@ items.search({
 
 items.search({
     query: 'abc',
-    filters: { anAggregation: ['abc'] },
+    filters: { anumber: ['abc'] },
 });
 
 // Aggregation 'bar' was never defined
 // @ts-expect-error
 items.aggregation({ name: 'bar' });
 
-items.aggregation({ name: 'anAggregation' });
+items.aggregation({ name: 'anumber' });
 
-itemsjs<(typeof myitems)[number]>([]).reindex(myitems);
+// Test searching with aggregations
+const search = items.search();
+const anumberAggregations = search.data.aggregations['anumber'];
+
+// $ExpectType string | number
+anumberAggregations.buckets[0].key;
+
+itemsjs<typeof myitems[number]>([]).reindex(myitems);
 
 const myItemsIds = myitems.map((v, i) => ({ id: i, ...v }));
 


### PR DESCRIPTION
Closes #64945

The key type for buckets should be its possible values based on an aggregation, not the name of the key itself. For example, if an aggregation is declared for the key `foo`, then the `key` field on `Bucket` should be the possible values of `foo`.

This PR also improves the type requirement on the aggregation generic (`A`) to ensure that it's a key of the item type `I`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Reproduction in comment <https://github.com/DefinitelyTyped/DefinitelyTyped/issues/64945#issuecomment-1497719391>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
