### PR TITLE
[Luxon] Provide generics to allow individual types to be valid/invalid

### DIFF
--- a/types/luxon/package.json
+++ b/types/luxon/package.json
@@ -10,48 +10,12 @@
     },
     "owners": [
         {
-            "name": "Hyeonseok Yang",
-            "githubUsername": "FourwingsY"
-        },
-        {
-            "name": "Jonathan Siebern",
-            "githubUsername": "jsiebern"
-        },
-        {
-            "name": "Matt R. Wilson",
-            "githubUsername": "mastermatt"
-        },
-        {
-            "name": "Pietro Vismara",
-            "githubUsername": "pietrovismara"
-        },
-        {
-            "name": "Janeene Beeforth",
-            "githubUsername": "dawnmist"
-        },
-        {
-            "name": "Jason Yu",
-            "githubUsername": "ycmjason"
-        },
-        {
-            "name": "Aitor Pérez Rodal",
-            "githubUsername": "Aitor1995"
-        },
-        {
-            "name": "Piotr Błażejewicz",
-            "githubUsername": "peterblazejewicz"
-        },
-        {
             "name": "Carson Full",
             "githubUsername": "carsonf"
         },
         {
-            "name": "Hugo Silva",
-            "githubUsername": "hugofpsilva"
-        },
-        {
-            "name": "Martin Badin",
-            "githubUsername": "martin-badin"
+            "name": "Piotr Błażejewicz",
+            "githubUsername": "peterblazejewicz"
         }
     ]
 }

--- a/types/luxon/src/_util.d.ts
+++ b/types/luxon/src/_util.d.ts
@@ -9,3 +9,6 @@ export type IfValid<ValidType, InvalidType, ThisIsValid extends boolean | undefi
     : ThisIsValid extends false ? InvalidType
     : CanBeInvalid extends true ? ValidType | InvalidType
     : ValidType;
+
+export type Valid = true;
+export type Invalid = false;

--- a/types/luxon/src/_util.d.ts
+++ b/types/luxon/src/_util.d.ts
@@ -1,4 +1,11 @@
 import { TSSettings } from "./settings";
 
 export type CanBeInvalid = TSSettings extends { throwOnInvalid: true } ? false : true;
-export type IfInvalid<T> = CanBeInvalid extends true ? T : never;
+
+export type DefaultValidity = CanBeInvalid extends true ? boolean : true;
+
+export type IfValid<ValidType, InvalidType, ThisIsValid extends boolean | undefined> = ThisIsValid extends true
+    ? ValidType
+    : ThisIsValid extends false ? InvalidType
+    : CanBeInvalid extends true ? ValidType | InvalidType
+    : ValidType;

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -7,7 +7,7 @@ import {
     ToISOTimeDurationOptions,
     ZoneOptions,
 } from "../index";
-import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid, Invalid, Valid } from "./_util";
 import { Duration, DurationLike, DurationUnits } from "./duration";
 import { Interval } from "./interval";
 import { Zone } from "./zone";
@@ -377,7 +377,7 @@ export interface ExplainedFormat {
     invalidReason?: string | undefined;
 }
 
-export type DateTimeMaybeValid = CanBeInvalid extends true ? (DateTime<true> | DateTime<false>) : DateTime;
+export type DateTimeMaybeValid = CanBeInvalid extends true ? (DateTime<Valid> | DateTime<Invalid>) : DateTime;
 
 /**
  * A DateTime is an immutable data structure representing a specific date and time and accompanying methods.
@@ -414,7 +414,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.now().toISO() //~> now in the ISO format
      */
-    static now(): DateTime<true>;
+    static now(): DateTime<Valid>;
 
     /**
      * Create a local DateTime
@@ -480,7 +480,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
     static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
     static local(year: number, month: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
     static local(year: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
-    static local(opts?: DateTimeJSOptions): DateTime<true>;
+    static local(opts?: DateTimeJSOptions): DateTime<Valid>;
 
     /**
      * Create a DateTime in UTC
@@ -547,7 +547,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
     static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTimeMaybeValid;
     static utc(year: number, month: number, options?: LocaleOptions): DateTimeMaybeValid;
     static utc(year: number, options?: LocaleOptions): DateTimeMaybeValid;
-    static utc(options?: LocaleOptions): DateTime<true>;
+    static utc(options?: LocaleOptions): DateTime<Valid>;
 
     /**
      * Create a DateTime from a JavaScript Date object. Uses the default zone.
@@ -580,7 +580,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
      * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
      */
-    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTime<true>;
+    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTime<Valid>;
 
     /**
      * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
@@ -747,7 +747,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent
      * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
      */
-    static invalid(reason: string, explanation?: string): DateTime<false>;
+    static invalid(reason: string, explanation?: string): DateTime<Invalid>;
 
     /**
      * Check if an object is a DateTime. Works across context boundaries
@@ -1451,14 +1451,14 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param opts - options that affect the creation of the Duration
      * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
      */
-    diffNow(unit?: DurationUnits, opts?: DiffOptions): Duration<true>;
+    diffNow(unit?: DurationUnits, opts?: DiffOptions): Duration<Valid>;
 
     /**
      * Return an Interval spanning between this DateTime and another DateTime
      *
      * @param otherDateTime - the other end point of the Interval
      */
-    until(otherDateTime: DateTime): IfValid<Interval<true>, DateTime<false>, IsValid>;
+    until(otherDateTime: DateTime): IfValid<Interval<Valid>, DateTime<Invalid>, IsValid>;
 
     /**
      * Return whether this DateTime is in the same unit of time as another DateTime.
@@ -1523,7 +1523,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      */
     static min<AllValid extends boolean>(
         ...dateTimes: Array<DateTime<AllValid>>
-    ): (AllValid extends true ? DateTime<true> : never) | (AllValid extends false ? DateTime<false> : never);
+    ): (AllValid extends true ? DateTime<Valid> : never) | (AllValid extends false ? DateTime<Invalid> : never);
 
     /**
      * Return the max of several date times
@@ -1532,7 +1532,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      */
     static max<AllValid extends boolean>(
         ...dateTimes: Array<DateTime<AllValid>>
-    ): (AllValid extends true ? DateTime<true> : never) | (AllValid extends false ? DateTime<false> : never);
+    ): (AllValid extends true ? DateTime<Valid> : never) | (AllValid extends false ? DateTime<Invalid> : never);
 
     // MISC
 

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -377,6 +377,8 @@ export interface ExplainedFormat {
     invalidReason?: string | undefined;
 }
 
+export type DateTimeMaybeValid = CanBeInvalid extends true ? (DateTime<true> | DateTime<false>) : DateTime;
+
 /**
  * A DateTime is an immutable data structure representing a specific date and time and accompanying methods.
  * It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
@@ -456,7 +458,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         second: number,
         millisecond: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static local(
         year: number,
         month: number,
@@ -465,7 +467,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         minute: number,
         second: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static local(
         year: number,
         month: number,
@@ -473,11 +475,11 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         hour: number,
         minute: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
-    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, opts?: DateTimeJSOptions): DateTime;
+    ): DateTimeMaybeValid;
+    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
     static local(opts?: DateTimeJSOptions): DateTime<true>;
 
     /**
@@ -523,7 +525,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         second: number,
         millisecond: number,
         options?: LocaleOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static utc(
         year: number,
         month: number,
@@ -532,7 +534,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         minute: number,
         second: number,
         options?: LocaleOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static utc(
         year: number,
         month: number,
@@ -540,11 +542,11 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         hour: number,
         minute: number,
         options?: LocaleOptions,
-    ): DateTime;
-    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, month: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, options?: LocaleOptions): DateTime;
+    ): DateTimeMaybeValid;
+    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, month: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, options?: LocaleOptions): DateTimeMaybeValid;
     static utc(options?: LocaleOptions): DateTime<true>;
 
     /**
@@ -554,7 +556,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options - configuration options for the DateTime
      * @param options.zone - the zone to place the DateTime into
      */
-    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTime;
+    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -566,7 +568,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
      * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
      */
-    static fromMillis(milliseconds: number, options?: DateTimeJSOptions): DateTime;
+    static fromMillis(milliseconds: number, options?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a number of seconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -616,7 +618,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
      */
-    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
+    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an ISO 8601 string
@@ -640,7 +642,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromISO('2016-W05-4')
      */
-    static fromISO(text: string, opts?: DateTimeOptions): DateTime;
+    static fromISO(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an RFC 2822 string
@@ -661,7 +663,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromRFC2822('25 Nov 2016 13:23 Z')
      */
-    static fromRFC2822(text: string, opts?: DateTimeOptions): DateTime;
+    static fromRFC2822(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an HTTP header date
@@ -685,7 +687,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
      */
-    static fromHTTP(text: string, opts?: DateTimeOptions): DateTime;
+    static fromHTTP(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an input string and format string.
@@ -701,12 +703,12 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param opts.numberingSystem - the numbering system to use when parsing. Will also set the resulting DateTime to this numbering system
      * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
      */
-    static fromFormat(text: string, fmt: string, opts?: DateTimeOptions): DateTime;
+    static fromFormat(text: string, fmt: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * @deprecated use fromFormat instead
      */
-    static fromString(text: string, format: string, options?: DateTimeOptions): DateTime;
+    static fromString(text: string, format: string, options?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a SQL date, time, or datetime
@@ -737,7 +739,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromSQL('09:12:34.342')
      */
-    static fromSQL(text: string, opts?: DateTimeOptions): DateTime;
+    static fromSQL(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create an invalid DateTime.
@@ -752,7 +754,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      *
      * @param o
      */
-    static isDateTime(o: unknown): o is DateTime;
+    static isDateTime(o: unknown): o is DateTimeMaybeValid;
 
     /**
      * Produce the format string for a set of options
@@ -1073,7 +1075,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param opts - options
      * @param opts.keepLocalTime - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this. Defaults to false.
      */
-    setZone(zone?: string | Zone, opts?: ZoneOptions): DateTime;
+    setZone(zone?: string | Zone, opts?: ZoneOptions): DateTimeMaybeValid;
 
     /**
      * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
@@ -1439,7 +1441,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * i2.diff(i1, ['months', 'days']).toObject() //=> { months: 16, days: 19.03125 }
      * i2.diff(i1, ['months', 'days', 'hours']).toObject() //=> { months: 16, days: 19, hours: 0.75 }
      */
-    diff(otherDateTime: DateTime, unit?: DurationUnits, opts?: DiffOptions): Duration;
+    diff(otherDateTime: DateTime, unit?: DurationUnits, opts?: DiffOptions): Duration<IsValid>;
 
     /**
      * Return the difference between this DateTime and right now.
@@ -1456,7 +1458,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      *
      * @param otherDateTime - the other end point of the Interval
      */
-    until(otherDateTime: DateTime): Interval;
+    until(otherDateTime: DateTime): IfValid<Interval<true>, DateTime<false>, IsValid>;
 
     /**
      * Return whether this DateTime is in the same unit of time as another DateTime.

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -1,4 +1,4 @@
-import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid, Invalid, Valid } from "./_util";
 import { ConversionAccuracy } from "./datetime";
 import { NumberingSystem } from "./misc";
 
@@ -76,7 +76,7 @@ export type DurationInput = Duration | number | DurationLikeObject;
  */
 export type DurationLike = Duration | DurationLikeObject | number;
 
-export type DurationMaybeValid = CanBeInvalid extends true ? (Duration<true> | Duration<false>) : Duration;
+export type DurationMaybeValid = CanBeInvalid extends true ? (Duration<Valid> | Duration<Invalid>) : Duration;
 
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour".
@@ -105,7 +105,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @param opts.numberingSystem - the numbering system to use
      * @param opts.conversionAccuracy - the conversion system to use
      */
-    static fromMillis(count: number, opts?: DurationOptions): Duration<true>;
+    static fromMillis(count: number, opts?: DurationOptions): Duration<Valid>;
 
     /**
      * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
@@ -126,7 +126,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @param opts.numberingSystem - the numbering system to use
      * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
      */
-    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration<true>;
+    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration<Valid>;
 
     /**
      * Create a Duration from DurationLike.
@@ -134,7 +134,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @param durationLike
      * Either a Luxon Duration, a number of milliseconds, or the object argument to Duration.fromObject()
      */
-    static fromDurationLike(durationLike: DurationLike): Duration<true>;
+    static fromDurationLike(durationLike: DurationLike): Duration<Valid>;
 
     /**
      * Create a Duration from an ISO 8601 duration string.
@@ -184,7 +184,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @param reason - simple string of why this datetime is invalid. Should not contain parameters or anything else data-dependent
      * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
      */
-    static invalid(reason: string, explanation?: string): Duration<false>;
+    static invalid(reason: string, explanation?: string): Duration<Invalid>;
 
     /**
      * Check if an object is a Duration. Works across context boundaries

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -1,4 +1,4 @@
-import { IfInvalid } from "./_util";
+import { DefaultValidity, IfValid } from "./_util";
 import { ConversionAccuracy } from "./datetime";
 import { NumberingSystem } from "./misc";
 
@@ -93,7 +93,7 @@ export type DurationLike = Duration | DurationLikeObject | number;
  *
  * There's are more methods documented below. In addition, for more information on subtler topics like internationalization and validity, see the external documentation.
  */
-export class Duration {
+export class Duration<IsValid extends boolean = DefaultValidity> {
     /**
      * Create Duration from a number of milliseconds.
      *
@@ -103,7 +103,7 @@ export class Duration {
      * @param opts.numberingSystem - the numbering system to use
      * @param opts.conversionAccuracy - the conversion system to use
      */
-    static fromMillis(count: number, opts?: DurationOptions): Duration;
+    static fromMillis(count: number, opts?: DurationOptions): Duration<true>;
 
     /**
      * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
@@ -124,7 +124,7 @@ export class Duration {
      * @param opts.numberingSystem - the numbering system to use
      * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
      */
-    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration;
+    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration<true>;
 
     /**
      * Create a Duration from DurationLike.
@@ -132,7 +132,7 @@ export class Duration {
      * @param durationLike
      * Either a Luxon Duration, a number of milliseconds, or the object argument to Duration.fromObject()
      */
-    static fromDurationLike(durationLike: DurationLike): Duration;
+    static fromDurationLike(durationLike: DurationLike): Duration<true>;
 
     /**
      * Create a Duration from an ISO 8601 duration string.
@@ -182,7 +182,7 @@ export class Duration {
      * @param reason - simple string of why this datetime is invalid. Should not contain parameters or anything else data-dependent
      * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
      */
-    static invalid(reason: string, explanation?: string): Duration;
+    static invalid(reason: string, explanation?: string): Duration<false>;
 
     /**
      * Check if an object is a Duration. Works across context boundaries
@@ -196,12 +196,12 @@ export class Duration {
     /**
      * Get the locale of a Duration, such as 'en-GB'
      */
-    get locale(): string | IfInvalid<null>;
+    get locale(): IfValid<string, null, IsValid>;
 
     /**
      * Get the numbering system of a Duration, such as 'beng'. The numbering system is used when formatting the Duration
      */
-    get numberingSystem(): string | IfInvalid<null>;
+    get numberingSystem(): IfValid<string, null, IsValid>;
 
     /**
      * Returns a string representation of this Duration formatted according to the specified format string. You may use these tokens:
@@ -227,7 +227,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("M S") //=> "12 518402000"
      */
-    toFormat(fmt: string, opts?: { floor?: boolean | undefined }): string | IfInvalid<"Invalid Duration">;
+    toFormat(fmt: string, opts?: { floor?: boolean | undefined }): IfValid<string, "Invalid Duration", IsValid>;
 
     /**
      * Returns a string representation of a Duration with all units included
@@ -266,7 +266,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
      */
-    toISO(): string | IfInvalid<null>;
+    toISO(): IfValid<string, null, IsValid>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
@@ -289,41 +289,41 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
      */
-    toISOTime(opts?: ToISOTimeDurationOptions): string | IfInvalid<null>;
+    toISOTime(opts?: ToISOTimeDurationOptions): IfValid<string, null, IsValid>;
 
     /**
      * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
      */
-    toJSON(): string | IfInvalid<null>;
+    toJSON(): IfValid<string, null, IsValid>;
 
     /**
      * Returns an ISO 8601 representation of this Duration appropriate for use in debugging.
      */
-    toString(): string | IfInvalid<null>;
+    toString(): IfValid<string, null, IsValid>;
 
     /**
      * Returns a millisecond value of this Duration.
      */
-    toMillis(): number | IfInvalid<typeof NaN>;
+    toMillis(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Returns a millisecond value of this Duration. Alias of {@link toMillis}
      */
-    valueOf(): number | IfInvalid<typeof NaN>;
+    valueOf(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
      *
      * @param duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
      */
-    plus(duration: DurationLike): Duration;
+    plus(duration: DurationLike): this;
 
     /**
      * Make this Duration shorter by the specified amount. Return a newly-constructed Duration.
      *
      * @param duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
      */
-    minus(duration: DurationLike): Duration;
+    minus(duration: DurationLike): this;
 
     /**
      * Scale this Duration by the specified amount. Return a newly-constructed Duration.
@@ -333,7 +333,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 1, minutes: 30 }).mapUnit((x, u) => u === "hour" ? x * 2 : x) //=> { hours: 2, minutes: 30 }
      */
-    mapUnits(fn: (x: number, u?: DurationUnit) => number): Duration;
+    mapUnits(fn: (x: number, u?: DurationUnit) => number): this;
 
     /**
      * Get the value of unit.
@@ -347,7 +347,7 @@ export class Duration {
      * @example
      * Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
      */
-    get(unit: DurationUnit): number | IfInvalid<typeof NaN>;
+    get(unit: DurationUnit): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * "Set" the values of specified units. Return a newly-constructed Duration.
@@ -359,7 +359,7 @@ export class Duration {
      * @example
      * dur.set({ hours: 8, minutes: 30 })
      */
-    set(values: DurationLikeObject): Duration;
+    set(values: DurationLikeObject): this;
 
     /**
      * "Set" the locale and/or numberingSystem.  Returns a newly-constructed Duration.
@@ -367,7 +367,7 @@ export class Duration {
      * @example
      * dur.reconfigure({ locale: 'en-GB' })
      */
-    reconfigure(opts?: DurationOptions): Duration;
+    reconfigure(opts?: DurationOptions): this;
 
     /**
      * Return the length of the duration in the specified unit.
@@ -381,7 +381,7 @@ export class Duration {
      * @example
      * Duration.fromObject({hours: 60}).as('days') //=> 2.5
      */
-    as(unit: DurationUnit): number | IfInvalid<typeof NaN>;
+    as(unit: DurationUnit): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Reduce this Duration to its canonical representation in its current units.
@@ -391,7 +391,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
      */
-    normalize(): Duration;
+    normalize(): this;
 
     /**
      * Rescale units to its largest representation.
@@ -399,7 +399,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ milliseconds: 90000 }).rescale().toObject() //=> { minutes: 1, seconds: 30 }
      */
-    rescale(): Duration;
+    rescale(): this;
 
     /**
      * Convert this Duration into its representation in a different set of units.
@@ -407,13 +407,13 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 1, seconds: 30 }).shiftTo('minutes', 'milliseconds').toObject() //=> { minutes: 60, milliseconds: 30000 }
      */
-    shiftTo(...units: DurationUnit[]): Duration;
+    shiftTo(...units: DurationUnit[]): this;
 
     /**
      * Shift this Duration to all available units.
      * Same as shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds")
      */
-    shiftToAll(): Duration;
+    shiftToAll(): this;
 
     /**
      * Return the negative of this Duration.
@@ -421,72 +421,72 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 1, seconds: 30 }).negate().toObject() //=> { hours: -1, seconds: -30 }
      */
-    negate(): Duration;
+    negate(): this;
 
     /**
      * Get the years.
      */
-    get years(): number | IfInvalid<typeof NaN>;
+    get years(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the quarters.
      */
-    get quarters(): number | IfInvalid<typeof NaN>;
+    get quarters(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the months.
      */
-    get months(): number | IfInvalid<typeof NaN>;
+    get months(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the weeks
      */
-    get weeks(): number | IfInvalid<typeof NaN>;
+    get weeks(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the days.
      */
-    get days(): number | IfInvalid<typeof NaN>;
+    get days(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the hours.
      */
-    get hours(): number | IfInvalid<typeof NaN>;
+    get hours(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the minutes.
      */
-    get minutes(): number | IfInvalid<typeof NaN>;
+    get minutes(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the seconds.
      */
-    get seconds(): number | IfInvalid<typeof NaN>;
+    get seconds(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Get the milliseconds.
      */
-    get milliseconds(): number | IfInvalid<typeof NaN>;
+    get milliseconds(): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Returns whether the Duration is invalid.
      * Diff operations on invalid DateTimes or Intervals return invalid Durations.
      */
-    get isValid(): boolean;
+    get isValid(): IfValid<true, false, IsValid>;
 
     /**
      * Returns an error code if this Duration became invalid, or null if the Duration is valid
      */
-    get invalidReason(): string | null;
+    get invalidReason(): IfValid<string, null, IsValid>;
 
     /**
      * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
      */
-    get invalidExplanation(): string | null;
+    get invalidExplanation(): IfValid<string | null, null, IsValid>;
 
     /**
      * Equality check
      * Two Durations are equal iff they have the same units and the same values for each unit.
      */
-    equals(other: Duration): boolean | IfInvalid<false>;
+    equals(other: Duration): IfValid<boolean, false, IsValid>;
 }

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -1,4 +1,4 @@
-import { DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
 import { ConversionAccuracy } from "./datetime";
 import { NumberingSystem } from "./misc";
 
@@ -76,6 +76,8 @@ export type DurationInput = Duration | number | DurationLikeObject;
  */
 export type DurationLike = Duration | DurationLikeObject | number;
 
+export type DurationMaybeValid = CanBeInvalid extends true ? (Duration<true> | Duration<false>) : Duration;
+
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour".
  * Conceptually, it is just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them.
@@ -151,7 +153,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @example
      * Duration.fromISO('P5Y3M').toObject() //=> { years: 5, months: 3 }
      */
-    static fromISO(text: string, opts?: DurationOptions): Duration;
+    static fromISO(text: string, opts?: DurationOptions): DurationMaybeValid;
 
     /**
      * Create a Duration from an ISO 8601 time string.
@@ -174,7 +176,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @example
      * Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
      */
-    static fromISOTime(text: string, opts?: DurationOptions): Duration;
+    static fromISOTime(text: string, opts?: DurationOptions): DurationMaybeValid;
 
     /**
      * Create an invalid Duration.
@@ -189,7 +191,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      *
      * @param o
      */
-    static isDuration(o: unknown): o is Duration;
+    static isDuration(o: unknown): o is DurationMaybeValid;
 
     private constructor(config: unknown);
 

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -1,4 +1,4 @@
-import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid, Invalid, Valid } from "./_util";
 import { DateObjectUnits, DateTime, DateTimeOptions, DiffOptions, LocaleOptions, ToISOTimeOptions } from "./datetime";
 import { Duration, DurationLike, DurationMaybeValid, DurationUnit } from "./duration";
 
@@ -9,7 +9,7 @@ export interface IntervalObject {
 
 export type DateInput = DateTime | DateObjectUnits | Date;
 
-export type IntervalMaybeValid = CanBeInvalid extends true ? (Interval<true> | Interval<false>) : Interval;
+export type IntervalMaybeValid = CanBeInvalid extends true ? (Interval<Valid> | Interval<Invalid>) : Interval;
 
 /**
  * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}.
@@ -35,7 +35,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
      * @param explanation - longer explanation, may include parameters and other useful debugging information.
      */
-    static invalid(reason: string, explanation?: string): Interval<false>;
+    static invalid(reason: string, explanation?: string): Interval<Invalid>;
 
     /**
      * Create an Interval from a start DateTime and an end DateTime. Inclusive of the start but not the end.
@@ -83,12 +83,12 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
     /**
      * Returns the start of the Interval
      */
-    get start(): IfValid<DateTime<true>, null, IsValid>;
+    get start(): IfValid<DateTime<Valid>, null, IsValid>;
 
     /**
      * Returns the end of the Interval
      */
-    get end(): IfValid<DateTime<true>, null, IsValid>;
+    get end(): IfValid<DateTime<Valid>, null, IsValid>;
 
     /**
      * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -1,6 +1,6 @@
-import { DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
 import { DateObjectUnits, DateTime, DateTimeOptions, DiffOptions, LocaleOptions, ToISOTimeOptions } from "./datetime";
-import { Duration, DurationLike, DurationUnit } from "./duration";
+import { Duration, DurationLike, DurationMaybeValid, DurationUnit } from "./duration";
 
 export interface IntervalObject {
     start?: DateTime | undefined;
@@ -8,6 +8,8 @@ export interface IntervalObject {
 }
 
 export type DateInput = DateTime | DateObjectUnits | Date;
+
+export type IntervalMaybeValid = CanBeInvalid extends true ? (Interval<true> | Interval<false>) : Interval;
 
 /**
  * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}.
@@ -41,7 +43,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param start
      * @param end
      */
-    static fromDateTimes(start: DateInput, end: DateInput): Interval;
+    static fromDateTimes(start: DateInput, end: DateInput): IntervalMaybeValid;
 
     /**
      * Create an Interval from a start DateTime and a Duration to extend to.
@@ -49,7 +51,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param start
      * @param duration - the length of the Interval.
      */
-    static after(start: DateInput, duration: DurationLike): Interval;
+    static after(start: DateInput, duration: DurationLike): IntervalMaybeValid;
 
     /**
      * Create an Interval from an end DateTime and a Duration to extend backwards to.
@@ -57,7 +59,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param end
      * @param duration - the length of the Interval.
      */
-    static before(end: DateInput, duration: DurationLike): Interval;
+    static before(end: DateInput, duration: DurationLike): IntervalMaybeValid;
 
     /**
      * Create an Interval from an ISO 8601 string.
@@ -67,14 +69,14 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param text - the ISO string to parse
      * @param opts - options to pass {@link DateTime.fromISO} and optionally {@link Duration.fromISO}
      */
-    static fromISO(text: string, opts?: DateTimeOptions): Interval;
+    static fromISO(text: string, opts?: DateTimeOptions): IntervalMaybeValid;
 
     /**
      * Check if an object is an Interval. Works across context boundaries
      *
      * @param o
      */
-    static isInterval(o: unknown): o is Interval;
+    static isInterval(o: unknown): o is IntervalMaybeValid;
 
     private constructor(config: unknown);
 
@@ -159,7 +161,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param values.start - the starting DateTime
      * @param values.end - the ending DateTime
      */
-    set(values?: IntervalObject): Interval;
+    set(values?: IntervalObject): IntervalMaybeValid;
 
     /**
      * Split this Interval at each of the specified DateTimes
@@ -219,23 +221,23 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * Return an Interval representing the union of this Interval and the specified Interval.
      * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
      */
-    union(other: Interval): Interval;
+    union(other: Interval): IntervalMaybeValid;
 
     /**
      * Merge an array of Intervals into an equivalent minimal set of Intervals.
      * Combines overlapping and adjacent Intervals.
      */
-    static merge(intervals: Interval[]): Interval[];
+    static merge(intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
      */
-    static xor(intervals: Interval[]): Interval[];
+    static xor(intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Return Intervals representing the spans of time in this Interval that not overlap with any of the specified Intervals.
      */
-    difference(...intervals: Interval[]): Interval[];
+    difference(...intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Returns a string representation of this Interval appropriate for debugging.
@@ -331,7 +333,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @example
      * Interval.fromDateTimes(dt1, dt2).toDuration('seconds').toObject() //=> { seconds: 88489.257 }
      */
-    toDuration(unit?: DurationUnit | DurationUnit[], opts?: DiffOptions): Duration;
+    toDuration(unit?: DurationUnit | DurationUnit[], opts?: DiffOptions): DurationMaybeValid;
 
     /**
      * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
@@ -341,5 +343,5 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @example
      * Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.plus({ hours: 2 }))
      */
-    mapEndpoints(mapFn: (d: DateTime) => DateTime): Interval;
+    mapEndpoints(mapFn: (d: DateTime) => DateTime): IntervalMaybeValid;
 }

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -1,4 +1,4 @@
-import { IfInvalid } from "./_util";
+import { DefaultValidity, IfValid } from "./_util";
 import { DateObjectUnits, DateTime, DateTimeOptions, DiffOptions, LocaleOptions, ToISOTimeOptions } from "./datetime";
 import { Duration, DurationLike, DurationUnit } from "./duration";
 
@@ -26,14 +26,14 @@ export type DateInput = DateTime | DateObjectUnits | Date;
  * * **Output** To convert the Interval into other representations, see {@link Interval#toString}, {@link Interval#toLocaleString}, {@link Interval#toISO}, {@link Interval#toISODate},
  * * {@link Interval#toISOTime}, {@link Interval#toFormat}, and {@link Interval#toDuration}.
  */
-export class Interval {
+export class Interval<IsValid extends boolean = DefaultValidity> {
     /**
      * Create an invalid Interval.
      *
      * @param reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
      * @param explanation - longer explanation, may include parameters and other useful debugging information.
      */
-    static invalid(reason: string, explanation?: string): Interval;
+    static invalid(reason: string, explanation?: string): Interval<false>;
 
     /**
      * Create an Interval from a start DateTime and an end DateTime. Inclusive of the start but not the end.
@@ -81,34 +81,34 @@ export class Interval {
     /**
      * Returns the start of the Interval
      */
-    get start(): DateTime | IfInvalid<null>;
+    get start(): IfValid<DateTime<true>, null, IsValid>;
 
     /**
      * Returns the end of the Interval
      */
-    get end(): DateTime | IfInvalid<null>;
+    get end(): IfValid<DateTime<true>, null, IsValid>;
 
     /**
      * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.
      */
-    get isValid(): boolean;
+    get isValid(): IfValid<true, false, IsValid>;
 
     /**
      * Returns an error code if this Interval is invalid, or null if the Interval is valid
      */
-    get invalidReason(): string | null;
+    get invalidReason(): IfValid<string, null, IsValid>;
 
     /**
      * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
      */
-    get invalidExplanation(): string | null;
+    get invalidExplanation(): IfValid<string | null, null, IsValid>;
 
     /**
      * Returns the length of the Interval in the specified unit.
      *
      * @param unit - the unit (such as 'hours' or 'days') to return the length in.
      */
-    length(unit?: DurationUnit): number | IfInvalid<typeof NaN>;
+    length(unit?: DurationUnit): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Returns the count of minutes, hours, days, months, or years included in the Interval, even in part.
@@ -117,14 +117,14 @@ export class Interval {
      *
      * @param unit - the unit of time to count. Defaults to 'milliseconds'.
      */
-    count(unit?: DurationUnit): number | IfInvalid<typeof NaN>;
+    count(unit?: DurationUnit): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Returns whether this Interval's start and end are both in the same unit of time
      *
      * @param unit - the unit of time to check sameness on
      */
-    hasSame(unit: DurationUnit): boolean | IfInvalid<false>;
+    hasSame(unit: DurationUnit): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval has the same start and end DateTimes.
@@ -136,21 +136,21 @@ export class Interval {
      *
      * @param dateTime
      */
-    isAfter(dateTime: DateTime): boolean | IfInvalid<false>;
+    isAfter(dateTime: DateTime): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval's end is before the specified DateTime.
      *
      * @param dateTime
      */
-    isBefore(dateTime: DateTime): boolean | IfInvalid<false>;
+    isBefore(dateTime: DateTime): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval contains the specified DateTime.
      *
      * @param dateTime
      */
-    contains(dateTime: DateTime): boolean | IfInvalid<false>;
+    contains(dateTime: DateTime): IfValid<boolean, false, IsValid>;
 
     /**
      * "Sets" the start and/or end dates. Returns a newly-constructed Interval.
@@ -166,7 +166,7 @@ export class Interval {
      *
      * @param dateTimes - the unit of time to count.
      */
-    splitAt(...dateTimes: DateTime[]): Interval[] | IfInvalid<[]>;
+    splitAt(...dateTimes: DateTime[]): IfValid<Interval[], [], IsValid>;
 
     /**
      * Split this Interval into smaller Intervals, each of the specified length.
@@ -174,14 +174,14 @@ export class Interval {
      *
      * @param duration - The length of each resulting interval.
      */
-    splitBy(duration: DurationLike): Interval[] | IfInvalid<[]>;
+    splitBy(duration: DurationLike): IfValid<Interval[], [], IsValid>;
 
     /**
      * Split this Interval into the specified number of smaller intervals.
      *
      * @param numberOfParts - The number of Intervals to divide the Interval into.
      */
-    divideEqually(numberOfParts: number): Interval[] | IfInvalid<[]>;
+    divideEqually(numberOfParts: number): IfValid<Interval[], [], IsValid>;
 
     /**
      * Return whether this Interval overlaps with the specified Interval
@@ -191,22 +191,22 @@ export class Interval {
     /**
      * Return whether this Interval's end is adjacent to the specified Interval's start.
      */
-    abutsStart(other: Interval): boolean | IfInvalid<false>;
+    abutsStart(other: Interval): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval's start is adjacent to the specified Interval's end.
      */
-    abutsEnd(other: Interval): boolean | IfInvalid<false>;
+    abutsEnd(other: Interval): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval engulfs the start and end of the specified Interval.
      */
-    engulfs(other: Interval): boolean | IfInvalid<false>;
+    engulfs(other: Interval): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Interval has the same start and end as the specified Interval.
      */
-    equals(other: Interval): boolean | IfInvalid<false>;
+    equals(other: Interval): IfValid<boolean, false, IsValid>;
 
     /**
      * Return an Interval representing the intersection of this Interval and the specified Interval.
@@ -240,7 +240,7 @@ export class Interval {
     /**
      * Returns a string representation of this Interval appropriate for debugging.
      */
-    toString(): string | IfInvalid<"Invalid Interval">;
+    toString(): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Returns a localized string representing this Interval. Accepts the same options as the
@@ -273,7 +273,7 @@ export class Interval {
     toLocaleString(
         formatOpts?: Intl.DateTimeFormatOptions,
         opts?: LocaleOptions,
-    ): string | IfInvalid<"Invalid Interval">;
+    ): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Returns an ISO 8601-compliant string representation of this Interval.
@@ -281,14 +281,14 @@ export class Interval {
      *
      * @param opts - The same options as {@link DateTime#toISO}
      */
-    toISO(opts?: ToISOTimeOptions): string | IfInvalid<"Invalid Interval">;
+    toISO(opts?: ToISOTimeOptions): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Returns an ISO 8601-compliant string representation of the dates in this Interval.
      * The time components are ignored.
      * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
      */
-    toISODate(): string | IfInvalid<"Invalid Interval">;
+    toISODate(): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Returns an ISO 8601-compliant string representation of the times in this Interval.
@@ -297,7 +297,7 @@ export class Interval {
      *
      * @param opts - The same options as {@link DateTime.toISO}
      */
-    toISOTime(opts?: ToISOTimeOptions): string | IfInvalid<"Invalid Interval">;
+    toISOTime(opts?: ToISOTimeOptions): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Returns a string representation of this Interval formatted according to the specified format string.
@@ -311,7 +311,7 @@ export class Interval {
         opts?: {
             separator?: string | undefined;
         },
-    ): string | IfInvalid<"Invalid Interval">;
+    ): IfValid<string, "Invalid Interval", IsValid>;
 
     /**
      * Return a Duration representing the time spanned by this interval.

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -1,4 +1,4 @@
-import { Zone } from "./zone";
+import { Zone, ZoneMaybeValid } from "./zone";
 
 /**
  * `Settings` contains static getters and setters that control Luxon's overall behavior.
@@ -24,7 +24,7 @@ export class Settings {
      * The default time zone object currently used to create DateTimes. Does not affect existing instances.
      * The default value is the system's time zone (the one set on the machine that runs this code).
      */
-    static get defaultZone(): Zone;
+    static get defaultZone(): ZoneMaybeValid;
     static set defaultZone(zone: Zone | string);
 
     /**

--- a/types/luxon/src/zone.d.ts
+++ b/types/luxon/src/zone.d.ts
@@ -1,4 +1,4 @@
-import { IfInvalid } from "./_util";
+import { DefaultValidity, IfValid } from "./_util";
 
 export interface ZoneOffsetOptions {
     /**
@@ -17,11 +17,11 @@ export interface ZoneOffsetOptions {
  */
 export type ZoneOffsetFormat = "narrow" | "short" | "techie";
 
-export abstract class Zone {
+export abstract class Zone<IsValid extends boolean = DefaultValidity> {
     /**
      * The type of zone
      */
-    get type(): string | IfInvalid<"invalid">;
+    get type(): IfValid<string, "invalid", IsValid>;
 
     /**
      * The name of this zone.
@@ -31,7 +31,7 @@ export abstract class Zone {
     /**
      * Returns whether the offset is known to be fixed for the whole year.
      */
-    get isUniversal(): boolean | IfInvalid<false>;
+    get isUniversal(): IfValid<boolean, false, IsValid>;
 
     /**
      * Returns the offset's common name (such as EST) at the specified timestamp
@@ -41,7 +41,7 @@ export abstract class Zone {
      * @param options.format - What style of offset to return.
      * @param options.locale - What locale to return the offset name in.
      */
-    offsetName(ts: number, options: ZoneOffsetOptions): string | IfInvalid<null>;
+    offsetName(ts: number, options: ZoneOffsetOptions): IfValid<string, null, IsValid>;
 
     /**
      * Returns the offset's value as a string
@@ -50,32 +50,32 @@ export abstract class Zone {
      * @param format - What style of offset to return.
      *                 Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
      */
-    formatOffset(ts: number, format: ZoneOffsetFormat): string | IfInvalid<"">;
+    formatOffset(ts: number, format: ZoneOffsetFormat): IfValid<string, "", IsValid>;
 
     /**
      * Return the offset in minutes for this zone at the specified timestamp.
      *
      * @param ts - Epoch milliseconds for which to compute the offset
      */
-    offset(ts: number): number | IfInvalid<typeof NaN>;
+    offset(ts: number): IfValid<number, typeof NaN, IsValid>;
 
     /**
      * Return whether this Zone is equal to another zone
      *
      * @param other - the zone to compare
      */
-    equals(other: Zone): boolean | IfInvalid<false>;
+    equals(other: Zone): IfValid<boolean, false, IsValid>;
 
     /**
      * Return whether this Zone is valid.
      */
-    get isValid(): boolean | IfInvalid<false>;
+    get isValid(): IfValid<true, false, IsValid>;
 }
 
 /**
  * A zone identified by an IANA identifier, like America/New_York
  */
-export class IANAZone extends Zone {
+export class IANAZone<IsValid extends boolean = DefaultValidity> extends Zone<IsValid> {
     /**
      * Same as constructor but has caching.
      */
@@ -117,14 +117,12 @@ export class IANAZone extends Zone {
     static isValidZone(zone: string): boolean;
 
     constructor(name: string);
-
-    get isValid(): true;
 }
 
 /**
  * A zone with a fixed offset (meaning no DST)
  */
-export class FixedOffsetZone extends Zone {
+export class FixedOffsetZone extends Zone<true> {
     /**
      * Get a singleton instance of UTC
      */
@@ -150,28 +148,23 @@ export class FixedOffsetZone extends Zone {
      * FixedOffsetZone.parseSpecifier("UTC-6:00")
      */
     static parseSpecifier(s: string): FixedOffsetZone;
-
-    get isValid(): true;
 }
 
 /**
  * A zone that failed to parse. You should never need to instantiate this.
  */
-export class InvalidZone extends Zone {
+export class InvalidZone extends Zone<false> {
     get type(): "invalid";
     get isUniversal(): false;
     get offsetFormat(): "";
-    get isValid(): false;
 }
 
 /**
  * Represents the system zone for this JavaScript environment.
  */
-export class SystemZone extends Zone {
+export class SystemZone extends Zone<true> {
     /**
      * Get a singleton instance of the system zone
      */
     static get instance(): SystemZone;
-
-    get isValid(): true;
 }

--- a/types/luxon/src/zone.d.ts
+++ b/types/luxon/src/zone.d.ts
@@ -1,4 +1,4 @@
-import { DefaultValidity, IfValid } from "./_util";
+import { CanBeInvalid, DefaultValidity, IfValid } from "./_util";
 
 export interface ZoneOffsetOptions {
     /**
@@ -16,6 +16,8 @@ export interface ZoneOffsetOptions {
  * Returning '+6', '+06:00', or '+0600' respectively
  */
 export type ZoneOffsetFormat = "narrow" | "short" | "techie";
+
+export type ZoneMaybeValid = CanBeInvalid extends true ? Zone<true> | Zone<false> : Zone;
 
 export abstract class Zone<IsValid extends boolean = DefaultValidity> {
     /**
@@ -79,7 +81,7 @@ export class IANAZone<IsValid extends boolean = DefaultValidity> extends Zone<Is
     /**
      * Same as constructor but has caching.
      */
-    static create(name: string): IANAZone;
+    static create(name: string): CanBeInvalid extends true ? (IANAZone<true> | IANAZone<false>) : IANAZone;
 
     /**
      * Reset local caches. Should only be necessary in testing scenarios.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -23,10 +23,10 @@ DateTime.DATE_MED; // $ExpectType DateTimeFormatOptions
 DateTime.DATE_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
 
 DateTime.local({ zone: "Atlantic/Azores" }); // $ExpectType DateTime<true>
-DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime<undefined>
+DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime<true> | DateTime<false>
 DateTime.utc(); // $ExpectType DateTime<true>
 DateTime.utc({ locale: "en-US" }); // $ExpectType DateTime<true>
-DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime<undefined>
+DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.utc(2019, { locale: "en-GB" }, 5);
 DateTime.isDateTime(0 as unknown); // $ExpectType boolean
@@ -140,7 +140,7 @@ dt.valueOf(); // $ExpectType number
 dt.toObject(); // $ExpectType Record<_ToObjectUnit, number> | Partial<Record<_ToObjectUnit, number>>
 // @ts-expect-error
 dt.toObject().locale;
-dt.toObject({ includeConfig: true }); // $ExpectType Partial<_ToObjectOutput<true>>
+dt.toObject({ includeConfig: true }); // $ExpectType _ToObjectOutput<true> | Partial<_ToObjectOutput<true>>
 dt.toObject({ includeConfig: true }).locale; // $ExpectType string | undefined
 dt.toUnixInteger(); // $ExpectType number
 
@@ -217,18 +217,18 @@ dt.setLocale("en-US").toLocaleString(f);
 
 DateTime.local().setZone("America/Los_Angeles");
 
-DateTime.utc(2017, 5, 15); // $ExpectType DateTime<undefined>
+DateTime.utc(2017, 5, 15); // $ExpectType DateTime<true> | DateTime<false>
 DateTime.utc(); // $ExpectType DateTime<true>
 DateTime.local().toUTC(); // $ExpectType DateTime<true>
 DateTime.utc().toLocal(); // $ExpectType DateTime<true>
 
-DateTime.max(dt, now); // $ExpectType DateTime<true | undefined>
-DateTime.min(dt, now); // $ExpectType DateTime<true | undefined>
+DateTime.max(dt, now); // $ExpectType DateTime<true> | DateTime<false>
+DateTime.min(dt, now); // $ExpectType DateTime<true> | DateTime<false>
 DateTime.min(now, now); // $ExpectType DateTime<true>
 
 const anything: unknown = 0;
 if (DateTime.isDateTime(anything)) {
-    anything; // $ExpectType DateTime<undefined>
+    anything; // $ExpectType DateTime<true> | DateTime<false>
 }
 
 const { input, result, zone } = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
@@ -248,8 +248,8 @@ Duration.fromDurationLike(dur); // $ExpectType Duration<true>
 Duration.fromDurationLike("");
 // @ts-expect-error
 new Duration({ hour: 2, minute: 7 });
-dt.plus(dur); // $ExpectType DateTime<undefined>
-dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime<undefined>
+dt.plus(dur); // $ExpectType DateTime<true> | DateTime<false>
+dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime<true> | DateTime<false>
 dur.hours; // $ExpectType number
 dur.minutes; // $ExpectType number
 dur.seconds; // $ExpectType number
@@ -266,7 +266,7 @@ dur.toMillis(); // $ExpectType number
 dur.mapUnits((x, u) => (u === "hours" ? x * 2 : x)); // $ExpectType Duration<true>
 
 if (Duration.isDuration(anything)) {
-    anything; // $ExpectType Duration<undefined>
+    anything; // $ExpectType Duration<true> | Duration<false>
 }
 // @ts-expect-error
 Duration.invalid();
@@ -279,9 +279,9 @@ const i = Interval.fromDateTimes(now, later);
 i.length(); // $ExpectType number
 i.length("years"); // $ExpectType number
 i.contains(DateTime.local(2019)); // $ExpectType boolean
-i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<undefined>
-i.mapEndpoints(d => d); // $ExpectType Interval<undefined>
-i.intersection(i); // $ExpectType Interval<undefined> | null
+i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<true> | Interval<false>
+i.mapEndpoints(d => d); // $ExpectType Interval<true> | Interval<false>
+i.intersection(i); // $ExpectType Interval<boolean> | null
 
 i.invalidReason; // $ExpectType string | null
 i.invalidExplanation; // $ExpectType string | null
@@ -291,14 +291,14 @@ i.toISODate(); // $ExpectType string
 i.toISOTime(); // $ExpectType string
 i.toString(); // $ExpectType string
 i.toLocaleString(); // $ExpectType string
-i.toDuration("months"); // $ExpectType Duration<undefined>
-i.toDuration(); // $ExpectType Duration<undefined>
+i.toDuration("months"); // $ExpectType Duration<true> | Duration<false>
+i.toDuration(); // $ExpectType Duration<true> | Duration<false>
 // @ts-expect-error
 i.divideEqually();
 i.divideEqually(5);
 
 if (Interval.isInterval(anything)) {
-    anything; // $ExpectType Interval<undefined>
+    anything; // $ExpectType Interval<true> | Interval<false>
 }
 // @ts-expect-error
 new Interval(now, later);
@@ -333,7 +333,7 @@ Settings.resetCaches();
 Settings.defaultZone = ianaZone;
 Settings.defaultZone = "America/Los_Angeles";
 Settings.defaultZone = Settings.defaultZone;
-Settings.defaultZone; // $ExpectType Zone<undefined>
+Settings.defaultZone; // $ExpectType Zone<true> | Zone<false>
 
 Settings.twoDigitCutoffYear;
 Settings.twoDigitCutoffYear = 42;
@@ -382,15 +382,15 @@ bogus.invalidExplanation; // $ExpectType string | null
 const local = DateTime.local(2017, 5, 15, 9, 10, 23);
 local.zoneName; // $ExpectType string | null
 local.toString(); // $ExpectType string
-local.setZone("America/Los_Angeles"); // $ExpectType DateTime<undefined>
-local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime<undefined>
+local.setZone("America/Los_Angeles"); // $ExpectType DateTime<true> | DateTime<false>
+local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime<true> | DateTime<false>
 
 const iso = DateTime.fromISO("2017-05-15T09:10:23");
 iso.zoneName; // $ExpectType string | null
 iso.toString(); // $ExpectType string
 
-DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime<undefined>
-DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime<undefined>
+DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime<true> | DateTime<false>
+DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime<true> | DateTime<false>
 
 /* Calendars */
 // prettier-ignore
@@ -410,32 +410,32 @@ DateTime.fromISO("2014-08-06T13:07:04.054").toFormat("yyyy LLL dd"); // $ExpectT
 /* Parsing */
 // @ts-expect-error
 DateTime.fromObject();
-DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime<undefined>
+DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromISO();
-DateTime.fromISO("2016-05-25"); // $ExpectType DateTime<undefined>
+DateTime.fromISO("2016-05-25"); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromJSDate();
-DateTime.fromJSDate(new Date()); // $ExpectType DateTime<undefined>
+DateTime.fromJSDate(new Date()); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromRFC2822();
-DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime<undefined>
+DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromHTTP();
-DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime<undefined>
+DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromSQL();
-DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime<undefined>
+DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromMillis();
-DateTime.fromMillis(1542674993410); // $ExpectType DateTime<undefined>
+DateTime.fromMillis(1542674993410); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromSeconds();
 DateTime.fromSeconds(1542674993); // $ExpectType DateTime<true>
 // @ts-expect-error
 DateTime.fromFormat();
-DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<undefined>
-DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime<undefined>
+DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<true> | DateTime<false>
+DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime<true> | DateTime<false>
 
 DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy").regex;
 DateTime.invalid("Timestamp out of range");
@@ -477,16 +477,16 @@ dur.shiftTo("days").toObject().days; // $ExpectType number | undefined
 dur.shiftTo("weeks", "hours").toObject().weeks; // $ExpectType number | undefined
 DateTime.local().plus(dur.shiftTo("milliseconds")).year; // $ExpectType number
 
-Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
-Duration.fromISOTime("21:37.000"); // $ExpectType Duration<undefined>
-Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
+Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration<true> | Duration<false>
+Duration.fromISOTime("21:37.000"); // $ExpectType Duration<true> | Duration<false>
+Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration<true> | Duration<false>
 
-end.diff(start, "hours", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
-end.diff(start, ["months", "days", "hours"]); // $ExpectType Duration<undefined>
+end.diff(start, "hours", { conversionAccuracy: "longterm" }); // $ExpectType Duration<true> | Duration<false>
+end.diff(start, ["months", "days", "hours"]); // $ExpectType Duration<true> | Duration<false>
 dur.reconfigure({ conversionAccuracy: "longterm" }); // $ExpectType Duration<true>
 
-start.until(end); // $ExpectType Interval<undefined>
-i.toDuration(["years", "months", "days"]); // $ExpectType Duration<undefined>
+start.until(end); // $ExpectType Interval<true> | DateTime<false> || DateTime<false> | Interval<true>
+i.toDuration(["years", "months", "days"]); // $ExpectType Duration<true> | Duration<false>
 
 dur.invalidReason; // $ExpectType string
 dur.invalidExplanation; // $ExpectType string | null

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -13,12 +13,6 @@ import {
     ZoneOffsetOptions,
 } from "luxon";
 
-declare module "luxon" {
-    interface TSSettings {
-        throwOnInvalid: true;
-    }
-}
-
 /* VERSION */
 VERSION; // $ExpectType string
 
@@ -28,11 +22,11 @@ DateTime.DATETIME_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
 DateTime.DATE_MED; // $ExpectType DateTimeFormatOptions
 DateTime.DATE_MED_WITH_WEEKDAY; // $ExpectType DateTimeFormatOptions
 
-DateTime.local({ zone: "Atlantic/Azores" }); // $ExpectType DateTime
-DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime
-DateTime.utc(); // $ExpectType DateTime
-DateTime.utc({ locale: "en-US" }); // $ExpectType DateTime
-DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime
+DateTime.local({ zone: "Atlantic/Azores" }); // $ExpectType DateTime<true>
+DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime<undefined>
+DateTime.utc(); // $ExpectType DateTime<true>
+DateTime.utc({ locale: "en-US" }); // $ExpectType DateTime<true>
+DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.utc(2019, { locale: "en-GB" }, 5);
 DateTime.isDateTime(0 as unknown); // $ExpectType boolean
@@ -43,7 +37,7 @@ new DateTime();
 
 const dt = DateTime.local(2017, 5, 15, 8, 30);
 
-const now = DateTime.now();
+const now = DateTime.now(); // $ExpectType DateTime<true>
 
 const fromObject = DateTime.fromObject(
     {
@@ -71,16 +65,16 @@ testIanaZone.formatOffset(dt.toMillis(), "techie"); // $ExpectType string
 testIanaZone.formatOffset(dt.toMillis(), "other_string");
 // @ts-expect-error
 testIanaZone.offsetName(dt.toMillis());
-testIanaZone.offsetName(dt.toMillis(), { format: "short" }); // $ExpectType string
-testIanaZone.offsetName(dt.toMillis(), { format: "long" }); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: "short" }); // $ExpectType string | null
+testIanaZone.offsetName(dt.toMillis(), { format: "long" }); // $ExpectType string | null
 // @ts-expect-error
 testIanaZone.offsetName(dt.toMillis(), { format: "other_string" });
-testIanaZone.offsetName(dt.toMillis(), { format: "short", locale: "en-us" }); // $ExpectType string
-testIanaZone.offsetName(dt.toMillis(), { locale: "en-gb" }); // $ExpectType string
+testIanaZone.offsetName(dt.toMillis(), { format: "short", locale: "en-us" }); // $ExpectType string | null
+testIanaZone.offsetName(dt.toMillis(), { locale: "en-gb" }); // $ExpectType string | null
 const ianaZoneTest = DateTime.fromObject(
     {},
     {
-        zone: ianaZone,
+        zone: testIanaZone,
     },
 );
 
@@ -112,17 +106,17 @@ getters.ordinal; // $ExpectType number
 getters.isInLeapYear; // $ExpectType boolean
 
 dt.toBSON(); // $ExpectType Date
-dt.toHTTP(); // $ExpectType string
-dt.toISO(); // $ExpectType string
-dt.toISO({ includeOffset: true, format: "extended" }); // $ExpectType string
-dt.toISO({ extendedZone: true, format: "extended" }); // $ExpectType string
-dt.toISODate(); // $ExpectType string
-dt.toISODate({ format: "basic" }); // $ExpectType string
-dt.toISOTime(); // $ExpectType string
-dt.toISOTime({ format: "basic" }); // $ExpectType string
-dt.toISOWeekDate(); // $ExpectType string
+dt.toHTTP(); // $ExpectType string | null
+dt.toISO(); // $ExpectType string | null
+dt.toISO({ includeOffset: true, format: "extended" }); // $ExpectType string | null
+dt.toISO({ extendedZone: true, format: "extended" }); // $ExpectType string | null
+dt.toISODate(); // $ExpectType string | null
+dt.toISODate({ format: "basic" }); // $ExpectType string | null
+dt.toISOTime(); // $ExpectType string | null
+dt.toISOTime({ format: "basic" }); // $ExpectType string | null
+dt.toISOWeekDate(); // $ExpectType string | null
 dt.toJSDate(); // $ExpectType Date
-dt.toJSON(); // $ExpectType string
+dt.toJSON(); // $ExpectType string | null
 dt.toLocaleParts(); // $ExpectType DateTimeFormatPart[]
 dt.toLocaleParts()[0].type; // $ExpectType DateTimeFormatPartTypes || keyof DateTimeFormatPartTypesRegistry
 dt.toLocaleParts()[0].value; // $ExpectType string
@@ -132,25 +126,47 @@ dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string
 dt.toLocaleString(DateTime.DATE_MED, {}); // $ExpectType string
 dt.toMillis(); // $ExpectType number
 dt.toMillis(); // $ExpectType number
-dt.toRelative(); // $ExpectType string
-dt.toRelativeCalendar(); // $ExpectType string
-dt.toRFC2822(); // $ExpectType string
+dt.toRelative(); // $ExpectType string | null
+dt.toRelativeCalendar(); // $ExpectType string | null
+dt.toRFC2822(); // $ExpectType string | null
 dt.toSeconds(); // $ExpectType number
-dt.toSQL(); // $ExpectType string
-dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
-dt.toSQLDate(); // $ExpectType string
-dt.toSQLTime(); // $ExpectType string
-dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
-dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
+dt.toSQL(); // $ExpectType string | null
+dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string | null
+dt.toSQLDate(); // $ExpectType string | null
+dt.toSQLTime(); // $ExpectType string | null
+dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string | null
+dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string | null
 dt.valueOf(); // $ExpectType number
-dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number> || Record<"year" | "month" | "day" | "hour" | "minute" | "second" | "millisecond", number>
+dt.toObject(); // $ExpectType Record<_ToObjectUnit, number> | Partial<Record<_ToObjectUnit, number>>
 // @ts-expect-error
 dt.toObject().locale;
-dt.toObject({ includeConfig: true }); // $ExpectType _ToObjectOutput<true>
+dt.toObject({ includeConfig: true }); // $ExpectType Partial<_ToObjectOutput<true>>
 dt.toObject({ includeConfig: true }).locale; // $ExpectType string | undefined
 dt.toUnixInteger(); // $ExpectType number
 
-// $ExpectType string
+// Known valid DateTime narrows out invalid returns
+now.toHTTP(); // $ExpectType string
+now.toISO(); // $ExpectType string
+now.toISO({ includeOffset: true, format: "extended" }); // $ExpectType string
+now.toISO({ extendedZone: true, format: "extended" }); // $ExpectType string
+now.toISODate(); // $ExpectType string
+now.toISODate({ format: "basic" }); // $ExpectType string
+now.toISOTime(); // $ExpectType string
+now.toISOTime({ format: "basic" }); // $ExpectType string
+now.toISOWeekDate(); // $ExpectType string
+now.toJSON(); // $ExpectType string
+now.toRelative(); // $ExpectType string
+now.toRelativeCalendar(); // $ExpectType string
+now.toRFC2822(); // $ExpectType string
+now.toSQL(); // $ExpectType string
+now.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
+now.toSQLDate(); // $ExpectType string
+now.toSQLTime(); // $ExpectType string
+now.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
+now.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
+now.toObject(); // $ExpectType Record<_ToObjectUnit, number>
+
+// $ExpectType string | null
 dt.toRelative({
     base: DateTime.local(),
     locale: "fr",
@@ -161,7 +177,7 @@ dt.toRelative({
     numberingSystem: "bali",
 });
 
-// $ExpectType string
+// $ExpectType string | null
 dt.toRelative({
     base: DateTime.local(),
     locale: "fr",
@@ -172,7 +188,7 @@ dt.toRelative({
     numberingSystem: "bali",
 });
 
-// $ExpectType string
+// $ExpectType string | null
 dt.toRelativeCalendar({
     base: DateTime.local(),
     locale: "fr",
@@ -185,14 +201,14 @@ dt.minus({ days: 7 });
 dt.startOf("day");
 dt.endOf("hour");
 dt.zone;
-dt.zoneName; // $ExpectType string
+dt.zoneName; // $ExpectType string | null
 dt.offset; // $ExpectType number
-dt.offsetNameShort; // $ExpectType string
-dt.offsetNameLong; // $ExpectType string
-dt.isOffsetFixed; // $ExpectType boolean
+dt.offsetNameShort; // $ExpectType string | null
+dt.offsetNameLong; // $ExpectType string | null
+dt.isOffsetFixed; // $ExpectType boolean | null
 dt.isInDST; // $ExpectType boolean
 
-dt.set({ hour: 3 }).hour; // $ExpectType HourNumbers
+dt.set({ hour: 3 }).hour; // $ExpectType number
 
 const f: { month: "long"; day: "numeric" } = { month: "long", day: "numeric" };
 dt.setLocale("fr").toLocaleString(f);
@@ -201,59 +217,60 @@ dt.setLocale("en-US").toLocaleString(f);
 
 DateTime.local().setZone("America/Los_Angeles");
 
-DateTime.utc(2017, 5, 15); // $ExpectType DateTime
-DateTime.utc(); // $ExpectType DateTime
-DateTime.local().toUTC(); // $ExpectType DateTime
-DateTime.utc().toLocal(); // $ExpectType DateTime
+DateTime.utc(2017, 5, 15); // $ExpectType DateTime<undefined>
+DateTime.utc(); // $ExpectType DateTime<true>
+DateTime.local().toUTC(); // $ExpectType DateTime<true>
+DateTime.utc().toLocal(); // $ExpectType DateTime<true>
 
-DateTime.max(dt, now); // $ExpectType DateTime
-DateTime.min(dt, now); // $ExpectType DateTime
+DateTime.max(dt, now); // $ExpectType DateTime<true | undefined>
+DateTime.min(dt, now); // $ExpectType DateTime<true | undefined>
+DateTime.min(now, now); // $ExpectType DateTime<true>
 
-const anything: any = 0;
+const anything: unknown = 0;
 if (DateTime.isDateTime(anything)) {
-    anything; // $ExpectType DateTime
+    anything; // $ExpectType DateTime<undefined>
 }
 
 const { input, result, zone } = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
 
 /* Duration */
-const dur = Duration.fromObject({ hours: 2, minutes: 7 }); // $ExpectType Duration
-Duration.fromObject({ hour: 2, minute: 7 }); // $ExpectType Duration
+const dur = Duration.fromObject({ hours: 2, minutes: 7 }); // $ExpectType Duration<true>
+Duration.fromObject({ hour: 2, minute: 7 }); // $ExpectType Duration<true>
 // @ts-expect-error
 Duration.fromObject({ locale: "ru" });
 // @ts-expect-error
 Duration.fromObject({ conversionAccuracy: "casual" });
-Duration.fromObject({}, { conversionAccuracy: "casual" }); // $ExpectType Duration
-Duration.fromDurationLike({ hours: 1 }); // $ExpectType Duration
-Duration.fromDurationLike(1000); // $ExpectType Duration
-Duration.fromDurationLike(dur); // $ExpectType Duration
+Duration.fromObject({}, { conversionAccuracy: "casual" }); // $ExpectType Duration<true>
+Duration.fromDurationLike({ hours: 1 }); // $ExpectType Duration<true>
+Duration.fromDurationLike(1000); // $ExpectType Duration<true>
+Duration.fromDurationLike(dur); // $ExpectType Duration<true>
 // @ts-expect-error
 Duration.fromDurationLike("");
 // @ts-expect-error
 new Duration({ hour: 2, minute: 7 });
-dt.plus(dur); // $ExpectType DateTime
-dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime
+dt.plus(dur); // $ExpectType DateTime<undefined>
+dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime<undefined>
 dur.hours; // $ExpectType number
 dur.minutes; // $ExpectType number
 dur.seconds; // $ExpectType number
-dur.set({ hour: 2, minutes: 15 }); // $ExpectType Duration
+dur.set({ hour: 2, minutes: 15 }); // $ExpectType Duration<true>
 
 dur.as("seconds"); // $ExpectType number
 dur.toObject();
 dur.toISO(); // $ExpectType string
 dur.toISOTime(); // $ExpectType string
-dur.normalize(); // $ExpectType Duration
-dur.rescale(); // $ExpectType Duration
-dur.shiftToAll(); // $ExpectType Duration
+dur.normalize(); // $ExpectType Duration<true>
+dur.rescale(); // $ExpectType Duration<true>
+dur.shiftToAll(); // $ExpectType Duration<true>
 dur.toMillis(); // $ExpectType number
-dur.mapUnits((x, u) => (u === "hours" ? x * 2 : x)); // $ExpectType Duration
+dur.mapUnits((x, u) => (u === "hours" ? x * 2 : x)); // $ExpectType Duration<true>
 
 if (Duration.isDuration(anything)) {
-    anything; // $ExpectType Duration
+    anything; // $ExpectType Duration<undefined>
 }
 // @ts-expect-error
 Duration.invalid();
-Duration.invalid("code", "because I said so"); // $ExpectType Duration
+Duration.invalid("code", "because I said so"); // $ExpectType Duration<false>
 Duration.isDuration(0 as unknown); // $ExpectType boolean
 
 /* Interval */
@@ -262,9 +279,9 @@ const i = Interval.fromDateTimes(now, later);
 i.length(); // $ExpectType number
 i.length("years"); // $ExpectType number
 i.contains(DateTime.local(2019)); // $ExpectType boolean
-i.set({ end: DateTime.local(2020) }); // $ExpectType Interval
-i.mapEndpoints(d => d); // $ExpectType Interval
-i.intersection(i); // $ExpectType Interval | null
+i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<undefined>
+i.mapEndpoints(d => d); // $ExpectType Interval<undefined>
+i.intersection(i); // $ExpectType Interval<undefined> | null
 
 i.invalidReason; // $ExpectType string | null
 i.invalidExplanation; // $ExpectType string | null
@@ -274,20 +291,20 @@ i.toISODate(); // $ExpectType string
 i.toISOTime(); // $ExpectType string
 i.toString(); // $ExpectType string
 i.toLocaleString(); // $ExpectType string
-i.toDuration("months"); // $ExpectType Duration
-i.toDuration(); // $ExpectType Duration
+i.toDuration("months"); // $ExpectType Duration<undefined>
+i.toDuration(); // $ExpectType Duration<undefined>
 // @ts-expect-error
 i.divideEqually();
 i.divideEqually(5);
 
 if (Interval.isInterval(anything)) {
-    anything; // $ExpectType Interval
+    anything; // $ExpectType Interval<undefined>
 }
 // @ts-expect-error
 new Interval(now, later);
 // @ts-expect-error
 Interval.invalid();
-Interval.invalid("code", "because I said so"); // $ExpectType Interval
+Interval.invalid("code", "because I said so"); // $ExpectType Interval<false>
 Interval.isInterval(0 as unknown); // $ExpectType boolean
 
 /* Info */
@@ -316,7 +333,7 @@ Settings.resetCaches();
 Settings.defaultZone = ianaZone;
 Settings.defaultZone = "America/Los_Angeles";
 Settings.defaultZone = Settings.defaultZone;
-Settings.defaultZone; // $ExpectType Zone
+Settings.defaultZone; // $ExpectType Zone<undefined>
 
 Settings.twoDigitCutoffYear;
 Settings.twoDigitCutoffYear = 42;
@@ -329,7 +346,7 @@ Settings.twoDigitCutoffYear = "123";
 /* Intl */
 // prettier-ignore
 DateTime.local().setLocale("el").toLocaleString(DateTime.DATE_FULL); // $ExpectType string
-dt.locale; // $ExpectType string
+dt.locale; // $ExpectType string | null
 DateTime.local().setLocale("fr").locale; // $ExpectType string
 DateTime.local().reconfigure({ locale: "fr" }).locale; // $ExpectType string
 
@@ -363,21 +380,21 @@ bogus.invalidReason; // $ExpectType string | null
 bogus.invalidExplanation; // $ExpectType string | null
 
 const local = DateTime.local(2017, 5, 15, 9, 10, 23);
-local.zoneName; // $ExpectType string
+local.zoneName; // $ExpectType string | null
 local.toString(); // $ExpectType string
-local.setZone("America/Los_Angeles"); // $ExpectType DateTime
-local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime
+local.setZone("America/Los_Angeles"); // $ExpectType DateTime<undefined>
+local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime<undefined>
 
 const iso = DateTime.fromISO("2017-05-15T09:10:23");
-iso.zoneName; // $ExpectType string
+iso.zoneName; // $ExpectType string | null
 iso.toString(); // $ExpectType string
 
-DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime
-DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime
+DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime<undefined>
+DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime<undefined>
 
 /* Calendars */
 // prettier-ignore
-DateTime.fromISO("2017-W23-3").plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string
+DateTime.fromISO("2017-W23-3").plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string | null
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: "hebrew" });
 dtHebrew.outputCalendar; // $ExpectType string
@@ -393,32 +410,32 @@ DateTime.fromISO("2014-08-06T13:07:04.054").toFormat("yyyy LLL dd"); // $ExpectT
 /* Parsing */
 // @ts-expect-error
 DateTime.fromObject();
-DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime
+DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromISO();
-DateTime.fromISO("2016-05-25"); // $ExpectType DateTime
+DateTime.fromISO("2016-05-25"); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromJSDate();
-DateTime.fromJSDate(new Date()); // $ExpectType DateTime
+DateTime.fromJSDate(new Date()); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromRFC2822();
-DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime
+DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromHTTP();
-DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime
+DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromSQL();
-DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime
+DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromMillis();
-DateTime.fromMillis(1542674993410); // $ExpectType DateTime
+DateTime.fromMillis(1542674993410); // $ExpectType DateTime<undefined>
 // @ts-expect-error
 DateTime.fromSeconds();
-DateTime.fromSeconds(1542674993); // $ExpectType DateTime
+DateTime.fromSeconds(1542674993); // $ExpectType DateTime<true>
 // @ts-expect-error
 DateTime.fromFormat();
-DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime
-DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime
+DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<undefined>
+DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime<undefined>
 
 DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy").regex;
 DateTime.invalid("Timestamp out of range");
@@ -442,7 +459,7 @@ dur.toObject().day;
 dur.as("minutes"); // $ExpectType number
 dur.shiftTo("minutes").toObject().minutes; // $ExpectType number | undefined
 // prettier-ignore
-DateTime.fromISO("2017-05-15").plus(dur).toISO(); // $ExpectType string
+DateTime.fromISO("2017-05-15").plus(dur).toISO(); // $ExpectType string | null
 
 const end = DateTime.fromISO("2017-03-13");
 const start = DateTime.fromISO("2017-02-13");
@@ -453,25 +470,25 @@ diffInMonths.toObject().months; // $ExpectType number | undefined
 const diff = end.diff(start);
 diff.toObject().milliseconds; // $ExpectType number | undefined
 end.diff(start, ["months", "days"]).months; // $ExpectType number
-end.diffNow(["months", "days"]); // $ExpectType Duration
+end.diffNow(["months", "days"]); // $ExpectType Duration<true>
 
 dur.as("days"); // $ExpectType number
 dur.shiftTo("days").toObject().days; // $ExpectType number | undefined
 dur.shiftTo("weeks", "hours").toObject().weeks; // $ExpectType number | undefined
 DateTime.local().plus(dur.shiftTo("milliseconds")).year; // $ExpectType number
 
-Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration
-Duration.fromISOTime("21:37.000"); // $ExpectType Duration
-Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration
+Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
+Duration.fromISOTime("21:37.000"); // $ExpectType Duration<undefined>
+Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
 
-end.diff(start, "hours", { conversionAccuracy: "longterm" }); // $ExpectType Duration
-end.diff(start, ["months", "days", "hours"]); // $ExpectType Duration
-dur.reconfigure({ conversionAccuracy: "longterm" }); // $ExpectType Duration
+end.diff(start, "hours", { conversionAccuracy: "longterm" }); // $ExpectType Duration<undefined>
+end.diff(start, ["months", "days", "hours"]); // $ExpectType Duration<undefined>
+dur.reconfigure({ conversionAccuracy: "longterm" }); // $ExpectType Duration<true>
 
-start.until(end); // $ExpectType Interval
-i.toDuration(["years", "months", "days"]); // $ExpectType Duration
+start.until(end); // $ExpectType Interval<undefined>
+i.toDuration(["years", "months", "days"]); // $ExpectType Duration<undefined>
 
-dur.invalidReason; // $ExpectType string | null
+dur.invalidReason; // $ExpectType string
 dur.invalidExplanation; // $ExpectType string | null
 
 /* Sample Zone Implementation */


### PR DESCRIPTION
Following up on #64995

In certain situations it's possible to know statically that a `DateTime` (etc) is valid, even without the `throwOnInvalid` enabled.

For example, it's probably common to do
```ts
DateTime.now().toISO()
```
This will always return a string, as now() always returns a valid DateTime.
This PR enables TS to know that.