### PR TITLE
fix(react-input-mask): change children type

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -59,7 +59,7 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
      */
     beforeMaskedStateChange?(states: BeforeMaskedStateChangeStates): InputState;
 
-    children?: () => JSX.Element;
+    children?: (inputProps: React.InputHTMLAttributes<HTMLInputElement>) => JSX.Element;
 };
 
 export class ReactInputMask extends React.Component<Props> {}

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -9,58 +9,59 @@
 import * as React from 'react';
 
 export interface Selection {
-  start: number;
-  end: number;
+    start: number;
+    end: number;
 }
 
 export interface InputState {
-  value: string;
-  selection: Selection | null;
+    value: string;
+    selection: Selection | null;
 }
 
 export interface BeforeMaskedStateChangeStates {
-  previousState: InputState;
-  currentState: InputState;
-  nextState: InputState;
+    previousState: InputState;
+    currentState: InputState;
+    nextState: InputState;
 }
 
-export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
-  /**
-   * Mask string. Format characters are:
-   * * `9`: `0-9`
-   * * `a`: `A-Z, a-z`
-   * * `\*`: `A-Z, a-z, 0-9`
-   *
-   * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
-   * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
-   */
-  mask: string | Array<(string | RegExp)>;
-  /**
-   * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
-   */
-  maskChar?: string | null | undefined;
-  maskPlaceholder?: string | null | undefined;
-  /**
-   * Show mask even in empty input without focus.
-   */
-  alwaysShowMask?: boolean | undefined;
-  /**
-   * Use inputRef instead of ref if you need input node to manage focus, selection, etc.
-   */
-  inputRef?: React.Ref<HTMLInputElement> | undefined;
-  /**
-   * In case you need to implement more complex masking behavior, you can provide
-   * beforeMaskedStateChange function to change masked value and cursor position
-   * before it will be applied to the input.
-   *
-   * * previousState: Input state before change. Only defined on change event.
-   * * currentState: Current raw input state. Not defined during component render.
-   * * nextState: Input state with applied mask. Contains value and selection fields.
-   */
-  beforeMaskedStateChange?(states: BeforeMaskedStateChangeStates): InputState;
-}
+export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+    /**
+     * Mask string. Format characters are:
+     * * `9`: `0-9`
+     * * `a`: `A-Z, a-z`
+     * * `\*`: `A-Z, a-z, 0-9`
+     *
+     * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
+     * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
+     */
+    mask: string | Array<string | RegExp>;
+    /**
+     * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
+     */
+    maskChar?: string | null | undefined;
+    maskPlaceholder?: string | null | undefined;
+    /**
+     * Show mask even in empty input without focus.
+     */
+    alwaysShowMask?: boolean | undefined;
+    /**
+     * Use inputRef instead of ref if you need input node to manage focus, selection, etc.
+     */
+    inputRef?: React.Ref<HTMLInputElement> | undefined;
+    /**
+     * In case you need to implement more complex masking behavior, you can provide
+     * beforeMaskedStateChange function to change masked value and cursor position
+     * before it will be applied to the input.
+     *
+     * * previousState: Input state before change. Only defined on change event.
+     * * currentState: Current raw input state. Not defined during component render.
+     * * nextState: Input state with applied mask. Contains value and selection fields.
+     */
+    beforeMaskedStateChange?(states: BeforeMaskedStateChangeStates): InputState;
 
-export class ReactInputMask extends React.Component<Props> {
-}
+    children?: () => JSX.Element;
+};
+
+export class ReactInputMask extends React.Component<Props> {}
 
 export default ReactInputMask;


### PR DESCRIPTION
the default children type is ReactNode, but for this lib the type of children need to be a function that returns a JSX.Element

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

