### PR TITLE
@types/ember-data: Allow `null` for `defaultValue`

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -159,7 +159,7 @@ export namespace DS {
     const VERSION: string;
 
     interface AttrOptions<T> {
-        defaultValue?: T extends Exclude<object, null> ? (() => T) : T | (() => T) | undefined;
+        defaultValue?: T extends Exclude<object, null> ? (() => T) : T | (() => T) | null | undefined;
         allowNull?: boolean | undefined; // TODO: restrict to boolean transform (TS 2.8)
         [key: string]: unknown;
     }


### PR DESCRIPTION
This PR adds `null` to the acceptable values for `defaultValue`. Before this change, it could only either be the type of the attr or undefined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
