### PR TITLE
[@types/sparqljs] `Update`s can have `base`s too

### DIFF
--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -106,6 +106,7 @@ export interface DescribeQuery extends BaseQuery {
 
 export interface Update {
     type: 'update';
+    base?: string | undefined;
     prefixes: { [prefix: string]: string; };
     updates: UpdateOperation[];
 }

--- a/types/sparqljs/sparqljs-tests.ts
+++ b/types/sparqljs/sparqljs-tests.ts
@@ -142,6 +142,7 @@ function updateQueries() {
 
     const update: SparqlJs.Update = {
         type: 'update',
+        base: 'http://example.com/',
         prefixes: {
             rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
         },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/RubenVerborgh/SPARQL.js/blob/66c1d26d2bc289f1bd414dcfca0383dc7cf368bc/lib/sparql.jison#L581) (also, runtime checks reveal the presence of `.base`)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~ `.base` has been on Updates for multiple major versions of `sparqljs` already.