### PR TITLE
Update `@wordpress/editor` store type to use modern wp data practices

### DIFF
--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/editor 13.6
+// Type definitions for @wordpress/editor 13.7
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -3,23 +3,10 @@
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 5.0
-
-import { dispatch, select, StoreDescriptor } from '@wordpress/data';
-
 export { storeConfig, transformStyles } from '@wordpress/block-editor';
+import { EditorStore } from './store';
 
-declare module '@wordpress/data' {
-    function dispatch(key: 'core/editor'): typeof import('./store/actions');
-    function select(key: 'core/editor'): typeof import('./store/selectors');
-}
-
-export interface EditorStoreDescriptor extends StoreDescriptor {
-    name: 'core/editor';
-}
-
-declare module '@wordpress/editor' {
-    const store: EditorStoreDescriptor;
-}
+export const store: EditorStore;
 
 export * from './components';
 export * from './utils';

--- a/types/wordpress__editor/package.json
+++ b/types/wordpress__editor/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@wordpress/core-data": "^6.0.0",
-        "@wordpress/data": "^8.5.0",
+        "@wordpress/data": "^9.0.0",
         "@wordpress/element": "^5.0.0"
     }
 }

--- a/types/wordpress__editor/store/index.d.ts
+++ b/types/wordpress__editor/store/index.d.ts
@@ -1,0 +1,7 @@
+import { createReduxStore } from '@wordpress/data';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+export interface EditorStore extends ReturnType<typeof createReduxStore<unknown, typeof actions, typeof selectors>> {
+    name: "core/editor";
+}

--- a/types/wordpress__editor/store/selectors.d.ts
+++ b/types/wordpress__editor/store/selectors.d.ts
@@ -1,5 +1,6 @@
 import { EditorSettings } from '@wordpress/block-editor';
 import { BlockInstance } from '@wordpress/blocks';
+import { SelectorWithCustomCurrySignature } from '@wordpress/data/src/types';
 import { EntityRecord, Page, Post, User } from '@wordpress/core-data';
 
 export {
@@ -56,6 +57,8 @@ export {
     isValidTemplate,
 } from '@wordpress/block-editor/store/selectors';
 
+type StateType = Record<string, unknown>;
+
 /**
  * Returns whether or not the user has the unfiltered_html capability.
  *
@@ -92,7 +95,7 @@ export function getActivePostLock(): string | undefined;
  *
  * @param attributeName - Autosave attribute name.
  */
-export function getAutosaveAttribute(attributeName: string): EntityRecord<any>[keyof EntityRecord<any>] | {};
+export function getAutosaveAttribute(state: StateType, attributeName: string): EntityRecord<any>[keyof EntityRecord<any>] | {};
 
 /**
  * Returns the post currently being edited in its last known saved state, not including unsaved
@@ -107,6 +110,7 @@ export function getCurrentPost(): Page | Post;
  * @param attributeName - Post attribute name.
  */
 export function getCurrentPostAttribute<T extends keyof (Page | Post)>(
+    state: StateType,
     attributeName: T
 ): (Page | Post)[T] | undefined;
 
@@ -137,9 +141,14 @@ export function getCurrentPostType(): string;
  *
  * @param attributeName - Post attribute name.
  */
-export function getEditedPostAttribute<T extends keyof (Page | Post)>(
-    attributeName: T
-): (Page | Post)[T] | undefined;
+export interface getEditedPostAttribute extends SelectorWithCustomCurrySignature {
+    <T extends keyof (Page | Post)>(
+        state: StateType,
+        attributeName: T
+      ): (Page | Post)[T] | undefined;
+
+    CurriedSignature: <T extends keyof (Page | Post)>(attributeName: T) => (Page | Post)[T] | undefined;
+}
 
 /**
  * Returns the content of the post being edited, preferring raw string edit before falling back to
@@ -204,7 +213,7 @@ export function getPostLockUser(): User | undefined | null;
  *
  * @returns Global application state prior to transaction.
  */
-export function getStateBeforeOptimisticTransaction(transactionId: object): any;
+export function getStateBeforeOptimisticTransaction(state: StateType, transactionId: object): any;
 
 /**
  * Returns a suggested post format for the current post, inferred only if there is a single block
@@ -234,7 +243,7 @@ export function hasEditorUndo(): boolean;
  *
  * @param predicate - Function given state, returning `true` if match.
  */
-export function inSomeHistory(predicate: (state: Record<string, any>) => boolean): boolean;
+export function inSomeHistory(state: StateType, predicate: (state: StateType) => boolean): boolean;
 
 /**
  * Returns `true` if the post is autosaving, or `false` otherwise.

--- a/types/wordpress__editor/wordpress__editor-tests.tsx
+++ b/types/wordpress__editor/wordpress__editor-tests.tsx
@@ -1,9 +1,9 @@
-import { dispatch, select } from '@wordpress/data';
+import { useDispatch, useSelect, dispatch, select } from '@wordpress/data';
 import * as e from '@wordpress/editor';
 
 declare const BLOCK_INSTANCE: import('@wordpress/blocks').BlockInstance;
 
-// $ExpectType EditorStoreDescriptor
+// $ExpectType EditorStore
 e.store;
 
 // $ExpectType "core/editor"
@@ -340,67 +340,73 @@ e.store.name;
 // Store
 // ============================================================================
 
+// Raw dispatch and select don't have type inference at the moment. :(
+// $ExpectType Object
+dispatch(e.store);
+// $ExpectType Object
+select(e.store);
+
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').autosave();
+useDispatch(e.store).autosave();
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').autosave({ foo: true, bar: false });
+useDispatch(e.store).autosave({ foo: true, bar: false });
 
 // $ExpectType void
-dispatch('core/editor').editPost({ content: 'foo' });
+useDispatch(e.store).editPost({ content: 'foo' });
 
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').resetEditorBlocks([BLOCK_INSTANCE]);
+useDispatch(e.store).resetEditorBlocks([BLOCK_INSTANCE]);
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').resetEditorBlocks([BLOCK_INSTANCE], { foo: 'bar' });
+useDispatch(e.store).resetEditorBlocks([BLOCK_INSTANCE], { foo: 'bar' });
 
 // $ExpectType void
-dispatch('core/editor').resetPost({ content: 'foo' });
+useDispatch(e.store).resetPost({ content: 'foo' });
 
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').savePost();
+useDispatch(e.store).savePost();
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').savePost({ content: 'foo' });
+useDispatch(e.store).savePost({ content: 'foo' });
 
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').setupEditor({ content: 'foo' });
+useDispatch(e.store).setupEditor({ content: 'foo' });
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').setupEditor({ content: 'foo' }, { content: 'bar' });
+useDispatch(e.store).setupEditor({ content: 'foo' }, { content: 'bar' });
 // $ExpectType IterableIterator<void>
-dispatch('core/editor').setupEditor({ content: 'foo' }, { content: 'bar' }, [
+useDispatch(e.store).setupEditor({ content: 'foo' }, { content: 'bar' }, [
     ['core/paragraph', {}, [['core/paragraph']]],
 ]);
 
 // $ExpectType void
-dispatch('core/editor').updateEditorSettings({ codeEditingEnabled: false });
+useDispatch(e.store).updateEditorSettings({ codeEditingEnabled: false });
 
 // $ExpectType void
-dispatch('core/editor').updatePostLock({ isLocked: false, user: null });
+useDispatch(e.store).updatePostLock({ isLocked: false, user: null });
 
-// $ExpectType string | undefined
-select('core/editor').getActivePostLock();
+useSelect(select => {
+    // $ExpectType string | undefined
+    select(e.store).getActivePostLock();
 
-// $ExpectType {}
-select('core/editor').getAutosaveAttribute('author');
+    // $ExpectType {}
+    select(e.store).getAutosaveAttribute('author');
+    // $ExpectType Page | Post
+    select(e.store).getCurrentPost();
+    // $ExpectType (RenderedText<"edit"> & { is_protected: boolean; block_version: string; }) | (RenderedText<"edit"> & { is_protected: boolean; block_version: string; }) | undefined
+    select(e.store).getCurrentPostAttribute('content');
+    // $ExpectType number | undefined
+    select(e.store).getCurrentPostAttribute('author');
+    // $ExpectType OmitNevers<Record<string, string>, { [x: string]: string; }> | undefined
+    select(e.store).getCurrentPostAttribute('meta');
 
-// $ExpectType Page | Post
-select('core/editor').getCurrentPost();
+    // $ExpectType EditorSettings
+    select(e.store).getEditorSettings();
 
-// $ExpectType (RenderedText<"edit"> & { is_protected: boolean; block_version: string; }) | (RenderedText<"edit"> & { is_protected: boolean; block_version: string; }) | undefined
-select('core/editor').getCurrentPostAttribute('content');
-// $ExpectType number | undefined
-select('core/editor').getCurrentPostAttribute('author');
-// $ExpectType OmitNevers<Record<string, string>, { [x: string]: string; }> | undefined
-select('core/editor').getCurrentPostAttribute('meta');
+    // $ExpectType any
+    select(e.store).getPostEdits().content;
+    // $ExpectType any
+    select(e.store).getPostEdits().author;
+    // $ExpectType any
+    select(e.store).getPostEdits().foo;
 
-// $ExpectType EditorSettings
-select('core/editor').getEditorSettings();
-
-// $ExpectType any
-select('core/editor').getPostEdits().content;
-// $ExpectType any
-select('core/editor').getPostEdits().author;
-// $ExpectType any
-select('core/editor').getPostEdits().foo;
-
-// $ExpectType boolean
-select('core/editor').inSomeHistory(state => state.foo === true);
+    // $ExpectType boolean
+    select(e.store).inSomeHistory(state => state.foo === true);
+}, []);


### PR DESCRIPTION
Ever since wordpress/data bundled its own types, all of the custom type declarations in DT are not compatible. This is because the previous approach to defining types for a WordPress data store was to **redeclare** the WordPress data module, overriding the types specified by dispatch and select.

Now that wordpress/data declares its own types, there is a conflict -- we can't declare them twice.

As far as I can tell, it is impossible to both support the modern approach to types (import the store object and use it directly, allowing wp-data itself to infer types) alongside the previous approach (specify the store's string ID, and let the ad-hoc wp data type declaration infer the type).

So we need to update every WordPress data store in DT to use this new convention, or else these packages won't be compatible with newer wp data versions.

The basic changes are:
1. Define the store interface to effectively be a store descriptor, specifying the action/selector types as needed.
2. For any selectors which have parameters, add the "store" parameter in front.
3. Update the tests to import the store directly instead of using the string selector.
4. Delete the wordpress data declaration.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/WordPress/gutenberg/pull/43315>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
