### PR TITLE
[react] Disable no-empty-interface globally in v15

### DIFF
--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3631,7 +3631,6 @@ declare namespace React {
 
 declare global {
     namespace JSX {
-        // tslint:disable-next-line:no-empty-interface
         interface Element extends React.ReactElement { }
         interface ElementClass extends React.Component<any> {
             render(): JSX.Element | null | false;
@@ -3639,7 +3638,6 @@ declare global {
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }
 
-        // tslint:disable-next-line:no-empty-interface
         interface IntrinsicAttributes extends React.Attributes { }
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 

--- a/types/react/v15/test/index.ts
+++ b/types/react/v15/test/index.ts
@@ -299,7 +299,6 @@ myComponent.reset();
 // Refs
 // --------------------------------------------------------------------------
 
-// tslint:disable-next-line:no-empty-interface
 interface RCProps { }
 
 class RefComponent extends React.Component<RCProps> {

--- a/types/react/v15/tslint.json
+++ b/types/react/v15/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-empty-interface": false,
         "no-object-literal-type-assertion": false,
         "no-unnecessary-qualifier": false
     }


### PR DESCRIPTION
Just syncs the tslint setting with later versions. Makes it easier to compare versions.