### PR TITLE
Fix break because of lib update

### DIFF
--- a/types/wicg-file-system-access/package.json
+++ b/types/wicg-file-system-access/package.json
@@ -1,0 +1,9 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=5.0": {
+            "*": ["ts5.0/*"]
+        }
+    }
+}

--- a/types/wicg-file-system-access/ts5.0/index.d.ts
+++ b/types/wicg-file-system-access/ts5.0/index.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for non-npm package File System Access API 2020.09
-// Project: https://github.com/WICG/file-system-access
-// Definitions by: Ingvar Stepanyan <https://github.com/RReverser>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.6
-
 export {};
 
 declare global {
@@ -79,12 +73,12 @@ interface FileSystemRemoveOptions {
     recursive?: boolean | undefined;
 }
 
-// type WriteParams =
-//     | { type: 'write'; position?: number | undefined; data: BufferSource | Blob | string }
-//     | { type: 'seek'; position: number }
-//     | { type: 'truncate'; size: number };
+type WriteParams =
+    | { type: 'write'; position?: number | undefined; data: BufferSource | Blob | string }
+    | { type: 'seek'; position: number }
+    | { type: 'truncate'; size: number };
 
-// type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
+type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 
 // TODO: remove this once https://github.com/microsoft/TSJS-lib-generator/issues/881 is fixed.
 // Native File System API especially needs this method.
@@ -92,11 +86,11 @@ interface WritableStream {
     close(): Promise<void>;
 }
 
-// class FileSystemWritableFileStream extends WritableStream {
-//     write(data: FileSystemWriteChunkType): Promise<void>;
-//     seek(position: number): Promise<void>;
-//     truncate(size: number): Promise<void>;
-// }
+class FileSystemWritableFileStream extends WritableStream {
+    write(data: FileSystemWriteChunkType): Promise<void>;
+    seek(position: number): Promise<void>;
+    truncate(size: number): Promise<void>;
+}
 
 interface FileSystemFileHandle extends FileSystemHandle {
     readonly kind: 'file';

--- a/types/wicg-file-system-access/ts5.0/tsconfig.json
+++ b/types/wicg-file-system-access/ts5.0/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "ES5",
+            "ES2015.Promise",
+            "ESNext.AsyncIterable",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wicg-file-system-access-tests.ts"
+    ]
+}

--- a/types/wicg-file-system-access/ts5.0/tslint.json
+++ b/types/wicg-file-system-access/ts5.0/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/wicg-file-system-access/ts5.0/wicg-file-system-access-tests.ts
+++ b/types/wicg-file-system-access/ts5.0/wicg-file-system-access-tests.ts
@@ -1,0 +1,104 @@
+(async () => {
+    let [fileHandle]: [FileSystemFileHandle] = await showOpenFilePicker();
+    [fileHandle] = await showOpenFilePicker({ multiple: false });
+    const fileHandles: FileSystemFileHandle[] = await showOpenFilePicker({
+        excludeAcceptAllOption: true,
+        multiple: true,
+        types: [{ accept: { 'image/*': ['.png', '.jpg'], 'text/plain': '.txt' } }],
+    });
+    let w: FileSystemWritableFileStream = await fileHandle.createWritable();
+    w = await fileHandle.createWritable({ keepExistingData: true });
+    await w.write('abc');
+    await w.write(new Uint8Array([1, 2, 3]));
+    await w.write({ type: 'seek', position: 0 });
+    await w.seek(1);
+    await w.write(new Blob(['xyz']));
+    await w.write({ type: 'write', position: 3, data: new Uint8Array([4, 5, 6]) });
+    await w.write({ type: 'truncate', size: 2 });
+    await w.truncate(1);
+    await w.close();
+
+    let permissionState: PermissionState = await fileHandle.queryPermission();
+    permissionState = await fileHandle.requestPermission({ mode: 'read' });
+    permissionState = await fileHandle.requestPermission({ mode: 'readwrite' });
+
+    const saveFilePickerOptions = {
+        suggestedName: 'image.svg'
+    };
+    const filePickerOptions = {
+        excludeAcceptAllOption: true,
+        types: [{ description: 'SVG images', accept: { 'image/svg': ['svg'] } }],
+    };
+
+    fileHandle = await showSaveFilePicker();
+    fileHandle = await showSaveFilePicker({
+        ...filePickerOptions
+    });
+    fileHandle = await showSaveFilePicker({
+        ...saveFilePickerOptions
+    });
+    fileHandle = await showSaveFilePicker({
+        ...saveFilePickerOptions,
+        ...filePickerOptions
+    });
+
+    const file: File = await fileHandle.getFile();
+    new ReadableStream().pipeTo(await fileHandle.createWritable());
+
+    let dirHandle: FileSystemDirectoryHandle = await showDirectoryPicker();
+    dirHandle = await showDirectoryPicker({});
+
+    (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
+        // Disable due to a bug in TSLint https://github.com/palantir/tslint/issues/3997:
+        // tslint:disable-next-line await-promise
+        for await (const [name, handle] of dirHandle) {
+            if (handle.kind === 'file') {
+                yield handle.getFile();
+            } else {
+                yield* recursivelyWalkDir(handle);
+            }
+        }
+    })(dirHandle);
+
+    const maybePath = await dirHandle.resolve(fileHandle);
+    if (maybePath) {
+        const pathItems: string[] = maybePath;
+    }
+
+    fileHandle = await dirHandle.getFileHandle('temp.txt');
+    fileHandle = await dirHandle.getFileHandle('temp.txt', { create: true });
+
+    dirHandle = await dirHandle.getDirectoryHandle('subdir', { create: false });
+
+    await dirHandle.removeEntry('temp.txt');
+    await dirHandle.removeEntry('nested-dir', { recursive: true });
+
+    dirHandle = await navigator.storage.getDirectory();
+
+    // Testing Chromium <=85 methods, remove when all Chromium-based browsers have upgraded.
+
+    fileHandle = await chooseFileSystemEntries();
+    fileHandle = await chooseFileSystemEntries({
+        type: 'open-file',
+        accepts: [{ description: 'Images', extensions: ['png', 'jpg'], mimeTypes: ['image/*'] }],
+        excludeAcceptAllOption: false,
+        multiple: false,
+    });
+    fileHandle = await chooseFileSystemEntries({ type: 'save-file' });
+    dirHandle = await chooseFileSystemEntries({ type: 'open-directory' });
+    dirHandle = await dirHandle.getDirectory('subdir', { create: true });
+    fileHandle = await dirHandle.getFile('file.txt');
+
+    permissionState = await fileHandle.requestPermission({ writable: false });
+    permissionState = await fileHandle.requestPermission({ writable: true });
+
+    (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
+        for await (const handle of dirHandle.getEntries()) {
+            if (handle.isFile) {
+                yield handle.getFile();
+            } else {
+                yield* recursivelyWalkDir(handle);
+            }
+        }
+    })(dirHandle);
+})();


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
