### PR TITLE
Update `ssh2` types to include missing `.end()` function.

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1757,6 +1757,16 @@ export interface SFTPWrapper extends EventEmitter {
      * Sends an attrs response for the request identified by id.
      */
     attrs(reqId: number, attrs: Attributes): void;
+    
+    /**
+     * Closes the channel.
+     */
+    end(): void;
+    
+    /**
+     * Closes the channel.
+     */
+    destroy(): void;
 }
 
 export interface PublicKeyEntry {

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1757,12 +1757,12 @@ export interface SFTPWrapper extends EventEmitter {
      * Sends an attrs response for the request identified by id.
      */
     attrs(reqId: number, attrs: Attributes): void;
-    
+
     /**
      * Closes the channel.
      */
     end(): void;
-    
+
     /**
      * Closes the channel.
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/master/lib/protocol/SFTP.js#L283
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

