### PR TITLE
chore: ran eslint-plugin-jsdoc/check-tag-names autofixer

### DIFF
--- a/types/angular-ui-bootstrap/index.d.ts
+++ b/types/angular-ui-bootstrap/index.d.ts
@@ -510,7 +510,6 @@ declare module 'angular' {
             /**
              * Sets the `aria-describedby` property on the modal.
              * The string should be an id (without the leading '#') pointing to the element that describes your modal.
-             * @type {string}
              * @memberOf IModalSettings
              */
             ariaDescribedBy?: string | undefined;
@@ -518,7 +517,6 @@ declare module 'angular' {
             /**
              * Sets the `aria-labelledby` property on the modal.
              * The string should be an id (without the leading '#') pointing to the element that labels your modal.
-             * @type {string}
              * @memberOf IModalSettings
              */
             ariaLabelledBy?: string | undefined;

--- a/types/app-root-path/index.d.ts
+++ b/types/app-root-path/index.d.ts
@@ -7,7 +7,6 @@ interface RootPath {
 
     /**
      * Application root directory absolute path
-     * @type {string}
      */
     path: string;
 

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -17,7 +17,6 @@ declare namespace asana {
          * Constructs a Client with instances of all the resources using the dispatcher.
          * It also keeps a reference to the dispatcher so that way the end user can have
          * access to it.
-         * @class
          * @classdesc A wrapper for the Asana API which is authenticated for one user
          * @param {Dispatcher} dispatcher The request dispatcher to use
          * @param {Object} options        Options to configure the client
@@ -89,77 +88,62 @@ declare namespace asana {
          * The internal dispatcher. This is mostly used by the resources but provided
          * for custom requests to the API or API features that have not yet been added
          * to the client.
-         * @type {Dispatcher}
          */
         dispatcher: Dispatcher;
         /**
          * An instance of the Attachments resource.
-         * @type {Attachments}
          */
         attachments: resources.Attachments;
         /**
          * An instance of the CustomFields resource.
-         * @type {CustomFields}
          */
         customFields: resources.CustomFields;
         /**
          * An instance of the Events resource.
-         * @type {Events}
          */
         events: resources.Events;
         /**
          * An instance of the Projects resource.
-         * @type {Projects}
          */
         projects: resources.Projects;
         /**
          * An instance of the Sections resource.
-         * @type {Sections}
          */
         sections: resources.Sections;
         /**
          * An instance of the Stories resource.
-         * @type {Stories}
          */
         stories: resources.Stories;
         /**
          * An instance of the Tags resource.
-         * @type {Tags}
          */
         tags: resources.Tags;
         /**
          * An instance of the Tasks resource.
-         * @type {Tasks}
          */
         tasks: resources.Tasks;
         /**
          * An instance of the UserTaskLists resource.
-         * @type {UserTaskLists}
          */
         userTaskLists: resources.UserTaskLists;
         /**
          * An instance of the Teams resource.
-         * @type {Teams}
          */
         teams: resources.Teams;
         /**
          * An instance of the Users resource.
-         * @type {Users}
          */
         users: resources.Users;
         /**
          * An instance of the Typeahead resource.
-         * @type {Typeahead}
          */
         typeahead: resources.Typeahead;
         /**
          * An instance of the Workspaces resource.
-         * @type {Workspaces}
          */
         workspaces: resources.Workspaces;
         /**
          * An instance of the Webhooks resource.
-         * @type {Webhooks}
          */
         webhooks: resources.Webhooks;
         /**
@@ -174,7 +158,6 @@ declare namespace asana {
         /**
          * Creates a dispatcher which will act as a basic wrapper for making HTTP
          * requests to the API, and handle authentication.
-         * @class
          * @classdesc A HTTP wrapper for the Asana API
          * @param {Object} options for default behavior of the Dispatcher
          * @option {Authenticator} [authenticator] Object to use for authentication.
@@ -201,7 +184,6 @@ declare namespace asana {
 
         /**
          * The relative API path for the current version of the Asana API.
-         * @type {String}
          */
         API_PATH: string;
     }
@@ -314,13 +296,11 @@ declare namespace asana {
 
         /**
          * The base URL for Asana
-         * @type {String}
          */
         asanaBaseUrl: string;
 
         /**
          * Whether requests should be automatically retried if rate limited.
-         * @type {Boolean}
          */
         retryOnRateLimit: boolean;
 
@@ -328,13 +308,11 @@ declare namespace asana {
          * Handler for unauthorized requests which may seek reauthorization.
          * Default behavior is available if configured with an Oauth authenticator
          * that has a refresh token, and will refresh the current access token.
-         * @type {Function}
          */
         handleUnauthorized: () => boolean | Promise<boolean>;
 
         /**
          * The amount of time in milliseconds to wait for a request to finish.
-         * @type {Number}
          */
         requestTimeout: number;
     }
@@ -382,7 +360,6 @@ declare namespace asana {
              *     be either the object returned from an access token request (which
              *     contains the token and some other metadata) or just the `access_token`
              *     field.
-             * @constructor
              */
             new (options: OauthAuthenticatorOptions): OauthAuthenticator;
         }
@@ -422,7 +399,6 @@ declare namespace asana {
          * A layer to abstract the differences between using different types of
          * authentication (Oauth vs. Basic). The Authenticator is responsible for
          * establishing credentials and applying them to outgoing requests.
-         * @constructor
          */
         interface Authenticator {
             /**
@@ -457,7 +433,6 @@ declare namespace asana {
              * @option {String} [redirectUri]  The default redirect URI
              * @option {String} [scope]        Scope to use, supports `default` and `scim`
              * @option {String} [asanaBaseUrl] Base URL to use for Asana, for debugging
-             * @constructor
              */
             new (options: AppOptions): App;
         }
@@ -535,7 +510,6 @@ declare namespace asana {
              * @option {String} error The string code identifying the error.
              * @option {String} [error_uri] A link to help and information about the error.
              * @option {String} [error_description] A description of the error.
-             * @constructor
              */
             new (options: OauthErrorOptions): OauthError;
         }
@@ -567,7 +541,6 @@ declare namespace asana {
              * redirecting to an authorization page on Asana, and redirecting back with
              * the credentials.
              * @param {Object} options See `BaseBrowserFlow` for options.
-             * @constructor
              */
             new (options: any): RedirectFlow;
         }
@@ -581,7 +554,6 @@ declare namespace asana {
              * An Oauth flow that runs in the browser and requests user authorization by
              * popping up a window and prompting the user.
              * @param {Object} options See `BaseBrowserFlow` for options.
-             * @constructor
              */
             new (options: any): PopupFlow;
         }
@@ -608,7 +580,6 @@ declare namespace asana {
              *     instructions to output to the user. Passed the authorize url.
              * @option {String function()} [prompt] String to output immediately before
              *     waiting for a line from stdin.
-             * @constructor
              */
             new (options: any): NativeFlow;
         }
@@ -653,7 +624,6 @@ declare namespace asana {
              *     directory of the extension to the receiver page. This is an HTML file
              *     that has been made web-accessible, and that calls the receiver method
              *     `Asana.auth.ChromeExtensionFlow.runReceiver();`.
-             * @constructor
              */
             new (options: any): ChromeExtensionFlow;
         }
@@ -676,7 +646,6 @@ declare namespace asana {
              * @option {String} [redirectUri] The URL that Asana should redirect to once
              *     user authorization is complete. Defaults to the URL configured in
              *     the app, and if none then the current page URL.
-             * @constructor
              */
             new (options: any): BaseBrowserFlow;
         }
@@ -826,7 +795,6 @@ declare namespace asana {
          * An _attachment_ object represents any file attached to a task in Asana,
          * whether it's an uploaded file or one associated via a third-party service
          * such as Dropbox or Google Drive.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Attachments extends TopLevelResource {
@@ -935,7 +903,6 @@ declare namespace asana {
          *
          * Sync tokens always expire after 24 hours, but may expire sooner, depending on
          * load on the service.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Events extends TopLevelResource {
@@ -1022,7 +989,6 @@ declare namespace asana {
          * change the team of a project via the API. Non-organization workspaces do not
          * have teams and so you should not specify the team of project in a
          * regular workspace.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Projects extends TopLevelResource {
@@ -1421,7 +1387,6 @@ declare namespace asana {
          *
          * Stories are a form of history in the system, and as such they are read-only.
          * Once generated, it is not possible to modify a story.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Stories extends TopLevelResource {
@@ -1510,7 +1475,6 @@ declare namespace asana {
          * simplify them in the future so it is not encouraged to rely too heavily on it.
          * Unlike projects, tags do not provide any ordering on the tasks they
          * are associated with.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Tags extends TopLevelResource {
@@ -1810,7 +1774,6 @@ declare namespace asana {
          * centered. In the Asana application, multiple tasks populate the middle pane
          * according to some view parameters, and the set of selected tasks determines
          * the more detailed information presented in the details pane.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Tasks extends TopLevelResource {
@@ -2301,7 +2264,6 @@ declare namespace asana {
         /**
          * A _team_ is used to group related projects and people together within an
          * organization. Each project in an organization is associated with a team.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Teams extends TopLevelResource {
@@ -2417,7 +2379,6 @@ declare namespace asana {
          * Like other objects in the system, users are referred to by numerical IDs.
          * However, the special string identifier `me` can be used anywhere
          * a user ID is accepted, to refer to the current authenticated user.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Users extends TopLevelResource {
@@ -2555,7 +2516,6 @@ declare namespace asana {
          *
          * Webhooks themselves contain only the information necessary to deliver the
          * events to the desired target as they are generated.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Webhooks extends TopLevelResource {
@@ -2671,7 +2631,6 @@ declare namespace asana {
          * using workspace-based APIs for organizations. Currently, and until after
          * some reasonable grace period following any further announcements, you can
          * still reference organizations in any `workspace` parameter.
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface Workspaces extends TopLevelResource {
@@ -2829,7 +2788,6 @@ declare namespace asana {
          * when they can address them. When building an integration it’s worth noting that tasks with due dates
          * will automatically move through assignee_status states as their due dates approach; read up on task
          * auto-promotion, https://asana.com/guide/help/fundamentals/my-tasks#gl-auto-promote, for more information
-         * @class
          * @param {Dispatcher} dispatcher The API dispatcher
          */
         interface UserTaskLists extends TopLevelResource {
@@ -2897,7 +2855,7 @@ declare namespace asana {
             new (dispatcher: Dispatcher): Resource;
 
             /**
-             * @type {number} Default number of items to get per page.
+             * Default number of items to get per page.
              */
             DEFAULT_PAGE_LIMIT: number;
 
@@ -2934,7 +2892,6 @@ declare namespace asana {
          * Base class for a resource accessible via the API. Uses a `Dispatcher` to
          * access the resources.
          * @param {Dispatcher} dispatcher
-         * @constructor
          */
         interface TopLevelResource {
             /**

--- a/types/bigint/index.d.ts
+++ b/types/bigint/index.d.ts
@@ -352,7 +352,7 @@ declare namespace BigInt {
     /**
      * do x=x+n where x is a bigInt and n is an integer.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt accumulator.
      * @param {number} n The number addend.
@@ -362,7 +362,7 @@ declare namespace BigInt {
     /**
      * do x=x+y for bigInts x and y.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt accumulator.
      * @param {BigInt} y The BigInt addend.
@@ -372,7 +372,7 @@ declare namespace BigInt {
     /**
      * do x=y on bigInts x and y.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt destination.
      * @param {BigInt} y The BigInt source.
@@ -382,7 +382,7 @@ declare namespace BigInt {
     /**
      * do x=n on bigInt x and integer n.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt destination.
      * @param {number} n The number source.
@@ -393,7 +393,7 @@ declare namespace BigInt {
      * set x to the greatest common divisor of bigInts x and y, (y is destroyed).
      *  This never overflows its array.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt first dividend.
      * @param {BigInt} y The BigInt second dividend.
@@ -403,7 +403,7 @@ declare namespace BigInt {
     /**
      * do x=x**(-1) mod n, for bigInts x and n. Returns 1 (0) if inverse does (doesn't) exist.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt base and the remainder result.
      * @param {BigInt} n The BigInt divisor.
@@ -415,7 +415,7 @@ declare namespace BigInt {
     /**
      * do x=x mod n for bigInts x and n. (This never overflows its array).
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt dividend and the remainder result.
      * @param {BigInt} n The BigInt divisor.
@@ -425,7 +425,7 @@ declare namespace BigInt {
     /**
      * do x=x*y for bigInts x and y.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt multiplicand and the product result.
      * @param {BigInt} y The BigInt multiplier.
@@ -435,7 +435,7 @@ declare namespace BigInt {
     /**
      * do x=x*y mod n for bigInts x,y,n.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt multiplicand and the remainder result.
      * @param {BigInt} y The BigInt multiplier.
@@ -447,7 +447,7 @@ declare namespace BigInt {
      * do x=x**y mod n, where x,y,n are bigInts (n is odd) and ** is exponentiation.
      *  0**0=1.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt base and the remainder result.
      * @param {BigInt} y The BigInt exponent.
@@ -459,7 +459,7 @@ declare namespace BigInt {
      * do b = an n-bit random BigInt.
      *  if s=1, then nth bit (most significant bit) is set to 1. n>=1.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} b The BigInt destination.
      * @param {number} n The number of bits.
@@ -470,7 +470,7 @@ declare namespace BigInt {
     /**
      * do ans = a random k-bit true random prime (not just probable prime) with 1 in the msb.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} ans The destination.
      * @param {number} k   The number of bits.
@@ -480,7 +480,7 @@ declare namespace BigInt {
     /**
      * do x=x-y for bigInts x and y. Negative answers will be 2s complement.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt minuend and the result difference.
      * @param {BigInt} y The BigInt subtrahend .
@@ -490,7 +490,7 @@ declare namespace BigInt {
     /**
      * do x=x+(y<<(ys*bpe))
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x  The BigInt accumulator.
      * @param {BigInt} y  The BigInt addend to be shifted.
@@ -501,7 +501,7 @@ declare namespace BigInt {
     /**
      * do carries and borrows so each element of the bigInt x fits in bpe bits.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt to process.
      */
@@ -510,7 +510,7 @@ declare namespace BigInt {
     /**
      * divide x by y giving quotient q and remainder r.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt dividend.
      * @param {BigInt} y The BigInt divisor.
@@ -523,7 +523,7 @@ declare namespace BigInt {
      * do x=floor(x/n) for bigInt x and integer n, and return the remainder.
      *  This never overflows its array.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt dividend and the quotient result.
      * @param {number} n The number divisor.
@@ -535,7 +535,7 @@ declare namespace BigInt {
     /**
      * sets a,b,d to positive bigInts such that d = GCD_(x,y) = a*x-b*y.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt to process.
      * @param {BigInt} y The BigInt to process.
@@ -549,7 +549,7 @@ declare namespace BigInt {
      * do x=floor(|x|/2)*sgn(x) for bigInt x in 2's complement.
      *  This never overflows its array.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt to process.
      */
@@ -558,7 +558,7 @@ declare namespace BigInt {
     /**
      * left shift bigInt x by n bits.  n<bpe.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt to process.
      * @param {number} n The number of bits.
@@ -568,7 +568,7 @@ declare namespace BigInt {
     /**
      * do x=a*x+b*y for bigInts x and y and integers a and b.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt first multiplicand.
      * @param {BigInt} y The BigInt second multiplicand.
@@ -580,7 +580,7 @@ declare namespace BigInt {
     /**
      * do x=x+b*(y<<(ys*bpe)) for bigInts x and y, and integers b and ys.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x  The BigInt to process.
      * @param {BigInt} y  The BigInt to process.
@@ -592,7 +592,7 @@ declare namespace BigInt {
     /**
      * Montgomery multiplication (see comments where the function is defined)
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x  The BigInt to process.
      * @param {BigInt} y  The BigInt to process.
@@ -604,7 +604,7 @@ declare namespace BigInt {
     /**
      * do x=x*n where x is a bigInt and n is an integer.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt multiplicand and the result product.
      * @param {number} n The number multiplier.
@@ -615,7 +615,7 @@ declare namespace BigInt {
      * right shift bigInt x by n bits.  0 <= n < bpe.
      *  This never overflows its array.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt to process.
      * @param {number} n The number to process.
@@ -625,7 +625,7 @@ declare namespace BigInt {
     /**
      * do x=x*x mod n for bigInts x,n.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x The BigInt base and the result remainder.
      * @param {BigInt} n The BigInt divisor.
@@ -635,7 +635,7 @@ declare namespace BigInt {
     /**
      * do x=x-(y<<(ys*bpe)). Negative answers will be 2s complement.
      *
-     * @private Intend to be internal function.
+     * @note Intended to be internal function.
      *
      * @param {BigInt} x  The BigInt minuend and the result difference.
      * @param {BigInt} y  The BigInt shifted subtrahend .

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -420,7 +420,7 @@ declare namespace Chai {
         /**
          * Throws a failure.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message    Message to display on error.
@@ -432,7 +432,7 @@ declare namespace Chai {
         /**
          * Asserts that object is truthy.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
@@ -441,7 +441,7 @@ declare namespace Chai {
         /**
          * Asserts that object is truthy.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
@@ -450,7 +450,7 @@ declare namespace Chai {
         /**
          * Asserts that object is falsy.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
@@ -459,7 +459,7 @@ declare namespace Chai {
         /**
          * Asserts that object is falsy.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
@@ -468,7 +468,7 @@ declare namespace Chai {
         /**
          * Asserts non-strict equality (==) of actual and expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -478,7 +478,7 @@ declare namespace Chai {
         /**
          * Asserts non-strict inequality (!=) of actual and expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -488,7 +488,7 @@ declare namespace Chai {
         /**
          * Asserts strict equality (===) of actual and expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -498,7 +498,7 @@ declare namespace Chai {
         /**
          * Asserts strict inequality (!==) of actual and expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -508,7 +508,7 @@ declare namespace Chai {
         /**
          * Asserts that actual is deeply equal to expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -518,7 +518,7 @@ declare namespace Chai {
         /**
          * Asserts that actual is not deeply equal to expected.
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -528,7 +528,7 @@ declare namespace Chai {
         /**
          * Alias to deepEqual
          *
-         * @type T   Type of the objects.
+         * T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
          * @param message   Message to display on error.
@@ -574,7 +574,7 @@ declare namespace Chai {
         /**
          * Asserts that value is true.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -583,7 +583,7 @@ declare namespace Chai {
         /**
          * Asserts that value is false.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -592,7 +592,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not true.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -601,7 +601,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not false.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -610,7 +610,7 @@ declare namespace Chai {
         /**
          * Asserts that value is null.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -619,7 +619,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not null.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -628,7 +628,7 @@ declare namespace Chai {
         /**
          * Asserts that value is NaN.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -637,7 +637,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not NaN.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -646,7 +646,7 @@ declare namespace Chai {
         /**
          * Asserts that the target is neither null nor undefined.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message    Message to display on error.
          */
@@ -655,7 +655,7 @@ declare namespace Chai {
         /**
          * Asserts that the target is either null or undefined.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message    Message to display on error.
          */
@@ -664,7 +664,7 @@ declare namespace Chai {
         /**
          * Asserts that value is undefined.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -673,7 +673,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not undefined.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -682,7 +682,7 @@ declare namespace Chai {
         /**
          * Asserts that value is a function.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -691,7 +691,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not a function.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -701,7 +701,7 @@ declare namespace Chai {
          * Asserts that value is an object of type 'Object'
          * (as revealed by Object.prototype.toString).
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          * @remarks The assertion does not match subclassed objects.
@@ -712,7 +712,7 @@ declare namespace Chai {
          * Asserts that value is not an object of type 'Object'
          * (as revealed by Object.prototype.toString).
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -721,7 +721,7 @@ declare namespace Chai {
         /**
          * Asserts that value is an array.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -730,7 +730,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not an array.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -739,7 +739,7 @@ declare namespace Chai {
         /**
          * Asserts that value is a string.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -748,7 +748,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not a string.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -757,7 +757,7 @@ declare namespace Chai {
         /**
          * Asserts that value is a number.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -766,7 +766,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not a number.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -776,7 +776,7 @@ declare namespace Chai {
          * Asserts that value is a finite number.
          * Unlike `.isNumber`, this will fail for `NaN` and `Infinity`.
          *
-         * @type T   Type of value
+         * T   Type of value
          * @param value    Actual value
          * @param message   Message to display on error.
          */
@@ -785,7 +785,7 @@ declare namespace Chai {
         /**
          * Asserts that value is a boolean.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -794,7 +794,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not a boolean.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
@@ -803,7 +803,7 @@ declare namespace Chai {
         /**
          * Asserts that value's type is name, as determined by Object.prototype.toString.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param name   Potential expected type name of value.
          * @param message   Message to display on error.
@@ -813,7 +813,7 @@ declare namespace Chai {
         /**
          * Asserts that value's type is not name, as determined by Object.prototype.toString.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param name   Potential expected type name of value.
          * @param message   Message to display on error.
@@ -823,7 +823,7 @@ declare namespace Chai {
         /**
          * Asserts that value is an instance of constructor.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
@@ -833,7 +833,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not an instance of constructor.
          *
-         * @type T   Type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
@@ -852,7 +852,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack includes needle.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   Container array, set or map.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -862,7 +862,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack includes needle.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   WeakSet container.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -872,7 +872,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack includes needle.
          *
-         * @type T   Type of haystack.
+         * T   Type of haystack.
          * @param haystack   Object.
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
@@ -891,7 +891,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   Container array, set or map.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -901,7 +901,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   WeakSet container.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -911,7 +911,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle.
          *
-         * @type T   Type of haystack.
+         * T   Type of haystack.
          * @param haystack   Object.
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
@@ -932,7 +932,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack includes needle. Deep equality is used.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   Container array, set or map.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -942,7 +942,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle.
          *
-         * @type T   Type of haystack.
+         * T   Type of haystack.
          * @param haystack   Object.
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
@@ -963,7 +963,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle. Deep equality is used.
          *
-         * @type T   Type of values in haystack.
+         * T   Type of values in haystack.
          * @param haystack   Container array, set or map.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
@@ -973,7 +973,7 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not includes needle. Deep equality is used.
          *
-         * @type T   Type of haystack.
+         * T   Type of haystack.
          * @param haystack   Object.
          * @param needle   Potential subset of the haystack's properties.
          * @param message   Message to display on error.
@@ -1097,7 +1097,7 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param message   Message to display on error.
@@ -1107,7 +1107,7 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param message   Message to display on error.
@@ -1118,7 +1118,7 @@ declare namespace Chai {
          * Asserts that object has a property named by property, which can be a string
          * using dot- and bracket-notation for deep reference.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param message   Message to display on error.
@@ -1129,7 +1129,7 @@ declare namespace Chai {
          * Asserts that object does not have a property named by property, which can be a
          * string using dot- and bracket-notation for deep reference.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param message   Message to display on error.
@@ -1139,8 +1139,8 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property with value given by value.
          *
-         * @type T   Type of object.
-         * @type V   Type of value.
+         * T   Type of object.
+         * V   Type of value.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param value   Potential expected property value.
@@ -1151,8 +1151,8 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property with value given by value.
          *
-         * @type T   Type of object.
-         * @type V   Type of value.
+         * T   Type of object.
+         * V   Type of value.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param value   Potential expected property value.
@@ -1164,8 +1164,8 @@ declare namespace Chai {
          * Asserts that object has a property named by property, which can be a string
          * using dot- and bracket-notation for deep reference.
          *
-         * @type T   Type of object.
-         * @type V   Type of value.
+         * T   Type of object.
+         * V   Type of value.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param value   Potential expected property value.
@@ -1177,8 +1177,8 @@ declare namespace Chai {
          * Asserts that object does not have a property named by property, which can be a
          * string using dot- and bracket-notation for deep reference.
          *
-         * @type T   Type of object.
-         * @type V   Type of value.
+         * T   Type of object.
+         * V   Type of value.
          * @param object   Container object.
          * @param property   Potential contained property of object.
          * @param value   Potential expected property value.
@@ -1189,7 +1189,7 @@ declare namespace Chai {
         /**
          * Asserts that object has a length property with the expected value.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Container object.
          * @param length   Potential expected length of object.
          * @param message   Message to display on error.
@@ -1329,7 +1329,7 @@ declare namespace Chai {
         /**
          * Asserts that set1 and set2 have the same members. Order is not take into account.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1340,7 +1340,7 @@ declare namespace Chai {
          * Asserts that set1 and set2 have the same members using deep equality checking.
          * Order is not take into account.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1351,7 +1351,7 @@ declare namespace Chai {
          * Asserts that set1 and set2 have the same members in the same order.
          * Uses a strict equality check (===).
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1362,7 +1362,7 @@ declare namespace Chai {
          * Asserts that set1 and set2 don’t have the same members in the same order.
          * Uses a strict equality check (===).
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1373,7 +1373,7 @@ declare namespace Chai {
          * Asserts that set1 and set2 have the same members in the same order.
          * Uses a deep equality check.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1384,7 +1384,7 @@ declare namespace Chai {
          * Asserts that set1 and set2 don’t have the same members in the same order.
          * Uses a deep equality check.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
          * @param message   Message to display on error.
@@ -1395,7 +1395,7 @@ declare namespace Chai {
          * Asserts that subset is included in superset in the same order beginning with the first element in superset.
          * Uses a strict equality check (===).
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1406,7 +1406,7 @@ declare namespace Chai {
          * Asserts that subset isn’t included in superset in the same order beginning with the first element in superset.
          * Uses a strict equality check (===).
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1417,7 +1417,7 @@ declare namespace Chai {
          * Asserts that subset is included in superset in the same order beginning with the first element in superset.
          * Uses a deep equality check.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1428,7 +1428,7 @@ declare namespace Chai {
          * Asserts that subset isn’t included in superset in the same order beginning with the first element in superset.
          * Uses a deep equality check.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1438,7 +1438,7 @@ declare namespace Chai {
         /**
          * Asserts that subset is included in superset. Order is not take into account.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1449,7 +1449,7 @@ declare namespace Chai {
          * Asserts that subset isn’t included in superset in any order.
          * Uses a strict equality check (===). Duplicates are ignored.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential not contained set of values.
          * @param message   Message to display on error.
@@ -1460,7 +1460,7 @@ declare namespace Chai {
          * Asserts that subset is included in superset using deep equality checking.
          * Order is not take into account.
          *
-         * @type T   Type of set values.
+         * T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
          * @param message   Message to display on error.
@@ -1470,7 +1470,7 @@ declare namespace Chai {
         /**
          * Asserts that non-object, non-array value inList appears in the flat array list.
          *
-         * @type T   Type of list values.
+         * T   Type of list values.
          * @param inList   Value expected to be in the list.
          * @param list   List of values.
          * @param message   Message to display on error.
@@ -1480,7 +1480,7 @@ declare namespace Chai {
         /**
          * Asserts that a function changes the value of a property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected to be modified.
@@ -1491,7 +1491,7 @@ declare namespace Chai {
         /**
          * Asserts that a function does not change the value of a property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected not to be modified.
@@ -1502,7 +1502,7 @@ declare namespace Chai {
         /**
          * Asserts that a function increases an object property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected to be increased.
@@ -1513,7 +1513,7 @@ declare namespace Chai {
         /**
          * Asserts that a function does not increase an object property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected not to be increased.
@@ -1524,7 +1524,7 @@ declare namespace Chai {
         /**
          * Asserts that a function decreases an object property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected to be decreased.
@@ -1535,7 +1535,7 @@ declare namespace Chai {
         /**
          * Asserts that a function does not decrease an object property.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
          * @param property   Property of object expected not to be decreased.
@@ -1546,7 +1546,7 @@ declare namespace Chai {
         /**
          * Asserts if value is not a false value, and throws if it is a true value.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Actual value.
          * @param message   Message to display on error.
          * @remarks This is added to allow for chai to be a drop-in replacement for
@@ -1557,7 +1557,7 @@ declare namespace Chai {
         /**
          * Asserts that object is extensible (can have new properties added to it).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1566,7 +1566,7 @@ declare namespace Chai {
         /**
          * Asserts that object is extensible (can have new properties added to it).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1575,7 +1575,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not extensible.
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1584,7 +1584,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not extensible.
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1594,7 +1594,7 @@ declare namespace Chai {
          * Asserts that object is sealed (can have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1604,7 +1604,7 @@ declare namespace Chai {
          * Asserts that object is sealed (can have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1613,7 +1613,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not sealed.
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1622,7 +1622,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not sealed.
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1632,7 +1632,7 @@ declare namespace Chai {
          * Asserts that object is frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1642,7 +1642,7 @@ declare namespace Chai {
          * Asserts that object is frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1652,7 +1652,7 @@ declare namespace Chai {
          * Asserts that object is not frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1662,7 +1662,7 @@ declare namespace Chai {
          * Asserts that object is not frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1674,7 +1674,7 @@ declare namespace Chai {
          * checks the size property. For non-function objects, it gets the count
          * of own enumerable string keys.
          *
-         * @type T   Type of object
+         * T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
          */
@@ -1685,7 +1685,7 @@ declare namespace Chai {
          * the length property. For Map and Set instances, it checks the size property.
          * For non-function objects, it gets the count of own enumerable string keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
@@ -1696,7 +1696,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1708,7 +1708,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1720,7 +1720,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1732,7 +1732,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1744,7 +1744,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1758,7 +1758,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1772,7 +1772,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1786,7 +1786,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1800,7 +1800,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1814,7 +1814,7 @@ declare namespace Chai {
          * You can also provide a single object instead of a `keys` array and its keys
          * will be used as the expected set of keys.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param keys   Keys to check
          * @param message    Message to display on error.
@@ -1825,7 +1825,7 @@ declare namespace Chai {
          * Asserts that object has a direct or inherited property named by property,
          * which can be a string using dot- and bracket-notation for nested reference.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param message    Message to display on error.
@@ -1837,7 +1837,7 @@ declare namespace Chai {
          * which can be a string using dot- and bracket-notation for nested reference.
          * The property cannot exist on the object nor anywhere in its prototype chain.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param message    Message to display on error.
@@ -1848,7 +1848,7 @@ declare namespace Chai {
          * Asserts that object has a property named by property with value given by value.
          * property can use dot- and bracket-notation for nested reference. Uses a strict equality check (===).
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param value    Value to test.
@@ -1860,7 +1860,7 @@ declare namespace Chai {
          * Asserts that object does not have a property named by property with value given by value.
          * property can use dot- and bracket-notation for nested reference. Uses a strict equality check (===).
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param value    Value to test.
@@ -1872,7 +1872,7 @@ declare namespace Chai {
          * Asserts that object has a property named by property with a value given by value.
          * property can use dot- and bracket-notation for nested reference. Uses a deep equality check.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param value    Value to test.
@@ -1884,7 +1884,7 @@ declare namespace Chai {
          * Asserts that object does not have a property named by property with value given by value.
          * property can use dot- and bracket-notation for nested reference. Uses a deep equality check.
          *
-         * @type T   Type of object.
+         * T   Type of object.
          * @param object   Object to test.
          * @param property    Property to test.
          * @param value    Value to test.

--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -341,17 +341,14 @@ declare namespace chrome {
      * and can shut down the app at anytime.
      */
     namespace app.runtime {
-        /** @enum */
         const PlayStoreStatus: {
             ENABLED: 'enabled',
             AVAILABLE: 'available',
             UNKNOWN: 'unknown'
         }
-        /** @enum */
         const ActionType: {
             NEW_NOTE: 'new_note'
         }
-        /** @enum */
         const LaunchSource: {
             ABOUT_PAGE: 'about_page',
             APP_LAUNCHER: 'app_launcher',
@@ -469,9 +466,7 @@ declare namespace chrome {
         }
 
         /**
-         * @enum
          * @internal
-         * @private
          */
         const _State: {
             NORMAL: 'normal',
@@ -817,7 +812,6 @@ declare namespace chrome {
 
         interface ChromeAppWindow extends AppWindow {
             /**
-             * @enum
              * Window state enum
              */
             readonly State: typeof _State;
@@ -1931,7 +1925,6 @@ declare namespace chrome {
 
         /**
          * The type of code being requested by the extension with requestPin function.
-         * @enum
          */
         const PinRequestType: {
             'PIN': 'PIN',
@@ -1939,7 +1932,6 @@ declare namespace chrome {
         };
         /**
          * The types of errors that can be presented to the user through the requestPin function.
-         * @enum
          */
         const PinRequestErrorType: {
             'INVALID_PIN': 'INVALID_PIN',
@@ -2073,7 +2065,6 @@ declare namespace chrome {
     namespace clipboard {
         /** Image type */
         type ImageType = 'png' | 'jpeg';
-        /** @enum */
         const DataItemType: {
             TEXT_PLAIN: 'textPlain',
             TEXT_HTML: 'textHtml'
@@ -2496,7 +2487,6 @@ declare namespace chrome {
      */
     namespace displaySource {
         /**
-         * @enum
          * @description
          * **'connection_error'**
          * The connection with sink cannot be established or has dropped unexpectedly.
@@ -2524,7 +2514,6 @@ declare namespace chrome {
             UNKNOWN_ERROR: 'unknown_error'
         };
         /**
-         * @enum
          * @description
          * **'connected'**
          * Connected using this Display Source (i.e., there is an active session)
@@ -2541,7 +2530,6 @@ declare namespace chrome {
             DISCONNECTED: 'Disconnected'
         };
         /**
-         * @enum
          * @description
          *
          * **'PBC'**
@@ -3169,7 +3157,6 @@ declare namespace chrome {
             'user';
         /**
          * Internal interfaces, not to be used directly
-         * @private
          * @internal
          */
         namespace _internal_ {
@@ -3301,7 +3288,6 @@ declare namespace chrome {
      *   {'fileSystem': ['write', 'retainEntries', 'directory']}
      */
     namespace fileSystem {
-        /** @enum */
         const ChildChangeType: {
             CREATED: 'created',
             REMOVED: 'removed',
@@ -3326,7 +3312,6 @@ declare namespace chrome {
          *    permission under 'fileSystem'. If the application has the 'write' permission under
          *    'fileSystem', the returned DirectoryEntry will be writable; otherwise it will be read-only.
          *    New in Chrome 31.
-         * @enum
          */
         const ChooseEntryType: {
             OPEN_FILE: 'openFile',
@@ -3421,7 +3406,6 @@ declare namespace chrome {
             writable?: boolean | undefined;
         }
 
-        /** @private */
         type FileEntryCallback<
             T extends ChooseEntryOptions,
             E = T extends ChooseFileEntryOptions ? FileEntry :
@@ -6351,11 +6335,10 @@ declare namespace chrome {
      */
     namespace notifications {
         /**
-         * @enum
-         * @prop BASIC - icon, title, message, expandedMessage, up to two buttons.
-         * @prop IMAGE - icon, title, message, expandedMessage, image, up to two buttons.
-         * @prop LIST - icon, title, message, items, up to two buttons. Users on Mac OS X only see the first item.
-         * @prop PROGRESS - icon, title, message, progress, up to two buttons.
+         * BASIC - icon, title, message, expandedMessage, up to two buttons.
+         * IMAGE - icon, title, message, expandedMessage, image, up to two buttons.
+         * LIST - icon, title, message, items, up to two buttons. Users on Mac OS X only see the first item.
+         * PROGRESS - icon, title, message, progress, up to two buttons.
          */
         const TemplateType: {
             BASIC: 'basic',
@@ -6364,9 +6347,8 @@ declare namespace chrome {
             PROGRESS: 'progress'
         }
         /**
-         * @enum
-         * @property GRANTED - User has elected to show notifications from the app . This is the default at install time.
-         * @property DENIED - User has elected not to show notifications from the app.
+         * GRANTED - User has elected to show notifications from the app . This is the default at install time.
+         * DENIED - User has elected not to show notifications from the app.
          */
         const PermissionLevel: {
             GRANTED: 'granted',
@@ -6622,7 +6604,6 @@ declare namespace chrome {
      */
     namespace platformKeys {
         /**
-         * @enum
          */
         const ClientCertificateType: {
             'RSA_SIGN': 'rsaSign',
@@ -6792,9 +6773,8 @@ declare namespace chrome {
      */
     namespace power {
         /**
-         * @enum
-         * @property SYSTEM - Prevent the system from sleeping in response to user inactivity.
-         * @property DISPLAY - Prevent the display from being turned off or dimmed or the system from sleeping in response to user inactivity.
+         * SYSTEM - Prevent the system from sleeping in response to user inactivity.
+         * DISPLAY - Prevent the display from being turned off or dimmed or the system from sleeping in response to user inactivity.
         */
         const Level: {
             SYSTEM: 'system',
@@ -7329,7 +7309,6 @@ declare namespace chrome {
         }
         interface FileSystemPermission {
             /**
-             * @enum {string}
              * @requires(CrOS) 'requestFileSystem' is only for ChromeOS
              */
             fileSystem: Array<'write' | 'retainEntries' | 'directory' | 'requestFileSystem'>;
@@ -9129,7 +9108,6 @@ declare namespace chrome {
      */
     namespace syncFileSystem {
         /**
-         * @enum
          * 'initializing'
          *  - The sync service is being initialized (e.g. restoring data from the database, checking connectivity and authenticating to the service etc).
          * 'running'
@@ -9150,7 +9128,6 @@ declare namespace chrome {
         };
 
         /**
-         * @enum
          * 'synced'
          *  - Not conflicting and has no pending local changes.
          * 'pending'
@@ -10772,7 +10749,6 @@ declare namespace chrome {
          * The extension is not guaranteed to receive this event prior to suspending.
          * **'resume'**
          * The OS has resumed and the user has logged back in, so the VPN should try to reconnect.
-         * @enum
          */
         const PlatformMessage: {
             CONNECTED: 'connected',
@@ -10792,7 +10768,6 @@ declare namespace chrome {
          * VPN connection was successful.
          * **'failure'**
          * VPN connection failed.
-         * @enum
          */
         const VpnConnectionState: {
             CONNECTED: 'connected',
@@ -10805,7 +10780,6 @@ declare namespace chrome {
          * Request the VPN client to show add configuration dialog to the user.
          * **'showConfigureDialog'**
          * Request the VPN client to show configuration settings dialog to the user.
-         * @enum
          */
         const UIEvent: {
             SHOW_ADD_DIALOG: 'showAddDialog',
@@ -11561,7 +11535,6 @@ declare namespace chrome {
 
     /**
      * New Chrome Event
-     * @constructor
      */
     const Event: {
         new <T extends Function>(): chrome.events.Event<T>;

--- a/types/cldrjs/index.d.ts
+++ b/types/cldrjs/index.d.ts
@@ -25,8 +25,6 @@ declare namespace self {
          * @kind property
          * @access public
          *
-         * @type {any}
-         *
          * @description
          * Language subtag {@link http://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions}
          */
@@ -37,8 +35,6 @@ declare namespace self {
          * @memberof cldr.Attributes
          * @kind property
          * @access public
-         *
-         * @type {any}
          *
          * @description
          * Script subtag {@link http://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions}
@@ -51,8 +47,6 @@ declare namespace self {
          * @kind property
          * @access public
          *
-         * @type {any}
-         *
          * @description
          * Region subtag {@link http://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions}
          */
@@ -63,8 +57,6 @@ declare namespace self {
          * @memberof cldr.Attributes
          * @kind property
          * @access public
-         *
-         * @type {any}
          *
          * @description
          * Region subtag (territory variant) {@link http://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions}
@@ -77,8 +69,6 @@ declare namespace self {
          * @kind property
          * @access public
          *
-         * @type {any}
-         *
          * @description
          * Language Id {@link http://www.unicode.org/reports/tr35/#Unicode_language_identifier}
          */
@@ -90,8 +80,6 @@ declare namespace self {
          * @kind property
          * @access public
          *
-         * @type {any}
-         *
          * @description
          * Maximized Language Id {@link http://www.unicode.org/reports/tr35/#Likely_Subtags}
          */
@@ -102,8 +90,6 @@ declare namespace self {
          * @memberof cldr.Attributes
          * @kind property
          * @access public
-         *
-         * @type {any}
          *
          * @description
          * Minimized Language Id {@link http://www.unicode.org/reports/tr35/#Likely_Subtags}
@@ -186,8 +172,6 @@ declare namespace self {
          * @kind property
          * @access public
          *
-         * @type {string}
-         *
          * @declaration
          * The locale string.
          */
@@ -198,8 +182,6 @@ declare namespace self {
          * @memberof cldr.CldrStatic
          * @kind property
          * @access public
-         *
-         * @type {cldr.Attributes}
          *
          * @declaration
          * The object created during instance initialization and used internally by .get()

--- a/types/confidence/index.d.ts
+++ b/types/confidence/index.d.ts
@@ -14,7 +14,6 @@
 export declare class Store {
 
     /**
-    * @constructor
     * @param {any} document - the configuration document for this document store
     */
     constructor(document?: any);

--- a/types/connect-timeout/index.d.ts
+++ b/types/connect-timeout/index.d.ts
@@ -31,7 +31,6 @@ declare module "connect-timeout" {
         interface TimeoutOptions {
             /**
              * @summary Controls if this module will "respond" in the form of forwarding an error.
-             * @type {boolean}
              */
             respond?: boolean | undefined;
         }

--- a/types/decorum/index.d.ts
+++ b/types/decorum/index.d.ts
@@ -241,7 +241,6 @@ declare namespace decorum {
 
     /**
      * Mechanism for overriding validation errors to provide for custom or localized error messages.
-     * @type {{IMessageHandlerMap}}
      */
     export let MessageHandlers: IMessageHandlerMap;
 

--- a/types/documentdb-server/documentdb-server-tests.ts
+++ b/types/documentdb-server/documentdb-server-tests.ts
@@ -259,7 +259,6 @@ function simple(prefix: string) {
  * A DocumentDB stored procedure that bulk deletes documents for a given query.<br/>
  * Note: You may need to execute this sproc multiple times (depending whether the sproc is able to delete every document within the execution timeout limit).
  *
- * @function
  * @param {string} query - A query that provides the documents to be deleted (e.g. "SELECT * FROM c WHERE c.founded_year = 2008")
  * @returns {Object.<number, boolean>} Returns an object with the two properties:<br/>
  *   deleted - contains a count of documents deleted<br/>
@@ -367,7 +366,6 @@ function bulkDeleteSproc(query: string) {
  * @example <caption>Set the property "message" to "Hello World" and the "messageDate" to the current date in the document where id = "bar".</caption>
  * updateSproc("bar", {$set: {message: "Hello World"}, $currentDate: {messageDate: ""}});
  *
- * @function
  * @param {string} id - The id for your document.
  * @param {object} update - the modifications to apply.
  * @returns {object} the updated document.

--- a/types/durandal/index.d.ts
+++ b/types/durandal/index.d.ts
@@ -404,7 +404,6 @@ declare module 'durandal/binder' {
 declare module 'durandal/activator' {
     /**
      * The default settings used by activators.
-     * @property {ActivatorSettings} defaults
     */
     export var defaults: DurandalActivatorSettings;
 
@@ -620,7 +619,6 @@ declare module 'plugins/dialog' {
 
     /**
     * Models a message box's message, title and options.
-    * @class
     */
     class Box {
         constructor(message: string, title?: string, options?: string[], autoclose?: boolean, settings?: Object);

--- a/types/dwt/v12/index.d.ts
+++ b/types/dwt/v12/index.d.ts
@@ -1251,829 +1251,691 @@ declare enum EnumDWT_MouseShape {
 }
 
 /**
- * @class
  */
 // properties (get/set) / sync functions
 interface WebTwain {
     /**
      * Returns or sets whether multi-page selection is supported.
-     * @type {bool}
      */
     AllowMultiSelect: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether allowing the plugin to send authentication request. The default value of this property is TRUE.
-     * @type {bool}
      */
     AllowPluginAuthentication: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the async mode is activated. With this mode, Dynamic Web TWAIN is able to upload/download files via HTTP/FTP asynchronously. The default value is false.
-     * @type {bool}
      */
     AsyncMode: boolean;
 
     /**
      * Returns or sets the background color of the main control. It is a value specifying the 24-bit RGB value.
-     * @type {int}
      */
     BackgroundColor: number;
 
     /**
      * Returns or sets the fill color of the selected area of an image when it is cut, erased or rotated. It is a value specifying the 24-bit RGB value.
-     * @type {int}
      */
     BackgroundFillColor: number;
 
     /**
      * [Deprecated.] Returns the number of barcode detected in an image.
-     * @type {int}
      */
     BarcodeCount: number;
 
     /**
      * Returns or sets the pixel bit depths for the current value of PixelType property. This is a runtime property.
-     * @type {short}
      */
     BitDepth: number;
 
     /**
      * Returns the current deviation of the pixels in the image.
-     * @type {float}
      */
     BlankImageCurrentStdDev: number;
 
     /**
      * Returns or sets the standard deviation of the pixels in the image.
-     * @type {float}
      */
     BlankImageMaxStdDev: number;
 
     /**
      * Returns or sets the dividing line between black and white. The default value is 128.
-     * @type {int}
      */
     BlankImageThreshold: number;
 
     /**
      * [Deprecated.] Returns or sets the border style.
-     * @type {EnumDWT_BorderStyle}
      */
     BorderStyle: EnumDWT_BorderStyle;
 
     /**
      * Returns or sets the brightness values available within the Source. This is a runtime property.
-     * @type {float}
      */
     Brightness: number;
 
     /**
      * [Deprecated.] Sets or returns whether brokerprocess is enabled for scanning.
-     * @type {int}
      */
     BrokerProcessType: number;
 
     /**
      * Sets or returns how much physical memory is allowed for storing images currently loaded in Dynamic Web TWAIN. Once the limit is reached, images will be cached on the hard disk.
-     * @type {int}
      */
     BufferMemoryLimit: number;
 
     /**
      * Specifies the capabiltiy to be negotiated. This is a runtime property.
-     * @type {EnumDWT_Cap}
      */
     Capability: EnumDWT_Cap;
 
     /**
      * Sets or returns the index (0-based) of a list to indicate the Current Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {int}
      */
     CapCurrentIndex: number;
 
     /**
      * Sets or returns the current value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {double}
      */
     CapCurrentValue: number;
 
     /**
      * Returns the index (0-based) of a list to indicate the Default Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime, read-only property.
-     * @type {int}
      */
     CapDefaultIndex: number;
 
     /**
      * Returns the default value in a range when the value of the CapType property is TWON_RANGE. This is a runtime, read-only property.
-     * @type {double}
      */
     CapDefaultValue: number;
 
     /**
      * Sets or returns the maximum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {double}
      */
     CapMaxValue: number;
 
     /**
      * Sets or returns the minimum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {double}
      */
     CapMinValue: number;
 
     /**
      * [Deprecated.] Sets or returns how many items are in the list when the value of the CapType property is TWON_ARRAY or TWON_ENUMERATION. For String data type, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {int}
      */
     CapNumItems: number;
 
     /**
      * [Deprecated.] Replaced by GetCapItemsString method and SetCapItemsString method.
-     * @type {string}
      */
     CapItemsString: string;
 
     /**
      * Sets or returns the step size in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {double}
      */
     CapStepSize: number;
 
     /**
      * Sets or returns the type of capability container used to exchange capability information between application and source. This is a runtime property.
-     * @type {EnumDWT_CapType}
      */
     CapType: EnumDWT_CapType;
 
     /**
      * Returns or sets the value of the capability specified by Capability property when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {double}
      */
     CapValue: number;
 
     /**
      * Sets or returns the string value for a capability when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {string}
      */
     CapValueString: string;
 
     /**
      * Sets or returns the value type for reading the value of a capability. This is a runtime property.
-     * @type {short}
      */
     CapValueType: number;
 
     /**
      * Returns or sets the contrast values available within the Source. This is a runtime property.
-     * @type {float}
      */
     Contrast: number;
 
     /**
      * Sets or returns the product name string for the application identity.
-     * @type {string}
      */
     ProductName: string;
 
     /**
      * Returns or sets current index of image in buffer. This is a runtime property.
-     * @type {short}
      */
     CurrentImageIndexInBuffer: number;
 
     /**
      * Returns the device name of current source. This is a runtime, read-only property.
-     * @type {string}
      */
     CurrentSourceName: string;
 
     /**
      * Returns the value indicating the data source status. This is a runtime, read-only property.
-     * @type {int}
      */
     DataSourceStatus: number;
 
     /**
      * Returns the device name of default source. This is a runtime, read-only property.
-     * @type {string}
      */
     DefaultSourceName: string;
 
     /**
      * Returns whether the source supports duplex. If so, it further returns the level of duplex the Source supports (one pass or two pass duplex). This is a runtime, read-only property.
-     * @type {int}
      */
     Duplex: number;
 
     /**
      * [Deprecated.] Returns or sets whether the user can zoom image using hot key.
-     * @type {bool}
      */
     EnableInteractiveZoom: boolean;
 
     /**
      * Returns the error code. This is a runtime, read-only property.
-     * @type {int}
      */
     ErrorCode: number;
 
     /**
      * Returns the error string. This is a runtime, read-only property.
-     * @type {string}
      */
     ErrorString: string;
 
     /**
      * Returns or sets whether to resize the image to fit the image to the width or height of the window. To use the property, the view mode should be set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {EnumDWT_FitWindowType}
      */
     FitWindowType: EnumDWT_FitWindowType;
 
     /**
      * Returns or sets the password used to log into the FTP server.
-     * @type {string}
      */
     FTPPassword: string;
 
     /**
      * Returns or sets the port number of the FTP server.
-     * @type {int}
      */
     FTPPort: number;
 
     /**
      * Returns or sets the user name used to log into the FTP server.
-     * @type {string}
      */
     FTPUserName: string;
 
     /**
      * Returns how many images are in buffer. This is a runtime, read-only property.
-     * @type {short}
      */
     HowManyImagesInBuffer: number;
 
     /**
      * Specifies the field name of uploaded image through POST.
-     * @type {string}
      */
     HttpFieldNameOfUploadedImage: string;
 
     /**
      * [Deprecated.] Sets or returns the password used to log into the HTTP server.
-     * @type {string}
      */
     HTTPPassword: string;
 
     /**
      * Returns or sets the port number of the HTTP server.
-     * @type {int}
      */
     HTTPPort: number;
 
     /**
      * Returns the response string from the HTTP server if an error occurs for HTTPUploadThroughPost() method. This is a runtime, read-only property.
-     * @type {string}
      */
     HTTPPostResponseString: string;
 
     /**
      * [Deprecated.] Returns or sets the user name used to log into the HTTP server.
-     * @type {string}
      */
     HTTPUserName: string;
 
     /**
      * Returns or sets whether the feature of disk caching is enabled.
-     * @type {bool}
      */
     IfAllowLocalCache: boolean;
 
     /**
      * Returns or sets whether insert or append new scanned images.
-     * @type {bool}
      */
     IfAppendImage: boolean;
 
     /**
      * Returns or sets whether the Source's Auto-brightness function is enabled. This is a runtime property.
-     * @type {bool}
      */
     IfAutoBright: boolean;
 
     /**
      * Returns or sets whether the data source (scanner) will discard blank images during scanning. The property works only if the device and its driver support discarding blank pages. You can find whether your device supports this capbility from its user manual. Or, you can use the built-in methods of Dynamic Web TWAIN to detect blank images: IsBlankImage, IsBlankImageEx.
-     * @type {bool}
      */
     IfAutoDiscardBlankpages: boolean;
 
     /**
      * Returns or sets whether the Source enable automatic document feeding process. This is a runtime property.
-     * @type {bool}
      */
     IfAutoFeed: boolean;
 
     /**
      * Turns automatic border detection on and off. The property works only if the device and its driver support detecting the border automatically. You can find whether your device supports this capbility from its user manual.
-     * @type {bool}
      */
     IfAutomaticBorderDetection: boolean;
 
     /**
      * Turns automatic skew correction on and off.
-     * @type {bool}
      */
     IfAutomaticDeskew: boolean;
 
     /**
      * Returns or sets whether the Source enables the automatic document scanning process. This is a runtime property.
-     * @type {bool}
      */
     IfAutoScan: boolean;
 
     /**
      * Returns or sets whether close the Data Source User Interface after acquire all images. Default value of this property is FALSE.
-     * @type {bool}
      */
     IfDisableSourceAfterAcquire: boolean;
 
     /**
      * Returns or sets whether the Source supports duplex. If TRUE, the scanner scans both sides of a paper; otherwise, the scanner will scan only one side of the image. This is a runtime property.
-     * @type {bool}
      */
     IfDuplexEnabled: boolean;
 
     /**
      * Returns or sets whether the Automatic Document Feeder (ADF) is enabled. This is a runtime property.
-     * @type {bool}
      */
     IfFeederEnabled: boolean;
 
     /**
      * Returns whether or not there are documents loaded in the Source's feeder when IfFeederEnabled and IfPaperDetectable are TRUE. This is a runtime, read-only property.
-     * @type {bool}
      */
     IfFeederLoaded: boolean;
 
     /**
      * Returns or sets whether to resize the image to fit the size of window when the view mode is set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {bool}
      */
     IfFitWindow: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the UI (User Interface) of Source runs in modal state. Default value of this property is TRUE.
-     * @type {bool}
      */
     IfModalUI: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses  Graphics Device Interface (GDI) when decoding images.
-     * @type {bool}
      */
     IfOpenImageWithGDIPlus: boolean;
 
     /**
      * Returns the value whether the Source has a paper sensor that can detect documents on the ADF or Flatbed. This is a runtime, read-only property.
-     * @type {bool}
      */
     IfPaperDetectable: boolean;
 
     /**
      * Returns or sets whether FTP passive mode is enabled.
-     * @type {bool}
      */
     IfPASVMode: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether communicate with device in a separate thread. Default value of this property is FALSE.
-     * @type {bool}
      */
     IfScanInNewThread: boolean;
 
     /**
      * Sets or returns whether to show the cancel dialog when uploading images to server.
-     * @type {bool}
      */
     IfShowCancelDialogWhenImageTransfer: boolean;
 
     /**
      * Returns or sets whether to show the file dialog box when saving scanned images or loading images from local folder.
-     * @type {bool}
      */
     IfShowFileDialog: boolean;
 
     /**
      * Returns or sets whether the Source displays a progress indicator during acquisition and transfer, regardless of whether the Source's user interface is active. This is a runtime property.
-     * @type {bool}
      */
     IfShowIndicator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the driver of the printer displays the User Interface.
-     * @type {bool}
      */
     IfShowPrintUI: boolean;
 
     /**
      * Returns or sets whether the progress bar will be displayed during the transaction. This is a runtime property.
-     * @type {bool}
      */
     IfShowProgressBar: boolean;
 
     /**
      * Returns or sets whether the Source displays the User Interface.
-     * @type {bool}
      */
     IfShowUI: boolean;
 
     /**
      * Returns or sets whether SSL is used when uploading or downloading images.
-     * @type {bool}
      */
     IfSSL: boolean;
 
     /**
      * Return or sets whether the Source allows to save many images in one TIFF file. The default value is FALSE.
-     * @type {bool}
      */
     IfTiffMultiPage: boolean;
 
     /**
      * Returns whether the Source supports acquisition with the UI (User Interface) disabled. If FALSE, indicates that this Source can only support acquisition with the UI enabled. This is a runtime, read-only property.
-     * @type {bool}
      */
     IfUIControllable: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses the new TWAIN Data Source Manager (TWAINDSM.dll) when acquiring images from TWAIN devices.
-     * @type {bool}
      */
     IfUseTwainDSM: boolean;
 
     /**
      * Specifies whether or not to automatically scroll to the last image or stay on the current image when loading or acquiring images
-     * @type {bool}
      */
     IfAutoScroll: boolean;
 
     /**
      * [Deprecated.] The number of bits in each image pixel (or bit depth). This is a runtime, read-only property.
-     * @type {short}
      */
     ImageBitsPerPixel: number;
 
     /**
      * Returns or sets whether a TWAIN driver or Native Scan of Mac OS X is used for document scanning. This property works for Mac edition only.
-     * @type {int}
      */
     ImageCaptureDriverType: number;
 
     /**
      * [Deprecated.] Returns or sets whether the image enumerator is enabled in Image Editor.
-     * @type {bool}
      */
     ImageEditorIfEnableEnumerator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is a modal window.
-     * @type {bool}
      */
     ImageEditorIfModal: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is read-only.
-     * @type {bool}
      */
     ImageEditorIfReadonly: boolean;
 
     /**
      * [Deprecated.] Returns or sets the title of Image Editor window.
-     * @type {string}
      */
     ImageEditorWindowTitle: string;
 
     /**
      * Returns the document number of the current image. This is a runtime, read-only property.
-     * @type {int}
      */
     ImageLayoutDocumentNumber: number;
 
     /**
      * Returns the value of the bottom-most edge of the current image frame (in Unit). This is a read-only runtime property.
-     * @type {float}
      */
     ImageLayoutFrameBottom: number;
 
     /**
      * Returns the value of the left-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {float}
      */
     ImageLayoutFrameLeft: number;
 
     /**
      * Returns the frame number of the current image. This is a runtime, read-only property.
-     * @type {int}
      */
     ImageLayoutFrameNumber: number;
 
     /**
      * Returns the value of the right-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {float}
      */
     ImageLayoutFrameRight: number;
 
     /**
      * Returns the value of the top-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {float}
      */
     ImageLayoutFrameTop: number;
 
     /**
      * Returns the page number of the current image. This is a runtime, read-only property.
-     * @type {Long}
      */
     ImageLayoutPageNumber: number;
 
     /**
      * [Deprecated.] Returns how tall/long, in pixels, the image is. This is a runtime, read-only property.
-     * @type {int}
      */
     ImageLength: number;
 
     /**
      * Returns or sets the margin between images when multiple images are displayed in Dynamic Web TWAIN.
-     * @type {short}
      */
     ImageMargin: number;
 
     /**
      * Returns the pixel type of the current image. This is a runtime, read-only property. Please note the property is only valid in OnPreTransfer and OnPostTransfer event.
-     * @type {EnumDWT_PixelType}
      */
     ImagePixelType: EnumDWT_PixelType;
 
     /**
      * [Deprecated.] Returns how width, in pixels, the image is. This is a runtime, read-only property.
-     * @type {int}
      */
     ImageWidth: number;
 
     /**
      * [Deprecated.] Returns the X resolution of the current image. X resolution is the number of pixels per Unit in the horizontal direction. This is a runtime, read-only property.
-     * @type {float}
      */
     ImageXResolution: number;
 
     /**
      * [Deprecated.] Returns the Y resolution of the current image. Y resolution is the number of pixels per Unit in the vertical direction. This is a runtime, read-only property.
-     * @type {float}
      */
     ImageYResolution: number;
 
     /**
      * Returns or sets the quality of JPEG files and PDF files using JPEG compression.
-     * @type {short}
      */
     JPEGQuality: number;
 
     /**
      * Returns or sets the log level for debugging.
-     * @type {short}
      */
     LogLevel: number;
 
     /**
      * Return the magnetic data if the scanner support magnetic data recognition.
-     * @type {string}
      */
     MagData: string;
 
     /**
      * Return the magnetic type if the scanner support magnetic data recognition.
-     * @type {short}
      */
     MagType: number;
 
     /**
      * Sets or returns the manufacture string for the application identity.
-     * @type {string}
      */
     Manufacturer: string;
 
     /**
      * Returns or sets the maximum number of images can be held in buffer.
-     * @type {short}
      */
     MaxImagesInBuffer: number;
 
     /**
      * [Deprecated.] Returns or sets how many threads can be used when you upload files through POST.
-     * @type {int}
      */
     MaxInternetTransferThreads: number;
 
     /**
      * Sets or returns the maximum allowed size when Dynamic Web TWAIN uploads a document.
-     * @type {int}
      */
     MaxUploadImageSize: number;
 
     /**
      * Returns or sets the shape of the mouse.
-     * @type {bool}
      */
     MouseShape: boolean;
 
     /**
      * Returns the X co-ordinate of the mouse. This is a runtime property.
-     * @type {int}
      */
     MouseX: number;
 
     /**
      * Returns the Y co-ordinate of the mouse. This is a runtime property.
-     * @type {int}
      */
     MouseY: number;
 
     /**
      * Returns or sets the page size(s) the Source can/should use to acquire image data. This is a runtime property.
-     * @type {short}
      */
     PageSize: number;
 
     /**
      * Returns or sets the name of the person who creates the PDF document.
-     * @type {string}
      */
     PDFAuthor: string;
 
     /**
      * Returns or sets the compression type of PDF files. This is a runtime property.
-     * @type {EnumDWT_PDFCompressionType}
      */
     PDFCompressionType: EnumDWT_PDFCompressionType;
 
     /**
      * Returns or sets the date when the PDF document is created.
-     * @type {string}
      */
     PDFCreationDate: string;
 
     /**
      * Returns or sets the name of the application that created the original document, if the PDF document is converted from another form.
-     * @type {string}
      */
     PDFCreator: string;
 
     /**
      * Returns or sets the keywords associated with the PDF document.
-     * @type {string}
      */
     PDFKeywords: string;
 
     /**
      * Returns or sets the date when the PDF document is last modified.
-     * @type {string}
      */
     PDFModifiedDate: string;
 
     /**
      * Returns or sets the name of the application that converted the PDF document from its native.
-     * @type {string}
      */
     PDFProducer: string;
 
     /**
      * Returns or sets the subject of the PDF document.
-     * @type {string}
      */
     PDFSubject: string;
 
     /**
      * Returns or sets the title of the PDF document.
-     * @type {string}
      */
     PDFTitle: string;
 
     /**
      * Returns or sets the value of the PDF version.
-     * @type {string}
      */
     PDFVersion: string;
 
     /**
      * Returns the number of transfers the Source is ready to supply, upon demand. This is a runtime, read-only property.
-     * @type {short}
      */
     PendingXfers: number;
 
     /**
      * Returns or sets the pixel flavor for acquired images. This is a runtime property.
-     * @type {short}
      */
     PixelFlavor: number;
 
     /**
      * Returns or sets the pixel type of current data source. This is a runtime property. Using this property after calling OpenSource() method and before calling AcquireImage().
-     * @type {EnumDWT_PixelType}
      */
     PixelType: EnumDWT_PixelType;
 
     /**
      * Sets or returns the product family string for the application identity.
-     * @type {string}
      */
     ProductFamily: string;
 
     /**
      * Sets the product key. A product key is generated in Licensing Tool which is intalled with Dynamic Web TWAIN. Each product key corresponds with a license.
-     * @type {string}
      */
     ProductKey: string;
 
     /**
      * [Deprecated.] Returns or sets the name of the proxy server.
-     * @type {string}
      */
     ProxyServer: string;
 
     /**
      * Returns or sets the current resolution for acquired images. This is a runtime property.
-     * @type {float}
      */
     Resolution: number;
 
     /**
      * Returns or sets how many scanned images are selected.
-     * @type {short}
      */
     SelectedImagesCount: number;
 
     /**
      * Returns or sets the border color of the selected image. It is a value specifying the 24-bit RGB value.
-     * @type {int}
      */
     SelectionImageBorderColor: number;
 
     /**
      * Specifies a fixed aspect ratio to be used for selecting an area.
-     * @type {float}
      */
     SelectionRectAspectRatio: number;
 
     /**
      * Returns how many sources are installed in the system. This is a runtime, read-only property.
-     * @type {int}
      */
     SourceCount: number;
 
     /**
      * [Deprecated.] Replaced by GetSourceNameItems method.
-     * @type {string}
      */
     SourceNameItems: string;
 
     /**
      * [Deprecated.]
-     * @type {string}
      */
     GetSourceNames: string;
 
     /**
      * Returns or sets the compression type of TIFF files. This is a runtime property.
-     * @type {EnumDWT_TIFFCompressionType}
      */
     TIFFCompressionType: EnumDWT_TIFFCompressionType;
 
     /**
      * Sets or returns the transfer mode.
-     * @type {EnumDWT_TransferMode}
      */
     TransferMode: EnumDWT_TransferMode;
 
     /**
      * Returns or sets the unit of measure. This is a runtime property.
-     * @type {short}
      */
     Unit: number;
 
     /**
      * Sets or returns the version info string for the application identity.
-     * @type {string}
      */
     VersionInfo: string;
 
     /**
      * Returns and sets the number of images you are willing to transfer per session. This is a runtime property.
-     * @type {short}
      */
     XferCount: number;
 
     /**
      * Returns or sets zoom factor for the image, only valid When the view mode is set to -1 by -1.
-     * @type {float}
      */
     Zoom: number;
 

--- a/types/dwt/v13/addon.ocr.d.ts
+++ b/types/dwt/v13/addon.ocr.d.ts
@@ -59,7 +59,6 @@ declare enum EnumDWT_OCROutputFormat {
 }
 
 /**
- * @class
  */
 interface OCR {
     /**

--- a/types/dwt/v13/addon.pdf.d.ts
+++ b/types/dwt/v13/addon.pdf.d.ts
@@ -17,7 +17,6 @@ declare enum EnumDWT_ConverMode {
 }
 
 /**
- * @class
  */
 interface PDF {
     /**

--- a/types/dwt/v13/addon.webcam.d.ts
+++ b/types/dwt/v13/addon.webcam.d.ts
@@ -166,7 +166,6 @@ interface VideoPropertySetting {
 }
 
 /**
- * @class
  */
 interface Webcam {
     IsModuleInstalled(): boolean;

--- a/types/dwt/v13/index.d.ts
+++ b/types/dwt/v13/index.d.ts
@@ -1415,25 +1415,21 @@ interface LicenseDetailItem {
 }
 
 /**
- * @class
  */
 // properties (get/set) / sync functions
 interface WebTwain {
     /**
      * Returns whether the instance of a DWT is initialized
-     * @type {boolean}
      */
     bReady: boolean;
 
     /**
      * Returns the runtime id of the dwt object
-     * @type {string}
      */
     readonly clientId: string;
 
     /**
      * Returns the runtime class for the dwt container DIV
-     * @type {string}
      */
     containerClass: string;
 
@@ -1450,847 +1446,706 @@ interface WebTwain {
 
     /**
     * Returns or sets whether multi-page selection is supported.
-    * @type {boolean}
     */
     AllowMultiSelect: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether allowing the plugin to send authentication request. The default value of this property is TRUE.
-     * @type {boolean}
      */
     AllowPluginAuthentication: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the async mode is activated. With this mode, Dynamic Web TWAIN is able to upload/download files via HTTP/FTP asynchronously. The default value is false.
-     * @type {boolean}
      */
     AsyncMode: boolean;
 
     /**
      * Returns or sets the background color of the main control. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     BackgroundColor: number;
 
     /**
      * Returns or sets the fill color of the selected area of an image when it is cut, erased or rotated. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     BackgroundFillColor: number;
 
     /**
      * Returns or sets the pixel bit depths for the current value of PixelType property. This is a runtime property.
-     * @type {number}
      */
     BitDepth: number;
 
     /**
      * Returns the current deviation of the pixels in the image.
-     * @type {number}
      */
     readonly BlankImageCurrentStdDev: number;
 
     /**
      * Returns or sets the standard deviation of the pixels in the image.
-     * @type {number}
      */
     BlankImageMaxStdDev: number;
 
     /**
      * Returns or sets the dividing line between black and white. The default value is 128.
-     * @type {number}
      */
     BlankImageThreshold: number;
 
     /**
      * [Deprecated.] Returns or sets the border style.
-     * @type {EnumDWT_BorderStyle}
      */
     BorderStyle: EnumDWT_BorderStyle;
 
     /**
      * Returns or sets the brightness values available within the Source. This is a runtime property.
-     * @type {number}
      */
     Brightness: number;
 
     /**
      * [Deprecated.] Sets or returns whether brokerprocess is enabled for scanning.
-     * @type {number}
      */
     BrokerProcessType: number;
 
     /**
      * Sets or returns how much physical memory is allowed for storing images currently loaded in Dynamic Web TWAIN. Once the limit is reached, images will be cached on the hard disk.
-     * @type {number}
      */
     BufferMemoryLimit: number;
 
     /**
      * Sets or returns the index (0-based) of a list to indicate the Current Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {number}
      */
     CapCurrentIndex: number;
 
     /**
      * Sets or returns the current value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapCurrentValue: number;
 
     /**
      * Returns the index (0-based) of a list to indicate the Default Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly CapDefaultIndex: number;
 
     /**
      * Returns the default value in a range when the value of the CapType property is TWON_RANGE. This is a runtime, read-only property.
-     * @type {number}
      */
     CapDefaultValue: number;
 
     /**
      * Retruns the description for a capability
-     * @type {string}
      */
     CapDescription: string;
 
     /**
      * Sets or returns the maximum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapMaxValue: number;
 
     /**
      * Sets or returns the minimum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapMinValue: number;
 
     /**
      * [Deprecated.] Sets or returns how many items are in the list when the value of the CapType property is TWON_ARRAY or TWON_ENUMERATION. For String data type, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {number}
      */
     CapNumItems: number;
 
     /**
      * Sets or returns the step size in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapStepSize: number;
 
     /**
      * Sets or returns the type of capability container used to exchange capability information between application and source. This is a runtime property.
-     * @type {EnumDWT_CapType}
      */
     CapType: EnumDWT_CapType;
 
     /**
      * Returns or sets the value of the capability specified by Capability property when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {number}
      */
     CapValue: number;
 
     /**
      * Sets or returns the string value for a capability when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {string}
      */
     CapValueString: string;
 
     /**
      * Sets or returns the value type for reading the value of a capability. This is a runtime property.
-     * @type {number}
      */
     CapValueType: number;
 
     /**
      * Specifies the capabiltiy to be negotiated. This is a runtime property.
-     * @type {EnumDWT_Cap}
      */
     Capability: EnumDWT_Cap;
 
     /**
      * Returns or sets the contrast values available within the Source. This is a runtime property.
-     * @type {number}
      */
     Contrast: number;
 
     /**
      * Returns or sets current index of image in buffer. This is a runtime property.
-     * @type {number}
      */
     CurrentImageIndexInBuffer: number;
 
     /**
      * Returns the device name of current source. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly CurrentSourceName: string;
 
     /**
      * Returns the value indicating the data source status. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly DataSourceStatus: number;
 
     /**
      * Returns the device name of default source. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly DefaultSourceName: string;
 
     /**
      * Returns whether the source supports duplex. If so, it further returns the level of duplex the Source supports (one pass or two pass duplex). This is a runtime, read-only property.
-     * @type {EnumDWT_DUPLEX}
      */
     readonly Duplex: EnumDWT_DUPLEX;
 
     /**
      * [Deprecated.] Returns or sets whether the user can zoom image using hot key.
-     * @type {boolean}
      */
     EnableInteractiveZoom: boolean;
 
     /**
      * Returns the error code. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ErrorCode: number;
 
     /**
      * Returns the error string. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly ErrorString: string;
 
     /**
      * Returns or sets the password used to log into the FTP server.
-     * @type {string}
      */
     FTPPassword: string;
 
     /**
      * Returns or sets the port number of the FTP server.
-     * @type {number}
      */
     FTPPort: number;
 
     /**
      * Returns or sets the user name used to log into the FTP server.
-     * @type {string}
      */
     FTPUserName: string;
 
     /**
      * Returns or sets whether to resize the image to fit the image to the width or height of the window. To use the property, the view mode should be set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {EnumDWT_FitWindowType}
      */
     FitWindowType: EnumDWT_FitWindowType;
 
     /**
      * Returns the response string from the HTTP server if an error occurs for HTTPUploadThroughPost() method. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly HTTPPostResponseString: string;
 
     /**
      * Returns whether a HTTP request has credentials
-     * @type {boolean}
      */
     HTTPRequestswithCredentials: boolean;
 
     /**
      * Returns or sets the height of the dwt viewer object
-     * @type {string|number}
      */
     Height: string | number;
 
     /**
      * Returns how many images are in buffer. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly HowManyImagesInBuffer: number;
 
     /**
      * Specifies the content type of a http upload.
-     * @type {string}
      */
     HttpContentTypeFieldValue: string;
 
     /**
      * Specifies the field name of uploaded image through POST.
-     * @type {string}
      */
     HttpFieldNameOfUploadedImage: string;
 
     /**
      * [Deprecated.] Sets or returns the password used to log into the HTTP server.
-     * @type {string}
      */
     HTTPPassword: string;
 
     /**
      * Returns or sets the port number of the HTTP server.
-     * @type {number|string}
      */
     HTTPPort: number | string;
 
     /**
      * [Deprecated.] Returns or sets the user name used to log into the HTTP server.
-     * @type {string}
      */
     HTTPUserName: string;
 
     /**
      * Returns or sets whether the feature of disk caching is enabled.
-     * @type {boolean}
      */
     IfAllowLocalCache: boolean;
 
     /**
      * Returns or sets whether insert or append new scanned images.
-     * @type {boolean}
      */
     IfAppendImage: boolean;
 
     /**
      * Returns or sets whether the Source's Auto-brightness function is enabled. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoBright: boolean;
 
     /**
      * Returns or sets whether the data source (scanner) will discard blank images during scanning. The property works only if the device and its driver support discarding blank pages. You can find whether your device supports this capbility from its user manual. Or, you can use the built-in methods of Dynamic Web TWAIN to detect blank images: IsBlankImage, IsBlankImageEx.
-     * @type {boolean}
      */
     IfAutoDiscardBlankpages: boolean;
 
     /**
      * Returns or sets whether the Source enable automatic document feeding process. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoFeed: boolean;
 
     /**
      * Returns or sets whether the Source enables the automatic document scanning process. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoScan: boolean;
 
     /**
      * Specifies whether or not to automatically scroll to the last image or stay on the current image when loading or acquiring images
-     * @type {boolean}
      */
     IfAutoScroll: boolean;
 
     /**
      * Turns automatic border detection on and off. The property works only if the device and its driver support detecting the border automatically. You can find whether your device supports this capbility from its user manual.
-     * @type {boolean}
      */
     IfAutomaticBorderDetection: boolean;
 
     /**
      * Turns automatic skew correction on and off.
-     * @type {boolean}
      */
     IfAutomaticDeskew: boolean;
 
     /**
      * Returns or sets whether close the Data Source User Interface after acquire all images. Default value of this property is FALSE.
-     * @type {boolean}
      */
     IfDisableSourceAfterAcquire: boolean;
 
     /**
      * Returns or sets whether the Source supports duplex. If TRUE, the scanner scans both sides of a paper; otherwise, the scanner will scan only one side of the image. This is a runtime property.
-     * @type {boolean}
      */
     IfDuplexEnabled: boolean;
 
     /**
      * Returns or sets whether the Automatic Document Feeder (ADF) is enabled. This is a runtime property.
-     * @type {boolean}
      */
     IfFeederEnabled: boolean;
 
     /**
      * Returns whether or not there are documents loaded in the Source's feeder when IfFeederEnabled and IfPaperDetectable are TRUE. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfFeederLoaded: boolean;
 
     /**
      * Returns or sets whether to resize the image to fit the size of window when the view mode is set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {boolean}
      */
     IfFitWindow: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the UI (User Interface) of Source runs in modal state. Default value of this property is TRUE.
-     * @type {boolean}
      */
     IfModalUI: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses  Graphics Device Interface (GDI) when decoding images.
-     * @type {boolean}
      */
     IfOpenImageWithGDIPlus: boolean;
 
     /**
      * Returns or sets whether FTP passive mode is enabled.
-     * @type {boolean}
      */
     IfPASVMode: boolean;
 
     /**
      * Returns the value whether the Source has a paper sensor that can detect documents on the ADF or Flatbed. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfPaperDetectable: boolean;
 
     /**
      * Returns or sets whether SSL is used when uploading or downloading images.
-     * @type {boolean}
      */
     IfSSL: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether communicate with device in a separate thread. Default value of this property is FALSE.
-     * @type {boolean}
      */
     IfScanInNewThread: boolean;
 
     /**
      * Sets or returns whether to show the cancel dialog when uploading images to server.
-     * @type {boolean}
      */
     IfShowCancelDialogWhenImageTransfer: boolean;
 
     /**
      * Returns or sets whether to show the file dialog box when saving scanned images or loading images from local folder.
-     * @type {boolean}
      */
     IfShowFileDialog: boolean;
 
     /**
      * Returns or sets whether the Source displays a progress indicator during acquisition and transfer, regardless of whether the Source's user interface is active. This is a runtime property.
-     * @type {boolean}
      */
     IfShowIndicator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the driver of the printer displays the User Interface.
-     * @type {boolean}
      */
     IfShowPrintUI: boolean;
 
     /**
      * Returns or sets whether the progress bar will be displayed during the transaction. This is a runtime property.
-     * @type {boolean}
      */
     IfShowProgressBar: boolean;
 
     /**
      * Returns or sets whether the Source displays the User Interface.
-     * @type {boolean}
      */
     IfShowUI: boolean;
 
     /**
      * Returns or sets whether to throw exceptions
-     * @type {boolean}
      */
     IfThrowException: boolean;
 
     /**
      * Return or sets whether the Source allows to save many images in one TIFF file. The default value is FALSE.
-     * @type {boolean}
      */
     IfTiffMultiPage: boolean;
 
     /**
      * Returns whether the Source supports acquisition with the UI (User Interface) disabled. If FALSE, indicates that this Source can only support acquisition with the UI enabled. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfUIControllable: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses the new TWAIN Data Source Manager (TWAINDSM.dll) when acquiring images from TWAIN devices.
-     * @type {boolean}
      */
     IfUseTwainDSM: boolean;
 
     /**
      * [Deprecated.] The number of bits in each image pixel (or bit depth). This is a runtime, read-only property.
-     * @type {number}
      */
     ImageBitsPerPixel: number;
 
     /**
      * Returns or sets whether a TWAIN driver or Native Scan of Mac OS X is used for document scanning. This property works for Mac edition only.
-     * @type {number}
      */
     ImageCaptureDriverType: number;
 
     /**
      * [Deprecated.] Returns or sets whether the image enumerator is enabled in Image Editor.
-     * @type {boolean}
      */
     ImageEditorIfEnableEnumerator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is a modal window.
-     * @type {boolean}
      */
     ImageEditorIfModal: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is read-only.
-     * @type {boolean}
      */
     ImageEditorIfReadonly: boolean;
 
     /**
      * [Deprecated.] Returns or sets the title of Image Editor window.
-     * @type {string}
      */
     ImageEditorWindowTitle: string;
 
     /**
      * Returns the document number of the current image. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutDocumentNumber: number;
 
     /**
      * Returns the value of the bottom-most edge of the current image frame (in Unit). This is a read-only runtime property.
-     * @type {number}
      */
     readonly ImageLayoutFrameBottom: number;
 
     /**
      * Returns the value of the left-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameLeft: number;
 
     /**
      * Returns the frame number of the current image. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameNumber: number;
 
     /**
      * Returns the value of the right-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameRight: number;
 
     /**
      * Returns the value of the top-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameTop: number;
 
     /**
      * Returns the page number of the current image. This is a runtime, read-only property.
-     * @type {Long}
      */
     readonly ImageLayoutPageNumber: number;
 
     /**
      * [Deprecated.] Returns how tall/long, in pixels, the image is. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageLength: number;
 
     /**
      * Returns or sets the margin between images when multiple images are displayed in Dynamic Web TWAIN.
-     * @type {number}
      */
     ImageMargin: number;
 
     /**
      * Returns the pixel type of the current image. This is a runtime, read-only property. Please note the property is only valid in OnPreTransfer and OnPostTransfer event.
-     * @type {EnumDWT_PixelType}
      */
     readonly ImagePixelType: EnumDWT_PixelType;
 
     /**
      * [Deprecated.] Returns how width, in pixels, the image is. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageWidth: number;
 
     /**
      * [Deprecated.] Returns the X resolution of the current image. X resolution is the number of pixels per Unit in the horizontal direction. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageXResolution: number;
 
     /**
      * [Deprecated.] Returns the Y resolution of the current image. Y resolution is the number of pixels per Unit in the vertical direction. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageYResolution: number;
 
     /**
      * Returns or sets the quality of JPEG files and PDF files using JPEG compression.
-     * @type {number}
      */
     JPEGQuality: number;
 
     /**
      * Returns or sets the log level for debugging.
-     * @type {number}
      */
     LogLevel: number;
 
     /**
      * Return the magnetic data if the scanner support magnetic data recognition.
-     * @type {string}
      */
     readonly MagData: string;
 
     /**
      * Return the magnetic type if the scanner support magnetic data recognition.
-     * @type {number}
      */
     readonly MagType: number;
 
     /**
      * Sets or returns the manufacture string for the application identity.
-     * @type {string}
      */
     Manufacturer: string;
 
     /**
      * Returns or sets the maximum number of images can be held in buffer.
-     * @type {number}
      */
     MaxImagesInBuffer: number;
 
     /**
      * [Deprecated.] Returns or sets how many threads can be used when you upload files through POST.
-     * @type {number}
      */
     MaxInternetTransferThreads: number;
 
     /**
      * Sets or returns the maximum allowed size when Dynamic Web TWAIN uploads a document.
-     * @type {number}
      */
     MaxUploadImageSize: number;
 
     /**
      * Returns or sets the shape of the mouse.
-     * @type {boolean}
      */
     MouseShape: boolean;
 
     /**
      * Returns the X co-ordinate of the mouse. This is a runtime property.
-     * @type {number}
      */
     readonly MouseX: number;
 
     /**
      * Returns the Y co-ordinate of the mouse. This is a runtime property.
-     * @type {number}
      */
     readonly MouseY: number;
 
     /**
      * Returns or sets the name of the person who creates the PDF document.
-     * @type {string}
      */
     PDFAuthor: string;
 
     /**
      * Returns or sets the compression type of PDF files. This is a runtime property.
-     * @type {EnumDWT_PDFCompressionType}
      */
     PDFCompressionType: EnumDWT_PDFCompressionType;
 
     /**
      * Returns or sets the date when the PDF document is created.
-     * @type {string}
      */
     PDFCreationDate: string;
 
     /**
      * Returns or sets the name of the application that created the original document, if the PDF document is converted from another form.
-     * @type {string}
      */
     PDFCreator: string;
 
     /**
      * Returns or sets the keywords associated with the PDF document.
-     * @type {string}
      */
     PDFKeywords: string;
 
     /**
      * Returns or sets the date when the PDF document is last modified.
-     * @type {string}
      */
     PDFModifiedDate: string;
 
     /**
      * Returns or sets the name of the application that converted the PDF document from its native.
-     * @type {string}
      */
     PDFProducer: string;
 
     /**
      * Returns or sets the subject of the PDF document.
-     * @type {string}
      */
     PDFSubject: string;
 
     /**
      * Returns or sets the title of the PDF document.
-     * @type {string}
      */
     PDFTitle: string;
 
     /**
      * Returns or sets the value of the PDF version.
-     * @type {string}
      */
     PDFVersion: string;
 
     /**
      * Returns or sets the page size(s) the Source can/should use to acquire image data. This is a runtime property.
-     * @type {EnumDWT_CapSupportedSizes}
      */
     PageSize: EnumDWT_CapSupportedSizes;
 
     /**
      * Returns the number of transfers the Source is ready to supply, upon demand. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly PendingXfers: number;
 
     /**
      * Returns or sets the pixel flavor for acquired images. This is a runtime property.
-     * @type {number}
      */
     PixelFlavor: number;
 
     /**
      * Returns or sets the pixel type of current data source. This is a runtime property. Using this property after calling OpenSource() method and before calling AcquireImage().
-     * @type {EnumDWT_PixelType}
      */
     PixelType: EnumDWT_PixelType;
 
     /**
      * Sets or returns the product family string for the application identity.
-     * @type {string}
      */
     ProductFamily: string;
 
     /**
      * Sets the product key. A product key is generated in Licensing Tool which is intalled with Dynamic Web TWAIN. Each product key corresponds with a license.
-     * @type {string}
      */
     ProductKey: string;
 
     /**
      * Sets or returns the product name string for the application identity.
-     * @type {string}
      */
     ProductName: string;
 
     /**
      * [Deprecated.] Returns or sets the name of the proxy server.
-     * @type {string}
      */
     ProxyServer: string;
 
     /**
      * Returns or sets the current resolution for acquired images. This is a runtime property.
-     * @type {number}
      */
     Resolution: number;
 
     /**
      * Returns or sets how many scanned images are selected.
-     * @type {number}
      */
     SelectedImagesCount: number;
 
     /**
      * Returns or sets the border color of the selected image. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     SelectionImageBorderColor: number;
 
     /**
      * Specifies a fixed aspect ratio to be used for selecting an area.
-     * @type {number}
      */
     SelectionRectAspectRatio: number;
 
     /**
      * Specifies whether to show the page number
-     * @type {boolean}
      */
     ShowPageNumber: boolean;
 
     /**
      * Returns how many sources are installed in the system. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly SourceCount: number;
 
     /**
      * Returns or sets the compression type of TIFF files. This is a runtime property.
-     * @type {EnumDWT_TIFFCompressionType}
      */
     TIFFCompressionType: EnumDWT_TIFFCompressionType;
 
     /**
      * Sets or returns the transfer mode.
-     * @type {EnumDWT_TransferMode}
      */
     TransferMode: EnumDWT_TransferMode;
 
     /**
      * Returns or sets the unit of measure. This is a runtime property.
-     * @type {EnumDWT_UnitType}
      */
     Unit: EnumDWT_UnitType;
 
     /**
      * Specifies whether to show the vertical scroll bar
-     * @type {boolean}
      */
     VScrollBar: boolean;
 
     /**
      * Sets or returns the version info string for the application identity.
-     * @type {string}
      */
     readonly VersionInfo: string;
 
     /**
      * Returns or sets the width of the dwt object viewer
-     * @type {string|number}
      */
     Width: string | number;
 
     /**
      * Returns and sets the number of images you are willing to transfer per session. This is a runtime property.
-     * @type {number}
      */
     XferCount: number;
 
     /**
      * Returns or sets zoom factor for the image, only valid When the view mode is set to -1 by -1.
-     * @type {number}
      */
     Zoom: number;
 

--- a/types/dwt/v14/Dynamsoft.d.ts
+++ b/types/dwt/v14/Dynamsoft.d.ts
@@ -1419,25 +1419,21 @@ interface LicenseDetailItem {
 }
 
 /**
- * @class
  */
 // properties (get/set) / sync functions
 interface WebTwain {
     /**
      * Returns whether the instance of a DWT is initialized
-     * @type {boolean}
      */
     bReady: boolean;
 
     /**
      * Returns the runtime id of the dwt object
-     * @type {string}
      */
     readonly clientId: string;
 
     /**
      * Returns the runtime class for the dwt container DIV
-     * @type {string}
      */
     containerClass: string;
 
@@ -1454,847 +1450,706 @@ interface WebTwain {
 
     /**
     * Returns or sets whether multi-page selection is supported.
-    * @type {boolean}
     */
     AllowMultiSelect: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether allowing the plugin to send authentication request. The default value of this property is TRUE.
-     * @type {boolean}
      */
     AllowPluginAuthentication: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the async mode is activated. With this mode, Dynamic Web TWAIN is able to upload/download files via HTTP/FTP asynchronously. The default value is false.
-     * @type {boolean}
      */
     AsyncMode: boolean;
 
     /**
      * Returns or sets the background color of the main control. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     BackgroundColor: number;
 
     /**
      * Returns or sets the fill color of the selected area of an image when it is cut, erased or rotated. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     BackgroundFillColor: number;
 
     /**
      * Returns or sets the pixel bit depths for the current value of PixelType property. This is a runtime property.
-     * @type {number}
      */
     BitDepth: number;
 
     /**
      * Returns the current deviation of the pixels in the image.
-     * @type {number}
      */
     readonly BlankImageCurrentStdDev: number;
 
     /**
      * Returns or sets the standard deviation of the pixels in the image.
-     * @type {number}
      */
     BlankImageMaxStdDev: number;
 
     /**
      * Returns or sets the dividing line between black and white. The default value is 128.
-     * @type {number}
      */
     BlankImageThreshold: number;
 
     /**
      * [Deprecated.] Returns or sets the border style.
-     * @type {EnumDWT_BorderStyle}
      */
     BorderStyle: EnumDWT_BorderStyle;
 
     /**
      * Returns or sets the brightness values available within the Source. This is a runtime property.
-     * @type {number}
      */
     Brightness: number;
 
     /**
      * [Deprecated.] Sets or returns whether brokerprocess is enabled for scanning.
-     * @type {number}
      */
     BrokerProcessType: number;
 
     /**
      * Sets or returns how much physical memory is allowed for storing images currently loaded in Dynamic Web TWAIN. Once the limit is reached, images will be cached on the hard disk.
-     * @type {number}
      */
     BufferMemoryLimit: number;
 
     /**
      * Sets or returns the index (0-based) of a list to indicate the Current Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {number}
      */
     CapCurrentIndex: number;
 
     /**
      * Sets or returns the current value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapCurrentValue: number;
 
     /**
      * Returns the index (0-based) of a list to indicate the Default Value when the value of the CapType property is TWON_ENUMERATION. If the data type of the capability is String, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly CapDefaultIndex: number;
 
     /**
      * Returns the default value in a range when the value of the CapType property is TWON_RANGE. This is a runtime, read-only property.
-     * @type {number}
      */
     CapDefaultValue: number;
 
     /**
      * Retruns the description for a capability
-     * @type {string}
      */
     CapDescription: string;
 
     /**
      * Sets or returns the maximum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapMaxValue: number;
 
     /**
      * Sets or returns the minimum value in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapMinValue: number;
 
     /**
      * [Deprecated.] Sets or returns how many items are in the list when the value of the CapType property is TWON_ARRAY or TWON_ENUMERATION. For String data type, the list is in CapItemsString property. For other data types, the list is in CapItems property. This is a runtime property.
-     * @type {number}
      */
     CapNumItems: number;
 
     /**
      * Sets or returns the step size in a range when the value of the CapType property is TWON_RANGE. This is a runtime property.
-     * @type {number}
      */
     CapStepSize: number;
 
     /**
      * Sets or returns the type of capability container used to exchange capability information between application and source. This is a runtime property.
-     * @type {EnumDWT_CapType}
      */
     CapType: EnumDWT_CapType;
 
     /**
      * Returns or sets the value of the capability specified by Capability property when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {number}
      */
     CapValue: number;
 
     /**
      * Sets or returns the string value for a capability when the value of the CapType property is TWON_ONEVALUE. This is a runtime property.
-     * @type {string}
      */
     CapValueString: string;
 
     /**
      * Sets or returns the value type for reading the value of a capability. This is a runtime property.
-     * @type {number}
      */
     CapValueType: number;
 
     /**
      * Specifies the capabiltiy to be negotiated. This is a runtime property.
-     * @type {EnumDWT_Cap}
      */
     Capability: EnumDWT_Cap;
 
     /**
      * Returns or sets the contrast values available within the Source. This is a runtime property.
-     * @type {number}
      */
     Contrast: number;
 
     /**
      * Returns or sets current index of image in buffer. This is a runtime property.
-     * @type {number}
      */
     CurrentImageIndexInBuffer: number;
 
     /**
      * Returns the device name of current source. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly CurrentSourceName: string;
 
     /**
      * Returns the value indicating the data source status. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly DataSourceStatus: number;
 
     /**
      * Returns the device name of default source. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly DefaultSourceName: string;
 
     /**
      * Returns whether the source supports duplex. If so, it further returns the level of duplex the Source supports (one pass or two pass duplex). This is a runtime, read-only property.
-     * @type {EnumDWT_DUPLEX}
      */
     readonly Duplex: EnumDWT_DUPLEX;
 
     /**
      * [Deprecated.] Returns or sets whether the user can zoom image using hot key.
-     * @type {boolean}
      */
     EnableInteractiveZoom: boolean;
 
     /**
      * Returns the error code. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ErrorCode: number;
 
     /**
      * Returns the error string. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly ErrorString: string;
 
     /**
      * Returns or sets the password used to log into the FTP server.
-     * @type {string}
      */
     FTPPassword: string;
 
     /**
      * Returns or sets the port number of the FTP server.
-     * @type {number}
      */
     FTPPort: number;
 
     /**
      * Returns or sets the user name used to log into the FTP server.
-     * @type {string}
      */
     FTPUserName: string;
 
     /**
      * Returns or sets whether to resize the image to fit the image to the width or height of the window. To use the property, the view mode should be set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {EnumDWT_FitWindowType}
      */
     FitWindowType: EnumDWT_FitWindowType;
 
     /**
      * Returns the response string from the HTTP server if an error occurs for HTTPUploadThroughPost() method. This is a runtime, read-only property.
-     * @type {string}
      */
     readonly HTTPPostResponseString: string;
 
     /**
      * Returns whether a HTTP request has credentials
-     * @type {boolean}
      */
     HTTPRequestswithCredentials: boolean;
 
     /**
      * Returns or sets the height of the dwt viewer object
-     * @type {string|number}
      */
     Height: string | number;
 
     /**
      * Returns how many images are in buffer. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly HowManyImagesInBuffer: number;
 
     /**
      * Specifies the content type of a http upload.
-     * @type {string}
      */
     HttpContentTypeFieldValue: string;
 
     /**
      * Specifies the field name of uploaded image through POST.
-     * @type {string}
      */
     HttpFieldNameOfUploadedImage: string;
 
     /**
      * [Deprecated.] Sets or returns the password used to log into the HTTP server.
-     * @type {string}
      */
     HTTPPassword: string;
 
     /**
      * Returns or sets the port number of the HTTP server.
-     * @type {number|string}
      */
     HTTPPort: number | string;
 
     /**
      * [Deprecated.] Returns or sets the user name used to log into the HTTP server.
-     * @type {string}
      */
     HTTPUserName: string;
 
     /**
      * Returns or sets whether the feature of disk caching is enabled.
-     * @type {boolean}
      */
     IfAllowLocalCache: boolean;
 
     /**
      * Returns or sets whether insert or append new scanned images.
-     * @type {boolean}
      */
     IfAppendImage: boolean;
 
     /**
      * Returns or sets whether the Source's Auto-brightness function is enabled. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoBright: boolean;
 
     /**
      * Returns or sets whether the data source (scanner) will discard blank images during scanning. The property works only if the device and its driver support discarding blank pages. You can find whether your device supports this capbility from its user manual. Or, you can use the built-in methods of Dynamic Web TWAIN to detect blank images: IsBlankImage, IsBlankImageEx.
-     * @type {boolean}
      */
     IfAutoDiscardBlankpages: boolean;
 
     /**
      * Returns or sets whether the Source enable automatic document feeding process. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoFeed: boolean;
 
     /**
      * Returns or sets whether the Source enables the automatic document scanning process. This is a runtime property.
-     * @type {boolean}
      */
     IfAutoScan: boolean;
 
     /**
      * Specifies whether or not to automatically scroll to the last image or stay on the current image when loading or acquiring images
-     * @type {boolean}
      */
     IfAutoScroll: boolean;
 
     /**
      * Turns automatic border detection on and off. The property works only if the device and its driver support detecting the border automatically. You can find whether your device supports this capbility from its user manual.
-     * @type {boolean}
      */
     IfAutomaticBorderDetection: boolean;
 
     /**
      * Turns automatic skew correction on and off.
-     * @type {boolean}
      */
     IfAutomaticDeskew: boolean;
 
     /**
      * Returns or sets whether close the Data Source User Interface after acquire all images. Default value of this property is FALSE.
-     * @type {boolean}
      */
     IfDisableSourceAfterAcquire: boolean;
 
     /**
      * Returns or sets whether the Source supports duplex. If TRUE, the scanner scans both sides of a paper; otherwise, the scanner will scan only one side of the image. This is a runtime property.
-     * @type {boolean}
      */
     IfDuplexEnabled: boolean;
 
     /**
      * Returns or sets whether the Automatic Document Feeder (ADF) is enabled. This is a runtime property.
-     * @type {boolean}
      */
     IfFeederEnabled: boolean;
 
     /**
      * Returns whether or not there are documents loaded in the Source's feeder when IfFeederEnabled and IfPaperDetectable are TRUE. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfFeederLoaded: boolean;
 
     /**
      * Returns or sets whether to resize the image to fit the size of window when the view mode is set to -1 by -1. You can use SetViewMode method to set the view mode.
-     * @type {boolean}
      */
     IfFitWindow: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the UI (User Interface) of Source runs in modal state. Default value of this property is TRUE.
-     * @type {boolean}
      */
     IfModalUI: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses  Graphics Device Interface (GDI) when decoding images.
-     * @type {boolean}
      */
     IfOpenImageWithGDIPlus: boolean;
 
     /**
      * Returns or sets whether FTP passive mode is enabled.
-     * @type {boolean}
      */
     IfPASVMode: boolean;
 
     /**
      * Returns the value whether the Source has a paper sensor that can detect documents on the ADF or Flatbed. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfPaperDetectable: boolean;
 
     /**
      * Returns or sets whether SSL is used when uploading or downloading images.
-     * @type {boolean}
      */
     IfSSL: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether communicate with device in a separate thread. Default value of this property is FALSE.
-     * @type {boolean}
      */
     IfScanInNewThread: boolean;
 
     /**
      * Sets or returns whether to show the cancel dialog when uploading images to server.
-     * @type {boolean}
      */
     IfShowCancelDialogWhenImageTransfer: boolean;
 
     /**
      * Returns or sets whether to show the file dialog box when saving scanned images or loading images from local folder.
-     * @type {boolean}
      */
     IfShowFileDialog: boolean;
 
     /**
      * Returns or sets whether the Source displays a progress indicator during acquisition and transfer, regardless of whether the Source's user interface is active. This is a runtime property.
-     * @type {boolean}
      */
     IfShowIndicator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the driver of the printer displays the User Interface.
-     * @type {boolean}
      */
     IfShowPrintUI: boolean;
 
     /**
      * Returns or sets whether the progress bar will be displayed during the transaction. This is a runtime property.
-     * @type {boolean}
      */
     IfShowProgressBar: boolean;
 
     /**
      * Returns or sets whether the Source displays the User Interface.
-     * @type {boolean}
      */
     IfShowUI: boolean;
 
     /**
      * Returns or sets whether to throw exceptions
-     * @type {boolean}
      */
     IfThrowException: boolean;
 
     /**
      * Return or sets whether the Source allows to save many images in one TIFF file. The default value is FALSE.
-     * @type {boolean}
      */
     IfTiffMultiPage: boolean;
 
     /**
      * Returns whether the Source supports acquisition with the UI (User Interface) disabled. If FALSE, indicates that this Source can only support acquisition with the UI enabled. This is a runtime, read-only property.
-     * @type {boolean}
      */
     readonly IfUIControllable: boolean;
 
     /**
      * Sets or returns whether Dynamic Web TWAIN uses the new TWAIN Data Source Manager (TWAINDSM.dll) when acquiring images from TWAIN devices.
-     * @type {boolean}
      */
     IfUseTwainDSM: boolean;
 
     /**
      * [Deprecated.] The number of bits in each image pixel (or bit depth). This is a runtime, read-only property.
-     * @type {number}
      */
     ImageBitsPerPixel: number;
 
     /**
      * Returns or sets whether a TWAIN driver or Native Scan of Mac OS X is used for document scanning. This property works for Mac edition only.
-     * @type {number}
      */
     ImageCaptureDriverType: number;
 
     /**
      * [Deprecated.] Returns or sets whether the image enumerator is enabled in Image Editor.
-     * @type {boolean}
      */
     ImageEditorIfEnableEnumerator: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is a modal window.
-     * @type {boolean}
      */
     ImageEditorIfModal: boolean;
 
     /**
      * [Deprecated.] Returns or sets whether the Image Editor is read-only.
-     * @type {boolean}
      */
     ImageEditorIfReadonly: boolean;
 
     /**
      * [Deprecated.] Returns or sets the title of Image Editor window.
-     * @type {string}
      */
     ImageEditorWindowTitle: string;
 
     /**
      * Returns the document number of the current image. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutDocumentNumber: number;
 
     /**
      * Returns the value of the bottom-most edge of the current image frame (in Unit). This is a read-only runtime property.
-     * @type {number}
      */
     readonly ImageLayoutFrameBottom: number;
 
     /**
      * Returns the value of the left-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameLeft: number;
 
     /**
      * Returns the frame number of the current image. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameNumber: number;
 
     /**
      * Returns the value of the right-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameRight: number;
 
     /**
      * Returns the value of the top-most edge of the current image frame (in Unit). This is a runtime, read-only property.
-     * @type {number}
      */
     readonly ImageLayoutFrameTop: number;
 
     /**
      * Returns the page number of the current image. This is a runtime, read-only property.
-     * @type {Long}
      */
     readonly ImageLayoutPageNumber: number;
 
     /**
      * [Deprecated.] Returns how tall/long, in pixels, the image is. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageLength: number;
 
     /**
      * Returns or sets the margin between images when multiple images are displayed in Dynamic Web TWAIN.
-     * @type {number}
      */
     ImageMargin: number;
 
     /**
      * Returns the pixel type of the current image. This is a runtime, read-only property. Please note the property is only valid in OnPreTransfer and OnPostTransfer event.
-     * @type {EnumDWT_PixelType}
      */
     readonly ImagePixelType: EnumDWT_PixelType;
 
     /**
      * [Deprecated.] Returns how width, in pixels, the image is. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageWidth: number;
 
     /**
      * [Deprecated.] Returns the X resolution of the current image. X resolution is the number of pixels per Unit in the horizontal direction. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageXResolution: number;
 
     /**
      * [Deprecated.] Returns the Y resolution of the current image. Y resolution is the number of pixels per Unit in the vertical direction. This is a runtime, read-only property.
-     * @type {number}
      */
     ImageYResolution: number;
 
     /**
      * Returns or sets the quality of JPEG files and PDF files using JPEG compression.
-     * @type {number}
      */
     JPEGQuality: number;
 
     /**
      * Returns or sets the log level for debugging.
-     * @type {number}
      */
     LogLevel: number;
 
     /**
      * Return the magnetic data if the scanner support magnetic data recognition.
-     * @type {string}
      */
     readonly MagData: string;
 
     /**
      * Return the magnetic type if the scanner support magnetic data recognition.
-     * @type {number}
      */
     readonly MagType: number;
 
     /**
      * Sets or returns the manufacture string for the application identity.
-     * @type {string}
      */
     Manufacturer: string;
 
     /**
      * Returns or sets the maximum number of images can be held in buffer.
-     * @type {number}
      */
     MaxImagesInBuffer: number;
 
     /**
      * [Deprecated.] Returns or sets how many threads can be used when you upload files through POST.
-     * @type {number}
      */
     MaxInternetTransferThreads: number;
 
     /**
      * Sets or returns the maximum allowed size when Dynamic Web TWAIN uploads a document.
-     * @type {number}
      */
     MaxUploadImageSize: number;
 
     /**
      * Returns or sets the shape of the mouse.
-     * @type {boolean}
      */
     MouseShape: boolean;
 
     /**
      * Returns the X co-ordinate of the mouse. This is a runtime property.
-     * @type {number}
      */
     readonly MouseX: number;
 
     /**
      * Returns the Y co-ordinate of the mouse. This is a runtime property.
-     * @type {number}
      */
     readonly MouseY: number;
 
     /**
      * Returns or sets the name of the person who creates the PDF document.
-     * @type {string}
      */
     PDFAuthor: string;
 
     /**
      * Returns or sets the compression type of PDF files. This is a runtime property.
-     * @type {EnumDWT_PDFCompressionType}
      */
     PDFCompressionType: EnumDWT_PDFCompressionType;
 
     /**
      * Returns or sets the date when the PDF document is created.
-     * @type {string}
      */
     PDFCreationDate: string;
 
     /**
      * Returns or sets the name of the application that created the original document, if the PDF document is converted from another form.
-     * @type {string}
      */
     PDFCreator: string;
 
     /**
      * Returns or sets the keywords associated with the PDF document.
-     * @type {string}
      */
     PDFKeywords: string;
 
     /**
      * Returns or sets the date when the PDF document is last modified.
-     * @type {string}
      */
     PDFModifiedDate: string;
 
     /**
      * Returns or sets the name of the application that converted the PDF document from its native.
-     * @type {string}
      */
     PDFProducer: string;
 
     /**
      * Returns or sets the subject of the PDF document.
-     * @type {string}
      */
     PDFSubject: string;
 
     /**
      * Returns or sets the title of the PDF document.
-     * @type {string}
      */
     PDFTitle: string;
 
     /**
      * Returns or sets the value of the PDF version.
-     * @type {string}
      */
     PDFVersion: string;
 
     /**
      * Returns or sets the page size(s) the Source can/should use to acquire image data. This is a runtime property.
-     * @type {EnumDWT_CapSupportedSizes}
      */
     PageSize: EnumDWT_CapSupportedSizes;
 
     /**
      * Returns the number of transfers the Source is ready to supply, upon demand. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly PendingXfers: number;
 
     /**
      * Returns or sets the pixel flavor for acquired images. This is a runtime property.
-     * @type {number}
      */
     PixelFlavor: number;
 
     /**
      * Returns or sets the pixel type of current data source. This is a runtime property. Using this property after calling OpenSource() method and before calling AcquireImage().
-     * @type {EnumDWT_PixelType}
      */
     PixelType: EnumDWT_PixelType;
 
     /**
      * Sets or returns the product family string for the application identity.
-     * @type {string}
      */
     ProductFamily: string;
 
     /**
      * Sets the product key. A product key is generated in Licensing Tool which is intalled with Dynamic Web TWAIN. Each product key corresponds with a license.
-     * @type {string}
      */
     ProductKey: string;
 
     /**
      * Sets or returns the product name string for the application identity.
-     * @type {string}
      */
     ProductName: string;
 
     /**
      * [Deprecated.] Returns or sets the name of the proxy server.
-     * @type {string}
      */
     ProxyServer: string;
 
     /**
      * Returns or sets the current resolution for acquired images. This is a runtime property.
-     * @type {number}
      */
     Resolution: number;
 
     /**
      * Returns or sets how many scanned images are selected.
-     * @type {number}
      */
     SelectedImagesCount: number;
 
     /**
      * Returns or sets the border color of the selected image. It is a value specifying the 24-bit RGB value.
-     * @type {number}
      */
     SelectionImageBorderColor: number;
 
     /**
      * Specifies a fixed aspect ratio to be used for selecting an area.
-     * @type {number}
      */
     SelectionRectAspectRatio: number;
 
     /**
      * Specifies whether to show the page number
-     * @type {boolean}
      */
     ShowPageNumber: boolean;
 
     /**
      * Returns how many sources are installed in the system. This is a runtime, read-only property.
-     * @type {number}
      */
     readonly SourceCount: number;
 
     /**
      * Returns or sets the compression type of TIFF files. This is a runtime property.
-     * @type {EnumDWT_TIFFCompressionType}
      */
     TIFFCompressionType: EnumDWT_TIFFCompressionType;
 
     /**
      * Sets or returns the transfer mode.
-     * @type {EnumDWT_TransferMode}
      */
     TransferMode: EnumDWT_TransferMode;
 
     /**
      * Returns or sets the unit of measure. This is a runtime property.
-     * @type {EnumDWT_UnitType}
      */
     Unit: EnumDWT_UnitType;
 
     /**
      * Specifies whether to show the vertical scroll bar
-     * @type {boolean}
      */
     VScrollBar: boolean;
 
     /**
      * Sets or returns the version info string for the application identity.
-     * @type {string}
      */
     readonly VersionInfo: string;
 
     /**
      * Returns or sets the width of the dwt object viewer
-     * @type {string|number}
      */
     Width: string | number;
 
     /**
      * Returns and sets the number of images you are willing to transfer per session. This is a runtime property.
-     * @type {number}
      */
     XferCount: number;
 
     /**
      * Returns or sets zoom factor for the image, only valid When the view mode is set to -1 by -1.
-     * @type {number}
      */
     Zoom: number;
 

--- a/types/dwt/v14/addon.ocr.d.ts
+++ b/types/dwt/v14/addon.ocr.d.ts
@@ -59,7 +59,6 @@ declare enum EnumDWT_OCROutputFormat {
 }
 
 /**
- * @class
  */
 interface OCR {
     /**

--- a/types/dwt/v14/addon.pdf.d.ts
+++ b/types/dwt/v14/addon.pdf.d.ts
@@ -17,7 +17,6 @@ declare enum EnumDWT_ConverMode {
 }
 
 /**
- * @class
  */
 interface PDF {
     /**

--- a/types/dwt/v14/addon.webcam.d.ts
+++ b/types/dwt/v14/addon.webcam.d.ts
@@ -168,7 +168,6 @@ interface VideoPropertySetting {
 }
 
 /**
- * @class
  */
 interface Webcam {
     IsModuleInstalled(): boolean;

--- a/types/dynatable/index.d.ts
+++ b/types/dynatable/index.d.ts
@@ -8,7 +8,6 @@
 
 interface JQuery {
     /**
-    * @constructor
     */
     dynatable: JQueryDynatable.Dynatable;
 }

--- a/types/ember/v1/index.d.ts
+++ b/types/ember/v1/index.d.ts
@@ -935,8 +935,6 @@ declare namespace Ember {
 
         /**
         Defines the properties that will be concatenated from the superclass (instead of overridden).
-        @property concatenatedProperties
-        @type Array
         @default null
         **/
         concatenatedProperties: any[];
@@ -944,14 +942,12 @@ declare namespace Ember {
         /**
         Destroyed object property flag. If this property is true the observers and bindings were
         already removed by the effect of calling the destroy() method.
-        @property isDestroyed
         @default false
         **/
         isDestroyed: boolean;
         /**
         Destruction scheduled flag. The destroy() method has been called. The object stays intact
         until the end of the run loop at which point the isDestroyed flag is set.
-        @property isDestroying
         @default false
         **/
         isDestroying: boolean;
@@ -1792,11 +1788,9 @@ declare namespace Ember {
               primary way of interacting with a promise is through its `then` method, which
               registers callbacks to receive either a promise's eventual value or the reason
               why the promise cannot be fulfilled.
-              @class RSVP.Promise
               @param {function} resolver
               @param {String} label optional string for labeling the promise.
               Useful for tooling.
-              @constructor
             */
             constructor(resolver: PromiseResolverFunction, label?: string);
 
@@ -1927,8 +1921,6 @@ declare namespace Ember {
         /**
         The controller associated with this route.
 
-        @property controller
-        @type Ember.Controller
         @since 1.6.0
         */
         controller: Controller;
@@ -1954,8 +1946,6 @@ declare namespace Ember {
         * passed to the `setupController` method.
         * used as the controller for the view being rendered by the route.
         * returned from a call to `controllerFor` for the route.
-        @property controllerName
-        @type String
         @default null
         @since 1.4.0
         */
@@ -2062,11 +2052,9 @@ declare namespace Ember {
 
         /**
         Configuration hash for this route's queryParams.
-        @property queryParams
         @for Ember.Route
-        @type Hash
         */
-        queryParams: {};
+        queryParams: Record<string, any>;
 
         /**
         Refresh the model on this route and any child routes, firing the
@@ -2236,8 +2224,6 @@ declare namespace Ember {
         This is similar with `viewName`, but is useful when you just want a custom
         template without a view.
 
-        @property templateName
-        @type String
         @default null
         @since 1.4.0
         */
@@ -2265,8 +2251,6 @@ declare namespace Ember {
         define a specific view, set this property.
         This is useful when multiple routes would benefit from using the same view
         because it doesn't require a custom `renderTemplate` method.
-        @property viewName
-        @type String
         @default null
         @since 1.4.0
         */
@@ -2308,8 +2292,6 @@ declare namespace Ember {
         on the `actions` hash handles it. To continue bubbling the action,
         you must return `true` from the handler
 
-        @property actions
-        @type Hash
         @default null
         */
         actions: ActionsHash;

--- a/types/express-brute-memcached/index.d.ts
+++ b/types/express-brute-memcached/index.d.ts
@@ -13,97 +13,81 @@ export interface MemcachedStoreOptions {
 
     /**
      * @summary Maximum key size allowed.
-     * @type {number}
      */
     maxKeySize: number;
 
     /**
      * @summary Maximum expiration time of keys (in seconds).
-     * @type {number}
      */
     maxExpiration: number;
 
     /**
      * @summary Maximum size of a value.
-     * @type {number}
      */
     maxValue: number;
 
     /**
      * @summary Maximum size of the connection pool.
-     * @type {number}
      */
     poolSize: number;
 
     /**
      * @summary Hashing algorithm used to generate the  hashRing  values
-     * @type {string}
      */
     algorithm: string;
 
     /**
      * @summary Time between reconnection attempts (in milliseconds).
-     * @type {number}
      */
     reconnect: number;
 
     /**
      * @summary Time after which Memcached sends a connection timeout (in milliseconds).
-     * @type {number}
      */
     timeout: number;
 
     /**
      * @summary Number of socket allocation retries per request.
-     * @type {number}
      */
     retries: number;
 
     /**
      * @summary Number of failed-attempts to a server before it is regarded as 'dead'.
-     * @type {number}
      */
     failures: number;
 
     /**
      * @summary Time between a server failure and an attempt to set it up back in service.
-     * @type {number}
      */
     retry: number;
 
     /**
      * @summary If true, authorizes the automatic removal of dead servers from the pool.
-     * @type {boolean}
      */
     remove: boolean;
 
     /**
      * @summary An array of  server_locations  to replace servers that fail and that are removed from the consistent hashing scheme.
-     * @type {Array}
      */
     failOverServers: Array<any>;
 
     /**
      * @summary True, whether to use  md5  as hashing scheme when keys exceed  maxKeySize .
-     * @type
      */
     keyCompression: boolean;
 
     /**
      * @summary Idle timeout for the connections.
-     * @type {number}
      */
     idle: number;
 }
 
 /**
  * @summary A memcached store adapter.
- * @class
  */
 export default class MemcachedStore {
     /**
      * @summary Constructor.
-     * @constructor
      * @param {string|Array}    hosts   The collection.
      * @param {Object}          options The otpions.
      */

--- a/types/express-brute/index.d.ts
+++ b/types/express-brute/index.d.ts
@@ -9,12 +9,10 @@ import express = require('express');
 
 /**
  * @summary Middleware.
- * @class
  */
 declare class ExpressBrute {
     /**
      * @summary Constructor.
-     * @constructor
      * @param {any} store The store.
      */
     constructor(store: any, options?: ExpressBrute.Options);
@@ -52,7 +50,6 @@ declare namespace ExpressBrute {
     export interface MemoryStoreOptions {
         /**
          * @summary Key prefix.
-         * @type {string}
          */
         prefix: string;
     }
@@ -71,19 +68,16 @@ declare namespace ExpressBrute {
     export interface Middleware {
         /**
          * @summary Allows you to override the value of failCallback for this middleware.
-         * @type {FailCallback}
          */
         failCallback?: FailCallback | undefined;
 
         /**
          * @summary Disregard IP address when matching requests if set to true. Defaults to false.
-         * @type {boolean}
          */
         ignoreIP?: boolean | undefined;
 
         /**
          * @summary Key.
-         * @type {Function}
          */
         key?: ((req: express.Request, res: express.Response, next: express.NextFunction) => any) | undefined;
     }
@@ -129,12 +123,10 @@ declare namespace ExpressBrute {
 
     /**
      * @summary In-memory store.
-     * @class
      */
     export class MemoryStore {
         /**
          * @summary Constructor.
-         * @constructor
          * @param {Object} options The options.
          */
         constructor(options?: MemoryStoreOptions);

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -606,12 +606,10 @@ type IGradientOptionsColorStops = Array<{
 interface IGradientOptions {
     /**
      * Horizontal offset for aligning gradients coming from SVG when outside pathgroups
-     * @type Number
      */
     offsetX?: number | undefined;
     /**
      * Vertical offset for aligning gradients coming from SVG when outside pathgroups
-     * @type Number
      */
     offsetY?: number | undefined;
     type?: string | undefined;
@@ -747,7 +745,6 @@ interface IPatternOptions {
     /**
      * crossOrigin value (one of "", "anonymous", "use-credentials")
      * @see https://developer.mozilla.org/en-US/docs/HTML/CORS_settings_attributes
-     * @type String
      */
     crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined;
     /**
@@ -1005,7 +1002,6 @@ interface IShadowOptions {
      * When `false`, the shadow will scale with the object.
      * When `true`, the shadow's offsetX, offsetY, and blur will not be affected by the object's scale.
      * default to false
-     * @type Boolean
      * @default
      */
     nonScaling?: boolean | undefined;
@@ -1068,7 +1064,6 @@ interface IStaticCanvasOptions {
     /**
      * Background color of canvas instance.
      * Should be set via {@link fabric.StaticCanvas#setBackgroundColor}.
-     * @type {(String|fabric.Pattern)}
      */
     backgroundColor?: string | Pattern | undefined;
     /**
@@ -1080,14 +1075,12 @@ interface IStaticCanvasOptions {
      * since 2.4.0 image caching is active, please when putting an image as background, add to the
      * canvas property a reference to the canvas it is on. Otherwise the image cannot detect the zoom
      * vale. As an alternative you can disable image objectCaching
-     * @type fabric.Image
      */
     backgroundImage?: Image | string | undefined;
     /**
      * Overlay color of canvas instance.
      * Should be set via {@link fabric.StaticCanvas#setOverlayColor}
      * @since 1.3.9
-     * @type {(String|fabric.Pattern)}
      */
     overlayColor?: string | Pattern | undefined;
     /**
@@ -1099,18 +1092,15 @@ interface IStaticCanvasOptions {
      * since 2.4.0 image caching is active, please when putting an image as overlay, add to the
      * canvas property a reference to the canvas it is on. Otherwise the image cannot detect the zoom
      * vale. As an alternative you can disable image objectCaching
-     * @type fabric.Image
      */
     overlayImage?: Image | undefined;
     /**
      * Indicates whether toObject/toDatalessObject should include default values
      * if set to false, takes precedence over the object value.
-     * @type Boolean
      */
     includeDefaultValues?: boolean | undefined;
     /**
      * Indicates whether objects' state should be saved
-     * @type Boolean
      */
     stateful?: boolean | undefined;
     /**
@@ -1120,17 +1110,14 @@ interface IStaticCanvasOptions {
      * since the renders are quequed and executed one per frame.
      * Disabling is suggested anyway and managing the renders of the app manually is not a big effort ( canvas.requestRenderAll() )
      * Left default to true to do not break documentation and old app, fiddles.
-     * @type Boolean
      */
     renderOnAddRemove?: boolean | undefined;
     /**
      * Indicates whether object controls (borders/controls) are rendered above overlay image
-     * @type Boolean
      */
     controlsAboveOverlay?: boolean | undefined;
     /**
      * Indicates whether the browser can be scrolled when using a touchscreen and dragging on the canvas
-     * @type Boolean
      */
     allowTouchScrolling?: boolean | undefined;
     /**
@@ -1144,18 +1131,15 @@ interface IStaticCanvasOptions {
     /**
      * if set to false background image is not affected by viewport transform
      * @since 1.6.3
-     * @type Boolean
      */
     backgroundVpt?: boolean | undefined;
     /**
      * if set to false overlay image is not affected by viewport transform
      * @since 1.6.3
-     * @type Boolean
      */
     overlayVpt?: boolean | undefined;
     /**
      * When true, canvas is scaled by devicePixelRatio for better rendering on retina screens
-     * @type Boolean
      */
     enableRetinaScaling?: boolean | undefined;
     /**
@@ -1180,7 +1164,6 @@ interface IStaticCanvasOptions {
      * If One of the corner of the bounding box of the object is on the canvas
      * the objects get rendered.
      * @memberOf fabric.StaticCanvas.prototype
-     * @type Boolean
      */
     skipOffscreen?: boolean | undefined;
     /**
@@ -1188,13 +1171,11 @@ interface IStaticCanvasOptions {
      * the clipPath object gets used when the canvas has rendered, and the context is placed in the
      * top left corner of the canvas.
      * clipPath will clip away controls, if you do not want this to happen use controlsAboveOverlay = true
-     * @type fabric.Object
      */
     clipPath?: Object | undefined;
     /**
      * When true, getSvgTransform() will apply the StaticCanvas.viewportTransform to the SVG transformation. When true,
      * a zoomed canvas will then produce zoomed SVG output.
-     * @type Boolean
      */
     svgViewportTransformation?: boolean | undefined;
 }
@@ -1392,7 +1373,6 @@ export class StaticCanvas {
      * Let the fabricJS call it. If you call it manually you could have more
      * animationFrame stacking on to of each other
      * for an imperative rendering, use canvas.renderAll
-     * @private
      * @return {fabric.Canvas} instance
      * @chainable
      */
@@ -1594,7 +1574,6 @@ export class StaticCanvas {
 
     /**
      * @static
-     * @type String
      * @default
      */
     static EMPTY_JSON: string;
@@ -1698,7 +1677,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
     /**
      * When true, objects can be transformed by one side (unproportionally)
      * when dragged on the corners that normally would not do that.
-     * @type Boolean
      * @default
      * @since fabric 4.0 // changed name and default value
      */
@@ -1710,7 +1688,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * If `null` or 'none' or any other string that is not a modifier key
      * feature is disabled feature disabled.
      * @since 1.6.2
-     * @type String
      */
     uniScaleKey?: string | undefined;
 
@@ -1737,7 +1714,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * If `null` or 'none' or any other string that is not a modifier key
      * feature is disabled feature disabled.
      * @since 1.6.2
-     * @type String
      * @default
      */
     centeredKey?: string | undefined;
@@ -1748,7 +1724,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * If `null` or 'none' or any other string that is not a modifier key
      * feature is disabled feature disabled.
      * @since 1.6.2
-     * @type String
      * @default
      */
     altActionKey?: string | undefined;
@@ -1770,7 +1745,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * If `null` or empty or containing any other string that is not a modifier key
      * feature is disabled.
      * @since 1.6.2
-     * @type String|Array
      * @default
      */
     selectionKey?: string | string[] | undefined;
@@ -1784,7 +1758,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * If `null` or 'none' or any other string that is not a modifier key
      * feature is disabled.
      * @since 1.6.5
-     * @type null|String
      * @default
      */
     altSelectionKey?: string | null | undefined;
@@ -1812,7 +1785,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Select only shapes that are fully contained in the dragged selection rectangle.
-     * @type Boolean
      * @default
      */
     selectionFullyContained?: boolean | undefined;
@@ -1844,7 +1816,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Cursor value used for disabled elements ( corners with disabled action )
-     * @type String
      * @since 2.0.0
      * @default
      */
@@ -1880,13 +1851,11 @@ interface ICanvasOptions extends IStaticCanvasOptions {
     /**
      * Indicates whether objects should remain in current stack position when selected.
      * When false objects are brought to top and rendered as part of the selection group
-     * @type Boolean
      */
     preserveObjectStacking?: boolean | undefined;
 
     /**
      * Indicates the angle that an object will lock to while rotating.
-     * @type Number
      * @since 1.6.7
      */
     snapAngle?: number | undefined;
@@ -1894,7 +1863,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
     /**
      * Indicates the distance from the snapAngle the rotation will lock to the snapAngle.
      * When `null`, the snapThreshold will default to the snapAngle.
-     * @type null|Number
      * @since 1.6.7
      * @default
      */
@@ -1902,7 +1870,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Indicates if the right click on canvas can output the context menu or not
-     * @type Boolean
      * @since 1.6.5
      * @default
      */
@@ -1910,7 +1877,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Indicates if the canvas can fire right click events
-     * @type Boolean
      * @since 1.6.5
      * @default
      */
@@ -1918,7 +1884,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Indicates if the canvas can fire middle click events
-     * @type Boolean
      * @since 1.7.8
      * @default
      */
@@ -1926,7 +1891,6 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Keep track of the subTargets for Mouse Events
-     * @type {Array.<fabric.Object>}
      * @since 3.6.0
      * @default
      */
@@ -1934,14 +1898,12 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 
     /**
      * Canvas width
-     * @type number
      * @default
      */
     width?: number | undefined;
 
     /**
      * Canvas height
-     * @type number
      * @default
      */
     height?: number | undefined;
@@ -1965,7 +1927,6 @@ export class Canvas {
 
     /**
      * When true, target detection is skipped when hovering over canvas. This can be used to improve performance.
-     * @type Boolean
      * @default
      */
     skipTargetFind: boolean;
@@ -1981,7 +1942,6 @@ export class Canvas {
      * If `null` or 'none' or any other string that is not a modifier key
      * feature is disabled.
      * @since 1.6.5
-     * @type null|String
      * @default
      */
     altSelectionKey?: string | undefined;
@@ -2112,7 +2072,6 @@ export class Canvas {
      */
     drawControls(ctx: CanvasRenderingContext2D): void;
     /**
-     * @private
      * @return {Boolean} true if the scaling occurred
      */
     _setObjectScale(
@@ -2126,7 +2085,6 @@ export class Canvas {
     ): boolean;
     /**
      * Scales object by invoking its scaleX/scaleY methods
-     * @private
      * @param {Number} x pointer's x coordinate
      * @param {Number} y pointer's y coordinate
      * @param {String} by Either 'x' or 'y' - specifies dimension constraint by which to scale an object.
@@ -2135,28 +2093,23 @@ export class Canvas {
      */
     _scaleObject(x: number, y: number, by?: 'x' | 'y' | 'equally'): boolean;
     /**
-     * @private
      * @param {fabric.Object} obj Object that was removed
      */
     _onObjectRemoved(obj: Object): void;
     /**
-     * @private
      * @param {fabric.Object} obj Object that was added
      */
     _onObjectAdded(obj: Object): void;
     /**
      * Resets the current transform to its original values and chooses the type of resizing based on the event
-     * @private
      */
     _resetCurrentTransform(): void;
     /**
-     * @private
      * Compares the old activeObject with the current one and fires correct events
      * @param {fabric.Object} obj old activeObject
      */
     _fireSelectionEvents(oldObjects: Object[], e?: Event): void;
     /**
-     * @private
      * @param {Object} object to set as active
      * @param {Event} [e] Event (passed along when firing "object:selected")
      * @return {Boolean} true if the selection happened
@@ -2186,7 +2139,6 @@ export class Canvas {
      * @param {Array} [objects] objects array to look into
      * @param {Object} [pointer] x,y object of point coordinates we want to check.
      * @return {fabric.Object} object that contains pointer
-     * @private
      */
     _searchPossibleTargets(objects: Object[], pointer: { x: number; y: number }): Object;
 
@@ -2310,13 +2262,11 @@ export class Ellipse {
 interface IGroupOptions extends IObjectOptions {
     /**
      * Indicates if click, mouseover, mouseout events & hoverCursor should also check for subtargets
-     * @type Boolean
      */
     subTargetCheck?: boolean | undefined;
     /**
      * setOnGroup is a method used for TextBox that is no more used since 2.0.0 The behavior is still
      * available setting this boolean to true.
-     * @type Boolean
      * @since 2.0.0
      * @default
      */
@@ -2431,29 +2381,24 @@ export class Group {
     addWithUpdate(object: Object): Group;
     /**
      * Retores original state of each of group objects (original state is that which was before group was created).
-     * @private
      * @return {fabric.Group} thisArg
      * @chainable
      */
     _restoreObjectsState(): Group;
     /**
-     * @private
      */
     _calcBounds(onlyWidthHeight?: boolean): void;
     /**
-     * @private
      * @param {Boolean} [skipCoordsChange] if true, coordinates of objects enclosed in a group do not change
      */
     _updateObjectsCoords(center?: Point): void;
     /**
      * Retores original state of each of group objects (original state is that which was before group was created).
-     * @private
      * @return {fabric.Group} thisArg
      * @chainable
      */
     _restoreObjectsState(): Group;
     /**
-     * @private
      */
     _onObjectRemoved(object: Object): void;
     /**
@@ -2506,32 +2451,27 @@ interface IImageOptions extends IObjectOptions {
      * When calling {@link fabric.Image.getSrc}, return value from element src with `element.getAttribute('src')`.
      * This allows for relative urls as image src.
      * @since 2.7.0
-     * @type Boolean
      */
     srcFromAttribute?: boolean | undefined;
     /**
      * minimum scale factor under which any resizeFilter is triggered to resize the image
      * 0 will disable the automatic resize. 1 will trigger automatically always.
      * number bigger than 1 are not implemented yet.
-     * @type Number
      */
     minimumScaleTrigger?: number | undefined;
     /**
      * key used to retrieve the texture representing this image
      * @since 2.0.0
-     * @type String
      */
     cacheKey?: string | undefined;
     /**
      * Image crop in pixels from original image size.
      * @since 2.0.0
-     * @type Number
      */
     cropX?: number | undefined;
     /**
      * Image crop in pixels from original image size.
      * @since 2.0.0
-     * @type Number
      */
     cropY?: number | undefined;
     /**
@@ -2609,7 +2549,6 @@ export class Image {
     /**
      * Calculate offset for center and scale factor for the image in order to respect
      * the preserveAspectRatio attribute
-     * @private
      * @return {Object}
      */
     parsePreserveAspectRatioAttribute(): any;
@@ -2691,7 +2630,6 @@ export class Line {
     ): Function;
     /**
      * Recalculates line points given width and height
-     * @private
      */
     calcLinePoints(): { x1: number; x2: number; y1: number; y2: number };
 }
@@ -2868,7 +2806,6 @@ interface IObjectOptions {
     /**
      * Selection Background color of an object. colored layer behind the object when it is active.
      * does not mix good with globalCompositeOperation methods.
-     * @type String
      */
     selectionBackgroundColor?: string | undefined;
 
@@ -2889,7 +2826,6 @@ interface IObjectOptions {
 
     /**
      * Line offset of an object's stroke
-     * @type Number
      * @default
      */
     strokeDashOffset?: number | undefined;
@@ -3007,13 +2943,11 @@ interface IObjectOptions {
 
     /**
      * When `true`, object horizontal skewing is locked
-     * @type Boolean
      */
     lockSkewingX?: boolean | undefined;
 
     /**
      * When `true`, object vertical skewing is locked
-     * @type Boolean
      */
     lockSkewingY?: boolean | undefined;
 
@@ -3025,7 +2959,6 @@ interface IObjectOptions {
     /**
      * When `true`, object is not exported in OBJECT/JSON
      * since 1.6.3
-     * @type Boolean
      * @default
      */
     excludeFromExport?: boolean | undefined;
@@ -3042,7 +2975,6 @@ interface IObjectOptions {
      * to disable it for groups.
      * default to false
      * since 1.7.0
-     * @type Boolean
      * @default false
      */
     statefullCache?: boolean | undefined;
@@ -3053,7 +2985,6 @@ interface IObjectOptions {
      * this setting is performance and application dependant.
      * default to true
      * since 1.7.0
-     * @type Boolean
      */
     noScaleCache?: boolean | undefined;
 
@@ -3062,9 +2993,7 @@ interface IObjectOptions {
      * When `true`, the stroke will always match the exact pixel size entered for stroke width.
      * default to false
      * @since 2.6.0
-     * @type Boolean
      * @default false
-     * @type Boolean
      */
     strokeUniform?: boolean | undefined;
 
@@ -3075,7 +3004,6 @@ interface IObjectOptions {
 
     /**
      * Determines if the fill or the stroke is drawn first (one of "fill" or "stroke")
-     * @type String
      */
     paintFirst?: string | undefined;
 
@@ -3083,7 +3011,6 @@ interface IObjectOptions {
      * List of properties to consider when checking if state
      * of an object is changed (fabric.Object#hasStateChanged)
      * as well as for history (undo/redo) purposes
-     * @type Array
      */
     stateProperties?: string[] | undefined;
 
@@ -3092,7 +3019,6 @@ interface IObjectOptions {
      * Those properties are checked by statefullCache ON ( or lazy mode if we want ) or from single
      * calls to Object.set(key, value). If the key is in this list, the object is marked as dirty
      * and refreshed at the next render
-     * @type Array
      */
     cacheProperties?: string[] | undefined;
 
@@ -3108,7 +3034,6 @@ interface IObjectOptions {
      * Meaningful ONLY when the object is used as clipPath.
      * if true, the clipPath will make the object clip to the outside of the clipPath
      * since 2.4.0
-     * @type boolean
      * @default false
      */
     inverted?: boolean | undefined;
@@ -3120,7 +3045,6 @@ interface IObjectOptions {
      * to the canvas, but clipping just a particular object.
      * WARNING this is beta, this feature may change or be renamed.
      * since 2.4.0
-     * @type boolean
      * @default false
      */
     absolutePositioned?: boolean | undefined;
@@ -3911,7 +3835,6 @@ export class Object {
     _getNonTransformedDimensions(): { x: number; y: number };
     /**
      * Returns the top, left coordinates
-     * @private
      * @return {fabric.Point}
      */
     _getLeftTopCoords(): Point;
@@ -3924,22 +3847,18 @@ export class Object {
     _getTransformedDimensions(skewX?: number, skewY?: number): { x: number; y: number };
 
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderFill(ctx: CanvasRenderingContext2D): void;
     /**
      * @param ctx
-     * @private
      */
     _renderStroke(ctx: CanvasRenderingContext2D): void;
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _removeShadow(ctx: CanvasRenderingContext2D): void;
     /**
-     * @private
      * Sets line dash
      * @param {CanvasRenderingContext2D} ctx Context to set the dash line on
      * @param {Array} dashArray array representing dashes
@@ -3951,7 +3870,6 @@ export class Object {
         alternative?: (ctx: CanvasRenderingContext2D) => void,
     ): void;
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Object} filler fabric.Pattern or fabric.Gradient
      * @return {Object} offset.offsetX offset for text rendering
@@ -3959,18 +3877,15 @@ export class Object {
      */
     _applyPatternGradientTransform(ctx: CanvasRenderingContext2D, filler: string | Pattern | Gradient): void;
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render(ctx: CanvasRenderingContext2D): void;
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderPaintInOrder(ctx: CanvasRenderingContext2D): void;
     /**
      * Returns the instance of the control visibility set for this object.
-     * @private
      * @returns {Object}
      */
     _getControlsVisibility(): {
@@ -3986,7 +3901,6 @@ export class Object {
     };
     /**
      * Determines which corner has been clicked
-     * @private
      * @param {Object} pointer The pointer indicating the mouse position
      * @return {String|Boolean} corner code (tl, tr, bl, br, etc.), or false if nothing is found
      */
@@ -3995,7 +3909,6 @@ export class Object {
         y: number;
     }): boolean | 'bl' | 'br' | 'mb' | 'ml' | 'mr' | 'mt' | 'tl' | 'tr' | 'mtr';
     /**
-     * @private
      * @param {String} key
      * @param {*} value
      */
@@ -4006,7 +3919,6 @@ export class Object {
      * @param {fabric.Object} Original object
      * @param {Function} Callback when complete
      * @param {Object} Extra parameters for fabric.Object
-     * @private
      * @return {fabric.Object}
      */
     static _fromObject(className: string, object: Object, callback?: Function, extraParam?: any): Object;
@@ -4104,7 +4016,6 @@ export class Polyline extends Object {
     /**
      * Calculate the polygon min and max point from points array,
      * returning an object with left, top, width, height to measure the polygon size
-     * @private
      * @return {Object} object.left X coordinate of the polygon leftmost point
      * @return {Object} object.top Y coordinate of the polygon topmost point
      * @return {Object} object.width distance between X coordinates of the polygon leftmost and rightmost point
@@ -4168,63 +4079,51 @@ interface TextOptions extends IObjectOptions {
     type?: string | undefined;
     /**
      * Font size (in pixels)
-     * @type Number
      */
     fontSize?: number | undefined;
     /**
      * Font weight (e.g. bold, normal, 400, 600, 800)
-     * @type {(Number|String)}
      */
     fontWeight?: string | number | undefined;
     /**
      * Font family
-     * @type String
      */
     fontFamily?: string | undefined;
     /**
      * Text decoration underline.
-     * @type Boolean
      */
     underline?: boolean | undefined;
     /**
      * Text decoration overline.
-     * @type Boolean
      */
     overline?: boolean | undefined;
     /**
      * Text decoration linethrough.
-     * @type Boolean
      */
     linethrough?: boolean | undefined;
     /**
      * Text alignment. Possible values: "left", "center", "right", "justify",
      * "justify-left", "justify-center" or "justify-right".
-     * @type String
      */
     textAlign?: string | undefined;
     /**
      * Font style . Possible values: "", "normal", "italic" or "oblique".
-     * @type String
      */
     fontStyle?: '' | 'normal' | 'italic' | 'oblique' | undefined;
     /**
      * Line height
-     * @type Number
      */
     lineHeight?: number | undefined;
     /**
      * Superscript schema object (minimum overlap)
-     * @type {Object}
      */
     superscript?: { size: number; baseline: number } | undefined;
     /**
      * Subscript schema object (minimum overlap)
-     * @type {Object}
      */
     subscript?: { size: number; baseline: number } | undefined;
     /**
      * Background color of text lines
-     * @type String
      */
     textBackgroundColor?: string | undefined;
     /**
@@ -4235,24 +4134,20 @@ interface TextOptions extends IObjectOptions {
     /**
      * Shadow object representing shadow of this shape.
      * <b>Backwards incompatibility note:</b> This property was named "textShadow" (String) until v1.2.11
-     * @type fabric.Shadow
      */
     shadow?: Shadow | string | undefined;
     /**
      * additional space between characters
      * expressed in thousands of em unit
-     * @type Number
      */
     charSpacing?: number | undefined;
     /**
      * Object containing character styles - top-level properties -> line numbers,
      * 2nd-level properties - charater numbers
-     * @type Object
      */
     styles?: any;
     /**
      * Baseline shift, stlyes only, keep at 0 for the main text object
-     * @type {Number}
      */
     deltaY?: number | undefined;
     /**
@@ -4262,14 +4157,12 @@ interface TextOptions extends IObjectOptions {
     text?: string | undefined;
     /**
      * List of properties to consider when checking if cache needs refresh
-     * @type Array
      */
     cacheProperties?: string[] | undefined;
     /**
      * List of properties to consider when checking if
      * state of an object is changed ({@link fabric.Object#hasStateChanged})
      * as well as for history (undo/redo) purposes
-     * @type Array
      */
     stateProperties?: string[] | undefined;
 }
@@ -4279,83 +4172,58 @@ export class Text extends Object {
     cursorOffsetCache: { top: number; left: number };
     /**
      * Properties which when set cause object to change dimensions
-     * @type Object
-     * @private
      */
     _dimensionAffectingProps: string[];
     /**
      * List of lines in text object
-     * @type Array<string>
      */
     textLines: string[];
     /**
      * List of grapheme lines in text object
-     * @private
-     * @type Array<string>
      */
     _textLines: string[][];
     /**
      * List of unwrapped grapheme lines in text object
-     * @private
-     * @type Array<string>
      */
     _unwrappedTextLines: string[][];
     /**
      * Use this regular expression to filter for whitespaces that is not a new line.
      * Mostly used when text is 'justify' aligned.
-     * @private
-     * @type RegExp
      */
     _reSpacesAndTabs: RegExp;
     /**
      * Use this regular expression to filter for whitespace that is not a new line.
      * Mostly used when text is 'justify' aligned.
-     * @private
-     * @type RegExp
      */
     _reSpaceAndTab: RegExp;
     /**
      * List of line widths
-     * @private
-     * @type Array<Number>
      */
     __lineWidths: number[];
     /**
      * List of line heights
-     * @private
-     * @type Array<Number>
      */
     __lineHeights: number[];
     /**
      * Contains characters bounding boxes for each line and char
-     * @private
-     * @type Array of char grapheme bounding boxes
+     * Array of char grapheme bounding boxes
      */
     __charBounds?: Array<
         Array<{ width: number; left: number; height?: number | undefined; kernedWidth?: number | undefined; deltaY?: number | undefined }>
     > | undefined;
     /**
      * Text Line proportion to font Size (in pixels)
-     * @private
-     * @type Number
      */
     _fontSizeMult: number;
     /**
-     * @private
-     * @type Number
      */
     _fontSizeFraction: number;
     /**
-     * @private
-     * @type boolean
      */
     __skipDimension: boolean;
     /**
      * use this size when measuring text. To avoid IE11 rounding errors
-     * @type {Number}
      * @default
-     * @readonly
-     * @private
      */
     CACHE_FONT_SIZE: number;
 
@@ -4554,14 +4422,12 @@ export class Text extends Object {
     /**
      * Measure a single line given its index. Used to calculate the initial
      * text bounding box. The values are calculated and stored in __lineWidths cache.
-     * @private
      * @param {Number} lineIndex line number
      * @return {Number} Line width
      */
     getLineWidth(lineIndex: number): number;
 
     /**
-     * @private
      * @param {Number} lineIndex index text line
      * @return {Number} Line left offset
      */
@@ -4569,7 +4435,6 @@ export class Text extends Object {
 
     /**
      * apply all the character style to canvas for rendering
-     * @private
      * @param {String} _char
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Number} lineIndex
@@ -4597,7 +4462,6 @@ export class Text extends Object {
      * broken up by visual lines (new lines and automatic wrapping).
      * The original text styles object is broken up by actual lines (new lines only),
      * which is only sufficient for Text / IText
-     * @private
      */
     _generateStyleMap(textInfo: {
         _unwrappedLines: string[];
@@ -4607,7 +4471,6 @@ export class Text extends Object {
     }): { [s: number]: { line: number; offset: number } };
 
     /**
-     * @private
      * Gets the width of character spacing
      */
     _getWidthOfCharSpacing(): number;
@@ -4616,7 +4479,6 @@ export class Text extends Object {
      * measure and return the width of a single character.
      * possibly overridden to accommodate different measure logic or
      * to hook some external lib for character measurement
-     * @private
      * @param {String} char to be measured
      * @param {Object} charStyle style of char to be measured
      * @param {String} [previousChar] previous char
@@ -4631,7 +4493,6 @@ export class Text extends Object {
     ): { width: number; kernedWidth: number };
 
     /**
-     * @private
      * @param {String} method
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {String} line Content of the line
@@ -4650,7 +4511,6 @@ export class Text extends Object {
     ): void;
 
     /**
-     * @private
      * @param {String} method
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Number} lineIndex
@@ -4671,7 +4531,6 @@ export class Text extends Object {
     ): void;
 
     /**
-     * @private
      * @param {String} method Method name ("fillText" or "strokeText")
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Array} line Text to render
@@ -4689,25 +4548,21 @@ export class Text extends Object {
     ): void;
 
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderText(ctx: CanvasRenderingContext2D): void;
 
     /**
-     * @private
      */
     _clearCache(): void;
 
     /**
      * Divides text into lines of text and lines of graphemes.
-     * @private
      * @returns {Object} Lines and text in the text
      */
     _splitText(): { _unwrappedLines: string[]; lines: string[]; graphemeText: string[]; graphemeLines: string[] };
 
     /**
-     * @private
      * @param {Object} prevStyle
      * @param {Object} thisStyle
      */
@@ -4715,7 +4570,6 @@ export class Text extends Object {
 
     /**
      * Set the font parameter of the context with the object properties or with charStyle
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Object} [charStyle] object with font style properties
      * @param {String} [charStyle.fontFamily] Font Family
@@ -4730,7 +4584,6 @@ export class Text extends Object {
     ): void;
 
     /**
-     * @private
      * @param {String} method Method name ("fillText" or "strokeText")
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {String} line Text to render
@@ -4748,69 +4601,56 @@ export class Text extends Object {
     ): void;
 
     /**
-     * @private
      */
     _shouldClearDimensionCache(): boolean;
 }
 interface ITextOptions extends TextOptions {
     /**
      * Index where text selection starts (or where cursor is when there is no selection)
-     * @type Number
      */
     selectionStart?: number | undefined;
     /**
      * Index where text selection ends
-     * @type Number
      */
     selectionEnd?: number | undefined;
     /**
      * Color of text selection
-     * @type String
      */
     selectionColor?: string | undefined;
     /**
      * Indicates whether text is selected
-     * @type Boolean
      */
     selected?: boolean | undefined;
     /**
      * Indicates whether text is in editing mode
-     * @type Boolean
      */
     isEditing?: boolean | undefined;
     /**
      * Indicates whether a text can be edited
-     * @type Boolean
      */
     editable?: boolean | undefined;
     /**
      * Border color of text object while it's in editing mode
-     * @type String
      */
     editingBorderColor?: string | undefined;
     /**
      * Width of cursor (in px)
-     * @type Number
      */
     cursorWidth?: number | undefined;
     /**
      * Color of default cursor (when not overwritten by character style)
-     * @type String
      */
     cursorColor?: string | undefined;
     /**
      * Delay between cursor blink (in ms)
-     * @type Number
      */
     cursorDelay?: number | undefined;
     /**
      * Duration of cursor fadein (in ms)
-     * @type Number
      */
     cursorDuration?: number | undefined;
     /**
      * Indicates whether internal text char widths can be cached
-     * @type Boolean
      */
     caching?: boolean | undefined;
     /**
@@ -4849,11 +4689,9 @@ export interface IText extends ITextOptions {}
 export class IText extends Text {
     fromPaste: boolean;
     /**
-     * @private
      */
     _currentCursorOpacity: number;
     /**
-     * @private
      */
     _reSpace: RegExp;
     /**
@@ -5209,7 +5047,6 @@ export class IText extends Text {
      */
     setCursorByClick(e: Event): void;
     /**
-     * @private
      */
     _getNewSelectionStartFromOffset(
         mouseOffset: { x: number; y: number },
@@ -5219,16 +5056,13 @@ export class IText extends Text {
         jlen: number,
     ): number;
     /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render(ctx: CanvasRenderingContext2D): void;
     /**
-     * @private
      */
     _updateTextarea(): void;
     /**
-     * @private
      */
     updateFromTextArea(): void;
     /**
@@ -5236,12 +5070,10 @@ export class IText extends Text {
      * can be overridden to do something different.
      * Scope of this implementation is: find the click position, set selectionStart
      * find selectionEnd, initialize the drawing of either cursor or selection area
-     * @private
      * @param {Object} Options (seems to have an event `e` parameter
      */
     _mouseDownHandler(options: any): void;
     /**
-     * @private
      * @return {Object} style contains style for hiddenTextarea
      */
     _calcTextareaPosition(): { left: string; top: string; fontSize: string; charHeight: number };
@@ -5249,14 +5081,12 @@ export class IText extends Text {
 interface ITextboxOptions extends ITextOptions {
     /**
      * Minimum width of textbox, in pixels.
-     * @type Number
      */
     minWidth?: number | undefined;
     /**
      * Minimum calculated width of a textbox, in pixels.
      * fixed to 2 so that an empty textbox cannot go to 0
      * and is still selectable without text.
-     * @type Number
      */
     dynamicMinWidth?: number | undefined;
     /**
@@ -5271,13 +5101,11 @@ interface ITextboxOptions extends ITextOptions {
     /**
      * Use this boolean property in order to split strings that have no white space concept.
      * this is a cheap way to help with chinese/japaense
-     * @type Boolean
      * @since 2.6.0
      */
     splitByGrapheme?: boolean | undefined;
     /**
      * Is the text wrapping
-     * @type Boolean
      */
     isWrapping?: boolean | undefined;
 }
@@ -5315,14 +5143,11 @@ export class Textbox extends IText {
     getMinWidth(): number;
     /**
      * Use this regular expression to split strings in breakable lines
-     * @private
-     * @type RegExp
      */
     _wordJoiners: RegExp;
     /**
      * Helper function to measure a string of text, given its lineIndex and charIndex offset
      * it gets called when charBounds are not available yet.
-     * @private
      * @param {Array} text characters
      * @param {number} lineIndex
      * @param {number} charOffset
@@ -5345,8 +5170,7 @@ export class Textbox extends IText {
      * broken up by visual lines (new lines and automatic wrapping).
      * The original text styles object is broken up by actual lines (new lines only),
      * which is only sufficient for Text / IText
-     * @private
-     * @type {Array} Line style { line: number, offset: number }
+     * Line style { line: number, offset: number }
      */
     _styleMap?: { [s: number]: { line: number; offset: number } } | undefined;
     /**
@@ -6631,7 +6455,6 @@ export class Control {
      * mainly for backward compatibility.
      * if you do not want to see a control, you can remove it
      * from the controlset.
-     * @type {Boolean}
      * @default true
      */
     visible: boolean;
@@ -6695,7 +6518,6 @@ export class Control {
     /**
      * Sets the length of the control. If null, defaults to object's cornerSize.
      * Expects both sizeX and sizeY to be set when set.
-     * @type {?Number}
      */
     sizeX?: number | undefined;
 
@@ -6708,7 +6530,6 @@ export class Control {
     /**
      * Sets the length of the touch area of the control. If null, defaults to object's touchCornerSize.
      * Expects both touchSizeX and touchSizeY to be set when set.
-     * @type {?Number}
      * @default null
      */
     touchSizeX?: number | undefined;
@@ -6716,7 +6537,6 @@ export class Control {
     /**
      * Sets the height of the touch area of the control. If null, defaults to object's touchCornerSize.
      * Expects both touchSizeX and touchSizeY to be set when set.
-     * @type {?Number}
      * @default null
      */
     touchSizeY?: number | undefined;

--- a/types/figlet/index.d.ts
+++ b/types/figlet/index.d.ts
@@ -355,7 +355,7 @@ declare namespace figlet {
     function text(txt: string, cb: (error: Error | null, result?: string) => void): void;
     function text(txt: string, font: Fonts, cb: (error: Error | null, result?: string) => void): void;
     /**
-     * @desc
+     * @description
      * This `unified-signatures` is disabled because `Fonts` type is too long
      */
     // tslint:disable-next-line: unified-signatures
@@ -363,7 +363,7 @@ declare namespace figlet {
 
     function textSync(txt: string, font?: Fonts): string;
     /**
-     * @desc
+     * @description
      * This `unified-signatures` is disabled because `Fonts` type is too long
      */
     function textSync(txt: string, options: Options): string;
@@ -400,7 +400,7 @@ declare namespace figlet {
     function fontsSync(): Fonts[];
 
     /**
-     * @desc
+     * @description
      * Load a custom font from a file.
      *
      * @param fontName

--- a/types/firebase-token-generator/index.d.ts
+++ b/types/firebase-token-generator/index.d.ts
@@ -16,7 +16,6 @@ declare class FirebaseTokenGenerator {
 
   /**
    * Builds a new object that can generate Firebase authentication tokens.
-   * @constructor
    * @param { String } secret The secret for the Firebase being used (get yours from the Firebase Admin Console).
    */
   constructor(secret: string);

--- a/types/firebird/index.d.ts
+++ b/types/firebird/index.d.ts
@@ -65,7 +65,7 @@ declare module 'firebird' {
         /**
          * Registers connection to listen for firebird event name, called from PL\SQL (in stored procedures or triggers) with post_event 'name'.
          *
-         * @desc
+         * @description
          * You may set callback for event with
          * @code connection.on('fbevent', function(name, count){ <your code>));.
          * Where name is event name, and count is number of times event were posted.
@@ -85,7 +85,7 @@ declare module 'firebird' {
          * @summary
          * Synchronously commits current transaction.
          *
-         * @desc
+         * @description
          * Notes:
          * There is only one transaction associated with connection.
          * Transacation is automatically started before any query if connection does not have active transaction (check @see inTransaction property).
@@ -97,7 +97,7 @@ declare module 'firebird' {
         /**
          * Asynchronous commit transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -107,7 +107,7 @@ declare module 'firebird' {
         /**
          * Synchronously rollbacks current transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          */
         rollbackSync(): void;
@@ -115,7 +115,7 @@ declare module 'firebird' {
         /**
          * Asynchronously rollbacks current transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -125,7 +125,7 @@ declare module 'firebird' {
         /**
          * Synchronously starts new default transaction.
          *
-         * @desc
+         * @description
          * The default transaction should be not in started state before call to this method.
          * Read notes in @see commitSync() .
          */
@@ -134,7 +134,7 @@ declare module 'firebird' {
         /**
          * Asynchronously starts new default transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -175,7 +175,7 @@ declare module 'firebird' {
     }
 
     /**
-     * @desc
+     * @description
      * Here is Firebird to Node data type accordance:
      *
      * | Firebird  | Node      |
@@ -207,7 +207,7 @@ declare module 'firebird' {
          * @summary
          * Synchronously fetches result rows.
          *
-         * @desc
+         * @description
          * If you pass "all" as rowCount - it will fetch all result rows.
          * If you pass less rowCount than are actually in result, it will return specified number of rows.
          * You may call fetchSync multiple times until all rows will be fetched.
@@ -238,7 +238,7 @@ declare module 'firebird' {
     /**
      * Represents SQL transaction.
      *
-     * @desc
+     * @description
      * To get instance of this object call @see startNewTransactionSync or @see startNewTransaction methods of @see Connection object.
      * Transaction objects may be reused after commit or rollback.
      */
@@ -261,7 +261,7 @@ declare module 'firebird' {
         /**
          * Synchronously commits this transaction.
          *
-         * @desc
+         * @description
          * Notes:
          * Transacation is automatically started before any query in context of this object
          * if this object does not have active transaction (check inTransaction property).
@@ -272,7 +272,7 @@ declare module 'firebird' {
         /**
          * Asynchronous commit transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -282,7 +282,7 @@ declare module 'firebird' {
          /**
           * Synchronously rollbacks transaction.
           *
-          * @desc
+          * @description
           * Read notes in @see commitSync() .
           */
         rollbackSync(): void;
@@ -290,7 +290,7 @@ declare module 'firebird' {
         /**
          * Asynchronously rollbacks transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -300,7 +300,7 @@ declare module 'firebird' {
         /**
          * Synchronously starts transaction.
          *
-         * @desc
+         * @description
          * The transaction should be not in started state before call to this method.
          * Read notes in @see commitSync() .
          * See @see inTransaction property.
@@ -310,7 +310,7 @@ declare module 'firebird' {
         /**
          * Asynchronously starts new transaction.
          *
-         * @desc
+         * @description
          * Read notes in @see commitSync() .
          *
          * @param callback function(err), where err is error object in case of error.
@@ -341,7 +341,7 @@ declare module 'firebird' {
         /**
          * Synchronously executes prepared statement with given parameters.
          *
-         * @desc
+         * @description
          * You may fetch rows with methods inherited from @see FBResult.
          * @see Statement is executed in context of default connection transaction.
          *
@@ -357,7 +357,7 @@ declare module 'firebird' {
         /**
          * Asynchronously executes prepared statement with given parameters.
          *
-         * @desc
+         * @description
          * @see FBStatement emits 'result' or 'error' event.
          * You may fetch rows with methods inherited from @see FBResult after 'result' event emitted.
          * Statement is executed in context of default connection transaction.
@@ -436,7 +436,7 @@ declare module 'firebird' {
     /**
      * Represents BLOB stream.
      *
-     * @desc
+     * @description
      * Create BLOB stream using
      * @code var strm = new fb.Stream(FBblob);.
      *

--- a/types/get-intrinsic/scripts/intrinsics-data.ts
+++ b/types/get-intrinsic/scripts/intrinsics-data.ts
@@ -16,13 +16,13 @@ const generator = function* () {};
 const asyncFn = async function () {};
 const asyncGen = async function* () {};
 
-const generatorFunction = generator ? /** @type {GeneratorFunctionConstructor} */ generator.constructor : undefined;
+const generatorFunction = generator ? generator.constructor : undefined;
 const generatorFunctionPrototype = generatorFunction ? generatorFunction.prototype : undefined;
 const generatorPrototype = generatorFunctionPrototype ? generatorFunctionPrototype.prototype : undefined;
 
-const asyncFunction = asyncFn ? /** @type {FunctionConstructor} */ asyncFn.constructor : undefined;
+const asyncFunction = asyncFn ? asyncFn.constructor : undefined;
 
-const asyncGenFunction = asyncGen ? /** @type {AsyncGeneratorFunctionConstructor} */ asyncGen.constructor : undefined;
+const asyncGenFunction = asyncGen ? asyncGen.constructor : undefined;
 const asyncGenFunctionPrototype = asyncGenFunction ? asyncGenFunction.prototype : undefined;
 const asyncGenPrototype = asyncGenFunctionPrototype ? asyncGenFunctionPrototype.prototype : undefined;
 

--- a/types/glidejs/index.d.ts
+++ b/types/glidejs/index.d.ts
@@ -33,7 +33,6 @@ declare namespace JQueryGlide {
         /**
          * Default: 500
          * Animation time in ms
-         * @type {number}
          */
         animationDuration?: number | undefined;
         /**

--- a/types/go/index.d.ts
+++ b/types/go/index.d.ts
@@ -205,7 +205,6 @@ declare namespace go {
         /**
         * This predicate controls whether or not the user can invoke the scrollToPart command.
         * This returns false if there is no argument Part and there are no selected Parts.
-        * @this {CommandHandler}
         * @param {Part=} part This defaults to the first selected Part of Diagram.selection
         * @return {boolean}
         * This returns true if Diagram.allowHorizontalScroll and Diagram.allowVerticalScroll are true.
@@ -361,7 +360,6 @@ declare namespace go {
         * This is normally invoked by the <code>Space</code> keyboard shortcut.
         * If there is no argument and there is no highlighted or selected Part, this command does nothing.
         * @expose
-        * @this {CommandHandler}
         * @param {Part=} part This defaults to the first highlighted Part of Diagram.highlighteds,
         *                     or, if there are no highlighted Parts, the first selected Part.
         */

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1683,7 +1683,6 @@ declare namespace google {
             selectionColor?: string | undefined;
             /**
              * Chart size
-             * @type {('small'|'medium'|'large')}
              * @default 'medium'
              */
             size?: string | undefined;

--- a/types/googlemaps.infobubble/index.d.ts
+++ b/types/googlemaps.infobubble/index.d.ts
@@ -10,7 +10,7 @@
  * @name CSS3 InfoBubble with tabs for Google Maps API V3
  * @version 0.8
  * @author Luke Mahe
- * @fileoverview
+ * @file
  * This library is a CSS Infobubble with tabs. It uses css3 rounded corners and
  * drop shadows and animations. It also allows tabs
  */

--- a/types/gulp-ruby-sass/index.d.ts
+++ b/types/gulp-ruby-sass/index.d.ts
@@ -48,7 +48,6 @@ interface SassOptions {
  * The interface includes the node-ruby-sass only options.
  * Attention: sourcemap option type differs from the same SassOption's type.
  * @interface Options
- * @extends SassOptions
  */
 interface Options extends SassOptions {
     verbose?: boolean | undefined;

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -259,8 +259,8 @@ declare namespace H {
         /**
          * It defines the number of lower and higher zoom levels, where cached content of the base map is rendered while content of the current zoom level is still loading.
          * Example: if range was set to {lower: 3, higher: 2} and current level is 10 then rendering engine will try to display cached tiles from lower zoom levels 7, 8, 9 and higher levels 11 and 12.
-         * @property lower {number} - The number of lower zoom levels to take into account, default is 0
-         * @property higher {number} - The number of higher zoom levels to take into account, default is 0
+         * lower {number} - The number of lower zoom levels to take into account, default is 0
+         * higher {number} - The number of higher zoom levels to take into account, default is 0
          */
         interface BackgroundRange {
             lower: number;
@@ -277,18 +277,18 @@ declare namespace H {
 
         /**
          * This type defines options which can be used to initialize the map.
-         * @property center {H.geo.IPoint=} - The initial center of the map, default is {lat:0, lng: 0}
-         * @property zoom {number=} - The initial zoom level of the map, default is 0 respectively the minimal zoom level of the base map
-         * @property bounds {H.geo.Rect=} - The view bounds to be displayed on the map. If provided, it takes precedence over center and zoom. and zoom if provided)
-         * @property layers {Array<H.map.layer.Layer>=} - A list of layers to render on top of the base map
-         * @property engineType: {H.Map.EngineType=} - The initial engine type to use, default is P2D
-         * @property pixelRatio {number} - The pixelRatio to use for over-sampling in cases of high-resolution displays, default is 1
-         * @property imprint {H.map.Imprint.Options=} - The imprint options or null to suppress the imprint
-         * @property renderBaseBackground {H.Map.BackgroundRange=} - Object describes how many cached zoom levels should be used as a base map background while base map tiles are loading.
+         * center {H.geo.IPoint=} - The initial center of the map, default is {lat:0, lng: 0}
+         * zoom {number=} - The initial zoom level of the map, default is 0 respectively the minimal zoom level of the base map
+         * bounds {H.geo.Rect=} - The view bounds to be displayed on the map. If provided, it takes precedence over center and zoom. and zoom if provided)
+         * layers {Array<H.map.layer.Layer>=} - A list of layers to render on top of the base map
+         * engineType: {H.Map.EngineType=} - The initial engine type to use, default is P2D
+         * pixelRatio {number} - The pixelRatio to use for over-sampling in cases of high-resolution displays, default is 1
+         * imprint {H.map.Imprint.Options=} - The imprint options or null to suppress the imprint
+         * renderBaseBackground {H.Map.BackgroundRange=} - Object describes how many cached zoom levels should be used as a base map background while base map tiles are loading.
          * Example: {lower: 3, higher: 2}
-         * @property autoColor {boolean=} - Indicates whether the UI's colors should automatically adjusted to the base layer, default is true. Up to now only the copyright style will be adjusted.
+         * autoColor {boolean=} - Indicates whether the UI's colors should automatically adjusted to the base layer, default is true. Up to now only the copyright style will be adjusted.
          * See H.map.layer.Layer.Options#dark
-         * @property margin {number=} - The size in pixel of the supplemental area to render for each side of the map
+         * margin {number=} - The size in pixel of the supplemental area to render for each side of the map
          * @property padding {H.map.ViewPort.Padding=} - The padding in pixels for each side of the map
          * @property fixedCenter {boolean=} - Indicates whether the center of the map should remain unchanged if the viewport's size or padding has been changed, default is true
          * @property noWrap {boolean=} - Indicates whether to wrap the world on longitude axes. When set to true, only one world will be rendered. Default is false, multiple worlds are rendered.
@@ -314,10 +314,10 @@ declare namespace H {
     namespace clustering {
         /**
          * This class represents the input data structure for data points to be clustered.
-         * @property lat {H.geo.Latitude} - The latitude coordinate of the data point's position
-         * @property lng {H.geo.Longitude} - The longitude coordinate of the data point's position
-         * @property wt {number} - The weight of the data point
-         * @property data {*} - Data associated with this data point
+         * lat {H.geo.Latitude} - The latitude coordinate of the data point's position
+         * lng {H.geo.Longitude} - The longitude coordinate of the data point's position
+         * wt {number} - The weight of the data point
+         * data {*} - Data associated with this data point
          */
         class DataPoint implements H.geo.IPoint {
             /**
@@ -477,8 +477,8 @@ declare namespace H {
         /**
          * The clustering provider serves clusters and noise point representation for the map depending on the provided data set.
          * Levels for clustering as well as custom cluster representation can be set via Options.
-         * @property min {number} - Minimum zoom level at which provider can cluster data
-         * @property max {number} - Maximum zoom level at which provider can cluster data
+         * min {number} - Minimum zoom level at which provider can cluster data
+         * max {number} - Maximum zoom level at which provider can cluster data
          */
         class Provider extends H.util.EventTarget {
             /**
@@ -619,11 +619,11 @@ declare namespace H {
         namespace Provider {
             /**
              * Options which are used within cluster calculations.
-             * @property eps {number=} - epsilon parameter for cluster calculation. For the FASTGRID strategy it must not exceed 256 and must take values that are power of 2.
+             * eps {number=} - epsilon parameter for cluster calculation. For the FASTGRID strategy it must not exceed 256 and must take values that are power of 2.
              * For the GRID and DYNAMICGRID strategies it can take values from 10 to 127. Default is 32.
-             * @property minWeight {number=} - the minimum points weight sum to form a cluster, default is 2
-             * @property projection {H.geo.IProjection=} - projection to use for clustering, default is H.geo.mercator
-             * @property strategy {H.clustering.Provider.Strategy=} - clustering stretegy, defaults to H.clustering.Provider.Strategy.FASTGRID
+             * minWeight {number=} - the minimum points weight sum to form a cluster, default is 2
+             * projection {H.geo.IProjection=} - projection to use for clustering, default is H.geo.mercator
+             * strategy {H.clustering.Provider.Strategy=} - clustering stretegy, defaults to H.clustering.Provider.Strategy.FASTGRID
              */
             interface ClusteringOptions {
                 eps?: number | undefined;
@@ -634,10 +634,10 @@ declare namespace H {
 
             /**
              * Options which are used to initialize the clustering Provider
-             * @property min {number=} - The minimal supported zoom level, default is 0
-             * @property max {number=} - The maximal supported zoom level, default is 22
-             * @property clusteringOptions {H.clustering.Provider.ClusteringOptions=} - options for clustering algorithm
-             * @property theme {H.clustering.ITheme=} - cluster and noise point graphical representation
+             * min {number=} - The minimal supported zoom level, default is 0
+             * max {number=} - The maximal supported zoom level, default is 22
+             * clusteringOptions {H.clustering.Provider.ClusteringOptions=} - options for clustering algorithm
+             * theme {H.clustering.ITheme=} - cluster and noise point graphical representation
              */
             interface Options {
                 min?: number | undefined;
@@ -767,8 +767,8 @@ declare namespace H {
             namespace Reader {
                 /**
                  * This type encapsulates configuration (initialization) properties for a H.data.geojson.Reader.
-                 * @property style {Function=} - The optional URL of the data file.
-                 * @property disableLegacyMode {boolean=} - An object providing additional reader configuration parameters.
+                 * style {Function=} - The optional URL of the data file.
+                 * disableLegacyMode {boolean=} - An object providing additional reader configuration parameters.
                  */
                 interface Options {
                     style?: ((mapObject: H.map.Object) => void) | undefined;
@@ -838,10 +838,10 @@ declare namespace H {
 
         /**
          * An interface to represent a geographic point. Every point in geo space is represented by three coordinates latitude, longitude and optional altitude.
-         * @property lat {H.geo.Latitude} - The latitude coordinate.
-         * @property lng {H.geo.Longitude} - The longitude coordinate.
-         * @property alt {H.geo.Altitude=} - The altitude coordinate.
-         * @property ctx {H.geo.AltitudeContext=} - The altitude context.
+         * lat {H.geo.Latitude} - The latitude coordinate.
+         * lng {H.geo.Longitude} - The longitude coordinate.
+         * alt {H.geo.Altitude=} - The altitude coordinate.
+         * ctx {H.geo.AltitudeContext=} - The altitude context.
          */
         interface IPoint {
             lat: H.geo.Latitude;
@@ -1153,11 +1153,11 @@ declare namespace H {
         /**
          * PixelProjection transforms pixel world coordinates at a certain scale (zoom level) to geographical coordinates and vice versa.
          * By default, it uses the Mercator projection to transform geographic points into the 2d plane map points, which are adjusted to the current scale.
-         * @property projection {H.geo.IProjection} - This property indicates the geographical projection that underlies the given PixelProjection.
-         * @property x {number} - This property holds the x-offset in the projection relative to the top-left corner of the screen.
-         * @property y {number} - This property holds the y-offset in the projection relative to the top-left corner of the screen.
-         * @property w {number} - This property holds a value indicating the width of the world in pixels.
-         * @property h {number} - This property holds a value indicating the height of the world in pixels.
+         * projection {H.geo.IProjection} - This property indicates the geographical projection that underlies the given PixelProjection.
+         * x {number} - This property holds the x-offset in the projection relative to the top-left corner of the screen.
+         * y {number} - This property holds the y-offset in the projection relative to the top-left corner of the screen.
+         * w {number} - This property holds a value indicating the width of the world in pixels.
+         * h {number} - This property holds a value indicating the height of the world in pixels.
          */
         class PixelProjection {
             /**
@@ -1230,18 +1230,18 @@ declare namespace H {
 
         /**
          * Class represents a geographical point, which is defined by the latitude, longitude and optional altitude.
-         * @property lat {H.geo.Latitude} - The latitude coordinate.
-         * @property lng {H.geo.Longitude} - The longitude coordinate.
-         * @property alt {H.geo.Altitude} - The altitude coordinate.
-         * @property ctx {H.geo.AltitudeContext} - The altitude context.
+         * lat {H.geo.Latitude} - The latitude coordinate.
+         * lng {H.geo.Longitude} - The longitude coordinate.
+         * alt {H.geo.Altitude} - The altitude coordinate.
+         * ctx {H.geo.AltitudeContext} - The altitude context.
          */
         class Point extends H.geo.AbstractGeometry implements IPoint {
             /**
              * Constructor
-             * @property lat {H.geo.Latitude} - The latitude coordinate.
-             * @property lng {H.geo.Longitude} - The longitude coordinate.
-             * @property opt_alt {H.geo.Altitude=} - The altitude coordinate.
-             * @property opt_ctx {H.geo.AltitudeContext=} - The altitude context.
+             * lat {H.geo.Latitude} - The latitude coordinate.
+             * lng {H.geo.Longitude} - The longitude coordinate.
+             * opt_alt {H.geo.Altitude=} - The altitude coordinate.
+             * opt_ctx {H.geo.AltitudeContext=} - The altitude context.
              */
             constructor(lat: H.geo.Latitude, lng: Longitude, opt_alt?: H.geo.Altitude, opt_ctx?: H.geo.AltitudeContext);
 
@@ -1623,7 +1623,6 @@ declare namespace H {
             setIcon(icon: (H.map.Icon | H.map.DomIcon)): H.map.AbstractMarker;
 
             /**
-             * @property draggable
              * @description This property ensure that the marker can receive drag events.
              */
             draggable?: boolean | undefined;
@@ -1632,14 +1631,14 @@ declare namespace H {
         namespace AbstractMarker {
             /**
              * Options used to initialize a AbstractMarker
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object.
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object.
              * This property is only needed if a customized Implementation of ObjectProvider wants to instantiate an object.
-             * @property icon {(H.map.Icon | H.map.DomIcon)=} - The icon to use for the visual representation, if omitted a default icon is used.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * icon {(H.map.Icon | H.map.DomIcon)=} - The icon to use for the visual representation, if omitted a default icon is used.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
              */
             interface Options {
                 min?: number | undefined;
@@ -1673,12 +1672,12 @@ declare namespace H {
         namespace ArrowStyle {
             /**
              * An object type to specify the style of arrows to render along a polyline
-             * @property fillColor {string=} - The CSS color value used to fill the arrow shapes. If omitted or the value evaluates to false it defaults to "rgba(255, 255, 255, 0.75)"
-             * @property width {number=} - The width of the arrow shape. The value is taken as a factor of the width of the line, where the arrow description is applied.
+             * fillColor {string=} - The CSS color value used to fill the arrow shapes. If omitted or the value evaluates to false it defaults to "rgba(255, 255, 255, 0.75)"
+             * width {number=} - The width of the arrow shape. The value is taken as a factor of the width of the line, where the arrow description is applied.
              * If omitted or the value is <= 0 it defaults to 1.2
-             * @property length {number=} - The length of the arrow shapes. The value is taken as a factor of the width of the line at the end of which the arrow is drawn.
+             * length {number=} - The length of the arrow shapes. The value is taken as a factor of the width of the line at the end of which the arrow is drawn.
              * If omitted or the value is <= 0 it defaults to 1.6
-             * @property frequency {number=} - The frequency of arrow shapes. The value is taken as factor of the length of the arrow. A value of 1 results in gapless arrows.
+             * frequency {number=} - The frequency of arrow shapes. The value is taken as factor of the length of the arrow. A value of 1 results in gapless arrows.
              * If omitted or the value is false it defaults to 5
              */
             interface Options {
@@ -1741,19 +1740,19 @@ declare namespace H {
 
         namespace Circle {
             /**
-             * @property style {H.map.SpatialStyle=} - the style to be used when tracing the polyline
-             * @property visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
-             * @property precision {number=} - The precision of a circle as a number of segments to be used when rendering the circle.
+             * style {H.map.SpatialStyle=} - the style to be used when tracing the polyline
+             * visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
+             * precision {number=} - The precision of a circle as a number of segments to be used when rendering the circle.
              * The value is clamped to the range between [4 ... 360], where 60 is
              * the default. Note that the lower the value the more angular and the less circle-like the shape appears and, conversely, the higher the value the smoother and more rounded the result.
              * Thus, starting at the extreme low end of the possible values, 4 produces a square, 6 a hexagon, while 30 results in a circle-like shape, although it appears increasingly angular as
              * the zoom level increases (as you zoom in), and finally 360 produces a smooth circle.
-             * @property zIndex {number=} - The z-index value of the circle, default is 0
-             * @property min {number=} - The minimum zoom level for which the circle is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the circle is visible, default is Infinity
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object.
+             * zIndex {number=} - The z-index value of the circle, default is 0
+             * min {number=} - The minimum zoom level for which the circle is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the circle is visible, default is Infinity
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object.
              * This property is only needed if a customized Implementation of ObjectProvider wants to instantiate an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
              */
             interface Options {
                 style?: H.map.SpatialStyle | H.map.SpatialStyle.Options | undefined;
@@ -1794,9 +1793,9 @@ declare namespace H {
         namespace DomIcon {
             /**
              * Options used to initialize a DomIcon
-             * @property onAttach {function(Element, H.map.DomIcon, H.map.DomMarker)=} - A callback which is invoked before a clone of the icon's element is appended and displayed on the map.
+             * onAttach {function(Element, H.map.DomIcon, H.map.DomMarker)=} - A callback which is invoked before a clone of the icon's element is appended and displayed on the map.
              * This callback can be used to setup the clone.
-             * @property onDetach {function(Element, H.map.DomIcon, H.map.DomMarker)=} - A callback which is invoked after a clone of the icon's element is removed from the map.
+             * onDetach {function(Element, H.map.DomIcon, H.map.DomMarker)=} - A callback which is invoked after a clone of the icon's element is removed from the map.
              * This callback can be used to clean up the clone.
              */
             interface Options {
@@ -1822,14 +1821,14 @@ declare namespace H {
         namespace DomMarker {
             /**
              * Options used to initialize a DomMarker
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to
              * instantiate an object.
-             * @property icon {H.map.DomIcon=} - The icon to use for the visual representation, if omitted a default icon is used.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
+             * icon {H.map.DomIcon=} - The icon to use for the visual representation, if omitted a default icon is used.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
              */
             interface Options {
                 min?: number | undefined;
@@ -1926,14 +1925,14 @@ declare namespace H {
         namespace Group {
             /**
              * Options used to initialize a group
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property visibility {boolean=} - Indicates whether the map object is visible, default is true
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * visibility {boolean=} - Indicates whether the map object is visible, default is true
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
-             * @property objects {Array<H.map.Object>=} - A list of map objects to add initially to this group.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * objects {Array<H.map.Object>=} - A list of map objects to add initially to this group.
              */
             interface Options {
                 min?: number | undefined;
@@ -2008,8 +2007,8 @@ declare namespace H {
 
         /**
          * An interface to specify a copyright note
-         * @property label {string} - A short textual representation of the copyright note, e.g. "DigitalGlobe 2009"
-         * @property alt {string} - A detailed textual representation of the copyright note, e.g. "copyright 2009 DigitalGlobe, Inc."
+         * label {string} - A short textual representation of the copyright note, e.g. "DigitalGlobe 2009"
+         * alt {string} - A detailed textual representation of the copyright note, e.g. "copyright 2009 DigitalGlobe, Inc."
          */
         interface ICopyright {
             label: string;
@@ -2136,12 +2135,12 @@ declare namespace H {
 
             /**
              * Options used to initialize a Icon
-             * @property size {H.math.ISize=} - The icon's size in pixel, default is the bitmap's natural size
-             * @property anchor {H.math.IPoint=} - The anchorage point in pixel, default is bottom-center
-             * @property hitArea {H.map.HitArea=} - The area to use for hit detection, default is the whole rectangular area
-             * @property asCanvas {H.map.HitArea=} - Indicates whether a non canvas bitmap is converted into a canvas, default is true. The conversion improves the rendering performance but it could
+             * size {H.math.ISize=} - The icon's size in pixel, default is the bitmap's natural size
+             * anchor {H.math.IPoint=} - The anchorage point in pixel, default is bottom-center
+             * hitArea {H.map.HitArea=} - The area to use for hit detection, default is the whole rectangular area
+             * asCanvas {H.map.HitArea=} - Indicates whether a non canvas bitmap is converted into a canvas, default is true. The conversion improves the rendering performance but it could
              * also cause a higher memory consumption.
-             * @property crossOrigin {boolean} - Specifies whether to use anonynous Cross-Origin Resource Sharing (CORS) when fetching an image to prevent resulting canvas from tainting, default is
+             * crossOrigin {boolean} - Specifies whether to use anonynous Cross-Origin Resource Sharing (CORS) when fetching an image to prevent resulting canvas from tainting, default is
              * false. The option is ignored by IE9-10.
              */
             interface Options {
@@ -2202,9 +2201,9 @@ declare namespace H {
         namespace Imprint {
             /**
              * Options to style an imprint
-             * @property invert {boolean=} - Indicates whether the logo is inverted. If omitted the current value remains, default is false.
-             * @property font {string=} - The font of the text. If omitted the current value remains, default is &quot;11px Arial,sans-serif&quot;.
-             * @property href {string=} - The URL of the &quot;Terms of use&quot; link. If omitted the current value remains, default is &quot;http://here.com/terms&quot;.
+             * invert {boolean=} - Indicates whether the logo is inverted. If omitted the current value remains, default is false.
+             * font {string=} - The font of the text. If omitted the current value remains, default is &quot;11px Arial,sans-serif&quot;.
+             * href {string=} - The URL of the &quot;Terms of use&quot; link. If omitted the current value remains, default is &quot;http://here.com/terms&quot;.
              */
             interface Options {
                 invert?: boolean | undefined;
@@ -2228,14 +2227,14 @@ declare namespace H {
         namespace Marker {
             /**
              * Options used to initialize a Marker
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property icon {H.map.Icon=} - The icon to use for the visual representation, if omitted a default icon is used.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * icon {H.map.Icon=} - The icon to use for the visual representation, if omitted a default icon is used.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
              */
             interface Options {
                 min?: number | undefined;
@@ -2372,13 +2371,13 @@ declare namespace H {
         namespace Object {
             /**
              * Options used to initialize a map object
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property visibility {boolean=} - Indicates whether the map object is visible at all, default is true
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * visibility {boolean=} - Indicates whether the map object is visible at all, default is true
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
              */
             interface Options {
                 min?: number | undefined;
@@ -2463,14 +2462,14 @@ declare namespace H {
         namespace Overlay {
             /**
              * Options used to initialize an Overlay
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property opacity {number=} - The opacity of the object in range from 0 (transparent) to 1 (opaque), default is 1.
-             * @property visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * opacity {number=} - The opacity of the object in range from 0 (transparent) to 1 (opaque), default is 1.
+             * visibility {boolean=} - Indicates whether the map object is visible at all, default is true.
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
              */
             interface Options {
                 min?: number | undefined;
@@ -2525,9 +2524,9 @@ declare namespace H {
 
         namespace Polygon {
             /**
-             * @property style {H.map.SpatialStyle | H.map.SpatialStyle.Options} - The style to be used when tracing the spatial object.
-             * @property arrows {H.map.ArrowStyle | H.map.ArrowStyle.Options} - The arrows style to be used when rendering the spatial object.
-             * @property visibility {boolean}
+             * style {H.map.SpatialStyle | H.map.SpatialStyle.Options} - The style to be used when tracing the spatial object.
+             * arrows {H.map.ArrowStyle | H.map.ArrowStyle.Options} - The arrows style to be used when rendering the spatial object.
+             * visibility {boolean}
              * Indicates whether the map object is visible, the default is true A map object is only treated as visible, if it self and all of its nesting parent groups are visible.
              */
             interface Options {
@@ -2751,15 +2750,15 @@ declare namespace H {
         namespace Polyline {
             /**
              * Options which are used to initialize a polyline
-             * @property style {(H.map.SpatialStyle | H.map.SpatialStyle.Options)=} - the style to be used when tracing the polyline
-             * @property arrows {(H.map.ArrowStyle | H.map.ArrowStyle.Options)=} - The arrows style to be used when rendering the polyline.
-             * @property visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * style {(H.map.SpatialStyle | H.map.SpatialStyle.Options)=} - the style to be used when tracing the polyline
+             * arrows {(H.map.ArrowStyle | H.map.ArrowStyle.Options)=} - The arrows style to be used when rendering the polyline.
+             * visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData
              */
             interface Options {
                 style?: (H.map.SpatialStyle | H.map.SpatialStyle.Options) | undefined;
@@ -2840,13 +2839,13 @@ declare namespace H {
         namespace Spatial {
             /**
              * Data to used as rendering hint for a label
-             * @property x {number} - The X coordinate of the first line's starting point
-             * @property y {number} - The Y coordinate of the first line's base line
-             * @property angle {number} - The clockwise rotation angle in radians
-             * @property font {string} - The CSS font-family
-             * @property size {number} - The CSS font-size
-             * @property color {string} - The CSS color
-             * @property text {string} - The text content, new line characters (\u000A) are interpreted as line breaks
+             * x {number} - The X coordinate of the first line's starting point
+             * y {number} - The Y coordinate of the first line's base line
+             * angle {number} - The clockwise rotation angle in radians
+             * font {string} - The CSS font-family
+             * size {number} - The CSS font-size
+             * color {string} - The CSS color
+             * text {string} - The text content, new line characters (\u000A) are interpreted as line breaks
              */
             interface Label {
                 x: number;
@@ -2860,15 +2859,15 @@ declare namespace H {
 
             /**
              * Options which are used to initialize spatial object object
-             * @property style {(H.map.SpatialStyle | H.map.SpatialStyle.Options)=} - the style to be used when tracing the spatial object
-             * @property arrows {(H.map.ArrowStyle | H.map.ArrowStyle.Options)=} - The arrows style to be used when rendering the spatial.
-             * @property visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
-             * @property zIndex {number=} - The z-index value of the map object, default is 0
-             * @property min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
-             * @property max {number=} - The maximum zoom level for which the object is visible, default is Infinity
-             * @property provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
+             * style {(H.map.SpatialStyle | H.map.SpatialStyle.Options)=} - the style to be used when tracing the spatial object
+             * arrows {(H.map.ArrowStyle | H.map.ArrowStyle.Options)=} - The arrows style to be used when rendering the spatial.
+             * visibility {boolean=} - An optional boolean value indicating whether this map object is visible, default is true
+             * zIndex {number=} - The z-index value of the map object, default is 0
+             * min {number=} - The minimum zoom level for which the object is visible, default is -Infinity
+             * max {number=} - The maximum zoom level for which the object is visible, default is Infinity
+             * provider {(H.map.provider.Provider | null)=} - The provider of this object. This property is only needed if a customized Implementation of ObjectProvider wants to instantiate
              * an object.
-             * @property data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
+             * data {*} - Optional arbitrary data to be stored with this map object. This data can be retrieved by calling getData.
              */
             interface Options {
                 style?: (H.map.SpatialStyle | H.map.SpatialStyle.Options) | undefined;
@@ -2885,16 +2884,16 @@ declare namespace H {
         /**
          * The SpatialStyle class represents a style with which spatial objects like polylines and polygons are drawn. A SpatialStyle instance is always treated as immutable to avoid inconstiencies
          * and must not modified.
-         * @property strokeColor {string} - The color of the stroke in CSS syntax, default is 'rgba(0, 85, 170, 0.6)'.
-         * @property fillColor {string} - The filling color in CSS syntax, default is 'rgba(0, 85, 170, 0.4)'.
-         * @property lineWidth {number} - The width of the line in pixels, default is 2.
-         * @property lineCap {H.map.SpatialStyle.LineCap} - The style of the end caps for a line, default is 'round'.
-         * @property lineJoin {H.map.SpatialStyle.LineJoin} - The type of corner created, when two lines meet, default is 'miter'.
-         * @property miterLimit {number} - The miter length is the distance between the inner corner and the outer corner where two lines meet. The default is 10.
-         * @property lineDash {Array<number>} - The line dash pattern as an even numbered list of distances to alternately produce a line and a space. The default is [].
-         * @property lineDashOffset {number} - The phase offset of the line dash pattern The default is 0.
-         * @property MAX_LINE_WIDTH {number} - This constant represents the maximum line width which can be used for rendering.
-         * @property DEFAULT_STYLE {H.map.SpatialStyle} - This static member defines the default style for spatial objects on the map. It's value is
+         * strokeColor {string} - The color of the stroke in CSS syntax, default is 'rgba(0, 85, 170, 0.6)'.
+         * fillColor {string} - The filling color in CSS syntax, default is 'rgba(0, 85, 170, 0.4)'.
+         * lineWidth {number} - The width of the line in pixels, default is 2.
+         * lineCap {H.map.SpatialStyle.LineCap} - The style of the end caps for a line, default is 'round'.
+         * lineJoin {H.map.SpatialStyle.LineJoin} - The type of corner created, when two lines meet, default is 'miter'.
+         * miterLimit {number} - The miter length is the distance between the inner corner and the outer corner where two lines meet. The default is 10.
+         * lineDash {Array<number>} - The line dash pattern as an even numbered list of distances to alternately produce a line and a space. The default is [].
+         * lineDashOffset {number} - The phase offset of the line dash pattern The default is 0.
+         * MAX_LINE_WIDTH {number} - This constant represents the maximum line width which can be used for rendering.
+         * DEFAULT_STYLE {H.map.SpatialStyle} - This static member defines the default style for spatial objects on the map. It's value is
          * { strokeColor: '#05A', fillColor: 'rgba(0, 85, 170, 0.4)', lineWidth: 1, lineCap: 'round', lineJoin: 'miter', miterLimit: 10, lineDash: [], lineDashOffset: 0 }
          */
         class SpatialStyle {
@@ -2945,15 +2944,15 @@ declare namespace H {
 
             /**
              * Options used to initialize a style. If a property is not set, the default value from H.map.SpatialStyle is taken.
-             * @property strokeColor {string=} - The color of the stroke in CSS syntax.
-             * @property fillColor {string=} - The color of the stroke in CSS syntax.
-             * @property lineWidth {number=} - The width of the line in pixels, default is 2. The maximum supported line width is 100.
-             * @property lineCap {H.map.SpatialStyle.LineCap=} - The style of the end caps for a line.
-             * @property lineJoin {H.map.SpatialStyle.LineJoin=} - The type of corner created, when two lines meet.
-             * @property miterLimit {number=} - The miter limit in pixel, default is 10. The maximum supported miter limit is 100
-             * @property lineDash {Array<number>} - The line dash pattern as an even numbered list of distances to alternately produce a line and a space. If the browser doesn't support this feature
+             * strokeColor {string=} - The color of the stroke in CSS syntax.
+             * fillColor {string=} - The color of the stroke in CSS syntax.
+             * lineWidth {number=} - The width of the line in pixels, default is 2. The maximum supported line width is 100.
+             * lineCap {H.map.SpatialStyle.LineCap=} - The style of the end caps for a line.
+             * lineJoin {H.map.SpatialStyle.LineJoin=} - The type of corner created, when two lines meet.
+             * miterLimit {number=} - The miter limit in pixel, default is 10. The maximum supported miter limit is 100
+             * lineDash {Array<number>} - The line dash pattern as an even numbered list of distances to alternately produce a line and a space. If the browser doesn't support this feature
              * this style property is ignored.
-             * @property lineDashOffset {number=} - The phase offset of the line dash pattern
+             * lineDashOffset {number=} - The phase offset of the line dash pattern
              */
             interface Options {
                 strokeColor?: string | undefined;
@@ -3061,10 +3060,10 @@ declare namespace H {
             /**
              * Update event is fired whenever view model data is changed. It contains property which hold currently requested data
              * @fixme find documentation and update constructor typings
-             * @property target {*} - Object which triggered the event
-             * @property currentTarget {*} - Object which has listener attached
-             * @property type {string} - Name of the dispatched event
-             * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+             * target {*} - Object which triggered the event
+             * currentTarget {*} - Object which has listener attached
+             * type {string} - Name of the dispatched event
+             * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
              */
             class UpdateEvent extends H.util.Event {
                 /**
@@ -3093,12 +3092,12 @@ declare namespace H {
         /**
          * ViewPort object holds information about the HTML element where the map is rendered. It contains information regarding the element (view port) size and triggers events when the element size
          * is changed.
-         * @property element {Element} - This property holds the HTML element, which defines the viewport.
-         * @property width {number} - This property holds this viewport&#x27;s current width
-         * @property height {number} - This property holds this viewport&#x27;s current height
-         * @property margin {number} - This property holds this viewport&#x27;s current margin value
-         * @property padding {H.map.ViewPort.Padding} - This property holds this viewport&#x27;s current padding
-         * @property center {H.math.Point} - This property holds this viewport&#x27;s current center point
+         * element {Element} - This property holds the HTML element, which defines the viewport.
+         * width {number} - This property holds this viewport&#x27;s current width
+         * height {number} - This property holds this viewport&#x27;s current height
+         * margin {number} - This property holds this viewport&#x27;s current margin value
+         * padding {H.map.ViewPort.Padding} - This property holds this viewport&#x27;s current padding
+         * center {H.math.Point} - This property holds this viewport&#x27;s current center point
          */
         class ViewPort extends H.util.EventTarget implements H.map.IInteraction {
             /**
@@ -3180,9 +3179,9 @@ declare namespace H {
         namespace ViewPort {
             /**
              * Options which may be used to initialize new ViewPort instance
-             * @property margin {number=} - The size in pixel of the supplemental area to render for each side of the map
-             * @property padding {H.map.ViewPort.Padding=} - The padding in pixels for each side of the map
-             * @property fixedCenter {boolean=} - Indicates whether the center of the map should remain unchanged if the viewport's size or or padding has been changed, default is true
+             * margin {number=} - The size in pixel of the supplemental area to render for each side of the map
+             * padding {H.map.ViewPort.Padding=} - The padding in pixels for each side of the map
+             * fixedCenter {boolean=} - Indicates whether the center of the map should remain unchanged if the viewport's size or or padding has been changed, default is true
              */
             interface Options {
                 margin?: number | undefined;
@@ -3192,10 +3191,10 @@ declare namespace H {
 
             /**
              * Represents viewport padding definition.
-             * @property top {number} - the padding on the top edge (in pixels)
-             * @property right {number} - the padding on the right edge (in pixels)
-             * @property bottom {number} - the padding on the bottom edge (in pixels)
-             * @property left {number} - the padding on the left edge (in pixels)
+             * top {number} - the padding on the top edge (in pixels)
+             * right {number} - the padding on the right edge (in pixels)
+             * bottom {number} - the padding on the bottom edge (in pixels)
+             * left {number} - the padding on the left edge (in pixels)
              */
             interface Padding {
                 top: number;
@@ -3300,8 +3299,8 @@ declare namespace H {
             namespace IMarkerLayer {
                 /**
                  * This type represents a response object returned by the H.map.layer.IMarkerLayer#requestMarkers function.
-                 * @property total {number} - The total number of markers, inclusive markers with not ready icons
-                 * @property markers {Array<H.map.AbstractMarker>} - The marker objects for the bounding rectangle (only ready)
+                 * total {number} - The total number of markers, inclusive markers with not ready icons
+                 * markers {Array<H.map.AbstractMarker>} - The marker objects for the bounding rectangle (only ready)
                  */
                 interface Response {
                     total: number;
@@ -3310,9 +3309,9 @@ declare namespace H {
 
                 /**
                  * This type represents a response object returned by the H.map.layer.IMarkerLayer#requestMarkers function.
-                 * @property number {number} - of returned tiles
-                 * @property requested {number} - number of requested tiles
-                 * @property objects {Array<H.map.AbstractMarker>} - the marker objects within requested tiled area
+                 * number {number} - of returned tiles
+                 * requested {number} - number of requested tiles
+                 * objects {Array<H.map.AbstractMarker>} - the marker objects within requested tiled area
                  */
                 interface TiledResponse {
                     number: number;
@@ -3358,8 +3357,8 @@ declare namespace H {
             namespace ITileLayer {
                 /**
                  * Options which are used to initialize a TileLayer object.
-                 * @property projection {H.geo.IProjection=} - an optional projection to be used for this layer, default is H.geo.mercator
-                 * @property opacity {number=} - tile layer opacity, default is 1
+                 * projection {H.geo.IProjection=} - an optional projection to be used for this layer, default is H.geo.mercator
+                 * opacity {number=} - tile layer opacity, default is 1
                  */
                 interface Options {
                     projection?: H.geo.IProjection | undefined;
@@ -3368,8 +3367,8 @@ declare namespace H {
 
                 /**
                  * A response object for a tile request. Contains total number of elements requested and an array of currently available Tiles
-                 * @property total {number} - the total number of requested tiles
-                 * @property tiles {Array<H.map.provider.Tile>} - the tiles which this provider can currently return synchronously
+                 * total {number} - the total number of requested tiles
+                 * tiles {Array<H.map.provider.Tile>} - the tiles which this provider can currently return synchronously
                  */
                 interface Response {
                     total: number;
@@ -3439,11 +3438,11 @@ declare namespace H {
             namespace Layer {
                 /**
                  * Options which can be used when creating new layer object.
-                 * @property min {number=} - The minimum zoom level for which the layer can provide data, default is 0
-                 * @property max {number=} - The maximum zoom level for which the layer can provide data, default is 22
-                 * @property dark {boolean=} - Indicates whether the content of this layer is mainly dark, default is false See also H.Map.Options#autoColor
-                 * @property projection {H.geo.IProjection=} - The projection to be used for this layer, default is H.geo.mercator
-                 * @property minWorldSize {number=} - The minimal world size at zoom level 0, default is 256
+                 * min {number=} - The minimum zoom level for which the layer can provide data, default is 0
+                 * max {number=} - The maximum zoom level for which the layer can provide data, default is 22
+                 * dark {boolean=} - Indicates whether the content of this layer is mainly dark, default is false See also H.Map.Options#autoColor
+                 * projection {H.geo.IProjection=} - The projection to be used for this layer, default is H.geo.mercator
+                 * minWorldSize {number=} - The minimal world size at zoom level 0, default is 256
                  */
                 interface Options {
                     min?: number | undefined;
@@ -3568,10 +3567,10 @@ declare namespace H {
             namespace ObjectLayer {
                 /**
                  * Configuration object which can be use to initialize the ObjectLayer.
-                 * @property tileSize {number=} - the size of the tiles rendered by this layer for polylines and polygons (must be power of 2, default is 256)
-                 * @property tileCacheSize {number=} - the number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
-                 * @property dataCacheSize {number=} - the number of tiles to cache which have render data only, default is 512
-                 * @property pixelRatio {number=} - The pixelRatio to use for over-sampling in cases of high-resolution displays
+                 * tileSize {number=} - the size of the tiles rendered by this layer for polylines and polygons (must be power of 2, default is 256)
+                 * tileCacheSize {number=} - the number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
+                 * dataCacheSize {number=} - the number of tiles to cache which have render data only, default is 512
+                 * pixelRatio {number=} - The pixelRatio to use for over-sampling in cases of high-resolution displays
                  */
                 interface Options {
                     tileSize?: number | undefined;
@@ -3582,8 +3581,8 @@ declare namespace H {
 
                 /**
                  * A response object returned by the H.map.layer.ObjectLayer#requestOverlays function.
-                 * @property total {number} - The total number of overlays within the requested bounds, inclusive overlays which are not ready loaded yet
-                 * @property overlays {Array<H.map.Overlay>} - A list all overlays which are ready to render
+                 * total {number} - The total number of overlays within the requested bounds, inclusive overlays which are not ready loaded yet
+                 * overlays {Array<H.map.Overlay>} - A list all overlays which are ready to render
                  */
                 interface OverlaysResponse {
                     total: number;
@@ -3620,7 +3619,7 @@ declare namespace H {
         namespace provider {
             /**
              * An ImageTileProvider uses network service to provide bitmap images as tiles.
-             * @property tileSize {number} - Size of a tile image supported by the provider
+             * tileSize {number} - Size of a tile image supported by the provider
              */
             class ImageTileProvider extends H.map.provider.RemoteTileProvider {
                 /**
@@ -3635,14 +3634,14 @@ declare namespace H {
             namespace ImageTileProvider {
                 /**
                  * Options to initialize an ImageTileProvider instance
-                 * @property uri {string=} - The provider's unique resource identifier which must not contain an underscore "_". If omitted an auto-generated unique Session ID is used. If a cross
+                 * uri {string=} - The provider's unique resource identifier which must not contain an underscore "_". If omitted an auto-generated unique Session ID is used. If a cross
                  * sessions consistent IDs is needed (e.g. for storing provider data) this property must be specified.
-                 * @property min {number=} - The minimal supported zoom level, default is 0
-                 * @property max {number=} - The maximal supported zoom level, default is 22
-                 * @property getCopyrights {(function(H.geo.Rect, number): ?Array<H.map.ICopyright>)=} - A function to replace the default implementation of H.map.provider.Provider#getCopyrights
-                 * @property tileSize {number=} - The size of a tile as edge length in pixels. It must be 2^n where n is in range [0 ... 30], default is 256
-                 * @property getURL {function(number, number, number)} - The function to create an URL for the specified tile. If it returns a falsy the tile is not requested.
-                 * @property crossOrigin {(string | boolean=)} - The CORS settings to use for the crossOrigin attribute for the image, if omitted or if the value evaluates to false no CORS settings
+                 * min {number=} - The minimal supported zoom level, default is 0
+                 * max {number=} - The maximal supported zoom level, default is 22
+                 * getCopyrights {(function(H.geo.Rect, number): ?Array<H.map.ICopyright>)=} - A function to replace the default implementation of H.map.provider.Provider#getCopyrights
+                 * tileSize {number=} - The size of a tile as edge length in pixels. It must be 2^n where n is in range [0 ... 30], default is 256
+                 * getURL {function(number, number, number)} - The function to create an URL for the specified tile. If it returns a falsy the tile is not requested.
+                 * crossOrigin {(string | boolean=)} - The CORS settings to use for the crossOrigin attribute for the image, if omitted or if the value evaluates to false no CORS settings
                  * are used.
                  */
                 interface Options {
@@ -3662,7 +3661,7 @@ declare namespace H {
 
             /**
              * This class represents invalidation states of a renderable object. A renderer can optimize its rendering strategies based on the information in this object.
-             * @property MARK_INITIAL {H.map.provider.Invalidations.Mark} - This constant represents the initial invalidation mark an invalidations object has.
+             * MARK_INITIAL {H.map.provider.Invalidations.Mark} - This constant represents the initial invalidation mark an invalidations object has.
              */
             class Invalidations {
                 /**
@@ -3744,13 +3743,13 @@ declare namespace H {
 
             /**
              * A MarkerTileProvider uses network service to provide markers on tile basis.
-             * @property requestTile {} - Request data on a tile basis
-             * @property cancelTile {} - Cancels tile from being requested using x, y, z coordinates (column, row, zoom)
-             * @property cancelTileByKey {} - Cancels tile from being requested using a tile-key
-             * @property uri {string} - This provider's unique resource identifier, if not provided at construction time it defaults to provider's uid
-             * @property min {number} - Minimum zoom level at which provider can serve data, set at construction time
-             * @property max {number} - Maximum zoom level at which provider can server data, set at construction time
-             * @property uid {string} - Provider instance unique identifier, generated at construction time
+             * requestTile {} - Request data on a tile basis
+             * cancelTile {} - Cancels tile from being requested using x, y, z coordinates (column, row, zoom)
+             * cancelTileByKey {} - Cancels tile from being requested using a tile-key
+             * uri {string} - This provider's unique resource identifier, if not provided at construction time it defaults to provider's uid
+             * min {number} - Minimum zoom level at which provider can serve data, set at construction time
+             * max {number} - Maximum zoom level at which provider can server data, set at construction time
+             * uid {string} - Provider instance unique identifier, generated at construction time
              */
             class MarkerTileProvider extends H.map.provider.RemoteTileProvider {
                 /**
@@ -3776,11 +3775,11 @@ declare namespace H {
             namespace MarkerTileProvider {
                 /**
                  * Options which are used to initialize the MarkerTileProvider object.
-                 * @property min {number=} - The minimal supported zoom level, default is 0
-                 * @property max {number=} - The maximal supported zoom level, default is 22
-                 * @property requestData {function(number, number, number, function(Array<H.map.AbstractMarker>), Function): H.util.ICancelable} - function that fetches marker data and creates array
+                 * min {number=} - The minimal supported zoom level, default is 0
+                 * max {number=} - The maximal supported zoom level, default is 22
+                 * requestData {function(number, number, number, function(Array<H.map.AbstractMarker>), Function): H.util.ICancelable} - function that fetches marker data and creates array
                  * of H.map.AbstractMarker that is passed success callback, if function fails to fetch data onError callback must be called
-                 * @property providesDomMarkers {boolean=} - indicates if markers provided are of type H.map.DomMarker or H.map.Marker, default is H.map.Marker
+                 * providesDomMarkers {boolean=} - indicates if markers provided are of type H.map.DomMarker or H.map.Marker, default is H.map.Marker
                  */
                 interface Options {
                     min?: number | undefined;
@@ -3909,10 +3908,10 @@ declare namespace H {
             /**
              * A Provider defines an object which works as a database for the map. Providers can exists in different forms they can implement client side object storage or they can request data from
              * the remote service.
-             * @property uri {string} - This provider's unique resource identifier, if not provided at construction time it defaults to provider's uid
-             * @property min {number} - Minimum zoom level at which provider can serve data, set at construction time
-             * @property max {number} - Maximum zoom level at which provider can server data, set at construction time
-             * @property uid {string} - Provider instance unique identifier, generated at construction time
+             * uri {string} - This provider's unique resource identifier, if not provided at construction time it defaults to provider's uid
+             * min {number} - Minimum zoom level at which provider can serve data, set at construction time
+             * max {number} - Maximum zoom level at which provider can server data, set at construction time
+             * uid {string} - Provider instance unique identifier, generated at construction time
              */
             class Provider extends H.util.EventTarget {
                 /**
@@ -3956,11 +3955,11 @@ declare namespace H {
             namespace Provider {
                 /**
                  * Options to initialize a Provider instance
-                 * @property uri {string=} - The provider's unique resource identifier which must not contain an underscore "_". If omitted an auto-generated unique Session ID is used. If a cross
+                 * uri {string=} - The provider's unique resource identifier which must not contain an underscore "_". If omitted an auto-generated unique Session ID is used. If a cross
                  * sessions consistent IDs is needed (e.g. for storing provider data) this property must be specified.
-                 * @property min {number=} - The minimal supported zoom level, default is 0
-                 * @property max {number=} - The maximal supported zoom level, default is 22
-                 * @property getCopyrights {(function(H.geo.Rect, number): ?Array<H.map.ICopyright>)=} - A function to replace the default implementation of H.map.provider.Provider#getCopyrights
+                 * min {number=} - The minimal supported zoom level, default is 0
+                 * max {number=} - The maximal supported zoom level, default is 22
+                 * getCopyrights {(function(H.geo.Rect, number): ?Array<H.map.ICopyright>)=} - A function to replace the default implementation of H.map.provider.Provider#getCopyrights
                  */
                 interface Options {
                     uri?: string | undefined;
@@ -4020,12 +4019,12 @@ declare namespace H {
             /**
              * Generic Tile object which represents a part of the world fiting into the Tile area represented by the Tiel coordinates (x - row, y - column) and the zoom level (z). Number of tiles
              * at particular zoom level (which means number of areas into world is being splitted) is defined as following: numberOfRows &#x3D; numberOfColumns &#x3D; 2^zoomlevel
-             * @property key {string} - Unique tile key generated by provider
-             * @property data {*} - Tile data (an image for example)
-             * @property valid {boolean} - This property holds a boolean flag indicating whether this tile is still valid (true) or whether it should be re-fetched (false)
-             * @property x {number} - Tile column
-             * @property y {number} - Tile row
-             * @property z {number} - Tile zoom level
+             * key {string} - Unique tile key generated by provider
+             * data {*} - Tile data (an image for example)
+             * valid {boolean} - This property holds a boolean flag indicating whether this tile is still valid (true) or whether it should be re-fetched (false)
+             * x {number} - Tile column
+             * y {number} - Tile row
+             * z {number} - Tile zoom level
              */
             class Tile {
                 /**
@@ -4048,13 +4047,13 @@ declare namespace H {
 
             /**
              * TileProvider is an abstract class to provide data on a tile basis
-             * @property requestTile {} - Request data on a tile basis
-             * @property cancelTile {} - Cancels tile from being requested using x, y, z coordinates (column, row, zoom)
-             * @property cancelTileByKey {} - Cancels tile from being requested using a tile-key
-             * @property uri {string} - This provider&#x27;s unique resource identifier, if not provided at construction time it defaults to provider&#x27;s uid
-             * @property min {number} - Minimum zoom level at which provider can serve data, set at construction time
-             * @property max {number} - Maximum zoom level at which provider can server data, set at construction time
-             * @property uid {string} - Provider instance unique identifier, generated at construction time
+             * requestTile {} - Request data on a tile basis
+             * cancelTile {} - Cancels tile from being requested using x, y, z coordinates (column, row, zoom)
+             * cancelTileByKey {} - Cancels tile from being requested using a tile-key
+             * uri {string} - This provider&#x27;s unique resource identifier, if not provided at construction time it defaults to provider&#x27;s uid
+             * min {number} - Minimum zoom level at which provider can serve data, set at construction time
+             * max {number} - Maximum zoom level at which provider can server data, set at construction time
+             * uid {string} - Provider instance unique identifier, generated at construction time
              */
             class TileProvider extends H.map.provider.Provider {
                 /**
@@ -4094,12 +4093,12 @@ declare namespace H {
 
             namespace TileProvider {
                 /**
-                 * @property uri {string=} - The provider&#x27;s unique resource identifier which must not contain an underscore &quot;_&quot;. If omitted an auto-generated unique Session ID is used.
+                 * uri {string=} - The provider&#x27;s unique resource identifier which must not contain an underscore &quot;_&quot;. If omitted an auto-generated unique Session ID is used.
                  * If a cross sessions consistent IDs is needed (e.g. for storing provider data) this property must be specified.
-                 * @property min {number=} - The minimal supported zoom level, default is 0
-                 * @property max {number=} - The maximal supported zoom level, default is 22
-                 * @property getCopyrights {(function(H.geo.Rect, number): Array<H.map.ICopyright>)=} - A function to replace the default implememtation of H.map.provider.Provider#getCopyrights
-                 * @property tileSize {number=} - The size of a tile as edge length in pixels. It must be 2^n where n is in range [0 ... 30], default is 256
+                 * min {number=} - The minimal supported zoom level, default is 0
+                 * max {number=} - The maximal supported zoom level, default is 22
+                 * getCopyrights {(function(H.geo.Rect, number): Array<H.map.ICopyright>)=} - A function to replace the default implememtation of H.map.provider.Provider#getCopyrights
+                 * tileSize {number=} - The size of a tile as edge length in pixels. It must be 2^n where n is in range [0 ... 30], default is 256
                  */
                 interface Options {
                     uri?: string | undefined;
@@ -4216,51 +4215,43 @@ declare namespace H {
                 /**
                  * The geographical area to render. Note that it is not the same as visible viewport. Specified bounds also include H.Map.Options#margin and
                  * optionally an additional margin in case of DOM node rendering for a better rendering experience.
-                 * @type {H.geo.Rect}
                  */
                 bounds: H.geo.Rect;
 
                 /**
                  * The zoom level to render the data for.
-                 * @type {number}
                  */
                 zoom: number;
 
                 /**
                  * The coordinates of the screen center in CSS pixels.
-                 * @type {H.math.Point}
                  */
                 screenCenter: H.math.Point;
 
                 /**
                  * The coordinates relative to the screen center where the rendering has the highest priority. If the layer has to request and/or process data
                  * asynchronously, it's recommended to prioritize the rendering close to this center.
-                 * @type {H.math.Point}
                  */
                 priorityCenter: H.math.Point;
 
                 /**
                  * The pixel projection to use to project geographical coordinates into screen coordinates and vice versa.
-                 * @type {H.geo.PixelProjection}
                  */
                 projection: H.geo.PixelProjection;
 
                 /**
                  * Indicates whether only cached data should be considered.
-                 * @type {boolean}
                  */
                 cacheOnly: boolean;
 
                 /**
                  * The size of the area to render.
-                 * @type {H.math.Size}
                  */
                 size: H.math.Size;
 
                 /**
                  * The pixelRatio to use for over-sampling in cases of high-resolution displays.
                  * See https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio.
-                 * @type {number}
                  */
                 pixelRatio: number;
             }
@@ -4373,9 +4364,9 @@ declare namespace H {
     namespace mapevents {
         /**
          * Behavior class uses map events and adds behavior functionality to the map. This allows map panning and zooming via using mouse wheel
-         * @property DRAGGING {number} - Map responds to user dragging via mouse or touch
-         * @property WHEELZOOM {number} - Map zooms in or out in respond to mouse wheel events
-         * @property DBLTAPZOOM {number} - Map zooms in or out in response to double click or double tap. For double tap if more that one touches are on the screen map will zoom out.
+         * DRAGGING {number} - Map responds to user dragging via mouse or touch
+         * WHEELZOOM {number} - Map zooms in or out in respond to mouse wheel events
+         * DBLTAPZOOM {number} - Map zooms in or out in response to double click or double tap. For double tap if more that one touches are on the screen map will zoom out.
          */
         class Behavior extends H.util.Disposable {
             /**
@@ -4418,8 +4409,8 @@ declare namespace H {
         namespace Behavior {
             /**
              * Options which are used to initialize the Behavior class.
-             * @property kinetics {H.util.kinetics.IKinetics=} - The parameters for the kinetic movement.
-             * @property enable {number=} - The bitmask of behaviors to enable like H.mapevents.Behavior.DRAGGING. All are enabled by default.
+             * kinetics {H.util.kinetics.IKinetics=} - The parameters for the kinetic movement.
+             * enable {number=} - The bitmask of behaviors to enable like H.mapevents.Behavior.DRAGGING. All are enabled by default.
              */
             interface Options {
                 kinetics?: H.util.kinetics.IKinetics | undefined;
@@ -4429,13 +4420,13 @@ declare namespace H {
 
         /**
          * ContextMenuEvent should be fired, when a user right-clicks or longpresses on a map object.
-         * @property viewportX {Array<H.util.ContextItem>} - Contains ContextItems, that will be used to create context menu entries. Should be filled by listeners of the "contextmenu" event
-         * @property viewportY {number} - Map viewport y position
-         * @property target {(H.map.Object | H.Map)} - Target for the event
-         * @property originalEvent {Event} - Original event
-         * @property currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
-         * @property type {string} - Name of the dispatched event
-         * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+         * viewportX {Array<H.util.ContextItem>} - Contains ContextItems, that will be used to create context menu entries. Should be filled by listeners of the "contextmenu" event
+         * viewportY {number} - Map viewport y position
+         * target {(H.map.Object | H.Map)} - Target for the event
+         * originalEvent {Event} - Original event
+         * currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
+         * type {string} - Name of the dispatched event
+         * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
          */
         class ContextMenuEvent extends H.util.Event {
             /**
@@ -4454,15 +4445,15 @@ declare namespace H {
 
         /**
          * Custom map event. Contains list of pointers on the map, list of changed pointers and original event. Inherits from H.util.Event.
-         * @property pointers {Array<H.mapevents.Pointer>} - Pointers which are currently on the screen
-         * @property changedPointers {Array<H.mapevents.Pointer>} - Pointers which has changed in course of event
-         * @property targetPointers {Array<H.mapevents.Pointer>} - Pointers which are on same target as the current pointer
-         * @property currentPointer {H.mapevents.Pointer} - Current pointer
-         * @property originalEvent {Event} - Original event fired by the browser
-         * @property target {(H.map.Object | H.Map)} - Object which triggered event. Can be the map object (i.e marker or polyline) or the map itself
-         * @property currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
-         * @property type {string} - Name of the dispatched event
-         * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+         * pointers {Array<H.mapevents.Pointer>} - Pointers which are currently on the screen
+         * changedPointers {Array<H.mapevents.Pointer>} - Pointers which has changed in course of event
+         * targetPointers {Array<H.mapevents.Pointer>} - Pointers which are on same target as the current pointer
+         * currentPointer {H.mapevents.Pointer} - Current pointer
+         * originalEvent {Event} - Original event fired by the browser
+         * target {(H.map.Object | H.Map)} - Object which triggered event. Can be the map object (i.e marker or polyline) or the map itself
+         * currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
+         * type {string} - Name of the dispatched event
+         * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
          */
         class Event extends H.util.Event {
             /**
@@ -4526,13 +4517,13 @@ declare namespace H {
 
         /**
          * Class representing pointer on the map surface. A pointer in platform specific definition would mean either mouse, touch, pen or any pointing device which can trigger browser events.
-         * @property viewportX {number} - X coordinate on the map's viewport
-         * @property viewportY {number} - Y coordinate on the map's viewport
-         * @property target {(H.map.Object | H.Map)} - Map object directly under the pointer. Can be null if if pointer is out of the map viewport
-         * @property id {number} - Pointer unique identifier.
-         * @property type {string} - Pointer type can be: 'mouse', 'touch' or 'pen'
-         * @property dragTarget {(H.map.Object | H.Map)} - Object which is currently dragged by the pointer
-         * @property button {H.mapevents.Pointer.Button} - Indicates which pointer device button has changed.
+         * viewportX {number} - X coordinate on the map's viewport
+         * viewportY {number} - Y coordinate on the map's viewport
+         * target {(H.map.Object | H.Map)} - Map object directly under the pointer. Can be null if if pointer is out of the map viewport
+         * id {number} - Pointer unique identifier.
+         * type {string} - Pointer type can be: 'mouse', 'touch' or 'pen'
+         * dragTarget {(H.map.Object | H.Map)} - Object which is currently dragged by the pointer
+         * button {H.mapevents.Pointer.Button} - Indicates which pointer device button has changed.
          */
         class Pointer {
             /**
@@ -4584,14 +4575,14 @@ declare namespace H {
 
         /**
          * WheelEvent is fired when the mouse wheel is used over the map. It contains information about cursor position and the map object which resides directly under the cursor.
-         * @property delta {number} - Wheel move delta
-         * @property viewportX {number} - Map viewport x position
-         * @property viewportY {number} - Map viewport y position
-         * @property target {(H.map.Object | H.Map)} - Target for the event
-         * @property originalEvent {Event} - Original mouse wheel event
-         * @property currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
-         * @property type {string} - Name of the dispatched event
-         * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+         * delta {number} - Wheel move delta
+         * viewportX {number} - Map viewport x position
+         * viewportY {number} - Map viewport y position
+         * target {(H.map.Object | H.Map)} - Target for the event
+         * originalEvent {Event} - Original mouse wheel event
+         * currentTarget {(H.map.Object | H.Map)} - Object which has listener attached
+         * type {string} - Name of the dispatched event
+         * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
          */
         class WheelEvent extends H.util.Event {
             /**
@@ -4620,8 +4611,8 @@ declare namespace H {
 
         /**
          * An interface for a 2-dimensional point consisting a x and y coordinate.
-         * @property x {number} - The point's coordinate on X-axis.
-         * @property y {number} - The point's coordinate on Y-axis.
+         * x {number} - The point's coordinate on X-axis.
+         * y {number} - The point's coordinate on Y-axis.
          */
         interface IPoint {
             x: number;
@@ -4630,8 +4621,8 @@ declare namespace H {
 
         /**
          * An interface for a 2-dimensional size consisting a with and a height.
-         * @property w {number} - The size's width.
-         * @property h {number} - The size's height.
+         * w {number} - The size's width.
+         * h {number} - The size's height.
          */
         interface ISize {
             w: number;
@@ -4640,8 +4631,8 @@ declare namespace H {
 
         /**
          * Class represents a 2-dimensional point, defined by x and y coordinates.
-         * @property x {number} - The point's coordinate on X-axis.
-         * @property y {number} - The point's coordinate on Y-axis.
+         * x {number} - The point's coordinate on X-axis.
+         * y {number} - The point's coordinate on Y-axis.
          */
         class Point implements IPoint {
             /**
@@ -4797,8 +4788,8 @@ declare namespace H {
 
         /**
          * Class for representing sizes consisting of a width and height.
-         * @property w {number} - The size's width value
-         * @property h {number} - The size's height value
+         * w {number} - The size's width value
+         * h {number} - The size's height value
          */
         class Size {
             /**
@@ -4912,9 +4903,9 @@ declare namespace H {
 
         namespace EnterpriseRoutingService {
             /**
-             * @property subDomain {string=} - The sub-domain of the routing service relative to the platform's base URL (default is 'route')
-             * @property path {string=} - The path of the map tile service, default is "routing/7.2"
-             * @property baseUrl {H.service.Url=} - The base URL of the service, defaults to the the platform's base URL if instance was created using H.service.Platform#getEnterpriseRoutingService
+             * subDomain {string=} - The sub-domain of the routing service relative to the platform's base URL (default is 'route')
+             * path {string=} - The path of the map tile service, default is "routing/7.2"
+             * baseUrl {H.service.Url=} - The base URL of the service, defaults to the the platform's base URL if instance was created using H.service.Platform#getEnterpriseRoutingService
              * method.
              */
             interface Options {
@@ -4967,8 +4958,8 @@ declare namespace H {
 
         namespace GeocodingService {
             /**
-             * @property subDomain {string=} - the sub-domain of the geo-coding service relative to the platform's base URL, default is 'geocoder'
-             * @property path {string=} - the path of the Geocoding service, default is '6.2'
+             * subDomain {string=} - the sub-domain of the geo-coding service relative to the platform's base URL, default is 'geocoder'
+             * path {string=} - the path of the Geocoding service, default is '6.2'
              */
             interface Options {
                 subDomain?: string | undefined;
@@ -4994,8 +4985,8 @@ declare namespace H {
         }
 
         /**
-         * @property id {number} - the ID associated internally with this request
-         * @property cancel {function()} - this function cancels the request and invokes the errback function
+         * id {number} - the ID associated internally with this request
+         * cancel {function()} - this function cancels the request and invokes the errback function
          */
         interface JsonpRequestHandle {
             id: number;
@@ -5074,12 +5065,12 @@ declare namespace H {
 
         namespace MapTileService {
             /**
-             * @property maps {Object<string, Object>} -
-             * @property schemes {Object<string, Object>} -
-             * @property tiletypes {Object<string, Object>} -
-             * @property formats {Object<string, Object>} -
-             * @property resolutions {Object<string, Object>} -
-             * @property languages {Object<string, Object>} -
+             * maps {Object<string, Object>} -
+             * schemes {Object<string, Object>} -
+             * tiletypes {Object<string, Object>} -
+             * formats {Object<string, Object>} -
+             * resolutions {Object<string, Object>} -
+             * languages {Object<string, Object>} -
              */
             interface Info {
                 maps: { [key: string]: any };
@@ -5091,10 +5082,10 @@ declare namespace H {
             }
 
             /**
-             * @property type {string=} - the type of the map tile service to communicate with, e.g. 'base' (default), 'aerial', etc. (refer to the Map Tile REST API documentation for available types)
-             * @property version {string=} - the map version hash to use for retrieving tiles, default is newest and will be automatically updated
-             * @property subDomain {string=} - the sub-domain of the map tile service relative to the platform's base URL, default is 'maps'
-             * @property path {string=} - the path of the map tile service, default is 'maptile/2.1'
+             * type {string=} - the type of the map tile service to communicate with, e.g. 'base' (default), 'aerial', etc. (refer to the Map Tile REST API documentation for available types)
+             * version {string=} - the map version hash to use for retrieving tiles, default is newest and will be automatically updated
+             * subDomain {string=} - the sub-domain of the map tile service relative to the platform's base URL, default is 'maps'
+             * path {string=} - the path of the map tile service, default is 'maptile/2.1'
              */
             interface Options {
                 type?: string | undefined;
@@ -5108,15 +5099,15 @@ declare namespace H {
          * A map type is an object holding tile layers corresponding to a map type (e.g. 'normal', 'satellite' or 'terrain'). A map type contains at least a map property which defines the basic
          * map layer for a given map type. In addition it can hold other map layers with the given style, e.g. base, xbase, traffic etc.
          * {@link https://developer.here.com/documentation/maps/content/api_reference/H.service.html#.MapType}
-         * @property map {H.map.layer.TileLayer} - the basic map tiles with all features and labels
-         * @property mapnight {H.map.layer.TileLayer} - the basic map tiles with all features and labels (night mode)
-         * @property xbase {H.map.layer.TileLayer=} - map tiles without features and labels
-         * @property xbasenight {H.map.layer.TileLayer=} - map tiles without features and labels (night mode)
-         * @property base {H.map.layer.TileLayer=} - map tiles without labels
-         * @property basenight {H.map.layer.TileLayer=} - map tiles without labels (night mode)
-         * @property trafficincidents {H.map.layer.TileLayer=} - map tiles with traffic flow highlighting
-         * @property transit {H.map.layer.TileLayer=} - map tiles with public transit lines highlighted
-         * @property labels {H.map.layer.TileLayer=} - transparent map tiles with labels only
+         * map {H.map.layer.TileLayer} - the basic map tiles with all features and labels
+         * mapnight {H.map.layer.TileLayer} - the basic map tiles with all features and labels (night mode)
+         * xbase {H.map.layer.TileLayer=} - map tiles without features and labels
+         * xbasenight {H.map.layer.TileLayer=} - map tiles without features and labels (night mode)
+         * base {H.map.layer.TileLayer=} - map tiles without labels
+         * basenight {H.map.layer.TileLayer=} - map tiles without labels (night mode)
+         * trafficincidents {H.map.layer.TileLayer=} - map tiles with traffic flow highlighting
+         * transit {H.map.layer.TileLayer=} - map tiles with public transit lines highlighted
+         * labels {H.map.layer.TileLayer=} - transparent map tiles with labels only
          */
         interface MapType {
             map: H.map.layer.TileLayer;
@@ -5231,9 +5222,9 @@ declare namespace H {
             }
 
             /**
-             * @property subDomain {string=} - the sub-domain of the places service relative to the platform's base URL, default is 'places'
-             * @property path {string=} - the path of the places service, default is 'places/v1'
-             * @property baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
+             * subDomain {string=} - the sub-domain of the places service relative to the platform's base URL, default is 'places'
+             * path {string=} - the path of the places service, default is 'places/v1'
+             * baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
              */
             interface Options {
                 subDomain?: string | undefined;
@@ -5360,13 +5351,13 @@ declare namespace H {
         namespace Platform {
             /**
              * Options used to create default layers
-             * @property tileSize {number=} - tile size to be queried from the HERE Map Tile API, default is 256
-             * @property ppi {number=} - 'ppi' parameter to use when querying tiles, default is not specified
-             * @property lg {string=} - optional primary language parameter, default is not specified
-             * @property lg2 {string=} - optional secondary language parameter, default is not specified
-             * @property style {string=} - optional 'style' parameter to use when querying map tiles, default is not specified
-             * @property pois {boolean=} - indicates if pois are displayed on the map
-             * @property crossOrigin {(string | boolean=)} - indicates if CORS headers should be used for default layers, if false is specified, CORS headers are not set, defaults to 'anonymous'.
+             * tileSize {number=} - tile size to be queried from the HERE Map Tile API, default is 256
+             * ppi {number=} - 'ppi' parameter to use when querying tiles, default is not specified
+             * lg {string=} - optional primary language parameter, default is not specified
+             * lg2 {string=} - optional secondary language parameter, default is not specified
+             * style {string=} - optional 'style' parameter to use when querying map tiles, default is not specified
+             * pois {boolean=} - indicates if pois are displayed on the map
+             * crossOrigin {(string | boolean=)} - indicates if CORS headers should be used for default layers, if false is specified, CORS headers are not set, defaults to 'anonymous'.
              * Be aware that storing of content is not possible if crossOrigin is not set to true (see H.Map#storeContent).
              */
             interface DefaultLayersOptions {
@@ -5380,11 +5371,11 @@ declare namespace H {
             }
 
             /**
-             * @property app_id {string} - The application ID to identify the client against the platform (mandatory to provide)
-             * @property app_code {string} - The application code to identify the client against the platform (mandatory to provide)
-             * @property baseUrl {H.service.Url=} - The base URL of the platform, default is http://api.here.com
-             * @property useCIT {boolean=} - Indicates whether the Customer Integration Testing should be used, default is false
-             * @property useHTTPS {boolean=} - Indicates whether secure communication should be used, default is false
+             * app_id {string} - The application ID to identify the client against the platform (mandatory to provide)
+             * app_code {string} - The application code to identify the client against the platform (mandatory to provide)
+             * baseUrl {H.service.Url=} - The base URL of the platform, default is http://api.here.com
+             * useCIT {boolean=} - Indicates whether the Customer Integration Testing should be used, default is false
+             * useHTTPS {boolean=} - Indicates whether secure communication should be used, default is false
              */
             interface Options {
                 apikey: string;
@@ -5428,9 +5419,9 @@ declare namespace H {
 
         namespace RoutingService {
             /**
-             * @property subDomain {string=} - the sub-domain of the routing service relative to the platform's base URL, default is 'route'
-             * @property path {string=} - the path of the map tile service, default is 'routing/7.2'
-             * @property baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
+             * subDomain {string=} - the sub-domain of the routing service relative to the platform's base URL, default is 'route'
+             * path {string=} - the path of the map tile service, default is 'routing/7.2'
+             * baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
              */
             interface Options {
                 subDomain?: string | undefined;
@@ -5628,7 +5619,7 @@ declare namespace H {
 
         /**
          * Options which are used to initialize the tile provider.
-         * @property crossOrigin {boolean=} - The string to be set for the crossOrigin attribute for loaded images
+         * crossOrigin {boolean=} - The string to be set for the crossOrigin attribute for loaded images
          */
         interface TileProviderOptions {
             crossOrigin?: boolean | undefined;
@@ -5671,9 +5662,9 @@ declare namespace H {
 
             namespace Service {
                 /**
-                 * @property subDomain {string=} - the sub-domain of the traffic incidents service relative to the platform's base URL, default is 'traffic'
-                 * @property path {string=} - the path of the traffic incidents service, default is 'traffic/6.1'
-                 * @property baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
+                 * subDomain {string=} - the sub-domain of the traffic incidents service relative to the platform's base URL, default is 'traffic'
+                 * path {string=} - the path of the traffic incidents service, default is 'traffic/6.1'
+                 * baseUrl {H.service.Url=} - an optional base URL if it differs from the platform's default base URL
                  */
                 interface Options {
                     subDomain?: string | undefined;
@@ -5898,12 +5889,12 @@ declare namespace H {
 
             namespace Service {
                 /**
-                 * @property maps {Object<string, Object>} -
-                 * @property schemes {Object<string, Object>} -
-                 * @property tiletypes {Object<string, Object>} -
-                 * @property formats {Object<string, Object>} -
-                 * @property resolutions {Object<string, Object>} -
-                 * @property languages {Object<string, Object>} -
+                 * maps {Object<string, Object>} -
+                 * schemes {Object<string, Object>} -
+                 * tiletypes {Object<string, Object>} -
+                 * formats {Object<string, Object>} -
+                 * resolutions {Object<string, Object>} -
+                 * languages {Object<string, Object>} -
                  */
                 interface Info {
                     maps: { [key: string]: any };
@@ -5915,10 +5906,10 @@ declare namespace H {
                 }
 
                 /**
-                 * @property type {string=} - the type of the map tile service to communicate with, e.g. 'base' (default), 'aerial', etc. (refer to the Map Tile REST API documentation for
+                 * type {string=} - the type of the map tile service to communicate with, e.g. 'base' (default), 'aerial', etc. (refer to the Map Tile REST API documentation for
                  * available types)
-                 * @property version {string=} - the map version hash to use for retrieving tiles, default is newest and will be automatically updated
-                 * @property subDomain {string=} - the sub-domain of the map tile service relative to the platform's base URL, default is 'maps'
+                 * version {string=} - the map version hash to use for retrieving tiles, default is newest and will be automatically updated
+                 * subDomain {string=} - the sub-domain of the map tile service relative to the platform's base URL, default is 'maps'
                  */
                 interface Options {
                     type?: string | undefined;
@@ -5943,12 +5934,12 @@ declare namespace H {
             namespace TileProvider {
                 /**
                  * Configuration object which can be used to initialize the TileProvider.
-                 * @property tileType {string=} - The tile type for which to request meta info
-                 * @property scheme {string=} - The map scheme for which to request meta info
-                 * @property tileCacheSize {number=} - The number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
-                 * @property tileSize {number=} - The size of the tiles rendered by this provider (must be power of 2, default is 256)
-                 * @property pixelRatio {number=} - The pixel ratio to use for over-sampling in cases of high-resolution displays
-                 * @property categoryFilter {Array<string>=} - A list of meta-info category names which should be suppressed. See Metainfo Tile for valid category names.
+                 * tileType {string=} - The tile type for which to request meta info
+                 * scheme {string=} - The map scheme for which to request meta info
+                 * tileCacheSize {number=} - The number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
+                 * tileSize {number=} - The size of the tiles rendered by this provider (must be power of 2, default is 256)
+                 * pixelRatio {number=} - The pixel ratio to use for over-sampling in cases of high-resolution displays
+                 * categoryFilter {Array<string>=} - A list of meta-info category names which should be suppressed. See Metainfo Tile for valid category names.
                  */
                 interface Options {
                     tileType?: string | undefined;
@@ -6101,8 +6092,8 @@ declare namespace H {
 
             namespace Service {
                 /**
-                 * @property subDomain {string=} - the sub-domain of the Venue Maps service relative to the platform's base URL, default is 'venue.maps'
-                 * @property path {string=} - the path to append after host name when making requests to the Venue Maps API, default is empty
+                 * subDomain {string=} - the sub-domain of the Venue Maps service relative to the platform's base URL, default is 'venue.maps'
+                 * path {string=} - the path to append after host name when making requests to the Venue Maps API, default is empty
                  */
                 interface Options {
                     subDomain?: string | undefined;
@@ -6186,9 +6177,9 @@ declare namespace H {
             namespace TileProvider {
                 /**
                  * Configuration object which can be used to initialize the TileProvider.
-                 * @property tileCacheSize {number=} - The number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
-                 * @property pixelRatio {number=} - The pixel ratio to use for over-sampling in cases of high-resolution displays
-                 * @property onSpaceCreated {function(H.service.venues.Space)=} - A callback function that is called on every created space (see H.service.venues.Space) object. The function can be
+                 * tileCacheSize {number=} - The number of fully rendered spatial tiles that are cached for immediate reuse, default is 32
+                 * pixelRatio {number=} - The pixel ratio to use for over-sampling in cases of high-resolution displays
+                 * onSpaceCreated {function(H.service.venues.Space)=} - A callback function that is called on every created space (see H.service.venues.Space) object. The function can be
                  * used for space object styling.
                  */
                 interface Options {
@@ -6285,13 +6276,13 @@ declare namespace H {
 
         namespace DistanceMeasurement {
             /**
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.RIGHT_BOTTOM
-             * @property startIcon {H.map.Icon=} - the icon to use for the first measurement point
-             * @property stopoverIcon {H.map.Icon=} - the icon to use for the intermediate measurement points
-             * @property endIcon {H.map.Icon=} - the icon to use for the last measurement point
-             * @property splitIcon {H.map.Icon=} - the icon to use for indicating position under pointer over the line where new point will be created once user clicks
-             * @property lineStyle {(H.map.SpatialStyle | H.map.SpatialStyle.Options)} - the style to use for connecting lines of the measurement points
-             * @property distanceFormatter {function(number)=} - Optional function used for formatting a distance. By default distance measurement tool will do the formatting according to the
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.RIGHT_BOTTOM
+             * startIcon {H.map.Icon=} - the icon to use for the first measurement point
+             * stopoverIcon {H.map.Icon=} - the icon to use for the intermediate measurement points
+             * endIcon {H.map.Icon=} - the icon to use for the last measurement point
+             * splitIcon {H.map.Icon=} - the icon to use for indicating position under pointer over the line where new point will be created once user clicks
+             * lineStyle {(H.map.SpatialStyle | H.map.SpatialStyle.Options)} - the style to use for connecting lines of the measurement points
+             * distanceFormatter {function(number)=} - Optional function used for formatting a distance. By default distance measurement tool will do the formatting according to the
              * specified measurement unit (see H.ui.UI.Options#unitSystem)
              */
             interface Options {
@@ -6424,8 +6415,8 @@ declare namespace H {
         namespace MapSettingsControl {
             /**
              * The map type entry is an object containing a display name and a map type object to which it refers.
-             * @property name {string} - label which describes the map type
-             * @property mapType {H.service.MapType} - reference to map type
+             * name {string} - label which describes the map type
+             * mapType {H.service.MapType} - reference to map type
              */
             interface Entry {
                 name: string;
@@ -6434,9 +6425,9 @@ declare namespace H {
 
             /**
              * {@link https://developer.here.com/documentation/maps/api_reference/H.ui.MapSettingsControl.html#.Options}
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
-             * @property entries {Array<H.ui.MapSettingsControl.MapTypeEntry>=} - the map type entries to be shown in this map settings control
-             * @property incidents {H.map.layer.Layer} - the traffic incidents layer to be activated by the map settings control
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
+             * entries {Array<H.ui.MapSettingsControl.MapTypeEntry>=} - the map type entries to be shown in this map settings control
+             * incidents {H.map.layer.Layer} - the traffic incidents layer to be activated by the map settings control
              */
             interface Options {
                 alignment?: H.ui.LayoutAlignment | undefined;
@@ -6458,8 +6449,8 @@ declare namespace H {
 
         namespace Pano {
             /**
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.RIGHT_BOTTOM
-             * @property mapTypes {H.service.MapTypes} - The map types to use
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.RIGHT_BOTTOM
+             * mapTypes {H.service.MapTypes} - The map types to use
              */
             interface Options {
                 alignment?: H.ui.LayoutAlignment | undefined;
@@ -6480,7 +6471,7 @@ declare namespace H {
 
         namespace ScaleBar {
             /**
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
              */
             interface Options {
                 alignment?: H.ui.LayoutAlignment | undefined;
@@ -6601,12 +6592,10 @@ declare namespace H {
             capture(canvas: HTMLCanvasElement, pixelRation: number, callback: (canvas?: HTMLCanvasElement) => void, opt_errback?: (error: string) => void): void;
 
             /**
-             * @callback ICapturable~captureCallback
              * @param canvas {HTMLCanvasElement=}
              */
 
             /**
-             * @callback ICapturable~errorCallback
              * @param error {string}
              */
         }
@@ -6614,14 +6603,14 @@ declare namespace H {
         namespace UI {
             /**
              * Optional parameters to be passed to the UI constructor.
-             * @property unitSystem {H.ui.UnitSystem=} - An optional unit system to be used by the UI, default is H.ui.UnitSystem.METRIC
-             * @property zoom {(H.ui.ZoomControl.Options | boolean)=} -
-             * @property zoomrectangle {(H.ui.ZoomRectangle.Options | boolean)=} -
-             * @property mapsettings {(H.ui.MapSettingsControl.Options | boolean)=} -
-             * @property scalebar {(H.ui.ScaleBar.Options | boolean)=} -
-             * @property panorama {(H.ui.Pano.Options | boolean)=} -
-             * @property distancemeasurement {(H.ui.DistanceMeasurement.Options | boolean)=} -
-             * @property locale {(H.ui.i18n.Localization | string)=} - defines language in which UI can be rendered. It can be predefined H.ui.i18n.Localization object with custom translation map,
+             * unitSystem {H.ui.UnitSystem=} - An optional unit system to be used by the UI, default is H.ui.UnitSystem.METRIC
+             * zoom {(H.ui.ZoomControl.Options | boolean)=} -
+             * zoomrectangle {(H.ui.ZoomRectangle.Options | boolean)=} -
+             * mapsettings {(H.ui.MapSettingsControl.Options | boolean)=} -
+             * scalebar {(H.ui.ScaleBar.Options | boolean)=} -
+             * panorama {(H.ui.Pano.Options | boolean)=} -
+             * distancemeasurement {(H.ui.DistanceMeasurement.Options | boolean)=} -
+             * locale {(H.ui.i18n.Localization | string)=} - defines language in which UI can be rendered. It can be predefined H.ui.i18n.Localization object with custom translation map,
              * or a string one of following 'en-US', 'de-DE', 'es-ES', 'fi-FI', 'fr-FR', 'it-IT', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ru-RU', 'tr-TR', 'zh-CN'. If not defined ui will use 'en-US'
              * by default
              */
@@ -6666,10 +6655,10 @@ declare namespace H {
 
         namespace ZoomControl {
             /**
-             * @property zoomSpeed {number=} - the speed if zooming in and out in levels per millisecond, defaults to 0.05
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, defaults to H.ui.LayoutAlignment.RIGHT_MIDDLE
-             * @property slider {boolean=} - flag whether to show the slider (true) or not, defaults to false
-             * @property sliderSnaps {boolean=} - flag whether slider should snap to the integer values or not, defaults to false. This option has effect only if slider is enabled.
+             * zoomSpeed {number=} - the speed if zooming in and out in levels per millisecond, defaults to 0.05
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, defaults to H.ui.LayoutAlignment.RIGHT_MIDDLE
+             * slider {boolean=} - flag whether to show the slider (true) or not, defaults to false
+             * sliderSnaps {boolean=} - flag whether slider should snap to the integer values or not, defaults to false. This option has effect only if slider is enabled.
              */
             interface Options {
                 zoomSpeed?: number | undefined;
@@ -6692,8 +6681,8 @@ declare namespace H {
 
         namespace ZoomRectangle {
             /**
-             * @property alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
-             * @property adjustZoom {function(number, H.Map): number=} - optional function that defines how zoom level should be changed, by default zoom level is picked to fit the
+             * alignment {H.ui.LayoutAlignment=} - the layout alignment which should be applied to this control, default is H.ui.LayoutAlignment.BOTTOM_RIGHT
+             * adjustZoom {function(number, H.Map): number=} - optional function that defines how zoom level should be changed, by default zoom level is picked to fit the
              * bounding rectangle into the view port.
              */
             interface Options {
@@ -7010,10 +6999,10 @@ declare namespace H {
 
         /**
          * This event indicates a change. It contains the old and the new value.
-         * @property target {*} - Object which triggered the event
-         * @property currentTarget {*} - Object which has listener attached
-         * @property type {string} - Name of the dispatched event
-         * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+         * target {*} - Object which triggered the event
+         * currentTarget {*} - Object which has listener attached
+         * type {string} - Name of the dispatched event
+         * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
          */
         class ChangeEvent extends H.util.Event {
             /**
@@ -7042,7 +7031,7 @@ declare namespace H {
 
         /**
          * This class represents a contextual information/action.
-         * @property SEPARATOR {H.util.ContextItem} - Separator for the context items
+         * SEPARATOR {H.util.ContextItem} - Separator for the context items
          */
         class ContextItem extends H.util.EventTarget {
             /**
@@ -7101,9 +7090,9 @@ declare namespace H {
         namespace ContextItem {
             /**
              * This type defines options which can be used to initialize the context item.
-             * @property label {string=} - the label of the context item
-             * @property disabled {boolean=} - flag indicatting whether context item is disabled or no, by default false
-             * @property callback {function(H.util.Event)=} - Optional callback function to call once context item is selected
+             * label {string=} - the label of the context item
+             * disabled {boolean=} - flag indicatting whether context item is disabled or no, by default false
+             * callback {function(H.util.Event)=} - Optional callback function to call once context item is selected
              */
             interface Options {
                 label?: string | undefined;
@@ -7132,10 +7121,10 @@ declare namespace H {
 
         /**
          * Base Event class which is used for all events dispatched by any EventTarget within the api.
-         * @property target {*} - Object which triggered the event
-         * @property currentTarget {*} - Object which has listener attached
-         * @property type {string} - Name of the dispatched event
-         * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+         * target {*} - Object which triggered the event
+         * currentTarget {*} - Object which has listener attached
+         * type {string} - Name of the dispatched event
+         * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
          */
         class Event {
             /**
@@ -7281,12 +7270,10 @@ declare namespace H {
             capture(canvas: HTMLCanvasElement, pixelRation: number, callback: (canvas?: HTMLCanvasElement) => void, opt_errback?: (error: string) => void): void;
 
             /**
-             * @callback ICapturable~captureCallback
              * @param canvas {HTMLCanvasElement=}
              */
 
             /**
-             * @callback ICapturable~errorCallback
              * @param error {string}
              */
         }
@@ -7382,10 +7369,10 @@ declare namespace H {
         namespace OList {
             /**
              * The event class for events that are dispatched by OList
-             * @property target {*} - Object which triggered the event
-             * @property currentTarget {*} - Object which has listener attached
-             * @property type {string} - Name of the dispatched event
-             * @property defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
+             * target {*} - Object which triggered the event
+             * currentTarget {*} - Object which has listener attached
+             * type {string} - Name of the dispatched event
+             * defaultPrevented {boolean} - Indicates if preventDefault was called on the current event
              */
             class Event extends H.util.Event {
                 /**
@@ -7510,8 +7497,8 @@ declare namespace H {
         namespace kinetics {
             /**
              * This interface defines kinetic move parameters used by map for kinetic drag.
-             * @property power {number} - Power multiplier. Multiplier is used to increase the speed of the kinetic move. By default map uses 1.
-             * @property duration {number} - Defines duration of the kinetic move.
+             * power {number} - Power multiplier. Multiplier is used to increase the speed of the kinetic move. By default map uses 1.
+             * duration {number} - Defines duration of the kinetic move.
              */
             interface IKinetics {
                 /**

--- a/types/i18next-node-fs-backend/index.d.ts
+++ b/types/i18next-node-fs-backend/index.d.ts
@@ -17,25 +17,21 @@ declare namespace i18nextNodeFsBackEnd {
     interface i18nextNodeFsBackEndOptions {
         /**
          * @summary Path where resources get loaded from.
-         * @type {string}
          */
         loadPath: string;
 
         /**
          * @summary Path to post missing resources
-         * @type {string}
          */
         addPath: string;
 
         /**
          * @summary jsonIndent to use when storing json files
-         * @type {number}
          */
         jsonIndent: number;
 
         /**
          * @summary custom parser
-         * @type {function}
          */
         parse?: ((data: any) => any) | undefined;
     }

--- a/types/imap/index.d.ts
+++ b/types/imap/index.d.ts
@@ -246,7 +246,6 @@ declare namespace Connection {
 }
 
 declare class Connection extends EventEmitter implements Connection.MessageFunctions {
-        /** @constructor */
         constructor(config: Connection.Config);
 
         // from NodeJS.EventEmitter

--- a/types/jpm/index.d.ts
+++ b/types/jpm/index.d.ts
@@ -117,13 +117,12 @@ declare module "sdk/context-menu" {
   }
   /**
    * A menu item
-   * @constructor
    */
   export function Item(options: {label: string, image?: string | undefined, accessKey?: string | undefined, context?: Context | Context[] | undefined,
     contentScript?: string | undefined, contentScriptFile?: string | undefined,  data?: any, onMessage?: ((message?: any) => any) | undefined}): Item;
   
   /**
-   * @constructor
+   * 
    * A menu separator
    */
   export function Separator(): Separator;
@@ -221,7 +220,6 @@ declare module "sdk/notifications" {
  */
 declare module "sdk/page-mod" {
   /**
-   * @constructor
    * @param options.include
    * @param options.contentStyle Lists stylesheets to attach, supplied as strings
    * @param options.contentStyleFile Lists stylesheets to attach, supplied in separate files
@@ -256,7 +254,6 @@ declare module "sdk/page-mod" {
 declare module "sdk/page-worker" {
 
   /**
-   * @constructor
    * @param options.contentURL The URL of the content to load in the worker
    * @param options.contentScript A string or an array of strings containing the texts of content scripts to load.
    *                              Content scripts specified by this option are loaded after those specified by the
@@ -300,7 +297,6 @@ declare module "sdk/page-worker" {
  */
 declare module "sdk/panel" {
   /**
-   * @constructor
    * @param options.contentURL The URL of the content to load in the panel. That is, they can't refer to remote scripts
    * @param options.width The width of the panel in pixels
    * @param options.height The height of the panel in pixels
@@ -452,7 +448,6 @@ declare module "sdk/request" {
    *                                 Content-Type header. You can use this to treat the content as a different MIME type,
    *                                 or to force text to be interpreted using a specific character
    * @param [options.anonymous=false] If true, the request will be sent without cookies or authentication headers
-   * @constructor
    */
   export function Request(options: {url?: string | FFAddonSDK.SDKURL | undefined, onComplete?: ((response: Response) => any) | undefined,
                           headers?: Object | undefined, content?: string | Object | undefined, contentType?: string | undefined, anonymous?: boolean | undefined,
@@ -776,7 +771,6 @@ declare module "sdk/timers" {
 declare module "sdk/ui/button/action" {
   /**
    * Creates an action button
-   * @constructor
    * @param options.id The button's ID. This is used internally to keep track of this button
    *                   The ID must be unique within your add-on
    * @param options.label The button's human-readable label. When the button is in the toolbar,
@@ -797,7 +791,6 @@ declare module "sdk/ui/button/action" {
 declare module "sdk/ui/button/toggle" {
   /**
    * Creates a toggle button
-   * @constructor
    * @param options.id The button's ID. This is used internally to keep track of this button
    *                   The ID must be unique within your add-on
    * @param options.label The button's human-readable label. When the button is in the toolbar,
@@ -838,7 +831,6 @@ declare module "sdk/ui/frame" {
    * @param options.onDetach This event is emitted when a frame instance is unloaded: for example, when the user
    *        closes a browser window, if that window has a toolbar containing this frame.
    *        After receiving this message, you ahould not attempt to communicate with the frame scripts
-   * @constructor
    */
   export function Frame(options: {url: string, name?: string | undefined, onMessage?: ((message: FFAddonSDK.FrameEvent) => any) | undefined,
                         onReady?: ((event: FFAddonSDK.FrameEvent) => any) | undefined, onLoad?: ((event: FFAddonSDK.FrameEvent) => any) | undefined,
@@ -851,7 +843,6 @@ declare module "sdk/ui/frame" {
  */
 declare module "sdk/ui/toolbar" {
   /**
-   * @constructor
    * @param options.title The toolbar's title. This appears as the name of the toolbar in the Firefox "Toolbars" menu
    *        It must be unique
    * @param options.title An array of items to appear in the toolbar. Each item in items must be an action button,
@@ -887,7 +878,6 @@ declare module "sdk/ui/toolbar" {
 declare module "sdk/ui/sidebar" {
 
   /**
-   * @constructor
    * @param options.id The id of the sidebar. This is used to identify this sidebar in its chrome window. It must be unique
    */
   export function Sidebar(options: {id?: string | undefined, title: string, url: string, onShow?: (() => any) | undefined, onHide?: (() => any) | undefined,
@@ -918,7 +908,6 @@ declare module "sdk/url" {
   /**
    * The URL constructor creates an object that represents a URL, verifying that the provided string is a valid URL in the process.
    * Any API in the SDK which has a URL parameter will accept URL objects, not raw strings, unless otherwise noted
-   * @constructor
    * @param source A string to be converted into a URL. If source is not a valid URI, this constructor will throw an exception
    * @param base Used to resolve relative source URLs into absolute ones
    */
@@ -927,7 +916,6 @@ declare module "sdk/url" {
   /**
    * The DataURL constructor creates an object that represents a data: URL,
    * verifying that the provided string is a valid data: URL in the process
-   * @constructor
    * @param uri A string to be parsed as Data URL. If is not a valid URI, this constructor will throw an exception
    */
   export function DataURL(uri: string): DataURL;

--- a/types/jquery.simplepagination/index.d.ts
+++ b/types/jquery.simplepagination/index.d.ts
@@ -10,21 +10,18 @@ interface SimplePaginationOptions {
     /**
      * Total number of items that will be used to calculate the pages.
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     items?: number | undefined;
     /**
      * Number of items displayed on each page.
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     itemsOnPage?: number | undefined;
     /**
      *     If specified, items and itemsOnPage will not be used to calculate the number of pages.
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     pages?: number | undefined;
@@ -32,63 +29,54 @@ interface SimplePaginationOptions {
      * How many page numbers should be visible while navigating.
      * Minimum allowed: 3 (previous, current & next)
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     displayedPages?: number | undefined;
     /**
      * How many page numbers are visible at the beginning/ending of the pagination.
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     edges?: number | undefined;
     /**
      * Which page will be selected immediately after init.
      * 
-     * @type {number}
      * @memberof SimplePaginationOptions
      */
     currentPage?: number | undefined;
     /**
      * A string used to build the href attribute, added before the page number.
      * 
-     * @type {string}
      * @memberof SimplePaginationOptions
      */
     hrefTextPrefix?: string | undefined;
     /**
      * Another string used to build the href attribute, added after the page number.
      * 
-     * @type {string}
      * @memberof SimplePaginationOptions
      */
     hrefTextSuffix?: string | undefined;
     /**
      * Text to be display on the previous button.
      * 
-     * @type {string}
      * @memberof SimplePaginationOptions
      */
     prevText?: string | undefined;
     /**
      * Text to be display on the next button.
      * 
-     * @type {string}
      * @memberof SimplePaginationOptions
      */
     nextText?: string | undefined;
     /**
      * The class of the CSS theme.
      * 
-     * @type {string}
      * @memberof SimplePaginationOptions
      */
     cssStyle?: string | undefined;
     /**
      * Set to false if you don't want to select the page immediately after click.
      * 
-     * @type {boolean}
      * @memberof SimplePaginationOptions
      */
     selectOnClick?: boolean | undefined;
@@ -99,7 +87,6 @@ interface SimplePaginationOptions {
      * clicking on the ellipse will replace the ellipse
      * with a number type input in which you can manually set the resulting page.
      * 
-     * @type {boolean}
      * @memberof SimplePaginationOptions
      */
     ellipsePageSet?: boolean | undefined;
@@ -107,7 +94,6 @@ interface SimplePaginationOptions {
     /**
      * A collection of labels that will be used to render the pagination items, replacing the numbers.
      * 
-     * @type {any[]}
      * @memberof SimplePaginationOptions
      */
     labelMap?: any[] | undefined;

--- a/types/jquery.total-storage/index.d.ts
+++ b/types/jquery.total-storage/index.d.ts
@@ -7,11 +7,11 @@
 /// <reference types="jquery"/>
 
 /**
-* @desc Set the value of a key to a string
+* @description Set the value of a key to a string
 * @example $.totalStorage('the_key', 'the_value');
-* @desc Set the value of a key to a number
+* @description Set the value of a key to a number
 * @example $.totalStorage('the_key', 800.2);
-* @desc Set the value of a key to a complex Array
+* @description Set the value of a key to a complex Array
 * @example    var myArray = new Array();
 *       myArray.push({name:'Jared', company:'Upstatement', zip:63124});
 *       myArray.push({name:'McGruff', company:'Police', zip:60652};
@@ -24,7 +24,7 @@
 interface JQueryTotalStorage {
 
     /**
-    * @desc Set or get a key's value
+    * @description Set or get a key's value
     * @param key Key to set.
     * @param value Value to set for key. If ommited, current value for key is returned.
     * @param options Not implemented.
@@ -32,25 +32,25 @@ interface JQueryTotalStorage {
     (key: string, value?: any, options?: JQueryTotalStorageOptions): any;
 
     /**
-    * @desc Set a key's value
+    * @description Set a key's value
     * @param key Key to set.
     * @param value Value to set for key.
     */
     setItem(key: string, value: any): any;
 
     /**
-    * @desc Get a key's value
+    * @description Get a key's value
     * @param key Key to get.
     */
     getItem(key: string): any;
 
     /**
-    * @desc Get all set values
+    * @description Get all set values
     */
     getAll(): any[];
 
     /**
-    * @desc Delete item by key
+    * @description Delete item by key
     * @param key Key of item to delete
     */
     deleteItem(key: string): boolean;

--- a/types/jstree/index.d.ts
+++ b/types/jstree/index.d.ts
@@ -11,8 +11,6 @@ interface JQueryStatic {
      * holds all jstree related functions and variables,
      * including the actual class and methods to create,
      * access and manipulate instances.
-     * @property jstree
-     * @type {JSTreeStatic}
      */
     jstree?: JSTreeStatic | undefined;
 
@@ -95,7 +93,6 @@ interface JSTreeStatic {
 
     /**
      * the jstree class constructor, used only internally
-     * @private
      * @name $.jstree.core(id)
      * @param {Number} id this instance's index
      */
@@ -869,7 +866,6 @@ interface VakataStatic {
 interface JSTree extends JQuery {
     /**
      * used to decorate an instance with a plugin. Used internally.
-     * @private
      * @name plugin(deco [, opts])
      * @param  {String} deco the plugin to decorate with
      * @param  {Object} opts options for the plugin
@@ -879,7 +875,6 @@ interface JSTree extends JQuery {
 
     /**
      * used to decorate an instance with a plugin. Used internally.
-     * @private
      * @name init(el, options)
      * @param {DOMElement|jQuery|String} el the element we are transforming
      * @param {Object} options options for this instance
@@ -896,7 +891,6 @@ interface JSTree extends JQuery {
 
     /**
      * part of the destroying of an instance. Used internally.
-     * @private
      * @name teardown()
      */
     teardown: () => void;
@@ -910,7 +904,6 @@ interface JSTree extends JQuery {
 
     /**
      * bind all events. Used internally.
-     * @private
      * @name bind()
      */
     bind: () => any;
@@ -919,14 +912,12 @@ interface JSTree extends JQuery {
 
     /**
      * part of the destroying of an instance. Used internally.
-     * @private
      * @name unbind()
      */
     unbind: () => any;
 
     /**
      * trigger an event. Used internally.
-     * @private
      * @name trigger(ev [, data])
      * @param  {String} ev the name of the event to trigger
      * @param  {Object} data additional data to pass with the event
@@ -945,7 +936,6 @@ interface JSTree extends JQuery {
 
     /**
      * returns the jQuery extended main UL node inside the instance container. Used internally.
-     * @private
      * @name get_container_ul()
      * @return {jQuery}
      */
@@ -953,7 +943,6 @@ interface JSTree extends JQuery {
 
     /**
      * gets string replacements (localization). Used internally.
-     * @private
      * @name get_string(key)
      * @param  {String} key
      * @return {String}
@@ -962,7 +951,6 @@ interface JSTree extends JQuery {
 
     /**
      * gets the first child of a DOM node. Used internally.
-     * @private
      * @name _firstChild(dom)
      * @param  {DOMElement} dom
      * @return {DOMElement}
@@ -971,7 +959,6 @@ interface JSTree extends JQuery {
 
     /**
      * gets the next sibling of a DOM node. Used internally.
-     * @private
      * @name _nextSibling(dom)
      * @param  {DOMElement} dom
      * @return {DOMElement}
@@ -980,7 +967,6 @@ interface JSTree extends JQuery {
 
     /**
      * gets the previous sibling of a DOM node. Used internally.
-     * @private
      * @name _previousSibling(dom)
      * @param  {DOMElement} dom
      * @return {DOMElement}
@@ -1101,7 +1087,6 @@ interface JSTree extends JQuery {
 
     /**
      * load an array of nodes (will also load unavailable nodes as soon as they appear in the structure). Used internally.
-     * @private
      * @name _load_nodes(nodes [, callback])
      * @param  {array} nodes
      * @param  {function} callback a function to be executed once loading is complete, the function is executed in the instance's scope and receives one argument - the array passed to _load_nodes
@@ -1121,7 +1106,6 @@ interface JSTree extends JQuery {
 
     /**
      * handles the actual loading of a node. Used only internally.
-     * @private
      * @name _load_node(obj [, callback])
      * @param  {mixed} obj
      * @param  {function} callback a function to be executed once loading is complete, the function is executed in the instance's scope and receives one argument - a boolean status
@@ -1131,7 +1115,6 @@ interface JSTree extends JQuery {
 
     /**
      * adds a node to the list of nodes to redraw. Used only internally.
-     * @private
      * @name _node_changed(obj)
      * @param  {mixed} obj
      */
@@ -1139,7 +1122,6 @@ interface JSTree extends JQuery {
 
     /**
      * appends HTML content to the tree. Used internally.
-     * @private
      * @name _append_html_data(obj, data)
      * @param  {mixed} obj the node to append to
      * @param  {String} data the HTML string to parse and append
@@ -1150,7 +1132,6 @@ interface JSTree extends JQuery {
 
     /**
      * appends JSON content to the tree. Used internally.
-     * @private
      * @name _append_json_data(obj, data)
      * @param  {mixed} dom the node to append to
      * @param  {String} data the JSON object to parse and append
@@ -1162,7 +1143,6 @@ interface JSTree extends JQuery {
 
     /**
      * parses a node from a jQuery object and appends them to the in memory tree model. Used internally.
-     * @private
      * @name _parse_model_from_html(d [, p, ps])
      * @param  {jQuery} d the jQuery object to parse
      * @param  {String} p the parent ID
@@ -1174,7 +1154,6 @@ interface JSTree extends JQuery {
     /**
      * parses a node from a JSON object (used when dealing with flat data, which has no nesting of children,
      * but has id and parent properties) and appends it to the in memory tree model. Used internally.
-     * @private
      * @name _parse_model_from_flat_json(d [, p, ps])
      * @param  {Object} d the JSON object to parse
      * @param  {String} p the parent ID
@@ -1185,7 +1164,6 @@ interface JSTree extends JQuery {
 
     /**
      * parses a node from a JSON object and appends it to the in memory tree model. Used internally.
-     * @private
      * @name _parse_model_from_json(d [, p, ps])
      * @param  {Object} d the JSON object to parse
      * @param  {String} p the parent ID
@@ -1196,7 +1174,6 @@ interface JSTree extends JQuery {
 
     /**
      * redraws all nodes that need to be redrawn. Used internally.
-     * @private
      * @name _redraw()
      * @trigger redraw.jstree
      */
@@ -1211,7 +1188,6 @@ interface JSTree extends JQuery {
 
     /**
      * redraws a single node's children. Used internally.
-     * @private
      * @name draw_children(node)
      * @param {mixed} node the node whose children will be redrawn
      */
@@ -1219,7 +1195,6 @@ interface JSTree extends JQuery {
 
     /**
      * redraws a single node. Used internally.
-     * @private
      * @name redraw_node(node, deep, is_callback, force_render)
      * @param {mixed} node the node to redraw
      * @param {Boolean} deep should child nodes be redrawn too
@@ -1243,7 +1218,6 @@ interface JSTree extends JQuery {
      * opens every parent of a node (node should be loaded)
      * @name _open_to(obj)
      * @param {mixed} obj the node to reveal
-     * @private
      */
     _open_to: (obj: any) => void;
 
@@ -1348,7 +1322,6 @@ interface JSTree extends JQuery {
 
     /**
      * called when a node is selected by the user. Used internally.
-     * @private
      * @name activate_node(obj, e)
      * @param {mixed} obj the node
      * @param {Object} e the related event
@@ -1358,7 +1331,6 @@ interface JSTree extends JQuery {
 
     /**
      * applies the hover state on a node, called when a node is hovered by the user. Used internally.
-     * @private
      * @name hover_node(obj)
      * @param {mixed} obj
      * @trigger hover_node.jstree
@@ -1367,7 +1339,6 @@ interface JSTree extends JQuery {
 
     /**
      * removes the hover state from a nodecalled when a node is no longer hovered by the user. Used internally.
-     * @private
      * @name dehover_node(obj)
      * @param {mixed} obj
      * @trigger dehover_node.jstree
@@ -1444,7 +1415,6 @@ interface JSTree extends JQuery {
     /**
      * gets the current state of the tree so that it can be restored later with `set_state(state)`. Used internally.
      * @name get_state()
-     * @private
      * @return {Object}
      */
     get_state: () => any;
@@ -1452,7 +1422,6 @@ interface JSTree extends JQuery {
     /**
      * sets the state of the tree. Used internally.
      * @name set_state(state [, callback])
-     * @private
      * @param {Object} state the state to restore
      * @param {Function} callback an optional function to execute once the state is restored.
      * @trigger set_state.jstree
@@ -1496,7 +1465,6 @@ interface JSTree extends JQuery {
 
     /**
      * set the text value of a node. Used internally, please use `rename_node(obj, val)`.
-     * @private
      * @name set_text(obj, val)
      * @param  {mixed} obj the node, you can pass an array to set the text on multiple nodes
      * @param  {String} val the new text value
@@ -1555,7 +1523,6 @@ interface JSTree extends JQuery {
 
     /**
      * check if an operation is premitted on the tree. Used internally.
-     * @private
      * @name check(chk, obj, par, pos)
      * @param  {String} chk the operation to check, can be "create_node", "rename_node", "delete_node", "copy_node" or "move_node"
      * @param  {mixed} obj the node
@@ -1816,7 +1783,6 @@ interface JSTree extends JQuery {
 
     /**
      * set the undetermined state where and if necessary. Used internally.
-     * @private
      * @name _undetermined()
      * @plugin checkbox
      */
@@ -1872,7 +1838,6 @@ interface JSTree extends JQuery {
     /**
      * Cascades checked state to a node and all its descendants. This function does NOT affect hidden and disabled nodes (or their descendants).
      * However if these unaffected nodes are already selected their ids will be included in the returned array.
-     * @private
      * @param {string} id the node ID
      * @param {bool} checkedState should the nodes be checked or not
      * @returns {Array} Array of all node id's (in this tree branch) that are checked.
@@ -1983,7 +1948,6 @@ interface JSTree extends JQuery {
      * @param {Number} i the object of items to show
      * @plugin contextmenu
      * @trigger show_contextmenu.jstree
-     * @private
      */
     _show_contextmenu: (obj: any, x: number, y: number, i: number) => void;
 
@@ -2015,7 +1979,6 @@ interface JSTree extends JQuery {
 
     /**
      * opens nodes that need to be opened to reveal the search results. Used only internally.
-     * @private
      * @name _search_open(d)
      * @param {Array} d an array of node IDs
      * @plugin search
@@ -2028,7 +1991,6 @@ interface JSTree extends JQuery {
 
     /**
      * used to sort a node's children
-     * @private
      * @name sort(obj [, deep])
      * @param  {mixed} obj the node
      * @param {Boolean} deep if set to `true` nodes are sorted recursively.

--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -113,40 +113,33 @@ declare namespace jsts {
          */
         export class LineIntersector {
             /**
-             * @type {int}
              */
             static COLLINEAR: number;
             /**
              * Indicates that line segments intersect in a line segment
              *
-             * @type {int}
              */
             static COLLINEAR_INTERSECTION: number;
             /**
-             * @type {int}
              */
             static DO_INTERSECT: number;
             /**
              * These are deprecated, due to ambiguous naming
              *
-             * @type {int}
              */
             static DONT_INTERSECT: number;
             /**
              * Indicates that line segments do not intersect
              *
-             * @type {int}
              */
             static NO_INTERSECTION: number;
             /**
              * Indicates that line segments intersect in a single point
              *
-             * @type {int}
              */
             static POINT_INTERSECTION: number;
 
             /**
-             * @constructor
              */
             constructor();
 
@@ -294,7 +287,6 @@ declare namespace jsts {
          */
         export class RobustLineIntersector extends LineIntersector {
             /**
-             * @constructor
              */
             constructor();
 
@@ -746,22 +738,18 @@ declare namespace jsts {
          */
         export class Coordinate {
             /**
-             * @constructor
              */
             constructor(x: number, y: number);
 
             /**
-             * @constructor
              */
             constructor(c: Coordinate);
 
             /**
-             * @constructor
              */
             constructor();
 
             /**
-             * @constructor
              */
             constructor(x: number, y: number, z: number);
 
@@ -2503,7 +2491,6 @@ declare namespace jsts {
 
         export class LineString extends Geometry {
             /**
-             * @constructor
              */
             constructor(points: Array<Coordinate>, factory?: any);
 
@@ -2552,8 +2539,6 @@ declare namespace jsts {
              */
             constructor(lineStrings: LineString[], factory: GeometryFactory);
             /**
-             * @constructor
-             *
              * @deprecated Use GeometryFactory instead
              */
             constructor(lineStrings: LineString[], precisionModel: PrecisionModel, SRID: number);
@@ -2586,7 +2571,6 @@ declare namespace jsts {
 
         export class Point extends Geometry {
             /**
-             * @constructor
              */
             constructor(coordinate: Coordinate, factory?: any);
 
@@ -2608,12 +2592,9 @@ declare namespace jsts {
 
         export class MultiPoint extends GeometryCollection {
             /**
-             * @constructor
              */
             constructor(points: Point[], factory: GeometryFactory);
             /**
-             * @constructor
-             *
              * @deprecated Use GeometryFactory instead
              */
             constructor(points: Point[], precisionModel: PrecisionModel, SRID: number);
@@ -2656,7 +2637,6 @@ declare namespace jsts {
          */
         export class Polygon extends Geometry {
             /**
-             * @constructor
              */
             constructor(shell: LinearRing, holes?: Array<LinearRing>, factory?: any);
 
@@ -2826,7 +2806,6 @@ declare namespace jsts {
          *          p0
          * @param {Coordinate}
          *          p1
-         * @constructor
          */
         export class LineSegment {
             p0: Coordinate;
@@ -3173,7 +3152,6 @@ declare namespace jsts {
              * <p>
              *
              * @see WKTReader
-             * @constructor
              */
             constructor();
 
@@ -3204,7 +3182,6 @@ declare namespace jsts {
          */
         export class WKTReader {
             /**
-             * @constructor
              */
             constructor(geometryFactory?: jsts.geom.GeometryFactory);
 
@@ -3224,7 +3201,6 @@ declare namespace jsts {
 
         export class WKTWriter {
             /**
-             * @constructor
              */
             constructor(geometryFactory?: jsts.geom.GeometryFactory);
 
@@ -3289,25 +3265,21 @@ declare namespace jsts {
                 /**
                  * Specifies a round line buffer end cap style.
                  *
-                 * @type {int}
                  */
                 static CAP_ROUND: number;
                 /**
                  * Specifies a flat line buffer end cap style.
                  *
-                 * @type {int}
                  */
                 static CAP_FLAT: number;
                 /**
                  * Specifies a square line buffer end cap style.
                  *
-                 * @type {int}
                  */
                 static CAP_SQUARE: number;
                 /**
                  * Specifies a round join style.
                  *
-                 * @type {int}
                  */
                 static JOIN_ROUND: number;
                 /**
@@ -3317,7 +3289,6 @@ declare namespace jsts {
                 /**
                  * Specifies a bevel join style.
                  *
-                 * @type {int}
                  */
                 static JOIN_BEVEL: number;
 
@@ -3326,20 +3297,17 @@ declare namespace jsts {
                  * value of 8 gives less than 2% max error in the buffer distance. For a max
                  * error of < 1%, use QS = 12. For a max error of < 0.1%, use QS = 18.
                  *
-                 * @type {int}
                  */
                 static DEFAULT_QUADRANT_SEGMENTS: number;
                 /**
                  * The default mitre limit Allows fairly pointy mitres.
                  *
-                 * @type {double}
                  */
                 static DEFAULT_MITRE_LIMIT: number;
 
                 /**
                  * Contains the parameters which describe how a buffer should be constructed.
                  *
-                 * @constructor
                  */
                 constructor(quadrantSegments?: number, endCapStyle?: number, joinStyle?: number, mitreLimit?: number);
 
@@ -3519,7 +3487,6 @@ declare namespace jsts {
                  * This value should be less than the decimal precision of double-precision
                  * values (16).
                  *
-                 * @type {int}
                  */
                 static MAX_PRECISION_DIGITS: number;
 
@@ -3531,7 +3498,6 @@ declare namespace jsts {
                  *          g the geometry to buffer.
                  * @param {BufferParameters}
                  *          bufParams the buffer parameters to use.
-                 * @constructor
                  */
                 constructor(g: Geometry, bufParams: BufferParameters);
 
@@ -3754,7 +3720,6 @@ declare namespace jsts {
                 /**
                  * A special value of segmentIndex used for locations inside area geometries.
                  *
-                 * @type {int}
                  */
                 static INSIDE_AREA: number;
 

--- a/types/jsuri/index.d.ts
+++ b/types/jsuri/index.d.ts
@@ -9,7 +9,6 @@ declare namespace jsuri {
   export class Uri {
     /**
      * Creates a new Uri object
-     * @constructor
      * @param {string} str
      */
     constructor(str?: string);

--- a/types/knockout.validation/index.d.ts
+++ b/types/knockout.validation/index.d.ts
@@ -38,7 +38,6 @@ interface KnockoutValidationConfiguration {
     /**
      * Indicates whether css error classes are added only
      * when properties are modified or at all times
-     * @type {[type]}
      */
     decorateElementOnModified?: boolean | undefined;
     /**

--- a/types/leadfoot/index.d.ts
+++ b/types/leadfoot/index.d.ts
@@ -567,7 +567,6 @@ declare module 'leadfoot/Command' {
     */
     class Command<T> implements Thenable<T> {
         /**
-         * @constructor module:leadfoot/Command
          * @param {module:leadfoot/Command|module:leadfoot/Session} parent
          * The parent command that this command is chained to, or a {@link module:leadfoot/Session} object if this is the
          * first command in a command chain.
@@ -591,14 +590,12 @@ declare module 'leadfoot/Command' {
         /**
          * The parent Command of the Command, if one exists.
          *
-         * @readonly
          */
         parent: Command<any>;
 
         /**
          * The parent Session of the Command.
          *
-         * @readonly
          */
         session: Session;
 
@@ -612,14 +609,12 @@ declare module 'leadfoot/Command' {
          * - depth (number): The depth of the context within the command chain. This is used to prevent traversal into
          *   higher filtering levels by {@link module:leadfoot/Command#end}.
          *
-         * @readonly
          */
         context: Command.Context;
 
         /**
          * The underlying Promise for the Command.
          *
-         * @readonly
          */
         promise: Promise<T>;
 
@@ -1685,14 +1680,12 @@ declare module 'leadfoot/Element' {
 
         /**
          * The opaque, remote-provided ID of the element.
-         * @readonly
          */
         elementId: string;
 
         /**
          * The session that the element belongs to.
          *
-         * @readonly
          */
         session: Session;
 
@@ -2393,14 +2386,12 @@ declare module 'leadfoot/Session' {
         /**
          * Information about the available features and bugs in the remote environment.
          *
-         * @readonly
          */
         capabilities: leadfoot.Capabilities;
 
         /**
          * The current session ID.
          *
-         * @readonly
          */
         sessionId: string;
 
@@ -2409,7 +2400,6 @@ declare module 'leadfoot/Session' {
          *
          * @member {module:leadfoot/Server} server
          * @memberOf module:leadfoot/Session#
-         * @readonly
          */
         server: Server;
 

--- a/types/leaflet/v0/index.d.ts
+++ b/types/leaflet/v0/index.d.ts
@@ -2088,7 +2088,6 @@ declare namespace L {
           * Instantiates a map object given a div element and optionally an
           * object literal with map options described below.
           *
-          * @constructor
           */
         new(id: HTMLElement, options?: Map.MapOptions): Map;
 
@@ -2096,7 +2095,6 @@ declare namespace L {
           * Instantiates a map object given a div element id and optionally an
           * object literal with map options described below.
           *
-          * @constructor
           */
         new(id: string, options?: Map.MapOptions): Map;
     }

--- a/types/lokijs/index.d.ts
+++ b/types/lokijs/index.d.ts
@@ -101,12 +101,12 @@ interface LokiObj {
 declare class LokiEventEmitter {
 
     /**
-     * @prop events - a hashmap, with each property being an array of callbacks
+     * events - a hashmap, with each property being an array of callbacks
      */
     public events: { [eventName: string]: ((...args: any[]) => any)[] };
 
     /**
-     * @prop asyncListeners - boolean determines whether or not the callbacks associated with each event
+     * asyncListeners - boolean determines whether or not the callbacks associated with each event
      * should happen in an async fashion or not
      * Default is false, which means events are synchronous
      */

--- a/types/lolex/index.d.ts
+++ b/types/lolex/index.d.ts
@@ -300,7 +300,7 @@ type InstalledMethods = {
 /**
  * Clock object created by calling `install();`.
  *
- * @type TClock   type of base clock (e.g BrowserClock).
+ * @typeparam {TClock}   type of base clock (e.g BrowserClock).
  */
 type InstalledClock<TClock extends Clock = Clock> = TClock & InstalledMethods;
 
@@ -311,7 +311,7 @@ type InstalledClock<TClock extends Clock = Clock> = TClock & InstalledMethods;
  * @param loopLimit    Maximum number of timers that will be run when calling runAll()
  *                     before assuming that we have an infinite loop and throwing an error
  *                     (by default, 1000).
- * @type TClock   Type of clock to create.
+ * @typeparam {TClock}   Type of clock to create.
  * @remarks The default epoch is 0.
  */
 export declare function createClock<TClock extends Clock = Clock>(now?: number | Date, loopLimit?: number): TClock;
@@ -356,7 +356,7 @@ export interface LolexInstallOpts {
  *
  * @param now   Current time for the clock, as with lolex.createClock().
  * @param toFake   Names of methods that should be faked.
- * @type TClock   Type of clock to create.
+ * @typeparam {TClock}   Type of clock to create.
  */
 export declare function install<TClock extends Clock = Clock>(opts?: LolexInstallOpts): InstalledClock<TClock>;
 

--- a/types/loopback/index.d.ts
+++ b/types/loopback/index.d.ts
@@ -274,14 +274,12 @@ declare namespace l {
        * var app = loopback();
        * ```
        *
-       * @property {string} version Version of LoopBack framework.  Static read-only property.
-       * @property {string} mime
-       * @property {boolean} isBrowser True if running in a browser environment; false otherwise.  Static read-only property.
-       * @property {boolean} isServer True if running in a server environment; false otherwise.  Static read-only property.
-       * @property {Registry} registry The global `Registry` object.
-       * @property {string} faviconFile Path to a default favicon shipped with LoopBack.
+       * version Version of LoopBack framework.  Static read-only property.
+       * isBrowser True if running in a browser environment; false otherwise.  Static read-only property.
+       * isServer True if running in a server environment; false otherwise.  Static read-only property.
+       * registry The global `Registry` object.
+       * faviconFile Path to a default favicon shipped with LoopBack.
        * Use as follows: `app.use(require('serve-favicon')(loopback.faviconFile));`
-       * @class loopback
        * @header loopback
        */
       class loopback {
@@ -309,8 +307,8 @@ declare namespace l {
              * Alter an existing Model class.
              * @param {Model} ModelCtor The model constructor to alter.
              * @options {any} config Additional configuration to apply
-             * @property {any} dataSource Attach the model to a dataSource.
-             * @property {any} [relations] Model relations to add/update
+             * dataSource Attach the model to a dataSource.
+             * [relations] Model relations to add/update
              * @header loopback.configureModel(ModelCtor, config
              */
 
@@ -320,8 +318,8 @@ declare namespace l {
              * Create a data source with passing the provided options to the connector
              * @param {string} name Optional name.
              * @options {any} options Data Source options
-             * @property {any} connector LoopBack connector.
-             * @property {*} [*] Other&nbsp;connector properties.
+             * connector LoopBack connector.
+             * [*] Other&nbsp;connector properties.
              * See the relevant connector documentation
              */
 
@@ -471,8 +469,8 @@ declare namespace l {
              * Alter an existing Model class.
              * @param {Model} ModelCtor The model constructor to alter.
              * @options {any} config Additional configuration to apply
-             * @property {any} dataSource Attach the model to a dataSource.
-             * @property {any} [relations] Model relations to add/update
+             * dataSource Attach the model to a dataSource.
+             * [relations] Model relations to add/update
              * @header loopback.configureModel(ModelCtor, config
              */
             configureModel(ModelCtor: Model, config: {dataSource: any, relations?: any}): void;
@@ -481,8 +479,8 @@ declare namespace l {
              * Create a data source with passing the provided options to the connector
              * @param {string} name Optional name.
              * @options {any} options Data Source options
-             * @property {any} connector LoopBack connector.
-             * @property {*} [*] Other&nbsp;connector properties.
+             * connector LoopBack connector.
+             * [*] Other&nbsp;connector properties.
              *   See the relevant connector documentation
              */
             createDataSource(name: string, options: {connector: any, properties?: any}): void;
@@ -605,9 +603,7 @@ declare namespace l {
       /**
        * Access context represents the context for a request to access protected
        * resource
-       * @class
        * @options {Context} context The context object
-       * @constructor
        */
       class AccessContext {
             /** context The context object */
@@ -644,14 +640,14 @@ declare namespace l {
       /**
        * Context
        * @interface
-       * @property {Principal[]} principals An Array of principals
-       * @property {() => void} model The model class
-       * @property {string} modelName The model name
-       * @property {string} modelId The model id
-       * @property {string} property The model property/method/relation name
-       * @property {string} method The model method to be invoked
-       * @property {string} accessType The access type
-       * @property {AccessToken} accessToken The access toke
+       * principals An Array of principals
+       * model The model class
+       * modelName The model name
+       * modelId The model id
+       * property The model property/method/relation name
+       * method The model method to be invoked
+       * accessType The access type
+       * accessToken The access toke
        * @returns {AccessContext}
        */
 
@@ -688,8 +684,6 @@ declare namespace l {
        * @param {string} accessType The access type
        * @param {string} permission The requested permission
        * @returns {AccessRequest}
-       * @class
-       * @constructor
        */
       class AccessRequest {
             constructor(model: string, property: string, accessType: string, permission: string);
@@ -720,7 +714,6 @@ declare namespace l {
        * @param {*} id The princiapl id
        * @param {string} [name] The principal name
        * @returns {Principal}
-       * @class
        */
       class Principal {
             constructor(type: string, id: any, name: string);
@@ -735,10 +728,10 @@ declare namespace l {
 
       /**
        * @interface
-       * @property {string} path HTTP path (relative to the model) at which the method is exposed.
-       * @property {'get' | 'post' | 'patch' | 'put' | 'del' | 'all'} verb HTTP method (verb) at which the method is available.
-       * @property {number} status    Default HTTP status set when the callback is called without an error.
-       * @property {number} errorStatus    Default HTTP status set when the callback is called with an error.
+       * path HTTP path (relative to the model) at which the method is exposed.
+       * verb HTTP method (verb) at which the method is available.
+       * status    Default HTTP status set when the callback is called without an error.
+       * errorStatus    Default HTTP status set when the callback is called with an error.
        */
       interface RemoteHttpOptions {
             /**
@@ -776,12 +769,12 @@ declare namespace l {
 
       /**
        * @interface
-       * @property {RemoteMethodArgument[]} accepts Defines arguments that the remote method accepts
-       * @property {string|string[]} description Text description of the method
-       * @property {RemoteHttpOptions} http The HTTP options for the remote method
-       * @property {boolean} isStatic Whether the method is static (eg. `MyModel.myMethod`)
-       * @property {string | string[]} notes Additional notes, used by API documentation generators like Swagger.
-       * @property {RemoteMethodArgument} returns Describes the remote method's callback arguments
+       * accepts Defines arguments that the remote method accepts
+       * description Text description of the method
+       * http The HTTP options for the remote method
+       * isStatic Whether the method is static (eg. `MyModel.myMethod`)
+       * notes Additional notes, used by API documentation generators like Swagger.
+       * returns Describes the remote method's callback arguments
       */
       interface RemoteMethodOptions {
             /**
@@ -835,13 +828,12 @@ declare namespace l {
 
       /**
        * @interface
-       * @property {string} arg    Argument name
-       * @property {string | string[]} description A text description of the argument.
-       * @property {any} http http    Object or Function    For input arguments: a function or an object describing mapping from HTTP request to the argument value.
-       * @property {boolean} required    True if argument is required; false otherwise.
-       * @property {boolean} root For callback arguments: set this property to true if your function has a single callback argument. Otherwise the root object returned is an object
-       * @property {"any" | "Array" | "Boolean" | "Buffer" | "Date" | "GeoPoint" | "null" | "Number" | "Object" | "String"} type
-       * @property {string} default Default value that will be used to populate loopback-explorer input fields and swagger documentation
+       * arg    Argument name
+       * description A text description of the argument.
+       * http http    Object or Function    For input arguments: a function or an object describing mapping from HTTP request to the argument value.
+       * required    True if argument is required; false otherwise.
+       * root For callback arguments: set this property to true if your function has a single callback argument. Otherwise the root object returned is an object
+       * default Default value that will be used to populate loopback-explorer input fields and swagger documentation
        */
       interface RemoteMethodArgument {
             /**
@@ -984,7 +976,7 @@ declare namespace l {
              * @param {*} modelId The model ID.
              * @param {any} sharedMethod The method in question.
              * @param {any} ctx The remote invocation context.
-             * @callback {() => void} callback The callback function.
+             * callback The callback function.
              * @param {string|Error} err The error object.
              * @param {boolean} allowed True if the request is allowed; false otherwise
              */
@@ -1008,7 +1000,7 @@ declare namespace l {
 
             /**
              * Get the `Application` object to which the Model is attached
-             * @callback {() => void} callback Callback function called with `(err, app)` arguments.
+             * callback Callback function called with `(err, app)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Application} app Attached application object.
              * @end
@@ -1024,7 +1016,7 @@ declare namespace l {
              * @param {string} paramName The argument name that the remote method accepts.
              * @param {string} getterName The getter name.
              * @param {boolean} hooks Whether to inherit before/after hooks.
-             * @callback {() => void} filterCallback The Optional filter function.
+             * filterCallback The Optional filter function.
              * @param {any} SharedMethod object. See [here](apidocs.strongloop.com/strong-remoting/#sharedmethod).
              * @param {any} RelationDefinition object which includes relation `type`, `ModelConstructor` of `modelFrom`, `modelTo`, `keyFrom`, `keyTo` and more relation definitions
              */
@@ -1080,8 +1072,8 @@ declare namespace l {
        * @param {string} name The SharedClass name
        * @param {() => void} constructor The constructor the SharedClass represents
        * @param {any} options Additional options.
-       * @property {() => void } ctor The constructor
-       * @property {any} http The HTTP settings
+       * ctor The constructor
+       * http The HTTP settings
        */
       class SharedClass {
             /** The SharedClass name */
@@ -1181,7 +1173,6 @@ declare namespace l {
        *    console.log(obj) // => the changed model
        * });
        * ```
-       * @class PersistedModel
        */
       class PersistedModel extends Model {
             /**
@@ -1207,7 +1198,7 @@ declare namespace l {
              * to reduce the number of results returned.
              * @param  {number} since Return only changes since this checkpoint.
              * @param  {any}   filter   Include only changes that match this filter, the same as for [#persistedmodel-find](find()).
-             * @callback {() => void} callback Callback function called with `(err, changes)` arguments.
+             * callback Callback function called with `(err, changes)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Array} changes An Array of [Change](#change) objects
              */
@@ -1218,7 +1209,7 @@ declare namespace l {
              * to reduce the number of results returned.
              * @param  {number} since Return only changes since this checkpoint.
              * @param  {any}   filter   Include only changes that match this filter, the same as for [#persistedmodel-find](find()).
-             * @callback {() => void} callback Callback function called with `(err, changes)` arguments.
+             * callback Callback function called with `(err, changes)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Array} changes An Array of [Change](#change) objects
              */
@@ -1243,7 +1234,7 @@ declare namespace l {
              * ```
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods).
-             * @callback {() => void} callback Callback function called with `(err, count)` arguments.  Required.
+             * callback Callback function called with `(err, count)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {number} count number of instances updated
              */
@@ -1257,7 +1248,7 @@ declare namespace l {
              * ```
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods).
-             * @callback {() => void} callback Callback function called with `(err, count)` arguments.  Required.
+             * callback Callback function called with `(err, count)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {number} count number of instances updated
              */
@@ -1266,7 +1257,7 @@ declare namespace l {
             /**
              * Create new instance of Model, and save to database
              * @param {any}|[{any}] data Optional data argument.  Can be either a single model instance or an Array of instances
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} models Model instances or null
              */
@@ -1319,7 +1310,7 @@ declare namespace l {
 
             /**
              * Get the current checkpoint ID
-             * @callback {() => void} callback Callback function called with `(err, currentCheckpointId)` arguments.  Required.
+             * callback Callback function called with `(err, currentCheckpointId)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {number} currentCheckpointId Current checkpoint ID
              */
@@ -1340,7 +1331,7 @@ declare namespace l {
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods)
              *
-             * @callback {() => void} callback Optional callback function called with `(err, info)` arguments.
+             * callback Optional callback function called with `(err, info)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} info Additional information about the command outcome.
              * @param {number} info.count number of instances (rows, documents) destroyed
@@ -1363,7 +1354,7 @@ declare namespace l {
             /**
              * Destroy model instance with the specified ID.
              * @param {*} id The ID value of model instance to delete.
-             * @callback {() => void} callback Callback function called with `(err)` arguments.  Required.
+             * callback Callback function called with `(err)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object)
              */
             static destroyById(id: any, callback: CallbackWithoutResult): void;
@@ -1379,7 +1370,7 @@ declare namespace l {
              * See [Change.diff()](#change-diff) for details
              * @param  {number}  since  Find deltas since this checkpoint.
              * @param  {Array}  remoteChanges  An Array of change objects.
-             * @callback {() => void} callback Callback function called with `(err, result)` arguments.  Required.
+             * callback Callback function called with `(err, result)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} result any with `deltas` and `conflicts` properties; see [Change.diff()](#change-diff) for details
              */
@@ -1401,7 +1392,7 @@ declare namespace l {
             /**
              * Check whether a model instance exists in database
              * @param {id} id Identifier of object (primary key value)
-             * @callback {() => void} callback Callback function called with `(err, exists)` arguments.  Required.
+             * callback Callback function called with `(err, exists)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {boolean} exists True if the instance with the specified ID exists; false otherwise
              */
@@ -1417,23 +1408,23 @@ declare namespace l {
              * Find all model instances that match `filter` specification.
              * See [Querying models](docs.strongloop.com/display/LB/Querying+models)
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {number} limit Maximum number of instances to return.
+             * limit Maximum number of instances to return.
              * <br/>See [Limit filter](docs.strongloop.com/display/LB/Limit+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * { where: { key: val, key2: {gt: 'val2'}, ...} }
              * ```
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforqueries)
-             * @callback {() => void} callback Callback function called with `(err, returned-instances)` arguments.    Required.
+             * callback Callback function called with `(err, returned-instances)` arguments.    Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Array} models Model instances matching the filter, or null if none found
              */
@@ -1453,17 +1444,17 @@ declare namespace l {
              * Find all model instances that match `filter` specification.
              * See [Querying models](docs.strongloop.com/display/LB/Querying+models)
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {number} limit Maximum number of instances to return.
+             * limit Maximum number of instances to return.
              * <br/>See [Limit filter](docs.strongloop.com/display/LB/Limit+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * { where: { key: val, key2: {gt: 'val2'}, ...} }
              * ```
@@ -1484,7 +1475,7 @@ declare namespace l {
             /**
              * Find object by ID with an optional filter for include/fields
              * @param {*} id Primary key value
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.  Required.
+             * callback Callback function called with `(err, instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance matching the specified ID or null if no instance matches
              */
@@ -1497,11 +1488,11 @@ declare namespace l {
              * Find object by ID with an optional filter for include/fields
              * @param {*} id Primary key value
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.  Required.
+             * callback Callback function called with `(err, instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance matching the specified ID or null if no instance matches
              */
@@ -1518,9 +1509,9 @@ declare namespace l {
              * Find object by ID with an optional filter for include/fields
              * @param {*} id Primary key value
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
              */
             static findById<T = any>(
@@ -1535,7 +1526,7 @@ declare namespace l {
              * Find one model instance that matches `filter` specification.
              * Same as `find`, but limited to one result;
              * Returns object, not collection
-             * @callback {() => void} callback Callback function called with `(err, returned-instance)` arguments.  Required.
+             * callback Callback function called with `(err, returned-instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Array} model First model instance that matches the filter or null if none found
              */
@@ -1548,21 +1539,21 @@ declare namespace l {
              * Same as `find`, but limited to one result;
              * Returns object, not collection
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * {where: { key: val, key2: {gt: 'val2'}, ...} }
              * ```
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforqueries)
-             * @callback {() => void} callback Callback function called with `(err, returned-instance)` arguments.  Required.
+             * callback Callback function called with `(err, returned-instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Array} model First model instance that matches the filter or null if none found
              */
@@ -1582,15 +1573,15 @@ declare namespace l {
              * Same as `find`, but limited to one result;
              * Returns object, not collection
              * @options {any} [filter] Optional Filter JSON object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * {where: { key: val, key2: {gt: 'val2'}, ...} }
              * ```
@@ -1615,7 +1606,7 @@ declare namespace l {
              * locate an existing object that matches the `data` argument
              *
              * @param {any} data Data to insert if object matching the `where` filter is not found.
-             * @callback {() => void} callback Callback function called with `cb(err, instance, created)` arguments.  Required.
+             * callback Callback function called with `cb(err, instance, created)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance matching the `where` filter, if found.
              * @param {boolean} created True if the instance matching the `where` filter was created
@@ -1633,24 +1624,24 @@ declare namespace l {
              * locate an existing object that matches the `data` argument
              *
              * @options {any} [filter] Optional Filter object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {number} limit Maximum number of instances to return.
+             * limit Maximum number of instances to return.
              * <br/>See [Limit filter](docs.strongloop.com/display/LB/Limit+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * {where: {key: val, key2: {gt: val2}, ...}}
              * ```
              * <br/>See
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforqueries).
              * @param {any} data Data to insert if object matching the `where` filter is not found.
-             * @callback {() => void} callback Callback function called with `cb(err, instance, created)` arguments.  Required.
+             * callback Callback function called with `cb(err, instance, created)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance matching the `where` filter, if found.
              * @param {boolean} created True if the instance matching the `where` filter was created
@@ -1676,17 +1667,17 @@ declare namespace l {
              * locate an existing object that matches the `data` argument
              *
              * @options {any} [filter] Optional Filter object; see below.
-             * @property {string|any|Array} fields Identify fields to include in return result.
+             * fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).
-             * @property {string|any|Array} include  See PersistedModel.include documentation.
+             * include  See PersistedModel.include documentation.
              * <br/>See [Include filter](docs.strongloop.com/display/LB/Include+filter).
-             * @property {number} limit Maximum number of instances to return.
+             * limit Maximum number of instances to return.
              * <br/>See [Limit filter](docs.strongloop.com/display/LB/Limit+filter).
-             * @property {string} order Sort order: either "ASC" for ascending or "DESC" for descending.
+             * order Sort order: either "ASC" for ascending or "DESC" for descending.
              * <br/>See [Order filter](docs.strongloop.com/display/LB/Order+filter).
-             * @property {number} skip number of results to skip.
+             * skip number of results to skip.
              * <br/>See [Skip filter](docs.strongloop.com/display/LB/Skip+filter).
-             * @property {any} where Where clause, like
+             * where Where clause, like
              * ```
              * {where: {key: val, key2: {gt: val2}, ...}}
              * ```
@@ -1720,7 +1711,7 @@ declare namespace l {
 
             /**
              * Get the source identifier for this model or dataSource
-             * @callback {() => void} callback Callback function called with `(err, id)` arguments.
+             * callback Callback function called with `(err, id)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {string} sourceId Source identifier for the model or dataSource
              */
@@ -1741,7 +1732,6 @@ declare namespace l {
             /**
              * Specify that a change to the model with the given ID has occurred
              * @param {*} id The ID of the model that has changed.
-             * @callback {() => void} callback
              * @param {Error} er
              */
             static rectifyChange(id: any, callback: CallbackWithoutResult): void;
@@ -1758,7 +1748,7 @@ declare namespace l {
              * Performs validation before replacing
              * @param {*} id The ID value of model instance to replace.
              * @param {any} data Data to replace.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.
+             * callback Callback function called with `(err, instance)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Replaced instance
              */
@@ -1775,8 +1765,8 @@ declare namespace l {
              * @param {*} id The ID value of model instance to replace.
              * @param {any} data Data to replace.
              * @options {any} [options] Options for replace
-             * @property {boolean} validate Perform validation before saving.  Default is true.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.
+             * validate Perform validation before saving.  Default is true.
+             * callback Callback function called with `(err, instance)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Replaced instance
              */
@@ -1796,7 +1786,7 @@ declare namespace l {
              * @param {*} id The ID value of model instance to replace.
              * @param {any} data Data to replace.
              * @options {any} [options] Options for replace
-             * @property {boolean} validate Perform validation before saving.  Default is true.
+             * validate Perform validation before saving.  Default is true.
              */
             static replaceById<T = any>(
                   id: any,
@@ -1811,7 +1801,7 @@ declare namespace l {
              * such that parameter `data.id` matches `id` of model instance; otherwise,
              * insert a new record.
              * @param {any} data The model instance data.
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} model Replaced model instance.
              */
@@ -1826,8 +1816,8 @@ declare namespace l {
              * insert a new record.
              * @param {any} data The model instance data.
              * @options {any} [options] Options for replaceOrCreate
-             * @property {boolean} validate Perform validation before saving.  Default is true.
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * validate Perform validation before saving.  Default is true.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} model Replaced model instance.
              */
@@ -1845,7 +1835,7 @@ declare namespace l {
              * insert a new record.
              * @param {any} data The model instance data.
              * @options {any} [options] Options for replaceOrCreate
-             * @property {boolean} validate Perform validation before saving.  Default is true.
+             * validate Perform validation before saving.  Default is true.
              */
             static replaceOrCreate<T = any>(
                   data: any,
@@ -1860,7 +1850,7 @@ declare namespace l {
              * @param  {Model} targetModel  Target this model class
              * @param  {any} [options]
              * @param {any} [options.filter] Replicate models that match this filter
-             * @callback {() => void} [callback] Callback function called with `(err, conflicts)` arguments.
+             * [callback] Callback function called with `(err, conflicts)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {Conflict[]} conflicts A list of changes that could not be replicated due to conflicts.
              * @param {any} checkpoints The new checkpoints to use as the "since"
@@ -1876,7 +1866,7 @@ declare namespace l {
 
             /**
              * Update multiple instances that match the where clause.
-             * @callback {() => void} callback Callback function called with `(err, info)` arguments.  Required.
+             * callback Callback function called with `(err, info)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} info Additional information about the command outcome.
              * @param {number} info.count number of instances (rows, documents) updated.
@@ -1905,7 +1895,7 @@ declare namespace l {
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods).
              * @param {any} data any containing data to replace matching instances, if any.
              *
-             * @callback {() => void} callback Callback function called with `(err, info)` arguments.  Required.
+             * callback Callback function called with `(err, info)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} info Additional information about the command outcome.
              * @param {number} info.count number of instances (rows, documents) updated.
@@ -1935,7 +1925,7 @@ declare namespace l {
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods).
              * @param {any} data any containing data to replace matching instances, if any.
              *
-             * @callback {() => void} callback Callback function called with `(err, info)` arguments.  Required.
+             * callback Callback function called with `(err, info)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} info Additional information about the command outcome.
              * @param {number} info.count number of instances (rows, documents) updated.
@@ -1974,7 +1964,7 @@ declare namespace l {
             /**
              * Update or insert a model instance
              * @param {any} data The model instance data to insert.
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} model Updated model instance
              */
@@ -1986,7 +1976,7 @@ declare namespace l {
             /**
              * Update or insert a model instance
              * @param {any} data The model instance data to insert.
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} model Updated model instance
              */
@@ -2006,7 +1996,7 @@ declare namespace l {
              * <br/>see
              * [Where filter](docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforothermethods).
              * @param {any} data The model instance data to insert.
-             * @callback {() => void} callback Callback function called with `cb(err, obj)` signature.
+             * callback Callback function called with `cb(err, obj)` signature.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} model Updated model instance
              */
@@ -2065,7 +2055,7 @@ declare namespace l {
 
             /**
              * Reload object from persistence.  Requires `id` member of `object` to be able to call `find`.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.  Required.
+             * callback Callback function called with `(err, instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance
              */
@@ -2080,7 +2070,7 @@ declare namespace l {
              * Replace attributes for a model instance and persist it into the datasource.
              * Performs validation before replacing
              * @param {any} data Data to replace.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.
+             * callback Callback function called with `(err, instance)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Replaced instance
              */
@@ -2094,8 +2084,8 @@ declare namespace l {
              * Performs validation before replacing
              * @param {any} data Data to replace.
              * @options {any} [options] Options for replace
-             * @property {boolean} validate Perform validation before saving.  Default is true.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.
+             * validate Perform validation before saving.  Default is true.
+             * callback Callback function called with `(err, instance)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Replaced instance
              */
@@ -2112,7 +2102,7 @@ declare namespace l {
              * Performs validation before replacing
              * @param {any} data Data to replace.
              * @options {any} [options] Options for replace
-             * @property {boolean} validate Perform validation before saving.  Default is true.
+             * validate Perform validation before saving.  Default is true.
              */
             replaceAttributes<T = any>(
                   data: any,
@@ -2124,7 +2114,7 @@ declare namespace l {
             /**
              * Save model instance. If the instance doesn't have an ID, then calls [create](#persistedmodelcreatedata-cb) instead.
              * Triggers: validate, save, update, or create.
-             * @callback {() => void} callback Optional callback function called with `(err, obj)` arguments.
+             * callback Optional callback function called with `(err, obj)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance saved or created
              */
@@ -2136,10 +2126,10 @@ declare namespace l {
              * Save model instance. If the instance doesn't have an ID, then calls [create](#persistedmodelcreatedata-cb) instead.
              * Triggers: validate, save, update, or create.
              * @options {any} [options] See below.
-             * @property {boolean} validate Perform validation before saving.  Default is true.
-             * @property {boolean} throws If true, throw a validation error; WARNING: This can crash Node.
+             * validate Perform validation before saving.  Default is true.
+             * throws If true, throw a validation error; WARNING: This can crash Node.
              * If false, report the error via callback.  Default is false.
-             * @callback {() => void} callback Optional callback function called with `(err, obj)` arguments.
+             * callback Optional callback function called with `(err, obj)` arguments.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Model instance saved or created
              */
@@ -2155,8 +2145,8 @@ declare namespace l {
              * Save model instance. If the instance doesn't have an ID, then calls [create](#persistedmodelcreatedata-cb) instead.
              * Triggers: validate, save, update, or create.
              * @options {any} [options] See below.
-             * @property {boolean} validate Perform validation before saving.  Default is true.
-             * @property {boolean} throws If true, throw a validation error; WARNING: This can crash Node.
+             * validate Perform validation before saving.  Default is true.
+             * throws If true, throw a validation error; WARNING: This can crash Node.
              * If false, report the error via callback.  Default is false.
              */
             save<T = any>(
@@ -2179,7 +2169,7 @@ declare namespace l {
              * Equivalent to `updateAttributes({name: 'value'}, cb)
              * @param {string} name Name of property.
              * @param {any} value Value of property.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.  Required.
+             * callback Callback function called with `(err, instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Updated instance
              */
@@ -2204,7 +2194,7 @@ declare namespace l {
              * Update set of attributes.  Performs validation before updating
              * Triggers: `validation`, `save` and `update` hooks
              * @param {any} data Data to update.
-             * @callback {() => void} callback Callback function called with `(err, instance)` arguments.  Required.
+             * callback Callback function called with `(err, instance)` arguments.  Required.
              * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
              * @param {any} instance Updated instance
              */
@@ -2341,14 +2331,14 @@ declare namespace l {
        * ```
        *
        * @options {any} [options] Each option Array is used to add additional keys to find an `accessToken` for a `request`.
-       * @property {Array} [cookies] Array of cookie names.
-       * @property {Array} [headers] Array of header names.
-       * @property {Array} [params] Array of param names.
-       * @property {boolean} [searchDefaultTokenKeys] Use the default search locations for Token in request
-       * @property {boolean} [enableDoublecheck] Execute middleware although an instance mounted earlier in the chain didn't find a token
-       * @property {boolean} [overwriteExistingToken] only has effect in combination with `enableDoublecheck`. If truthy, will allow to overwrite an existing accessToken.
-       * @property {() => void|string} [model] AccessToken model name or class to use.
-       * @property {string} [currentUserLiteral] string literal for the current user.
+       * [cookies] Array of cookie names.
+       * [headers] Array of header names.
+       * [params] Array of param names.
+       * [searchDefaultTokenKeys] Use the default search locations for Token in request
+       * [enableDoublecheck] Execute middleware although an instance mounted earlier in the chain didn't find a token
+       * [overwriteExistingToken] only has effect in combination with `enableDoublecheck`. If truthy, will allow to overwrite an existing accessToken.
+       * [model] AccessToken model name or class to use.
+       * [currentUserLiteral] string literal for the current user.
        * @header loopback.token([options])
        */
       function token(
@@ -2375,13 +2365,12 @@ declare namespace l {
        * **Default ACLs*
        *  - DENY EVERYONE `*`
        *  - ALLOW EVERYONE creat
-       * @property {string} id Generated token ID.
-       * @property {number} ttl Time to live in seconds, 2 weeks by default.
-       * @property {Date} created When the token was created.
-       * @property {any} settings Extends the `Model.settings` object.
-       * @property {number} settings.accessTokenIdLength Length of the base64-encoded string access token. Default value is 64.
+       * id Generated token ID.
+       * ttl Time to live in seconds, 2 weeks by default.
+       * created When the token was created.
+       * settings Extends the `Model.settings` object.
+       * settings.accessTokenIdLength Length of the base64-encoded string access token. Default value is 64.
        * Increase the length for a more secure access token
-       * @class AccessToken
        * @inherits {PersistedModel}
        */
       class AccessToken extends PersistedModel {
@@ -2399,7 +2388,6 @@ declare namespace l {
 
             /**
              * Create a cryptographically random access token id
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {string} toke
              */
@@ -2409,7 +2397,6 @@ declare namespace l {
              * Find a token for the given `any`
              * @param {any} req
              * @param {any} [options] Options for finding the token
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {AccessToken} toke
              */
@@ -2418,7 +2405,6 @@ declare namespace l {
             /**
              * Validate the token.
              *
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {boolean} isValid
              */
@@ -2445,20 +2431,19 @@ declare namespace l {
        * to access (read/write/execute)
        * the protected resource
        * @header ACL
-       * @property {string} model Name of the model.
-       * @property {string} property Name of the property, method, scope, or relation.
-       * @property {string} accessType Type of access being granted: one of READ, WRITE, or EXECUTE.
-       * @property {string} permission Type of permission granted. One of
+       * model Name of the model.
+       * property Name of the property, method, scope, or relation.
+       * accessType Type of access being granted: one of READ, WRITE, or EXECUTE.
+       * permission Type of permission granted. One of
        *  - ALARM: Generate an alarm, in a system-dependent way, the access specified in the permissions component of the ACL entry.
        *  - ALLOW: Explicitly grants access to the resource.
        *  - AUDIT: Log, in a system-dependent way, the access specified in the permissions component of the ACL entry.
        *  - DENY: Explicitly denies access to the resource.
-       * @property {string} principalType Type of the principal; one of: Application, Use, Role.
-       * @property {string} principalId ID of the principal - such as appId, userId or roleId.
-       * @property {any} settings Extends the `Model.settings` object.
-       * @property {string} settings.defaultPermission Default permission setting: ALLOW, DENY, ALARM, or AUDIT. Default is ALLOW.
+       * principalType Type of the principal; one of: Application, Use, Role.
+       * principalId ID of the principal - such as appId, userId or roleId.
+       * settings Extends the `Model.settings` object.
+       * settings.defaultPermission Default permission setting: ALLOW, DENY, ALARM, or AUDIT. Default is ALLOW.
        * Set to DENY to prohibit all API access by default
-       * @class ACL
        * @inherits PersistedMode
        */
       class ACL extends PersistedModel {
@@ -2491,11 +2476,11 @@ declare namespace l {
             /**
              * Check if the request has the permission to access.
              * @options {any} context See below.
-             * @property {any[]} principals An Array of principals.
-             * @property {string|Model} model The model name or model class.
-             * @property {*} id The model instance ID.
-             * @property {string} property The property/method/relation name.
-             * @property {string} accessType The access type:
+             * principals An Array of principals.
+             * model The model name or model class.
+             * id The model instance ID.
+             * property The property/method/relation name.
+             * accessType The access type:
              *   READ, REPLICATE, WRITE, or EXECUTE.
              * @param {() => void} callback Callback functio
              */
@@ -2507,7 +2492,7 @@ declare namespace l {
              * @param {string} model The model name
              * @param {*} modelId The model id
              * @param {string} method The method name
-             * @callback {() => void} callback Callback function
+             * callback Callback function
              * @param {string|Error} err The error object
              * @param {boolean} allowed is the request allow
              */
@@ -2520,7 +2505,7 @@ declare namespace l {
              * @param {string} model The model name.
              * @param {string} property The property/method/relation name.
              * @param {string} accessType The access type.
-             * @callback {() => void} callback Callback function.
+             * callback Callback function.
              * @param {string|Error} err The error object
              * @param {AccessRequest} result The access permissio
              */
@@ -2561,16 +2546,16 @@ declare namespace l {
 
       /**
        * Manage client applications and organize their users
-       * @property {string} id  Generated ID.
-       * @property {string} name Name; required.
-       * @property {string} description Text description
-       * @property {string} icon string Icon image URL.
-       * @property {string} owner User ID of the developer who registers the application.
-       * @property {string} email E-mail address
-       * @property {boolean} emailVerified Whether the e-mail is verified.
-       * @property {string} url OAuth 2.0  application URL.
-       * @property {string}[]} callbackUrls The OAuth 2.0 code/token callback URL.
-       * @property {string} status Status of the application; Either `production`, `sandbox` (default), or `disabled`.
+       * id  Generated ID.
+       * name Name; required.
+       * description Text description
+       * icon string Icon image URL.
+       * owner User ID of the developer who registers the application.
+       * email E-mail address
+       * emailVerified Whether the e-mail is verified.
+       * url OAuth 2.0  application URL.
+       * []} callbackUrls The OAuth 2.0 code/token callback URL.
+       * status Status of the application; Either `production`, `sandbox` (default), or `disabled`.
        * @property {Date} created Date Application object was created.  Default: current date.
        * @property {Date} modified Date Application object was modified.  Default: current date
        * @property {any} pushSettings.apns APNS configuration, see the options
@@ -2682,7 +2667,6 @@ declare namespace l {
              * Authenticate the application id and key
              * @param {Any} appId
              * @param {string} key
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {string} matched The matching key; one of:
              * - clientKey
@@ -2706,7 +2690,6 @@ declare namespace l {
 
             /**
              * Reset keys for the application instance
-             * @callback {() => void} callback
              * @param {Error} err
              */
 
@@ -2715,7 +2698,6 @@ declare namespace l {
             /**
              * Reset keys for a given application by the appId
              * @param {Any} appId
-             * @callback {() => void} callback
              * @param {Error} err
              */
 
@@ -2725,18 +2707,17 @@ declare namespace l {
       /**
        * Change list entry.
        *
-       * @property {string} id Hash of the modelName and ID.
-       * @property {string} rev The current model revision.
-       * @property {string} prev The previous model revision.
-       * @property {number} checkpoint The current checkpoint at time of the change.
-       * @property {string} modelName Model name.
-       * @property {string} modelId Model ID.
-       * @property {any} settings Extends the `Model.settings` object.
-       * @property {string} settings.hashAlgorithm Algorithm used to create cryptographic hash, used as argument
+       * id Hash of the modelName and ID.
+       * rev The current model revision.
+       * prev The previous model revision.
+       * checkpoint The current checkpoint at time of the change.
+       * modelName Model name.
+       * modelId Model ID.
+       * settings Extends the `Model.settings` object.
+       * settings.hashAlgorithm Algorithm used to create cryptographic hash, used as argument
        * to [crypto.createHash](nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm).  Default is sha1.
-       * @property {boolean} settings.ignoreErrors By default, when changes are rectified, an error will throw an exception.
+       * settings.ignoreErrors By default, when changes are rectified, an error will throw an exception.
        * However, if this setting is true, then errors will not throw exceptions.
-       * @class Change
        * @inherits {PersistedModel}
        */
       class Change extends PersistedModel {
@@ -2798,7 +2779,6 @@ declare namespace l {
              * @param  {string}   modelName
              * @param  {number}   since         Compare changes after this checkpoint
              * @param  {Change[]} remoteChanges A set of changes to compare
-             * @callback  {() => void} callback
              * @param {Error} err
              * @param {any} result See above.
              */
@@ -2808,7 +2788,6 @@ declare namespace l {
              * Find or create a change for the given model
              * @param  {string}   modelName
              * @param  {string}   modelId
-             * @callback  {() => void} callback
              * @param {Error} err
              * @param {Change} change
              * @end
@@ -2844,7 +2823,6 @@ declare namespace l {
              * Track the recent change of the given modelIds
              * @param  {string}   modelName
              * @param  {Array}    modelIds
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {Array} changes Changes that were tracke
              */
@@ -2865,7 +2843,6 @@ declare namespace l {
 
             /**
              * Get a change's current revision based on current data.
-             * @callback  {() => void} callback
              * @param {Error} err
              * @param {string} rev The current revisio
              */
@@ -2891,7 +2868,6 @@ declare namespace l {
 
             /**
              * Update (or create) the change with the current revision
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {Change} chang
              */
@@ -2914,9 +2890,8 @@ declare namespace l {
        * @param {*} modelId
        * @param {PersistedModel} SourceModel
        * @param {PersistedModel} TargetModel
-       * @property {ModelClass} source The source model instance
-       * @property {ModelClass} target The target model instance
-       * @class Change.Conflic
+       * source The source model instance
+       * target The target model instance
        */
       class Conflict {
             source: any;
@@ -2925,7 +2900,6 @@ declare namespace l {
 
             /**
              * Get the conflicting changes
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {Change} sourceChange
              * @param {Change} targetChang
@@ -2934,7 +2908,6 @@ declare namespace l {
 
             /**
              * Fetch the conflicting models
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {PersistedModel} source
              * @param {PersistedModel} targe
@@ -2948,7 +2921,6 @@ declare namespace l {
              * and appear as if the source change was based on the target, they will be
              * replicated normally as part of the next replicate() call
              * This is effectively resolving the conflict using the source version
-             * @callback {() => void} callback
              * @param {Error} err
              */
             resolve(callback: (err: Error) => void): void;
@@ -2957,21 +2929,18 @@ declare namespace l {
              * Resolve the conflict using the supplied instance data
              * @param {any} data The set of changes to apply on the model
              * instance. Use `null` value to delete the source instance instead.
-             * @callback {() => void} callback
              * @param {Error} err
              */
             resolveManually(data: any, callback: (err: Error) => void): void;
 
             /**
              * Resolve the conflict using the instance data in the source model
-             * @callback {() => void} callback
              * @param {Error} err
              */
             resolveUsingSource(callback: (err: Error) => void): void;
 
             /**
              * Resolve the conflict using the instance data in the target model
-             * @callback {() => void} callback
              * @param {Error} err
              */
             resolveUsingTarget(callback: (err: Error) => void): void;
@@ -2996,7 +2965,6 @@ declare namespace l {
              * - `Change.DELETE`: Source and or target model was deleted.
              * - `Change.UNKNOWN`: the conflict type is uknown or due to an erro
              *
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {string} type The conflict type
              */
@@ -3005,12 +2973,11 @@ declare namespace l {
 
       /**
        * Email model.  Extends LoopBack base [Model](#model-new-model).
-       * @property {string} to Email addressee.  Required.
-       * @property {string} from Email sender address.  Required.
-       * @property {string} subject Email subject string.  Required.
-       * @property {string} text Text body of email.
-       * @property {string} html HTML body of email
-       * @class Email
+       * to Email addressee.  Required.
+       * from Email sender address.  Required.
+       * subject Email subject string.  Required.
+       * text Text body of email.
+       * html HTML body of email
        * @inherits {Model}
        */
       class Email extends Model {
@@ -3061,7 +3028,6 @@ declare namespace l {
 
       /**
        * Data model for key-value databases.
-       * @class
        */
       class KeyValueModel {
             /**
@@ -3192,7 +3158,6 @@ declare namespace l {
 
       /**
        * The Role model
-       * @class Role
        * @inherits {PersistedModel}
        * @header Role objec
        */
@@ -3200,7 +3165,7 @@ declare namespace l {
             /**
              * List roles for a given principal.
              * @param {any} context The security context.
-             * @callback {() => void} callback Callback function.
+             * callback Callback function.
              * @param {Error} err Error object.
              * @param {string[]} roles An Array of role IDs
              */
@@ -3218,7 +3183,7 @@ declare namespace l {
              * Check if a given principal is in the specified role.
              * @param {string} role The role name.
              * @param {any} context The context object.
-             * @callback {() => void} callback Callback function.
+             * callback Callback function.
              * @param {Error} err Error object.
              * @param {boolean} isInRole True if the principal is in the specified role.
              */
@@ -3245,10 +3210,9 @@ declare namespace l {
 
       /**
        * The `RoleMapping` model extends from the built in `loopback.Model` type.
-       * @property {string} id Generated ID.
-       * @property {string} name Name of the role.
-       * @property {string} Description Text description.
-       * @class RoleMapping
+       * id Generated ID.
+       * name Name of the role.
+       * Description Text description.
        * @inherits {PersistedModel}
        */
       class RoleMapping extends PersistedModel {
@@ -3263,7 +3227,6 @@ declare namespace l {
 
             /**
              * Get the application principal
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {Application} application
              */
@@ -3271,7 +3234,6 @@ declare namespace l {
 
             /**
              * Get the child role principal
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {User} childUser
              */
@@ -3279,7 +3241,6 @@ declare namespace l {
 
             /**
              * Get the user principal
-             * @callback {() => void} callback
              * @param {Error} err
              * @param {User} user
              */
@@ -3291,7 +3252,6 @@ declare namespace l {
        * For a protected resource, does the client application have the authorization
        * from the resource owner (user or system)
        * Scope has many resource access entrie
-       * @class scope
        */
       class Scope {
             /**
@@ -3300,7 +3260,6 @@ declare namespace l {
              * @param {string} model The model name
              * @param {string} property The property/method/relation name
              * @param {string} accessType The access type
-             * @callback {() => void} callback
              * @param {string|Error} err The error object
              * @param {AccessRequest} result The access permission
              */
@@ -3319,16 +3278,16 @@ declare namespace l {
        * - ALLOW OWNER `findById`
        * - ALLOW OWNER `updateAttributes`
        *
-       * @property {string} username Must be unique.
-       * @property {string} password Hidden from remote clients.
-       * @property {string} email Must be valid email.
-       * @property {boolean} emailVerified Set when a user's email has been verified via `confirm()`.
-       * @property {string} verificationToken Set when `verify()` is called.
-       * @property {string} realm The namespace the user belongs to. See [Partitioning users with realms](docs.strongloop.com/display/public/LB/Partitioning+users+with+realms) for details.
-       * @property {Date} created The property is not used by LoopBack, you are free to use it for your own purposes.
-       * @property {Date} lastUpdated The property is not used by LoopBack, you are free to use it for your own purposes.
-       * @property {string} status The property is not used by LoopBack, you are free to use it for your own purposes.
-       * @property {any} settings Extends the `Model.settings` object.
+       * username Must be unique.
+       * password Hidden from remote clients.
+       * email Must be valid email.
+       * emailVerified Set when a user's email has been verified via `confirm()`.
+       * verificationToken Set when `verify()` is called.
+       * realm The namespace the user belongs to. See [Partitioning users with realms](docs.strongloop.com/display/public/LB/Partitioning+users+with+realms) for details.
+       * created The property is not used by LoopBack, you are free to use it for your own purposes.
+       * lastUpdated The property is not used by LoopBack, you are free to use it for your own purposes.
+       * status The property is not used by LoopBack, you are free to use it for your own purposes.
+       * settings Extends the `Model.settings` object.
        * @property {boolean} settings.emailVerificationRequired Require the email verification
        * process before allowing a login.
        * @property {number} settings.ttl Default time to live (in seconds) for the `AccessToken` created by `User.login() / user.createAccessToken()`.
@@ -3403,7 +3362,6 @@ declare namespace l {
              * @param {Any} userId
              * @param {string} token The validation token
              * @param {string} redirect URL to redirect the user to once confirmed
-             * @callback {() => void} callback
              * @param {Error} er
              */
             static confirm(userId: any, token: string, redirect: string, callback?: (err: Error) => void): Promise<void> | void;
@@ -3431,7 +3389,7 @@ declare namespace l {
              * @param {any} credentials username/password or email/password
              * @param {string[]|string} [include] Optionally set it to "user" to include
              * the user info
-             * @callback {() => void} callback Callback function
+             * callback Callback function
              * @param {Error} err Error object
              * @param {AccessToken} token Access token if login is successfu
              */
@@ -3447,7 +3405,6 @@ declare namespace l {
              * ```
              *
              * @param {string} accessTokenID
-             * @callback {() => void} callback
              * @param {Error} er
              */
             static logout(accessTokenID: string, callback?: (err: Error) => void): Promise<void> | void;
@@ -3465,8 +3422,7 @@ declare namespace l {
              * Create a short lived acess token for temporary login. Allows users
              * to change passwords if forgotten
              * @options {any} options
-             * @prop {string} email The user's email address
-             * @callback {() => void} callback
+             * email The user's email address
              * @param {Error} er
              */
             static resetPassword(options: {}, callback?: (err: Error) => void): Promise<void> | void;
@@ -3476,7 +3432,7 @@ declare namespace l {
              * customize how access tokens are generate
              * @param {number} ttl The requested ttl
              * @param {any} [options] The options for access token, such as scope, appId
-             * @callback {() => void} cb The callback function
+             * cb The callback function
              * @param {string|Error} err The error string or object
              * @param {AccessToken} token The generated access token object
              */
@@ -3485,7 +3441,7 @@ declare namespace l {
             /**
              * Compare the given `password` with the users hashed password
              * @param {string} password The plain text password
-             * @callback {() => void} callback Callback function
+             * callback Callback function
              * @param {Error} err Error object
              * @param {boolean} isMatch Returns true if the given `password` matches recor
              */
@@ -3506,17 +3462,17 @@ declare namespace l {
              * ```
              *
              * @options {any} options
-             * @property {string} type Must be 'email'.
-             * @property {string} to Email address to which verification email is sent.
-             * @property {string} from Sender email addresss, for example
+             * type Must be 'email'.
+             * to Email address to which verification email is sent.
+             * from Sender email addresss, for example
              *   `'noreply@myapp.com'`.
-             * @property {string} subject Subject line text.
-             * @property {string} text Text of email.
-             * @property {string} template Name of template that displays verification
+             * subject Subject line text.
+             * text Text of email.
+             * template Name of template that displays verification
              *  page, for example, `'verify.ejs'.
-             * @property {string} redirect Page to which user will be redirected after
+             * redirect Page to which user will be redirected after
              *  they verify their email, for example `'/'` for root URI.
-             * @property {() => void} generateVerificationToken A function to be used to
+             * generateVerificationToken A function to be used to
              *  generate the verification token. It must accept the user object and a
              *  callback function. This function should NOT add the token to the user
              *  object, instead simply execute the callback with the token! User saving

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -435,7 +435,6 @@ declare namespace mapboxgl {
          * the padding offsets.
          *
          * @name showPadding
-         * @type {boolean}
          * @instance
          * @memberof Map
          */

--- a/types/mapbox-gl/v1/index.d.ts
+++ b/types/mapbox-gl/v1/index.d.ts
@@ -395,7 +395,6 @@ declare namespace mapboxgl {
          * the padding offsets.
          *
          * @name showPadding
-         * @type {boolean}
          * @instance
          * @memberof Map
          */

--- a/types/mapsjs/index.d.ts
+++ b/types/mapsjs/index.d.ts
@@ -26,7 +26,6 @@ export function clusterPoints(options: {
 
 /**
  * An immutable envelope
- * @class envelope
  */
 export class envelope {
     constructor(minX: number, minY: number, maxX: number, maxY: number);
@@ -215,7 +214,6 @@ export module envelope {
 /**
  * A general geometry which can represent a point, line, polygon,
  * mulitpoint, multilinestring
- * @class geometry
  */
 export class geometry {
     constructor(isPath?: boolean, isClosed?: boolean);
@@ -368,7 +366,6 @@ export module geometry {
     
     /**
      * A polyline object which is an open path geometry with one or more paths.
-     * @class polyline
      */
     class polyline extends geometry {
         constructor(geom: geometry);
@@ -440,7 +437,6 @@ export module geometry {
     
     /**
       * A polyline object which is a closed path geometry with one or more paths.
-      * @class polygon
       */
     class polygon extends geometry {
         constructor(geom: geometry);
@@ -545,7 +541,6 @@ export module geometry {
 
 /**
  * A style specification for geometry objects.
- * @class geometryStyle
  */
 export class geometryStyle {
     constructor(options?: styleObj);
@@ -632,7 +627,6 @@ export var license: string;
 
 /**
  * A simple point class with x and y coordinates.
- * @class point
  */
 export class point {
 
@@ -896,7 +890,6 @@ export module sphericalMercator {
 
 /**
  * A geometry object decorated with a geometry style object
- * @class styledGeometry
  */
 export class styledGeometry {
     constructor(geom: geometry, gStyle?: geometryStyle);
@@ -1105,7 +1098,6 @@ export module tile {
     
     /**
      * A tile layer is a view on the map containing an array of rectangular content.
-     * @class layer
      */
     export class layer {
         constructor(id: string, useBackdrop?: boolean, maxConcurrentRequests?: number);
@@ -1345,7 +1337,6 @@ export module tile {
      * A layerOptions object is a method for constructing a tile layer for 
      * immediate use, for example by passing it to the jQuery widget or
      * in the knockout binding.
-     * @class layerOptions
      */
     export class layerOptions {
         constructor(id: string, options: {
@@ -1387,7 +1378,6 @@ export module tile {
     /**
      * The quad class represents a quad tile within three dimensional
      * coordinate space.
-     * @class quad
      */
     export class quad {
 
@@ -1462,7 +1452,6 @@ export module tile {
     /**
      * A tile renderer handles converting JSON vector content loaded from the
      * MapDotNet REST feature service into a canvas rendering on a tile.
-     * @class renderer
      */
     export class renderer {
         constructor(options? : {
@@ -1506,7 +1495,6 @@ export module tile {
     
     /**
      * An auto-ranging density map renderer.
-     * @class rendererDensityMap
      */
     export class rendererDensityMap {
         
@@ -1575,7 +1563,6 @@ export module tile {
     
     /**
      * This is a base requestor class.
-     * @class requestor
      */
     export class requestor {
         
@@ -1702,7 +1689,6 @@ export module tile {
 
     /**
      * A tile requestor for Microsoft Bing maps.
-     * @class requestorBing
      */
     export class requestorBing extends requestor {
         
@@ -1773,7 +1759,6 @@ export module tile {
 
     /**
      * The bitmap or vector tile requestor using MapDotNet REST services.
-     * @class requestorMDN
      */
     export class requestorMDNRest extends requestor {
         constructor(endpoint: string, options?: {
@@ -1792,7 +1777,6 @@ export module tile {
     /**
      * Creates an instance of a descriptor for describing content from a 
      * MapDotNet UX REST map service.
-     * @class descriptorMDNRestMap
      */
     export class descriptorMDNRestMap {
         constructor(mapId: string, options?: {
@@ -2041,7 +2025,6 @@ export module tile {
     /**
      * Creates an instance of a descriptor for describing content from
      * a MapDotNet REST feature service.
-     * @class descriptorMDNRestFeature
      */
     export class descriptorMDNRestFeature {
         constructor(mapId: string, layerId: string, options?: {
@@ -2146,7 +2129,6 @@ export module tile {
      * This is a generic tile requestor suitable for several third-party
      * tile servers. These include open street map, map quest, cloudmade, 
      * Nokia, etc.
-     * @class requestorOpen
      */
     export class requestorOpen extends requestor {
         constructor(endpoint: string, subdomains: string[], options?: {
@@ -2160,7 +2142,6 @@ export module tile {
      * This is a requestor for local collections of data. These local collections may 
      * originate from inlined code or from datasources other than a MapDotNet REST 
      * feature service.
-     * @class requestorLocal
      */
     export class requestorLocal extends requestor {
         constructor(options?: {
@@ -2201,7 +2182,6 @@ export module tile {
     /**
      * Local descriptor object for describing source data when the source
      * data is fecthed by a local requestor.
-     * @class descriptorLocal
      */
     export class descriptorLocal {
         constructor(options: {

--- a/types/memwatch-next/index.d.ts
+++ b/types/memwatch-next/index.d.ts
@@ -8,7 +8,6 @@ declare module "memwatch-next" {
 
     /**
      * Compare the state of your heap between two points in time, telling you what has been allocated, and what has been released.
-     * @class
      */
     export class HeapDiff {
         /**
@@ -39,25 +38,21 @@ declare module "memwatch-next" {
     export interface LeakInformation {
         /**
          * End date.
-         * @type {Date}
          */
         end: Date,
 
         /**
          * Growth.
-         * @type {number}
          */
         growth: number;
 
         /**
          * Reason leak.
-         * @type {string}
          */
         reason: string;
 
         /**
          * Start date.
-         * @type {Date}
          */
         start: Date;
     }

--- a/types/meteor-roles/index.d.ts
+++ b/types/meteor-roles/index.d.ts
@@ -25,8 +25,6 @@ declare namespace Roles {
      *     Roles.userIsInRole(user, 'support-staff') // => true
      *     Roles.userIsInRole(user, 'admin') // => false
      *
-     * @property GLOBAL_GROUP
-     * @type String
      * @static
      * @final
      */
@@ -43,8 +41,6 @@ declare namespace Roles {
      *
      *     `Roles.subscription.ready()` // => `true` if user roles have been loaded
      *
-     * @property subscription
-     * @type Object
      * @for Roles
      */
     var subscription : Subscription;
@@ -281,8 +277,6 @@ declare module "meteor/alanning:roles" {
          *     Roles.userIsInRole(user, 'support-staff') // => true
          *     Roles.userIsInRole(user, 'admin') // => false
          *
-         * @property GLOBAL_GROUP
-         * @type String
          * @static
          * @final
          */
@@ -299,8 +293,6 @@ declare module "meteor/alanning:roles" {
          *
          *     `Roles.subscription.ready()` // => `true` if user roles have been loaded
          *
-         * @property subscription
-         * @type Object
          * @for Roles
          */
         var subscription : Subscription;

--- a/types/meteor-roles/meteor-roles-tests.ts
+++ b/types/meteor-roles/meteor-roles-tests.ts
@@ -97,7 +97,6 @@ Meteor.methods({
     /**
      * delete a user from a specific group
      *
-     * @method deleteUser
      * @param {String} targetUserId _id of user to delete
      * @param {String} group Company to update permissions for
      */

--- a/types/neo4j/index.d.ts
+++ b/types/neo4j/index.d.ts
@@ -56,31 +56,26 @@ export interface CypherOptions {
 export interface GraphDatabaseOptions {
     /**
      * HTTP agent.
-     * @type {any}
      */
     agent?: any;
 
     /**
      * Authentication information.
-     * @type {string|Authentication}
      */
     auth: string | Authentication;
 
     /**
      * HTTP headers.
-     * @type {Object}
      */
     headers?: {} | undefined;
 
     /**
      * Proxy address.
-     * @type {string}
      */
     proxy?: string | undefined;
 
     /**
      * URL connection.
-     * @type {string}
      */
     url: string;
 }
@@ -123,50 +118,42 @@ export interface Transaction {
 
 /**
  * Database.
- * @class
  */
 export class GraphDatabase {
     /**
      * Constructor.
-     * @constructor
      * @param {string} url A URL connection.
      */
     constructor(url: string);
 
     /**
      * Constructor.
-     * @constructor
      * @param {GraphDatabaseOptions} options Connection options.
      */
     constructor(options: GraphDatabaseOptions);
 
     /**
      * Agent.
-     * @type {any}
      */
     agent: any;
 
     /**
      * Credentials.
-     * @type {Authentication}
      */
     auth: Authentication;
 
     /**
      * Headers.
-     * @type {Object}
      */
     headers: {};
 
     /**
      * Proxy.
-     * @type {any}
      */
     proxy: any;
 
     /**
      * URL connection.
-     * @type {string}
      */
     url: string;
 

--- a/types/ng-file-upload/index.d.ts
+++ b/types/ng-file-upload/index.d.ts
@@ -21,79 +21,64 @@ declare module 'angular' {
         interface FileUploadOptions {
             /**
              * Standard HTML accept attr, browser specific select popup window
-             * @type {string}
              */
             ngfAccept?: string | undefined;
             /**
              * Default true, allow dropping files only for Chrome webkit browser
-             * @type {boolean}
              */
             ngfAllowDir?: boolean | undefined;
             /**
              * Default false, enable firefox image paste by making element contenteditable
-             * @type {boolean}
              */
             ngfEnableFirefoxPaste?: boolean | undefined;
             /**
              * Default false, hides element if file drag&drop is not
-             * @type {boolean}
              */
             ngfHideOnDropNotAvailable?: boolean | undefined;
             /**
              * Validate error name: minDuration
-             * @type {(number|string)}
              */
             ngfMinDuration?: number | string | undefined;
             /**
              * Validate error name: minSize
-             * @type {(number|string)}
              */
             ngfMinSize?: number | string | undefined;
             /**
              * Validate error name: minRatio
-             * @type {(number|string)}
              */
             ngfMinRatio?: number | string | undefined;
             /**
              * Validate error name: maxDuration
-             * @type {(number|string)}
              */
             ngfMaxDuration?: number | string | undefined;
             /**
              * Maximum number of files allowed to be selected or dropped, validate error name: maxFiles
-             * @type {number}
              */
             ngfMaxFiles?: number | undefined;
             /**
              * Validate error name: maxSize
-             * @type {(number|string)}
              */
             ngfMaxSize?: number | string | undefined;
             /**
              * Validate error name: maxTotalSize
-             * @type {(number|string)}
              */
             ngfMaxTotalSize?: number | string | undefined;
             /**
              * Allows selecting multiple files
-             * @type {boolean}
              */
             ngfMultiple?: boolean | undefined;
             /**
              * List of comma separated valid aspect ratio of images in float or 2:3 format
-             * @type {string}
              */
             ngfRatio?: string | undefined;
             /**
              * Default false, whether to propagate drag/drop events.
-             * @type {boolean}
              */
             ngfStopPropagation?: boolean | undefined;
             /**
              * Default false, if true file.$error will be set if the dimension or duration
              * values for validations cannot be calculated for example image load error or unsupported video by the browser.
              * By default it would assume the file is valid if the duration or dimension cannot be calculated by the browser.
-             * @type {boolean}
              */
             ngfValidateForce?: boolean | undefined;
         }
@@ -245,12 +230,10 @@ declare module 'angular' {
              * {file: file, info: Upload.jsonBlob({id: id, name: name, ...})} send fields as json blob, 'application/json' content_type
              * {picFile: Upload.rename(file, 'profile.jpg'), title: title} send file with picFile key and profile.jpg file name
              *
-             * @type {Object}
              */
             data: any;
             /**
              * upload.php script, node.js route, or servlet url
-             * @type {string}
              */
             url: string;
             /**
@@ -261,7 +244,6 @@ declare module 'angular' {
              * This is to accommodate server implementations expecting nested data object keys in .key or [key] format.
              * Example: data: {rec: {name: 'N', pic: file}} sent as: rec[name] -> N, rec[pic] -> file
              * data: {rec: {name: 'N', pic: file}, objectKey: '.k'} sent as: rec.name -> N, rec.pic -> file
-             * @type {string}
              */
             objectKey?: string | undefined;
             /**
@@ -269,32 +251,26 @@ declare module 'angular' {
              * ''(multiple entries with same key) format.
              * Example: data: {rec: [file[0], file[1], ...]} sent as: rec[0] -> file[0], rec[1] -> file[1],...
              * data: {rec: {rec: [f[0], f[1], ...], arrayKey: '[]'} sent as: rec[] -> f[0], rec[] -> f[1],...
-             * @type {string}
              */
             arrayKey?: string | undefined;
             /**
              * Uploaded file size so far on the server
-             * @type {string}
              */
             resumeSizeUrl?: string | undefined;
             /**
              * Reads the uploaded file size from resumeSizeUrl GET response
-             * @type {Function}
              */
             resumeSizeResponseReader?: Function | undefined;
             /**
              * Function that returns a prommise which will be resolved to the upload file size on the server.
-             * @type {[type]}
              */
             resumeSize?: Function | undefined;
             /**
              * Upload in chunks of specified size
-             * @type {(number|string)}
              */
             resumeChunkSize?: number | string | undefined;
             /**
              * Default false, experimental as hotfix for potential library conflicts with other plugins
-             * @type {boolean}
              */
             disableProgress?: boolean | undefined;
         }

--- a/types/ngmap/index.d.ts
+++ b/types/ngmap/index.d.ts
@@ -42,19 +42,15 @@ declare namespace angular.map {
            /**
              * Icon for the foreground.
              * If a string is provided, it is treated as though it were an Icon with the string as url.
-             * @type {(string|Icon|Symbol)}
              */
             icon?: string|google.maps.Icon|google.maps.Symbol | undefined;
             /**
              * Adds a label to the marker. The label can either be a string, or a MarkerLabel object.
              * Only the first character of the string will be displayed.
-             * @type {string}
              */
             label?: string | undefined;
             /**
              * Map on which to display Marker.
-             * @type {(Map|StreetViewPanorama)}
-             *
              */
             map?: google.maps.Map|google.maps.StreetViewPanorama | undefined;
             /** The marker's opacity between 0.0 and 1.0. */

--- a/types/nodal/index.d.ts
+++ b/types/nodal/index.d.ts
@@ -160,40 +160,34 @@ export class Composer<T extends Model> {
    * @param {Array} rows Rows from sql result
    * @param {Boolean} grouped Are these models grouped, if so, different procedure
    * @return {Nodal.ModelArray}
-   * @private
    */
   private __parseModelsFromRows__(rows, grouped?);
   /**
    * Collapses linked list of queries into an array (for .reduce, .map etc)
    * @return {Array}
-   * @private
    */
   private __collapse__();
   /**
    * Removes last limit command from a collapsed array of composer commands
    * @param {Array} [composerArray] Array of composer commands
    * @return {Array}
-   * @private
    */
   private __removeLastLimitCommand__(composerArray);
   /**
    * Gets last limit command from a collapsed array of composer commands
    * @param {Array} [composerArray] Array of composer commands
    * @return {Array}
-   * @private
    */
   private __getLastLimitCommand__(composerArray);
   /**
    * Determines whether this composer query represents a grouped query or not
    * @return {Boolean}
-   * @private
    */
   private __isGrouped__();
   /**
    * Reduces an array of composer queries to a single query information object
    * @param {Array} [composerArray]
    * @return {Object} Looks like {commands: [], joins: []}
-   * @private
    */
   private __reduceToQueryInformation__(composerArray);
   /**
@@ -201,13 +195,11 @@ export class Composer<T extends Model> {
    * @param {Array} [commandArray]
    * @param {Array} [includeColumns=*] Which columns to include, includes all by default
    * @return {Object} Looks like {sql: [], params: []}
-   * @private
    */
   private __reduceCommandsToQuery__(commandArray, includeColumns?);
   /**
    * Retrieve all joined column data for a given join
    * @param {string} joinName The name of the join relationship
-   * @private
    */
   private __joinedColumns__(joinName);
   /**
@@ -215,14 +207,12 @@ export class Composer<T extends Model> {
    * @param {Array} [includeColumns=*] Which columns to include, includes all by default
    * @param {boolean} [disableJoins=false] Disable joins if you just want a subset of data
    * @return {Object} Has "params" and "sql" properties.
-   * @private
    */
   private __generateQuery__(includeColumns?, disableJoins?);
   /**
    * Generate a SQL count query
    * @param {boolean} [useLimit=false] Generates COUNT using limit command as well
    * @return {Object} Has "params" and "sql" properties.
-   * @private
    */
   private __generateCountQuery__(useLimit?);
   /**
@@ -231,7 +221,6 @@ export class Composer<T extends Model> {
    * @param {Object} queryInfo Must be format {commands: [], joins: []}
    * @param {Array} [includeColumns=*] Which columns to include, includes all by default
    * @return {Object} Has "params" and "sql" properties.
-   * @private
    */
   private __addJoinsToQuery__(query, queryInfo, includeColumns?);
   /**
@@ -239,7 +228,6 @@ export class Composer<T extends Model> {
    * @param {Object} comparisons Comparisons object. {age__lte: 27}, for example.
    * @param {Nodal.Model} Model the model to use as the basis for comparison. Default to current model.
    * @return {Array}
-   * @private
    */
   private __parseComparisons__(comparisons, model?);
   private __filterHidden__(modelConstructor, comparisonsArray);
@@ -636,13 +624,11 @@ export class Model {
   /**
    * Runs all verifications before saving
    * @param {function} callback Method to execute upon completion. Returns true if OK, false if failed
-   * @private
    */
   __verify__(callback: Function): any;
   /**
    * Saves model to database
    * @param {function} callback Method to execute upon completion, returns error if failed (including validations didn't pass)
-   * @private
    */
   private __save__(callback);
   /**
@@ -820,13 +806,11 @@ export class Model {
   static isHidden(field: string): any;
   /**
    * Prepare model for use
-   * @private
    */
   private __initialize__();
   __load__(data: any, fromStorage?: boolean, fromSeed?: boolean): this;
   /**
    * Validates provided fieldList (or all fields if not provided)
-   * @private
    * @param {optional Array} fieldList fields to validate
    */
   private __validate__(field?);
@@ -839,7 +823,6 @@ export class Model {
   /**
    * Destroys model reference in database
    * @param {function} callback Method to execute upon completion, returns error if failed
-   * @private
    */
   private __destroy__(callback);
 }
@@ -863,7 +846,6 @@ export interface IModelData {
 }
 /**
  * Factory for creating models
- * @class
  */
 export class ModelFactory {
   private Model;

--- a/types/nodemailer-stub-transport/index.d.ts
+++ b/types/nodemailer-stub-transport/index.d.ts
@@ -13,13 +13,11 @@ declare namespace StubTransportStatic {
     export interface Options {
         /**
          * Specifies a custom error.
-         * @type {any}
          */
         error?: any;
 
         /**
          * Value that indicates if the BCC addresses must be included in generated message.
-         * @type {boolean}
          */
         keepBcc?: boolean | undefined;
     }

--- a/types/nwsapi/index.d.ts
+++ b/types/nwsapi/index.d.ts
@@ -18,7 +18,6 @@ declare function nwsapi(global: nwsapi.Global): nwsapi.NWSAPI;
 declare namespace nwsapi {
     // tslint:disable: no-redundant-jsdoc-2
     /**
-     * @enum
      * The `MatcherMode` type should be described using a **TypeScript** enum,\
      * but **TypeScript** doesn't treat `true`, `false` or `null`
      * as constant expressions in enum initializers.

--- a/types/onfleet__node-onfleet/Resources/Administrators.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Administrators.d.ts
@@ -23,10 +23,10 @@ declare namespace Admin {
     }
 
     /**
-     * @prop email - The administrator’s complete name.
-     * @prop name - The administrator’s email address.
-     * @prop phone - Optional. The administrator's phone number.
-     * @prop isReadOnly - Optional. Whether this administrator can perform write operations.
+     * email - The administrator’s complete name.
+     * name - The administrator’s email address.
+     * phone - Optional. The administrator's phone number.
+     * isReadOnly - Optional. Whether this administrator can perform write operations.
      */
     interface CreateAdminProps {
         email: string;

--- a/types/onfleet__node-onfleet/Resources/Destinations.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Destinations.d.ts
@@ -12,11 +12,11 @@ declare namespace Destination {
     type Location = [Longitude, Latitude];
 
     /**
-     * @prop { string } [apartment] - The suite or apartment number, or any additional relevant information.
-     * @prop { string } city - The name of the municipality.
-     * @prop { string } country - The name of the country.
-     * @prop { string } [name] - A name associated with this address, for example, "Transamerica Pyramid".
-     * @prop { string } number - The number component of this address, it may also contain letters.
+     * [apartment] - The suite or apartment number, or any additional relevant information.
+     * city - The name of the municipality.
+     * country - The name of the country.
+     * [name] - A name associated with this address, for example, "Transamerica Pyramid".
+     * number - The number component of this address, it may also contain letters.
      * @prop { string } [postalCode] - The postal or zip code.
      * @prop { string } [state] - The name of the state, province or jurisdiction.
      * @prop { string } street - The name of the street.

--- a/types/onfleet__node-onfleet/Resources/Teams.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Teams.d.ts
@@ -23,10 +23,10 @@ declare namespace Team {
     }
 
     /**
-     * @prop managers - An array of managing administrator IDs.
-     * @prop name - A unique name for the team.
-     * @prop workers - An array of worker IDs.
-     * @prop hub - Optional. The ID of the team's hub.
+     * managers - An array of managing administrator IDs.
+     * name - A unique name for the team.
+     * workers - An array of worker IDs.
+     * hub - Optional. The ID of the team's hub.
      */
     interface CreateTeamProps {
         managers: string[];

--- a/types/onfleet__node-onfleet/Resources/Workers.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Workers.d.ts
@@ -51,11 +51,11 @@ declare namespace Worker {
     }
 
     /**
-     * @prop filter - Optional. A comma-separated list of fields to return, if all are not desired. For example, name, location
-     * @prop phones - Optional. A comma-separated list of workers' phone numbers.
-     * @prop states - Optional. A comma-separated list of worker states, where 0 is off-duty,
+     * filter - Optional. A comma-separated list of fields to return, if all are not desired. For example, name, location
+     * phones - Optional. A comma-separated list of workers' phone numbers.
+     * states - Optional. A comma-separated list of worker states, where 0 is off-duty,
      * 1 is idle (on-duty, no active task) and 2 is active (on-duty, active task).
-     * @prop teams - Optional. A comma-separated list of the team IDs that workers must be part of.
+     * teams - Optional. A comma-separated list of the team IDs that workers must be part of.
      */
     interface GetWorkerQueryProps {
         filter?: string | undefined;
@@ -69,11 +69,11 @@ declare namespace Worker {
     }
 
     /**
-     * @prop name - The worker’s complete name.
-     * @prop phone - A valid phone number as per the worker’s organization’s country.
-     * @prop teams - One or more team IDs of which the worker is a member.
-     * @prop vehicle - Optional. The worker’s vehicle; providing no vehicle details is equivalent to the worker being on foot.
-     * @prop capacity - Optional. The maximum number of units this worker can carry, for route optimization purposes.
+     * name - The worker’s complete name.
+     * phone - A valid phone number as per the worker’s organization’s country.
+     * teams - One or more team IDs of which the worker is a member.
+     * vehicle - Optional. The worker’s vehicle; providing no vehicle details is equivalent to the worker being on foot.
+     * capacity - Optional. The maximum number of units this worker can carry, for route optimization purposes.
      * @prop displayName - Optional. This value is used in place of the worker's actual name within sms notifications,
      * delivery tracking pages, and across organization boundaries (connections).
      */

--- a/types/openfin/_v2/api/application/application.d.ts
+++ b/types/openfin/_v2/api/application/application.d.ts
@@ -49,9 +49,8 @@ export interface RvmLaunchOptions {
     userAppConfigArgs?: object | undefined;
 }
 /**
- * @typedef {object} ApplicationOption
  * @summary Application creation options.
- * @desc This is the options object required by {@link Application.start Application.start}.
+ * @description This is the options object required by {@link Application.start Application.start}.
  *
  * The following options are required:
  * * `uuid` is required in the app manifest as well as by {@link Application.start Application.start}
@@ -65,36 +64,36 @@ export interface RvmLaunchOptions {
  * This object inherits all the properties of the window creation {@link Window~options options} object,
  * which will take priority over those of the same name that may be provided in `mainWindowOptions`.
  *
- * @property {boolean} [disableIabSecureLogging=false]
+ * [disableIabSecureLogging=false]
  * When set to `true` it will disable IAB secure logging for the app.
  *
- * @property {boolean} [fdc3Api=false]
+ * [fdc3Api=false]
  * A flag to enable FDC3 API.  When set to `true` the `fdc3` API object is present for all windows
  *
- * @property {string} [loadErrorMessage="There was an error loading the application."]
+ * [loadErrorMessage="There was an error loading the application."]
  * An error message to display when the application (launched via manifest) fails to load.
  * A dialog box will be launched with the error message just before the runtime exits.
  * Load fails such as failed DNS resolutions or aborted connections as well as cancellations, _e.g.,_ `window.stop()`,
  * will trigger this dialog.
  * Client response codes such as `404 Not Found` are not treated as fails as they are valid server responses.
  *
- * @property {Window~options} [mainWindowOptions]
+ * [mainWindowOptions]
  * The options of the main window of the application.
  * For a description of these options, click the link (in the Type column).
  *
- * @property {string} [name]
+ * [name]
  * The name of the application (and the application's main window).
  *
  * If provided, _must_ match `uuid`.
  *
- * @property {boolean} [nonPersistent=false]
+ * [nonPersistent=false]
  * A flag to configure the application as non-persistent.
  * Runtime exits when there are no persistent apps running.
  *
- * @property {boolean} [plugins=false]
+ * [plugins=false]
  * Enable Flash at the application level.
  *
- * @property {boolean} [spellCheck=false]
+ * [spellCheck=false]
  * Enable spell check at the application level.
  *
  * @property {string} [url="about:blank"]
@@ -185,7 +184,6 @@ export default class ApplicationModule extends Base {
 /**
  * @classdesc An object representing an application. Allows the developer to create,
  * execute, show/close an application as well as listen to <a href="tutorial-Application.EventEmitter.html">application events</a>.
- * @class
  * @hideconstructor
  */
 export declare class Application extends EmitterBase<ApplicationEvents> {
@@ -423,7 +421,7 @@ export declare class Application extends EmitterBase<ApplicationEvents> {
     setAppLogUsername(username: string): Promise<void>;
     /**
      * @summary Retrieves information about the system tray.
-     * @desc The only information currently returned is the position and dimensions.
+     * @description The only information currently returned is the position and dimensions.
      * @return {Promise.<TrayInfo>}
      * @tutorial Application.getTrayIconInfo
      */

--- a/types/openfin/_v2/api/clipboard/clipboard.d.ts
+++ b/types/openfin/_v2/api/clipboard/clipboard.d.ts
@@ -1,12 +1,6 @@
 import { Base } from '../base';
 import { WriteRequestType, WriteAnyRequestType } from './write-request';
 /**
- * WriteRequestType interface
- * @typedef { object } WriteRequestType
- * @property { string } name The name of the running application
- * @property { string } uuid The uuid of the running application
- */
-/**
  * The Clipboard API allows reading and writing to the clipboard in multiple formats.
  * @namespace
  */

--- a/types/openfin/_v2/api/external-application/external-application.d.ts
+++ b/types/openfin/_v2/api/external-application/external-application.d.ts
@@ -39,7 +39,6 @@ export default class ExternalApplicationModule extends Base {
  * - Processes which have connected to an OpenFin runtime via an adapter
  * - Processes started via `System.launchExternalApplication`
  * - Processes monitored via `System.monitorExternalProcess`
- * @class
  * @hideconstructor
  */
 export declare class ExternalApplication extends EmitterBase<ExternalApplicationEvents> {

--- a/types/openfin/_v2/api/frame/frame.d.ts
+++ b/types/openfin/_v2/api/frame/frame.d.ts
@@ -64,7 +64,6 @@ export default class _FrameModule extends Base {
  *
  * The fin.Frame namespace represents a way to interact with `iframes` and facilitates the discovery of current context
  * (iframe or main window) as well as the ability to listen for <a href="tutorial-Frame.EventEmitter.html">frame-specific events</a>.
- * @class
  * @alias Frame
  * @hideconstructor
  */

--- a/types/openfin/_v2/api/notification/notification.d.ts
+++ b/types/openfin/_v2/api/notification/notification.d.ts
@@ -20,7 +20,6 @@ export interface NotificationCallback {
  * A notification is typically used to alert the user of some important event which
  * requires his or her attention. Notifications are a child or your application that
  * are controlled by the runtime.
- * @class
  * @alias Notification
  * @hideconstructor
  */

--- a/types/openfin/_v2/api/platform/layout.d.ts
+++ b/types/openfin/_v2/api/platform/layout.d.ts
@@ -10,49 +10,46 @@ export interface PresetLayoutOptions {
 }
 /**
  * InitLayoutOptions interface
- * @typedef { object } InitLayoutOptions
- * @property { string } [containerId] The id attribute of the container where the window's Layout should be initialized.  If not provided
+ * [containerId] The id attribute of the container where the window's Layout should be initialized.  If not provided
  * then an element with id `layout-container` is used. We recommend using a div element.
  */
 /**
  * PresetLayoutOptions interface
- * @typedef { object } PresetLayoutOptions
- * @property { LayoutPresetTypes } presetType Which preset layout arrangement to use.
+ * presetType Which preset layout arrangement to use.
  * The preset options are `columns`, `grid`, `rows`, and `tabs`.
  */
 /**
  * LayoutConfig interface
- * @typedef { object } LayoutConfig
- * @property { Array<LayoutItem> } content Content of the layout.  There can only be one top-level LayoutItem in the content array.
+ * content Content of the layout.  There can only be one top-level LayoutItem in the content array.
  * We do not recommend trying to build Layouts or LayoutItems by hand and instead use calls such as {@link Platform#getSnapshot getSnapshot}
  * or our {@link https://openfin.github.io/golden-prototype/config-gen Layout Config Generation Tool }.
- * @property { LayoutSettings } settings Configuration for certain Layout behaviors. See the LayoutSettings interface.
+ * settings Configuration for certain Layout behaviors. See the LayoutSettings interface.
  */
 /**
  * LayoutItem Interface
- * @typedef { object } LayoutItem Represents the arrangement of Views within a Platform window's Layout.  We do not recommend trying
+ * LayoutItem Represents the arrangement of Views within a Platform window's Layout.  We do not recommend trying
  * to build Layouts or LayoutItems by hand and instead use calls such as {@link Platform#getSnapshot getSnapshot} or our
  * {@link https://openfin.github.io/golden-prototype/config-gen Layout Config Generation Tool }.
- * @property { string } type The type of the item. Possible values are 'row', 'column', 'stack', and 'component'.
- * @property { Array<LayoutItem> } [content] An array of configurations for items that will be created as children of this item.
- * @property { string } [componentName] Only a `component` type will have this property and it should be set to `view`.
- * @property { View~options } [componentState] Only a `component` type will have this property and it represents the view
+ * type The type of the item. Possible values are 'row', 'column', 'stack', and 'component'.
+ * [content] An array of configurations for items that will be created as children of this item.
+ * [componentName] Only a `component` type will have this property and it should be set to `view`.
+ * [componentState] Only a `component` type will have this property and it represents the view
  * options of a given component.
  */
 /**
  * LayoutSettings Interface
- * @typedef { object } LayoutSettings Represents a potential ways to customize behavior of your Layout
- * @property { boolean } hasHeaders Turns tab headers on or off.
+ * LayoutSettings Represents a potential ways to customize behavior of your Layout
+ * hasHeaders Turns tab headers on or off.
  * If false, the layout will be displayed with splitters only.
- * @property { boolean } popoutWholeStack Whether the popout button will only act on the entire stack,
+ * popoutWholeStack Whether the popout button will only act on the entire stack,
  * as opposed to only the active tab.
- * @property { boolean } reorderEnabled If true, the user can re-arrange the layout by
+ * reorderEnabled If true, the user can re-arrange the layout by
  * dragging items by their tabs to the desired location.
- * @property { boolean } showCloseIcon Whether to show the close button on stack header
+ * showCloseIcon Whether to show the close button on stack header
  * (not to be confused with close button on every tab).
- * @property { boolean } showMaximiseIcon Whether to show the maximize button on stack header.
+ * showMaximiseIcon Whether to show the maximize button on stack header.
  * The button will maximize the current tab to fill the entire window.
- * @property { boolean } showPopoutIcon Whether to show the popout button on stack header.
+ * showPopoutIcon Whether to show the popout button on stack header.
  * The button will create a new window with current tab as its content.
  * In case `popoutWholeStack` is set to true, all tabs in the stack will be in the new window.
  */

--- a/types/openfin/_v2/api/system/system.d.ts
+++ b/types/openfin/_v2/api/system/system.d.ts
@@ -27,230 +27,200 @@ export interface ServiceIdentifier {
 }
 /**
  * AppAssetInfo interface
- * @typedef { object } AppAssetInfo
- * @property { string } src  The URL to a zip file containing the package files (executables, dlls, etc…)
- * @property { string } alias The name of the asset
- * @property { string } version The version of the package
- * @property { string } target Specify default executable to launch. This option can be overridden in launchExternalProcess
- * @property { string } args The default command line arguments for the aforementioned target.
- * @property { boolean } mandatory When set to true, the app will fail to load if the asset cannot be downloaded.
+ * src  The URL to a zip file containing the package files (executables, dlls, etc…)
+ * alias The name of the asset
+ * version The version of the package
+ * target Specify default executable to launch. This option can be overridden in launchExternalProcess
+ * args The default command line arguments for the aforementioned target.
+ * mandatory When set to true, the app will fail to load if the asset cannot be downloaded.
  * When set to false, the app will continue to load if the asset cannot be downloaded. (Default: true)
  */
 /**
  * AppAssetRequest interface
- * @typedef { object } AppAssetRequest
- * @property { string } alias The name of the asset
+ * alias The name of the asset
  */
 /**
  * ApplicationInfo interface
- * @typedef { object } ApplicationInfo
- * @property { boolean } isRunning  true when the application is running
- * @property { string } uuid uuid of the application
- * @property { string } parentUuid uuid of the application that launches this application
+ * isRunning  true when the application is running
+ * uuid uuid of the application
+ * parentUuid uuid of the application that launches this application
  */
 /**
- * @typedef { object } ClearCacheOption
  * @summary Clear cache options.
- * @desc These are the options required by the clearCache function.
+ * @description These are the options required by the clearCache function.
  *
- * @property {boolean} appcache html5 application cache
- * @property {boolean} cache browser data cache for html files and images
- * @property {boolean} cookies browser cookies
- * @property {boolean} localStorage browser data that can be used across sessions
+ * appcache html5 application cache
+ * cache browser data cache for html files and images
+ * cookies browser cookies
+ * localStorage browser data that can be used across sessions
  */
 /**
  * CookieInfo interface
- * @typedef { object } CookieInfo
- * @property { string } name  The name of the cookie
- * @property { string } domain The domain of the cookie
- * @property { string } path The path of the cookie
+ * name  The name of the cookie
+ * domain The domain of the cookie
+ * path The path of the cookie
  */
 /**
  * CookieOption interface
- * @typedef { object } CookieOption
- * @property { string } name The name of the cookie
+ * name The name of the cookie
  */
 /**
  * CpuInfo interface
- * @typedef { object } CpuInfo
- * @property { string } model The model of the cpu
- * @property { number } speed The number in MHz
- * @property { Time } times The numbers of milliseconds the CPU has spent in different modes.
+ * model The model of the cpu
+ * speed The number in MHz
+ * times The numbers of milliseconds the CPU has spent in different modes.
  */
 /**
  * CrashReporterOption interface
- * @typedef { object } CrashReporterOption
- * @property { boolean } diagnosticMode In diagnostic mode the crash reporter will send diagnostic logs to
+ * diagnosticMode In diagnostic mode the crash reporter will send diagnostic logs to
  *  the OpenFin reporting service on runtime shutdown
- * @property { boolean } isRunning check if it's running
+ * isRunning check if it's running
  */
 /**
  * DipRect interface
- * @typedef { object } DipRect
- * @property { Rect } dipRect The DIP coordinates
- * @property { Rect } scaledRect The scale coordinates
+ * dipRect The DIP coordinates
+ * scaledRect The scale coordinates
  */
 /**
  * DipScaleRects interface
- * @typedef { object } DipScaleRects
- * @property { Rect } dipRect The DIP coordinates
- * @property { Rect } scaledRect The scale coordinates
+ * dipRect The DIP coordinates
+ * scaledRect The scale coordinates
  */
 /**
  * DownloadPreloadInfo interface
- * @typedef { object } DownloadPreloadInfo
- * @desc downloadPreloadScripts function return value
- * @property { string } url url to the preload script
- * @property { string } error error during preload script acquisition
- * @property { boolean } succeess download operation success
+ * @description downloadPreloadScripts function return value
+ * url url to the preload script
+ * error error during preload script acquisition
+ * succeess download operation success
  */
 /**
  * DownloadPreloadOption interface
- * @typedef { object } DownloadPreloadOption
- * @desc These are the options object required by the downloadPreloadScripts function
- * @property { string } url url to the preload script
+ * @description These are the options object required by the downloadPreloadScripts function
+ * url url to the preload script
  */
 /**
  * Entity interface
- * @typedef { object } Entity
- * @property { string } type The type of the entity
- * @property { string } uuid The uuid of the entity
+ * type The type of the entity
+ * uuid The uuid of the entity
  */
 /**
  * EntityInfo interface
- * @typedef { object } EntityInfo
- * @property { string } name The name of the entity
- * @property { string } uuid The uuid of the entity
- * @property { Identity } parent The parent of the entity
- * @property { string } entityType The type of the entity
+ * name The name of the entity
+ * uuid The uuid of the entity
+ * parent The parent of the entity
+ * entityType The type of the entity
  */
 /**
  * ExternalApplicationInfo interface
- * @typedef { object } ExternalApplicationInfo
- * @property { Identity } parent The parent identity
+ * parent The parent identity
  */
 /**
  * ExternalConnection interface
- * @typedef { object } ExternalConnection
- * @property { string } token The token to broker an external connection
- * @property { string } uuid The uuid of the external connection
+ * token The token to broker an external connection
+ * uuid The uuid of the external connection
  */
 /**
  * ExternalProcessRequestType interface
- * @typedef { object } ExternalProcessRequestType
- * @property { string } path The file path to where the running application resides
- * @property { string } arguments The argument passed to the running application
- * @property { LaunchExternalProcessListener } listener This is described in the {LaunchExternalProcessListner} type definition
+ * path The file path to where the running application resides
+ * arguments The argument passed to the running application
+ * listener This is described in the {LaunchExternalProcessListner} type definition
  */
 /**
  * FrameInfo interface
- * @typedef { object } FrameInfo
- * @property { string } name The name of the frame
- * @property { string } uuid The uuid of the frame
- * @property { EntityType } entityType The entity type, could be 'window', 'iframe', 'external connection' or 'unknown'
- * @property { Identity } parent The parent identity
+ * name The name of the frame
+ * uuid The uuid of the frame
+ * entityType The entity type, could be 'window', 'iframe', 'external connection' or 'unknown'
+ * parent The parent identity
  */
 /**
  * GetLogRequestType interface
- * @typedef { object } GetLogRequestType
- * @property { string } name The name of the running application
- * @property { number } endFile The file length of the log file
- * @property { number } sizeLimit The set size limit of the log file
+ * name The name of the running application
+ * endFile The file length of the log file
+ * sizeLimit The set size limit of the log file
  */
 /**
  * GpuInfo interface
- * @typedef { object } GpuInfo
- * @property { string } name The graphics card name
+ * name The graphics card name
  */
 /**
  * HostSpecs interface
- * @typedef { object } HostSpecs
- * @property { boolean } aeroGlassEnabled Value to check if Aero Glass theme is supported on Windows platforms
- * @property { string } arch "x86" for 32-bit or "x86_64" for 64-bit
- * @property { Array<CpuInfo> } cpus The same payload as Node's os.cpus()
- * @property { GpuInfo } gpu The graphics card name
- * @property { number } memory The same payload as Node's os.totalmem()
- * @property { string } name The OS name and version/edition
- * @property { boolean } screenSaver Value to check if screensaver is running. Supported on Windows only
+ * aeroGlassEnabled Value to check if Aero Glass theme is supported on Windows platforms
+ * arch "x86" for 32-bit or "x86_64" for 64-bit
+ * cpus The same payload as Node's os.cpus()
+ * gpu The graphics card name
+ * memory The same payload as Node's os.totalmem()
+ * name The OS name and version/edition
+ * screenSaver Value to check if screensaver is running. Supported on Windows only
  */
 /**
  * Identity interface
- * @typedef { object } Identity
- * @property { string } name Optional - the name of the component
- * @property { string } uuid Universally unique identifier of the application
+ * name Optional - the name of the component
+ * uuid Universally unique identifier of the application
  */
 /**
  * LogInfo interface
- * @typedef { object } LogInfo
- * @property { string } name The filename of the log
- * @property { number } size The size of the log in bytes
- * @property { string } date The unix time at which the log was created "Thu Jan 08 2015 14:40:30 GMT-0500 (Eastern Standard Time)"
+ * name The filename of the log
+ * size The size of the log in bytes
+ * date The unix time at which the log was created "Thu Jan 08 2015 14:40:30 GMT-0500 (Eastern Standard Time)"
  */
 /**
  * ManifestInfo interface
- * @typedef { object } ManifestInfo
- * @property { string } uuid The uuid of the application
- * @property { string } manifestUrl The runtime manifest URL
+ * uuid The uuid of the application
+ * manifestUrl The runtime manifest URL
  */
 /**
  * MonitorDetails interface
- * @typedef { object } MonitorDetails
- * @property { DipScaleRects } available The available DIP scale coordinates
- * @property { Rect } availableRect The available monitor coordinates
- * @property { string } deviceId The device id of the display
- * @property { boolean } displayDeviceActive true if the display is active
- * @property { number } deviceScaleFactor The device scale factor
- * @property { Rect } monitorRect The monitor coordinates
- * @property { string } name The name of the display
- * @property { Point } dpi The dots per inch
- * @property { DipScaleRects } monitor The monitor coordinates
+ * available The available DIP scale coordinates
+ * availableRect The available monitor coordinates
+ * deviceId The device id of the display
+ * displayDeviceActive true if the display is active
+ * deviceScaleFactor The device scale factor
+ * monitorRect The monitor coordinates
+ * name The name of the display
+ * dpi The dots per inch
+ * monitor The monitor coordinates
  */
 /**
  * MonitorInfo interface
- * @typedef { object } MonitorInfo
- * @property { number } deviceScaleFactor The device scale factor
- * @property { Point } dpi The dots per inch
- * @property { Array<MonitorDetails> } nonPrimaryMonitors The array of monitor details
- * @property { MonitorDetails } primaryMonitor The monitor details
- * @property { string } reason always "api-query"
- * @property { TaskBar } taskBar The taskbar on monitor
- * @property { DipRect } virtualScreen The virtual display screen coordinates
+ * deviceScaleFactor The device scale factor
+ * dpi The dots per inch
+ * nonPrimaryMonitors The array of monitor details
+ * primaryMonitor The monitor details
+ * reason always "api-query"
+ * taskBar The taskbar on monitor
+ * virtualScreen The virtual display screen coordinates
  */
 /**
- * @typedef { verbose | info | warning | error | fatal } LogLevel
  * @summary Log verbosity levels.
- * @desc Describes the minimum level (inclusive) above which logs will be written
+ * @description Describes the minimum level (inclusive) above which logs will be written
  *
- * @property { string } verbose all logs written
- * @property { string } info info and above
- * @property { string } warning warning and above
- * @property { string } error error and above
- * @property { string } fatal fatal only, indicates a crash is imminent
+ * verbose all logs written
+ * info info and above
+ * warning warning and above
+ * error error and above
+ * fatal fatal only, indicates a crash is imminent
  */
 /**
  * PointTopLeft interface
- * @typedef { object } PointTopLeft
- * @property { number } top The mouse top position in virtual screen coordinates
- * @property { number } left The mouse left position in virtual screen coordinates
+ * top The mouse top position in virtual screen coordinates
+ * left The mouse left position in virtual screen coordinates
  */
 /**
  * Point interface
- * @typedef { object } Point
- * @property { number } x The mouse x position
- * @property { number } y The mouse y position
+ * x The mouse x position
+ * y The mouse y position
  */
 /**
  * ProcessInfo interface
- * @typedef { object } ProcessInfo
- * @property { number } cpuUsage The percentage of total CPU usage
- * @property { string } name The application name
- * @property { number } nonPagedPoolUsage The current nonpaged pool usage in bytes
- * @property { number } pageFaultCount The number of page faults
- * @property { number } pagedPoolUsage The current paged pool usage in bytes
- * @property { number } pagefileUsage The total amount of memory in bytes that the memory manager has committed
- * @property { number } peakNonPagedPoolUsage The peak nonpaged pool usage in bytes
- * @property { number } peakPagedPoolUsage The peak paged pool usage in bytes
- * @property { number } peakPagefileUsage The peak value in bytes of pagefileUsage during the lifetime of this process
+ * cpuUsage The percentage of total CPU usage
+ * name The application name
+ * nonPagedPoolUsage The current nonpaged pool usage in bytes
+ * pageFaultCount The number of page faults
+ * pagedPoolUsage The current paged pool usage in bytes
+ * pagefileUsage The total amount of memory in bytes that the memory manager has committed
+ * peakNonPagedPoolUsage The peak nonpaged pool usage in bytes
+ * peakPagedPoolUsage The peak paged pool usage in bytes
+ * peakPagefileUsage The peak value in bytes of pagefileUsage during the lifetime of this process
  * @property { number } peakWorkingSetSize The peak working set size in bytes
  * @property { number } processId The native process identifier
  * @property { string } uuid The application UUID
@@ -258,156 +228,136 @@ export interface ServiceIdentifier {
  */
 /**
  * ProxyConfig interface
- * @typedef { object } ProxyConfig
- * @property { string } proxyAddress The configured proxy address
- * @property { number } proxyPort The configured proxy port
- * @property { string } type The proxy Type
+ * proxyAddress The configured proxy address
+ * proxyPort The configured proxy port
+ * type The proxy Type
  */
 /**
  * ProxyInfo interface
- * @typedef { object } ProxyInfo
- * @property { ProxyConfig } config The proxy config
- * @property { ProxySystemInfo } system The proxy system info
+ * config The proxy config
+ * system The proxy system info
  */
 /**
  * ProxySystemInfo interface
- * @typedef { object } ProxySystemInfo
- * @property { string } autoConfigUrl The auto configuration url
- * @property { string } bypass The proxy bypass info
- * @property { boolean } enabled Value to check if a proxy is enabled
- * @property { string } proxy The proxy info
+ * autoConfigUrl The auto configuration url
+ * bypass The proxy bypass info
+ * enabled Value to check if a proxy is enabled
+ * proxy The proxy info
  */
 /**
  * Rect interface
- * @typedef { object } Rect
- * @property { number } bottom The bottom-most coordinate
- * @property { number } left The left-most coordinate
- * @property { number } right The right-most coordinate
- * @property { number } top The top-most coordinate
+ * bottom The bottom-most coordinate
+ * left The left-most coordinate
+ * right The right-most coordinate
+ * top The top-most coordinate
  */
 /**
  * RegistryInfo interface
- * @typedef { object } RegistryInfo
- * @property { any } data The registry data
- * @property { string } rootKey The registry root key
- * @property { string } subkey The registry key
- * @property { string } type The registry type
- * @property { string } value The registry value name
+ * data The registry data
+ * rootKey The registry root key
+ * subkey The registry key
+ * type The registry type
+ * value The registry value name
  */
 /**
  * RuntimeDownloadOptions interface
- * @typedef { object } RuntimeDownloadOptions
- * @desc These are the options object required by the downloadRuntime function.
- * @property { string } version The given version to download
+ * @description These are the options object required by the downloadRuntime function.
+ * version The given version to download
  */
 /**
  * RuntimeInfo interface
- * @typedef { object } RuntimeInfo
- * @property { string } architecture The runtime build architecture
- * @property { string } manifestUrl The runtime manifest URL
- * @property { number } port The runtime websocket port
- * @property { string } securityRealm The runtime security realm
- * @property { string } version The runtime version
- * @property { object } args the command line argument used to start the Runtime
- * @property { string } chromeVersion The chrome version
+ * architecture The runtime build architecture
+ * manifestUrl The runtime manifest URL
+ * port The runtime websocket port
+ * securityRealm The runtime security realm
+ * version The runtime version
+ * args the command line argument used to start the Runtime
+ * chromeVersion The chrome version
  */
 /**
  * RVMInfo interface
- * @typedef { object } RVMInfo
- * @property { string } action The name of action: "get-rvm-info"
- * @property { string } appLogDirectory The app log directory
- * @property { string } path The path of OpenfinRVM.exe
- * @property { string } 'start-time' The start time of RVM
- * @property { string } version The version of RVM
- * @property { string } 'working-dir' The working directory
+ * action The name of action: "get-rvm-info"
+ * appLogDirectory The app log directory
+ * path The path of OpenfinRVM.exe
+ * 'start-time' The start time of RVM
+ * version The version of RVM
+ * 'working-dir' The working directory
  */
 /**
  * RvmLaunchOptions interface
- * @typedef { object } RvmLaunchOptions
- * @property { boolean } [noUi] true if no UI when launching
- * @property { object } [userAppConfigArgs] The user app configuration args
+ * [noUi] true if no UI when launching
+ * [userAppConfigArgs] The user app configuration args
  */
 /**
  * ServiceIdentifier interface
- * @typedef { object } ServiceIdentifier
- * @property { string } name The name of the service
+ * name The name of the service
  */
 /**
  * ServiceConfiguration interface
- * @typedef { object } ServiceConfiguration
- * @property { object } config The service configuration
- * @property { string } name The name of the service
+ * config The service configuration
+ * name The name of the service
  */
 /**
  * ShortCutConfig interface
- * @typedef { object } ShortCutConfig
- * @property { boolean } desktop true if application has a shortcut on the desktop
- * @property { boolean } startMenu true if application has shortcut in the start menu
- * @property { boolean } systemStartup true if application will be launched on system startup
+ * desktop true if application has a shortcut on the desktop
+ * startMenu true if application has shortcut in the start menu
+ * systemStartup true if application will be launched on system startup
  */
 /**
  * SubOptions interface
- * @typedef { Object } SubOptions
- * @property { number } timestamp The event timestamp
+ * timestamp The event timestamp
  */
 /**
  * TaskBar interface
- * @typedef { object } TaskBar
- * @property { string } edge which edge of a monitor the taskbar is on
- * @property { Rect } rect The taskbar coordinates
+ * edge which edge of a monitor the taskbar is on
+ * rect The taskbar coordinates
  */
 /**
  * TerminateExternalRequestType interface
- * @typedef { object } TerminateExternalRequestType
- * @property { string } uuid The uuid of the running application
- * @property { number } timeout Time out period before the running application terminates
- * @property { boolean } killtree Value to terminate the running application
+ * uuid The uuid of the running application
+ * timeout Time out period before the running application terminates
+ * killtree Value to terminate the running application
  */
 /**
  * Time interface
- * @typedef { object } Time
- * @property { number } user The number of milliseconds the CPU has spent in user mode
- * @property { number } nice The number of milliseconds the CPU has spent in nice mode
- * @property { number } sys The number of milliseconds the CPU has spent in sys mode
- * @property { number } idle The number of milliseconds the CPU has spent in idle mode
- * @property { number } irq The number of milliseconds the CPU has spent in irq mode
+ * user The number of milliseconds the CPU has spent in user mode
+ * nice The number of milliseconds the CPU has spent in nice mode
+ * sys The number of milliseconds the CPU has spent in sys mode
+ * idle The number of milliseconds the CPU has spent in idle mode
+ * irq The number of milliseconds the CPU has spent in irq mode
  */
 /**
  * TrayInfo interface
- * @typedef { object } TrayInfo
- * @property { Bounds } bounds The bound of tray icon in virtual screen pixels
- * @property { MonitorInfo } monitorInfo Please see fin.System.getMonitorInfo for more information
- * @property { number } x copy of bounds.x
- * @property { number } y copy of bounds.y
+ * bounds The bound of tray icon in virtual screen pixels
+ * monitorInfo Please see fin.System.getMonitorInfo for more information
+ * x copy of bounds.x
+ * y copy of bounds.y
  */
 /**
  * WindowDetail interface
- * @typedef { object } WindowDetail
- * @property { number } bottom The bottom-most coordinate of the window
- * @property { number } height The height of the window
- * @property { boolean } isShowing Value to check if the window is showing
- * @property { number } left The left-most coordinate of the window
- * @property { string } name The name of the window
- * @property { number } right The right-most coordinate of the window
- * @property { string } state The window state
- * @property { number } top The top-most coordinate of the window
- * @property { number } width The width of the window
+ * bottom The bottom-most coordinate of the window
+ * height The height of the window
+ * isShowing Value to check if the window is showing
+ * left The left-most coordinate of the window
+ * name The name of the window
+ * right The right-most coordinate of the window
+ * state The window state
+ * top The top-most coordinate of the window
+ * width The width of the window
  */
 /**
  * WindowInfo interface
- * @typedef { object } WindowInfo
- * @property { Array<WindowDetail> } childWindows The array of child windows details
- * @property { WindowDetail } mainWindow The main window detail
- * @property { string } uuid The uuid of the application
+ * childWindows The array of child windows details
+ * mainWindow The main window detail
+ * uuid The uuid of the application
  */
 /**
  * CertifiedAppInfo interface
- * @typedef { object } CertifiedAppInfo
- * @property { boolean } isRunning true if the app is running
- * @property { boolean } [isOptedIntoCertfiedApp] true if the app has opted into certification
- * @property { boolean } [isCertified] true if the app is certified
- * @property { boolean } [isSSLCertified] true if the app manifest's SSL certificate is valid
- * @property { boolean } [isPresentInAppDirectory] true if the app is present in the OpenFin app directory
+ * isRunning true if the app is running
+ * [isOptedIntoCertfiedApp] true if the app has opted into certification
+ * [isCertified] true if the app is certified
+ * [isSSLCertified] true if the app manifest's SSL certificate is valid
+ * [isPresentInAppDirectory] true if the app is present in the OpenFin app directory
  */
 /**
  * An object representing the core of OpenFin Runtime. Allows the developer

--- a/types/openfin/_v2/api/view/view.d.ts
+++ b/types/openfin/_v2/api/view/view.d.ts
@@ -58,29 +58,28 @@ export default class ViewModule extends Base {
     getCurrentSync(): View;
 }
 /**
- * @typedef {object} View~options
  * @summary View creation options.
- * @desc This is the options object required by {@link View.create View.create}.
+ * @description This is the options object required by {@link View.create View.create}.
  *
  * Note that `name` and `target` are the only required properties — albeit the `url` property is usually provided as well
  * (defaults to `"about:blank"` when omitted).
  *
- * @property {object} [experimental]
+ * [experimental]
  * Configurations for API injection.
  *
- * @property {boolean} [experimental.childWindows] Configure if the runtime should enable child windows for views.
+ * [experimental.childWindows] Configure if the runtime should enable child windows for views.
  *
- * @property {object} [api]
+ * [api]
  * Configurations for API injection.
  *
- * @property {object} [api.iframe] Configure if the the API should be injected into iframes based on domain.
+ * [api.iframe] Configure if the the API should be injected into iframes based on domain.
  *
- * @property {boolean} [api.iframe.crossOriginInjection=false] Controls if the `fin` API object is present for cross origin iframes.
- * @property {boolean} [api.iframe.sameOriginInjection=true] Controls if the `fin` API object is present for same origin iframes.
+ * [api.iframe.crossOriginInjection=false] Controls if the `fin` API object is present for cross origin iframes.
+ * [api.iframe.sameOriginInjection=true] Controls if the `fin` API object is present for same origin iframes.
  *
- * @property {object} [autoResize] AutoResize options
+ * [autoResize] AutoResize options
  *
- * @property {object} [bounds] initial bounds
+ * [bounds] initial bounds
  *
  * @property {string} [backgroundColor="#FFF"] - _Updatable._
  * The view’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color
@@ -150,7 +149,6 @@ export default class ViewModule extends Base {
  * To change that behavior, see the processAffinity {@link View~options view option}.
  *
  * A View's lifecycle is tied to its owning window and can be re-attached to a different window at any point during its lifecycle.
- * @class
  * @alias View
  * @hideconstructor
  */
@@ -181,7 +179,7 @@ export declare class View extends WebContents<ViewEvents> {
      * @return {Promise.<void>}
      * @function focus
      * @memberof View
-     * @emits focused
+     * @fires focused
      * @instance
      * @tutorial View.focus
      * @experimental

--- a/types/openfin/_v2/api/window/window.d.ts
+++ b/types/openfin/_v2/api/window/window.d.ts
@@ -120,32 +120,29 @@ export interface FindInPageOptions {
     medialCapitalAsWordStart?: boolean | undefined;
 }
 /**
- * @typedef { object } Margins
- * @property { string } [marginType]
+ * [marginType]
  * Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen,
  * you will also need to specify `top`, `bottom`, `left`, and `right`.
  *
- * @property { number } [top] The top margin of the printed web page, in pixels.
- * @property { number } [bottom] The bottom margin of the printed web page, in pixels.
- * @property { number } [left] The left margin of the printed web page, in pixels.
- * @property { number } [right] The right margin of the printed web page, in pixels.
+ * [top] The top margin of the printed web page, in pixels.
+ * [bottom] The bottom margin of the printed web page, in pixels.
+ * [left] The left margin of the printed web page, in pixels.
+ * [right] The right margin of the printed web page, in pixels.
  */
 /**
- * @typedef { object } Dpi
- * @property { number } [horizontal] The horizontal dpi
- * @property { number } [vertical] The vertical dpi
+ * [horizontal] The horizontal dpi
+ * [vertical] The vertical dpi
  */
 /**
- * @typedef { object } PrintOptions
- * @property { boolean } [silent=false] Don't ask user for print settings.
- * @property { boolean } [printBackground=false] Prints the background color and image of the web page.
- * @property { string } [deviceName=''] Set the printer device name to use.
- * @property { boolean } [color=true] Set whether the printed web page will be in color or grayscale.
- * @property { Margins } [margins] Set margins for the printed web page
- * @property { boolean } [landscape=false] Whether the web page should be printed in landscape mode.
- * @property { number } [scaleFactor] The scale factor of the web page.
- * @property { number } [pagesPerSheet] The number of pages to print per page sheet.
- * @property { boolean } [collate] Whether the web page should be collated.
+ * [silent=false] Don't ask user for print settings.
+ * [printBackground=false] Prints the background color and image of the web page.
+ * [deviceName=''] Set the printer device name to use.
+ * [color=true] Set whether the printed web page will be in color or grayscale.
+ * [margins] Set margins for the printed web page
+ * [landscape=false] Whether the web page should be printed in landscape mode.
+ * [scaleFactor] The scale factor of the web page.
+ * [pagesPerSheet] The number of pages to print per page sheet.
+ * [collate] Whether the web page should be collated.
  * @property { number } [copies] The number of copies of the web page to print.
  * @property { Record<string, number> } [pageRanges] The page range to print. Should have two keys: from and to.
  * @property { string } [duplexMode] Set the duplex mode of the printed web page. Can be simplex, shortEdge, or longEdge.
@@ -153,42 +150,40 @@ export interface FindInPageOptions {
  */
 /**
  * PrinterInfo interface
- * @typedef { object } PrinterInfo
- * @property { string } name Printer Name
- * @property { string } description Printer Description
- * @property { number } status Printer Status
- * @property { boolean } isDefault Indicates that system's default printer
+ * name Printer Name
+ * description Printer Description
+ * status Printer Status
+ * isDefault Indicates that system's default printer
  */
 /**
- * @typedef {object} Window~options
  * @summary Window creation options.
- * @desc This is the options object required by {@link Window.create Window.create}.
+ * @description This is the options object required by {@link Window.create Window.create}.
  *
  * Note that `name` is the only required property — albeit the `url` property is usually provided as well
  * (defaults to `"about:blank"` when omitted).
  *
  * _This jsdoc typedef mirrors the `WindowOptions` TypeScript interface in `@types/openfin`._
  *
- * @property {object} [accelerator]
+ * [accelerator]
  * Enable keyboard shortcuts for devtools, zoom, reload, and reload ignoring cache.
  *
- * @property {boolean} [accelerator.devtools=false]
+ * [accelerator.devtools=false]
  * If `true`, enables the devtools keyboard shortcut:<br>
  * `Ctrl` + `Shift` + `I` _(Toggles Devtools)_
  *
- * @property {boolean} [accelerator.reload=false]
+ * [accelerator.reload=false]
  * If `true`, enables the reload keyboard shortcuts:<br>
  * `Ctrl` + `R` _(Windows)_<br>
  * `F5` _(Windows)_<br>
  * `Command` + `R` _(Mac)_
  *
- * @property {boolean} [accelerator.reloadIgnoringCache=false]
+ * [accelerator.reloadIgnoringCache=false]
  * If `true`, enables the reload-from-source keyboard shortcuts:<br>
  * `Ctrl` + `Shift` + `R` _(Windows)_<br>
  * `Shift` + `F5` _(Windows)_<br>
  * `Command` + `Shift` + `R` _(Mac)_
  *
- * @property {boolean} [accelerator.zoom=false]
+ * [accelerator.zoom=false]
  * If `true`, enables the zoom keyboard shortcuts:<br>
  * `Ctrl` + `+` _(Zoom In)_<br>
  * `Ctrl` + `Shift` + `+` _(Zoom In)_<br>
@@ -197,7 +192,7 @@ export interface FindInPageOptions {
  * `Ctrl` + `Scroll` _(Zoom In & Out)_<br>
  * `Ctrl` + `0` _(Restore to 100%)_
  *
- * @property {object} [alphaMask] - _Experimental._  _Updatable._
+ * [alphaMask] - _Experimental._  _Updatable._
  * <br>
  * alphaMask turns anything of matching RGB value transparent.
  * <br>
@@ -208,8 +203,8 @@ export interface FindInPageOptions {
  * * Windows Aero must be enabled
  * * Won't make visual sense on Pixel-pushed environments such as Citrix
  * * Not supported on rounded corner windows
- * @property {number} [alphaMask.red=-1] 0-255
- * @property {number} [alphaMask.green=-1] 0-255
+ * [alphaMask.red=-1] 0-255
+ * [alphaMask.green=-1] 0-255
  * @property {number} [alphaMask.blue=-1] 0-255
  *
  * @property {boolean} [alwaysOnTop=false] - _Updatable._
@@ -407,74 +402,64 @@ export interface FindInPageOptions {
  * When set to `false`, the window will appear immediately without waiting for content to be loaded.
  */
 /**
- * @typedef {object} CapturePageOptions
- * @property { Area } [area] The area of the window to be captured.
- * @property { string } [format='png'] The format of the captured image.  Can be 'png', 'jpg', or 'bmp'.
- * @property { number } [quality=100] Number representing quality of JPEG image only. Between 0 - 100.
+ * [area] The area of the window to be captured.
+ * [format='png'] The format of the captured image.  Can be 'png', 'jpg', or 'bmp'.
+ * [quality=100] Number representing quality of JPEG image only. Between 0 - 100.
  */
 /**
- * @typedef { object } Area
- * @property { number } height Area's height
- * @property { number } width Area's width
- * @property { number } x X coordinate of area's starting point
- * @property { number } y Y coordinate of area's starting point
+ * height Area's height
+ * width Area's width
+ * x X coordinate of area's starting point
+ * y Y coordinate of area's starting point
  */
 /**
- * @typedef { object } WindowMovementOptions
- * @property { boolean } moveIndependently - Move a window independently of its group or along with its group. Defaults to false.
+ * moveIndependently - Move a window independently of its group or along with its group. Defaults to false.
  */
 /**
- * @typedef {object} FindInPageOptions
- * @property {boolean} [forward=true] Whether to search forward or backward.
- * @property {boolean} [findNext=false] Whether the operation is first request or a follow up.
- * @property {boolean} [matchCase=false] Whether search should be case-sensitive.
- * @property {boolean} [wordStart=false] Whether to look only at the start of words.
- * @property {boolean} [medialCapitalAsWordStart=false]
+ * [forward=true] Whether to search forward or backward.
+ * [findNext=false] Whether the operation is first request or a follow up.
+ * [matchCase=false] Whether search should be case-sensitive.
+ * [wordStart=false] Whether to look only at the start of words.
+ * [medialCapitalAsWordStart=false]
  * When combined with wordStart, accepts a match in the middle of a word if the match begins with an uppercase letter followed by a<br>
  * lowercase or non-letter. Accepts several other intra-word matches.
  */
 /**
- * @typedef {object} Transition
- * @property {Opacity} opacity - The Opacity transition
- * @property {Position} position - The Position transition
- * @property {Size} size - The Size transition
+ * opacity - The Opacity transition
+ * position - The Position transition
+ * size - The Size transition
  */
 /**
- * @typedef {object} TransitionOptions
- * @property {boolean} interrupt - This option interrupts the current animation. When false it pushes
+ * interrupt - This option interrupts the current animation. When false it pushes
 this animation onto the end of the animation queue.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
  */
 /**
- * @typedef {object} Size
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} width - Optional if height is present. Defaults to the window's current width.
- * @property {number} height - Optional if width is present. Defaults to the window's current height.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * width - Optional if height is present. Defaults to the window's current width.
+ * height - Optional if width is present. Defaults to the window's current height.
  */
 /**
- * @typedef {object} Position
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} left - Defaults to the window's current left position in virtual screen coordinates.
- * @property {number} top - Defaults to the window's current top position in virtual screen coordinates.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * left - Defaults to the window's current left position in virtual screen coordinates.
+ * top - Defaults to the window's current top position in virtual screen coordinates.
  */
 /**
- * @typedef {object} Opacity
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} opacity - This value is clamped from 0.0 to 1.0.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * opacity - This value is clamped from 0.0 to 1.0.
  */
 /**
  * Bounds is a interface that has the properties of height,
  * width, left, top which are all numbers
- * @typedef { object } Bounds
- * @property { number } height Get the application height bound
- * @property { number } width Get the application width bound
- * @property { number } top Get the application top bound
- * @property { number } left Get the application left bound
- * @property { number } right Get the application right bound
- * @property { number } bottom Get the application bottom bound
+ * height Get the application height bound
+ * width Get the application width bound
+ * top Get the application top bound
+ * left Get the application left bound
+ * right Get the application right bound
+ * bottom Get the application bottom bound
  */
 /**
  * @classdesc A basic window that wraps a native HTML window. Provides more fine-grained
@@ -482,7 +467,6 @@ this animation onto the end of the animation queue.
  * By default a window does not show upon instantiation; instead the window's show() method
  * must be invoked manually. The new window appears in the same process as the parent window.
  * It has the ability to listen for <a href="tutorial-Window.EventEmitter.html">window specific events</a>.
- * @class
  * @alias Window
  * @hideconstructor
  */
@@ -589,7 +573,7 @@ export declare class _Window extends WebContents<WindowEvents> {
      * Gives focus to the window.
      * @return {Promise.<void>}
      * @function focus
-     * @emits focused
+     * @fires focused
      * @memberOf Window
      * @instance
      * @tutorial Window.focus
@@ -942,7 +926,7 @@ export declare class _Window extends WebContents<WindowEvents> {
     setAsForeground(): Promise<void>;
     /**
      * Sets the window's size and position.
-     * @property { Bounds } bounds This is a * @type {string} name - name of the window.object that holds the propertys of
+     * bounds This is a * @type {string} name - name of the window.object that holds the propertys of
      * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.setBounds

--- a/types/openfin/v50/_v2/api/application/application.d.ts
+++ b/types/openfin/v50/_v2/api/application/application.d.ts
@@ -49,9 +49,8 @@ export interface RvmLaunchOptions {
     userAppConfigArgs?: object | undefined;
 }
 /**
- * @typedef {object} ApplicationOption
  * @summary Application creation options.
- * @desc This is the options object required by {@link Application.start Application.start}.
+ * @description This is the options object required by {@link Application.start Application.start}.
  *
  * The following options are required:
  * * `uuid` is required in the app manifest as well as by {@link Application.start Application.start}
@@ -65,36 +64,36 @@ export interface RvmLaunchOptions {
  * This object inherits all the properties of the window creation {@link Window~options options} object,
  * which will take priority over those of the same name that may be provided in `mainWindowOptions`.
  *
- * @property {boolean} [disableIabSecureLogging=false]
+ * [disableIabSecureLogging=false]
  * When set to `true` it will disable IAB secure logging for the app.
  *
- * @property {boolean} [fdc3Api=false]
+ * [fdc3Api=false]
  * A flag to enable FDC3 API.  When set to `true` the `fdc3` API object is present for all windows
  *
- * @property {string} [loadErrorMessage="There was an error loading the application."]
+ * [loadErrorMessage="There was an error loading the application."]
  * An error message to display when the application (launched via manifest) fails to load.
  * A dialog box will be launched with the error message just before the runtime exits.
  * Load fails such as failed DNS resolutions or aborted connections as well as cancellations, _e.g.,_ `window.stop()`,
  * will trigger this dialog.
  * Client response codes such as `404 Not Found` are not treated as fails as they are valid server responses.
  *
- * @property {Window~options} [mainWindowOptions]
+ * [mainWindowOptions]
  * The options of the main window of the application.
  * For a description of these options, click the link (in the Type column).
  *
- * @property {string} [name]
+ * [name]
  * The name of the application (and the application's main window).
  *
  * If provided, _must_ match `uuid`.
  *
- * @property {boolean} [nonPersistent=false]
+ * [nonPersistent=false]
  * A flag to configure the application as non-persistent.
  * Runtime exits when there are no persistent apps running.
  *
- * @property {boolean} [plugins=false]
+ * [plugins=false]
  * Enable Flash at the application level.
  *
- * @property {boolean} [spellCheck=false]
+ * [spellCheck=false]
  * Enable spell check at the application level.
  *
  * @property {string} [url="about:blank"]
@@ -185,7 +184,6 @@ export default class ApplicationModule extends Base {
 /**
  * @classdesc An object representing an application. Allows the developer to create,
  * execute, show/close an application as well as listen to <a href="tutorial-Application.EventEmitter.html">application events</a>.
- * @class
  * @hideconstructor
  */
 export declare class Application extends EmitterBase<ApplicationEvents> {
@@ -416,7 +414,7 @@ export declare class Application extends EmitterBase<ApplicationEvents> {
     setAppLogUsername(username: string): Promise<void>;
     /**
      * @summary Retrieves information about the system tray.
-     * @desc The only information currently returned is the position and dimensions.
+     * @description The only information currently returned is the position and dimensions.
      * @return {Promise.<TrayInfo>}
      * @tutorial Application.getTrayIconInfo
      */

--- a/types/openfin/v50/_v2/api/clipboard/clipboard.d.ts
+++ b/types/openfin/v50/_v2/api/clipboard/clipboard.d.ts
@@ -2,9 +2,8 @@ import { Base } from '../base';
 import { WriteRequestType, WriteAnyRequestType } from './write-request';
 /**
  * WriteRequestType interface
- * @typedef { object } WriteRequestType
- * @property { string } name The name of the running application
- * @property { string } uuid The uuid of the running application
+ * name The name of the running application
+ * uuid The uuid of the running application
  */
 /**
  * The Clipboard API allows reading and writing to the clipboard in multiple formats.

--- a/types/openfin/v50/_v2/api/external-application/external-application.d.ts
+++ b/types/openfin/v50/_v2/api/external-application/external-application.d.ts
@@ -39,7 +39,6 @@ export default class ExternalApplicationModule extends Base {
  * - Processes which have connected to an OpenFin runtime via an adapter
  * - Processes started via `System.launchExternalApplication`
  * - Processes monitored via `System.monitorExternalProcess`
- * @class
  * @hideconstructor
  */
 export declare class ExternalApplication extends EmitterBase<ExternalApplicationEvents> {

--- a/types/openfin/v50/_v2/api/external-window/external-window.d.ts
+++ b/types/openfin/v50/_v2/api/external-window/external-window.d.ts
@@ -30,7 +30,6 @@ export default class ExternalWindowModule extends Base {
  * They are also compatible with OpenFin's Layouts service to facilitate
  * complete positional control over all running applications.<br>
  * External Windows has the ability to listen for <a href="tutorial-ExternalWindow.EventEmitter.html"> external window-specific events</a>.
- * @class
  * @alias ExternalWindow
  * @hideconstructor
  */
@@ -61,7 +60,7 @@ export declare class ExternalWindow extends EmitterBase<ExternalWindowEvents> {
     /**
      * Gives focus to the external window.
      * @return {Promise.<void>}
-     * @emits ExternalWindow#focused
+     * @fires ExternalWindow#focused
      * @experimental
      * @tutorial Window.focus
      */
@@ -215,7 +214,6 @@ export declare class ExternalWindow extends EmitterBase<ExternalWindowEvents> {
     setAsForeground(): Promise<void>;
     /**
      * Sets the external window's size and position.
-     * @property { Bounds } bounds
      * @return {Promise.<void>}
      * @experimental
      * @tutorial Window.setBounds

--- a/types/openfin/v50/_v2/api/frame/frame.d.ts
+++ b/types/openfin/v50/_v2/api/frame/frame.d.ts
@@ -64,7 +64,6 @@ export default class _FrameModule extends Base {
  *
  * The fin.Frame namespace represents a way to interact with `iframes` and facilitates the discovery of current context
  * (iframe or main window) as well as the ability to listen for <a href="tutorial-Frame.EventEmitter.html">frame-specific events</a>.
- * @class
  * @alias Frame
  * @hideconstructor
  */

--- a/types/openfin/v50/_v2/api/notification/notification.d.ts
+++ b/types/openfin/v50/_v2/api/notification/notification.d.ts
@@ -20,7 +20,6 @@ export interface NotificationCallback {
  * A notification is typically used to alert the user of some important event which
  * requires his or her attention. Notifications are a child or your application that
  * are controlled by the runtime.
- * @class
  * @alias Notification
  * @hideconstructor
  */

--- a/types/openfin/v50/_v2/api/platform/layout.d.ts
+++ b/types/openfin/v50/_v2/api/platform/layout.d.ts
@@ -10,34 +10,31 @@ export interface PresetLayoutOptions {
 }
 /**
  * InitLayoutOptions interface
- * @typedef { object } InitLayoutOptions
- * @property { string } [containerId] The id attribute of the container where the window's Layout should be initialized.  If not provided
+ * [containerId] The id attribute of the container where the window's Layout should be initialized.  If not provided
  * then an element with id `layout-container` is used.
- * @property { LayoutConfig } [layout] The layout configuration to be initialized. If not provided then the layout included in window
+ * [layout] The layout configuration to be initialized. If not provided then the layout included in window
  * options is used.
  */
 /**
  * PresetLayoutOptions interface
- * @typedef { object } PresetLayoutOptions
- * @property { LayoutPresetTypes } presetType Which preset layout arrangement to use.
+ * presetType Which preset layout arrangement to use.
  * The preset options are `columns`, `grid`, `rows`, and `tabs`.
  */
 /**
  * LayoutConfig interface
- * @typedef { object } LayoutConfig
- * @property { Array<LayoutItem> } content Content of the layout.  There can only be one top-level LayoutItem in the content array.
+ * content Content of the layout.  There can only be one top-level LayoutItem in the content array.
  * We do not recommend trying to build Layouts or LayoutItems by hand and instead use calls such as {@link Platform#getSnapshot getSnapshot}
  * or our {@link https://openfin.github.io/golden-prototype/config-gen Layout Config Generation Tool }.
  */
 /**
  * LayoutItem Interface
- * @typedef { object } LayoutItem Represents the arrangement of Views within a Platform window's Layout.  We do not recommend trying
+ * LayoutItem Represents the arrangement of Views within a Platform window's Layout.  We do not recommend trying
  * to build Layouts or LayoutItems by hand and instead use calls such as {@link Platform#getSnapshot getSnapshot} or our
  * {@link https://openfin.github.io/golden-prototype/config-gen Layout Config Generation Tool }.
- * @property { string } type The type of the item. Possible values are 'row', 'column', 'stack', and 'component'.
- * @property { Array<LayoutItem> } [content] An array of configurations for items that will be created as children of this item.
- * @property { string } [componentName] Only a `component` type will have this property and it should be set to `view`.
- * @property { View~options } [componentState] Only a `component` type will have this property and it represents the view
+ * type The type of the item. Possible values are 'row', 'column', 'stack', and 'component'.
+ * [content] An array of configurations for items that will be created as children of this item.
+ * [componentName] Only a `component` type will have this property and it should be set to `view`.
+ * [componentState] Only a `component` type will have this property and it represents the view
  * options of a given component.
  */
 /**

--- a/types/openfin/v50/_v2/api/system/system.d.ts
+++ b/types/openfin/v50/_v2/api/system/system.d.ts
@@ -25,230 +25,200 @@ interface ServiceIdentifier {
 }
 /**
  * AppAssetInfo interface
- * @typedef { object } AppAssetInfo
- * @property { string } src  The URL to a zip file containing the package files (executables, dlls, etc…)
- * @property { string } alias The name of the asset
- * @property { string } version The version of the package
- * @property { string } target Specify default executable to launch. This option can be overridden in launchExternalProcess
- * @property { string } args The default command line arguments for the aforementioned target.
- * @property { boolean } mandatory When set to true, the app will fail to load if the asset cannot be downloaded.
+ * src  The URL to a zip file containing the package files (executables, dlls, etc…)
+ * alias The name of the asset
+ * version The version of the package
+ * target Specify default executable to launch. This option can be overridden in launchExternalProcess
+ * args The default command line arguments for the aforementioned target.
+ * mandatory When set to true, the app will fail to load if the asset cannot be downloaded.
  * When set to false, the app will continue to load if the asset cannot be downloaded. (Default: true)
  */
 /**
  * AppAssetRequest interface
- * @typedef { object } AppAssetRequest
- * @property { string } alias The name of the asset
+ * alias The name of the asset
  */
 /**
  * ApplicationInfo interface
- * @typedef { object } ApplicationInfo
- * @property { boolean } isRunning  true when the application is running
- * @property { string } uuid uuid of the application
- * @property { string } parentUuid uuid of the application that launches this application
+ * isRunning  true when the application is running
+ * uuid uuid of the application
+ * parentUuid uuid of the application that launches this application
  */
 /**
- * @typedef { object } ClearCacheOption
  * @summary Clear cache options.
- * @desc These are the options required by the clearCache function.
+ * @description These are the options required by the clearCache function.
  *
- * @property {boolean} appcache html5 application cache
- * @property {boolean} cache browser data cache for html files and images
- * @property {boolean} cookies browser cookies
- * @property {boolean} localStorage browser data that can be used across sessions
+ * appcache html5 application cache
+ * cache browser data cache for html files and images
+ * cookies browser cookies
+ * localStorage browser data that can be used across sessions
  */
 /**
  * CookieInfo interface
- * @typedef { object } CookieInfo
- * @property { string } name  The name of the cookie
- * @property { string } domain The domain of the cookie
- * @property { string } path The path of the cookie
+ * name  The name of the cookie
+ * domain The domain of the cookie
+ * path The path of the cookie
  */
 /**
  * CookieOption interface
- * @typedef { object } CookieOption
- * @property { string } name The name of the cookie
+ * name The name of the cookie
  */
 /**
  * CpuInfo interface
- * @typedef { object } CpuInfo
- * @property { string } model The model of the cpu
- * @property { number } speed The number in MHz
- * @property { Time } times The numbers of milliseconds the CPU has spent in different modes.
+ * model The model of the cpu
+ * speed The number in MHz
+ * times The numbers of milliseconds the CPU has spent in different modes.
  */
 /**
 * CrashReporterOption interface
-* @typedef { object } CrashReporterOption
-* @property { boolean } diagnosticMode In diagnostic mode the crash reporter will send diagnostic logs to
+* diagnosticMode In diagnostic mode the crash reporter will send diagnostic logs to
 *  the OpenFin reporting service on runtime shutdown
-* @property { boolean } isRunning check if it's running
+* isRunning check if it's running
 */
 /**
  * DipRect interface
- * @typedef { object } DipRect
- * @property { Rect } dipRect The DIP coordinates
- * @property { Rect } scaledRect The scale coordinates
+ * dipRect The DIP coordinates
+ * scaledRect The scale coordinates
  */
 /**
  * DipScaleRects interface
- * @typedef { object } DipScaleRects
- * @property { Rect } dipRect The DIP coordinates
- * @property { Rect } scaledRect The scale coordinates
+ * dipRect The DIP coordinates
+ * scaledRect The scale coordinates
  */
 /**
  * DownloadPreloadInfo interface
- * @typedef { object } DownloadPreloadInfo
- * @desc downloadPreloadScripts function return value
- * @property { string } url url to the preload script
- * @property { string } error error during preload script acquisition
- * @property { boolean } succeess download operation success
+ * @description downloadPreloadScripts function return value
+ * url url to the preload script
+ * error error during preload script acquisition
+ * succeess download operation success
  */
 /**
  * DownloadPreloadOption interface
- * @typedef { object } DownloadPreloadOption
- * @desc These are the options object required by the downloadPreloadScripts function
- * @property { string } url url to the preload script
+ * @description These are the options object required by the downloadPreloadScripts function
+ * url url to the preload script
  */
 /**
  * Entity interface
- * @typedef { object } Entity
- * @property { string } type The type of the entity
- * @property { string } uuid The uuid of the entity
+ * type The type of the entity
+ * uuid The uuid of the entity
  */
 /**
  * EntityInfo interface
- * @typedef { object } EntityInfo
- * @property { string } name The name of the entity
- * @property { string } uuid The uuid of the entity
- * @property { Identity } parent The parent of the entity
- * @property { string } entityType The type of the entity
+ * name The name of the entity
+ * uuid The uuid of the entity
+ * parent The parent of the entity
+ * entityType The type of the entity
  */
 /**
  * ExternalApplicationInfo interface
- * @typedef { object } ExternalApplicationInfo
- * @property { Identity } parent The parent identity
+ * parent The parent identity
  */
 /**
  * ExternalConnection interface
- * @typedef { object } ExternalConnection
- * @property { string } token The token to broker an external connection
- * @property { string } uuid The uuid of the external connection
+ * token The token to broker an external connection
+ * uuid The uuid of the external connection
  */
 /**
  * ExternalProcessRequestType interface
- * @typedef { object } ExternalProcessRequestType
- * @property { string } path The file path to where the running application resides
- * @property { string } arguments The argument passed to the running application
- * @property { LaunchExternalProcessListener } listener This is described in the {LaunchExternalProcessListner} type definition
+ * path The file path to where the running application resides
+ * arguments The argument passed to the running application
+ * listener This is described in the {LaunchExternalProcessListner} type definition
  */
 /**
  * FrameInfo interface
- * @typedef { object } FrameInfo
- * @property { string } name The name of the frame
- * @property { string } uuid The uuid of the frame
- * @property { EntityType } entityType The entity type, could be 'window', 'iframe', 'external connection' or 'unknown'
- * @property { Identity } parent The parent identity
+ * name The name of the frame
+ * uuid The uuid of the frame
+ * entityType The entity type, could be 'window', 'iframe', 'external connection' or 'unknown'
+ * parent The parent identity
  */
 /**
  * GetLogRequestType interface
- * @typedef { object } GetLogRequestType
- * @property { string } name The name of the running application
- * @property { number } endFile The file length of the log file
- * @property { number } sizeLimit The set size limit of the log file
+ * name The name of the running application
+ * endFile The file length of the log file
+ * sizeLimit The set size limit of the log file
  */
 /**
  * GpuInfo interface
- * @typedef { object } GpuInfo
- * @property { string } name The graphics card name
+ * name The graphics card name
  */
 /**
  * HostSpecs interface
- * @typedef { object } HostSpecs
- * @property { boolean } aeroGlassEnabled Value to check if Aero Glass theme is supported on Windows platforms
- * @property { string } arch "x86" for 32-bit or "x86_64" for 64-bit
- * @property { Array<CpuInfo> } cpus The same payload as Node's os.cpus()
- * @property { GpuInfo } gpu The graphics card name
- * @property { number } memory The same payload as Node's os.totalmem()
- * @property { string } name The OS name and version/edition
- * @property { boolean } screenSaver Value to check if screensaver is running. Supported on Windows only
+ * aeroGlassEnabled Value to check if Aero Glass theme is supported on Windows platforms
+ * arch "x86" for 32-bit or "x86_64" for 64-bit
+ * cpus The same payload as Node's os.cpus()
+ * gpu The graphics card name
+ * memory The same payload as Node's os.totalmem()
+ * name The OS name and version/edition
+ * screenSaver Value to check if screensaver is running. Supported on Windows only
  */
 /**
  * Identity interface
- * @typedef { object } Identity
- * @property { string } name Optional - the name of the component
- * @property { string } uuid Universally unique identifier of the application
+ * name Optional - the name of the component
+ * uuid Universally unique identifier of the application
  */
 /**
  * LogInfo interface
- * @typedef { object } LogInfo
- * @property { string } name The filename of the log
- * @property { number } size The size of the log in bytes
- * @property { string } date The unix time at which the log was created "Thu Jan 08 2015 14:40:30 GMT-0500 (Eastern Standard Time)"
+ * name The filename of the log
+ * size The size of the log in bytes
+ * date The unix time at which the log was created "Thu Jan 08 2015 14:40:30 GMT-0500 (Eastern Standard Time)"
  */
 /**
 * ManifestInfo interface
-* @typedef { object } ManifestInfo
-* @property { string } uuid The uuid of the application
-* @property { string } manifestUrl The runtime manifest URL
+* uuid The uuid of the application
+* manifestUrl The runtime manifest URL
 */
 /**
  * MonitorDetails interface
- * @typedef { object } MonitorDetails
- * @property { DipScaleRects } available The available DIP scale coordinates
- * @property { Rect } availableRect The available monitor coordinates
- * @property { string } deviceId The device id of the display
- * @property { boolean } displayDeviceActive true if the display is active
- * @property { number } deviceScaleFactor The device scale factor
- * @property { Rect } monitorRect The monitor coordinates
- * @property { string } name The name of the display
- * @property { Point } dpi The dots per inch
- * @property { DipScaleRects } monitor The monitor coordinates
+ * available The available DIP scale coordinates
+ * availableRect The available monitor coordinates
+ * deviceId The device id of the display
+ * displayDeviceActive true if the display is active
+ * deviceScaleFactor The device scale factor
+ * monitorRect The monitor coordinates
+ * name The name of the display
+ * dpi The dots per inch
+ * monitor The monitor coordinates
  */
 /**
  * MonitorInfo interface
- * @typedef { object } MonitorInfo
- * @property { number } deviceScaleFactor The device scale factor
- * @property { Point } dpi The dots per inch
- * @property { Array<MonitorDetails> } nonPrimaryMonitors The array of monitor details
- * @property { MonitorDetails } primaryMonitor The monitor details
- * @property { string } reason always "api-query"
- * @property { TaskBar } taskBar The taskbar on monitor
- * @property { DipRect } virtualScreen The virtual display screen coordinates
+ * deviceScaleFactor The device scale factor
+ * dpi The dots per inch
+ * nonPrimaryMonitors The array of monitor details
+ * primaryMonitor The monitor details
+ * reason always "api-query"
+ * taskBar The taskbar on monitor
+ * virtualScreen The virtual display screen coordinates
  */
 /**
- * @typedef { verbose | info | warning | error | fatal } LogLevel
  * @summary Log verbosity levels.
- * @desc Describes the minimum level (inclusive) above which logs will be written
+ * @description Describes the minimum level (inclusive) above which logs will be written
  *
- * @property { string } verbose all logs written
- * @property { string } info info and above
- * @property { string } warning warning and above
- * @property { string } error error and above
- * @property { string } fatal fatal only, indicates a crash is imminent
+ * verbose all logs written
+ * info info and above
+ * warning warning and above
+ * error error and above
+ * fatal fatal only, indicates a crash is imminent
  */
 /**
  * PointTopLeft interface
- * @typedef { object } PointTopLeft
- * @property { number } top The mouse top position in virtual screen coordinates
- * @property { number } left The mouse left position in virtual screen coordinates
+ * top The mouse top position in virtual screen coordinates
+ * left The mouse left position in virtual screen coordinates
  */
 /**
  * Point interface
- * @typedef { object } Point
- * @property { number } x The mouse x position
- * @property { number } y The mouse y position
+ * x The mouse x position
+ * y The mouse y position
  */
 /**
  * ProcessInfo interface
- * @typedef { object } ProcessInfo
- * @property { number } cpuUsage The percentage of total CPU usage
- * @property { string } name The application name
- * @property { number } nonPagedPoolUsage The current nonpaged pool usage in bytes
- * @property { number } pageFaultCount The number of page faults
- * @property { number } pagedPoolUsage The current paged pool usage in bytes
- * @property { number } pagefileUsage The total amount of memory in bytes that the memory manager has committed
- * @property { number } peakNonPagedPoolUsage The peak nonpaged pool usage in bytes
- * @property { number } peakPagedPoolUsage The peak paged pool usage in bytes
- * @property { number } peakPagefileUsage The peak value in bytes of pagefileUsage during the lifetime of this process
+ * cpuUsage The percentage of total CPU usage
+ * name The application name
+ * nonPagedPoolUsage The current nonpaged pool usage in bytes
+ * pageFaultCount The number of page faults
+ * pagedPoolUsage The current paged pool usage in bytes
+ * pagefileUsage The total amount of memory in bytes that the memory manager has committed
+ * peakNonPagedPoolUsage The peak nonpaged pool usage in bytes
+ * peakPagedPoolUsage The peak paged pool usage in bytes
+ * peakPagefileUsage The peak value in bytes of pagefileUsage during the lifetime of this process
  * @property { number } peakWorkingSetSize The peak working set size in bytes
  * @property { number } processId The native process identifier
  * @property { string } uuid The application UUID
@@ -256,147 +226,128 @@ interface ServiceIdentifier {
  */
 /**
  * ProxyConfig interface
- * @typedef { object } ProxyConfig
- * @property { string } proxyAddress The configured proxy address
- * @property { number } proxyPort The configured proxy port
- * @property { string } type The proxy Type
+ * proxyAddress The configured proxy address
+ * proxyPort The configured proxy port
+ * type The proxy Type
  */
 /**
  * ProxyInfo interface
- * @typedef { object } ProxyInfo
- * @property { ProxyConfig } config The proxy config
- * @property { ProxySystemInfo } system The proxy system info
+ * config The proxy config
+ * system The proxy system info
  */
 /**
  * ProxySystemInfo interface
- * @typedef { object } ProxySystemInfo
- * @property { string } autoConfigUrl The auto configuration url
- * @property { string } bypass The proxy bypass info
- * @property { boolean } enabled Value to check if a proxy is enabled
- * @property { string } proxy The proxy info
+ * autoConfigUrl The auto configuration url
+ * bypass The proxy bypass info
+ * enabled Value to check if a proxy is enabled
+ * proxy The proxy info
  */
 /**
  * Rect interface
- * @typedef { object } Rect
- * @property { number } bottom The bottom-most coordinate
- * @property { number } left The left-most coordinate
- * @property { number } right The right-most coordinate
- * @property { number } top The top-most coordinate
+ * bottom The bottom-most coordinate
+ * left The left-most coordinate
+ * right The right-most coordinate
+ * top The top-most coordinate
  */
 /**
  * RegistryInfo interface
- * @typedef { object } RegistryInfo
- * @property { any } data The registry data
- * @property { string } rootKey The registry root key
- * @property { string } subkey The registry key
- * @property { string } type The registry type
- * @property { string } value The registry value name
+ * data The registry data
+ * rootKey The registry root key
+ * subkey The registry key
+ * type The registry type
+ * value The registry value name
  */
 /**
  * RuntimeDownloadOptions interface
- * @typedef { object } RuntimeDownloadOptions
- * @desc These are the options object required by the downloadRuntime function.
- * @property { string } version The given version to download
+ * @description These are the options object required by the downloadRuntime function.
+ * version The given version to download
  */
 /**
  * RuntimeInfo interface
- * @typedef { object } RuntimeInfo
- * @property { string } architecture The runtime build architecture
- * @property { string } manifestUrl The runtime manifest URL
- * @property { number } port The runtime websocket port
- * @property { string } securityRealm The runtime security realm
- * @property { string } version The runtime version
- * @property { object } args the command line argument used to start the Runtime
- * @property { string } chromeVersion The chrome version
+ * architecture The runtime build architecture
+ * manifestUrl The runtime manifest URL
+ * port The runtime websocket port
+ * securityRealm The runtime security realm
+ * version The runtime version
+ * args the command line argument used to start the Runtime
+ * chromeVersion The chrome version
  */
 /**
  * RVMInfo interface
- * @typedef { object } RVMInfo
- * @property { string } action The name of action: "get-rvm-info"
- * @property { string } appLogDirectory The app log directory
- * @property { string } path The path of OpenfinRVM.exe
- * @property { string } 'start-time' The start time of RVM
- * @property { string } version The version of RVM
- * @property { string } 'working-dir' The working directory
+ * action The name of action: "get-rvm-info"
+ * appLogDirectory The app log directory
+ * path The path of OpenfinRVM.exe
+ * 'start-time' The start time of RVM
+ * version The version of RVM
+ * 'working-dir' The working directory
  */
 /**
  * RvmLaunchOptions interface
- * @typedef { object } RvmLaunchOptions
- * @property { boolean } [noUi] true if no UI when launching
- * @property { object } [userAppConfigArgs] The user app configuration args
+ * [noUi] true if no UI when launching
+ * [userAppConfigArgs] The user app configuration args
  */
 /**
 * ServiceIdentifier interface
-* @typedef { object } ServiceIdentifier
-* @property { string } name The name of the service
+* name The name of the service
 */
 /**
 * ServiceConfiguration interface
-* @typedef { object } ServiceConfiguration
-* @property { object } config The service configuration
-* @property { string } name The name of the service
+* config The service configuration
+* name The name of the service
 */
 /**
  * ShortCutConfig interface
- * @typedef { object } ShortCutConfig
- * @property { boolean } desktop true if application has a shortcut on the desktop
- * @property { boolean } startMenu true if application has shortcut in the start menu
- * @property { boolean } systemStartup true if application will be launched on system startup
+ * desktop true if application has a shortcut on the desktop
+ * startMenu true if application has shortcut in the start menu
+ * systemStartup true if application will be launched on system startup
  */
 /**
  * SubOptions interface
- * @typedef { Object } SubOptions
- * @property { number } timestamp The event timestamp
+ * timestamp The event timestamp
  */
 /**
  * TaskBar interface
- * @typedef { object } TaskBar
- * @property { string } edge which edge of a monitor the taskbar is on
- * @property { Rect } rect The taskbar coordinates
+ * edge which edge of a monitor the taskbar is on
+ * rect The taskbar coordinates
  */
 /**
  * TerminateExternalRequestType interface
- * @typedef { object } TerminateExternalRequestType
- * @property { string } uuid The uuid of the running application
- * @property { number } timeout Time out period before the running application terminates
- * @property { boolean } killtree Value to terminate the running application
+ * uuid The uuid of the running application
+ * timeout Time out period before the running application terminates
+ * killtree Value to terminate the running application
  */
 /**
  * Time interface
- * @typedef { object } Time
- * @property { number } user The number of milliseconds the CPU has spent in user mode
- * @property { number } nice The number of milliseconds the CPU has spent in nice mode
- * @property { number } sys The number of milliseconds the CPU has spent in sys mode
- * @property { number } idle The number of milliseconds the CPU has spent in idle mode
- * @property { number } irq The number of milliseconds the CPU has spent in irq mode
+ * user The number of milliseconds the CPU has spent in user mode
+ * nice The number of milliseconds the CPU has spent in nice mode
+ * sys The number of milliseconds the CPU has spent in sys mode
+ * idle The number of milliseconds the CPU has spent in idle mode
+ * irq The number of milliseconds the CPU has spent in irq mode
  */
 /**
  * TrayInfo interface
- * @typedef { object } TrayInfo
- * @property { Bounds } bounds The bound of tray icon in virtual screen pixels
- * @property { MonitorInfo } monitorInfo Please see fin.System.getMonitorInfo for more information
- * @property { number } x copy of bounds.x
- * @property { number } y copy of bounds.y
+ * bounds The bound of tray icon in virtual screen pixels
+ * monitorInfo Please see fin.System.getMonitorInfo for more information
+ * x copy of bounds.x
+ * y copy of bounds.y
  */
 /**
  * WindowDetail interface
- * @typedef { object } WindowDetail
- * @property { number } bottom The bottom-most coordinate of the window
- * @property { number } height The height of the window
- * @property { boolean } isShowing Value to check if the window is showing
- * @property { number } left The left-most coordinate of the window
- * @property { string } name The name of the window
- * @property { number } right The right-most coordinate of the window
- * @property { string } state The window state
- * @property { number } top The top-most coordinate of the window
- * @property { number } width The width of the window
+ * bottom The bottom-most coordinate of the window
+ * height The height of the window
+ * isShowing Value to check if the window is showing
+ * left The left-most coordinate of the window
+ * name The name of the window
+ * right The right-most coordinate of the window
+ * state The window state
+ * top The top-most coordinate of the window
+ * width The width of the window
  */
 /**
  * WindowInfo interface
- * @typedef { object } WindowInfo
- * @property { Array<WindowDetail> } childWindows The array of child windows details
- * @property { WindowDetail } mainWindow The main window detail
- * @property { string } uuid The uuid of the application
+ * childWindows The array of child windows details
+ * mainWindow The main window detail
+ * uuid The uuid of the application
  */
 /**
  * An object representing the core of OpenFin Runtime. Allows the developer

--- a/types/openfin/v50/_v2/api/view/view.d.ts
+++ b/types/openfin/v50/_v2/api/view/view.d.ts
@@ -58,29 +58,28 @@ export default class ViewModule extends Base {
     getCurrentSync(): View;
 }
 /**
- * @typedef {object} View~options
  * @summary View creation options.
- * @desc This is the options object required by {@link View.create View.create}.
+ * @description This is the options object required by {@link View.create View.create}.
  *
  * Note that `name` and `target` are the only required properties — albeit the `url` property is usually provided as well
  * (defaults to `"about:blank"` when omitted).
  *
- * @property {object} [experimental]
+ * [experimental]
  * Configurations for API injection.
  *
- * @property {boolean} [experimental.childWindows] Configure if the runtime should enable child windows for views.
+ * [experimental.childWindows] Configure if the runtime should enable child windows for views.
  *
- * @property {object} [api]
+ * [api]
  * Configurations for API injection.
  *
- * @property {object} [api.iframe] Configure if the the API should be injected into iframes based on domain.
+ * [api.iframe] Configure if the the API should be injected into iframes based on domain.
  *
- * @property {boolean} [api.iframe.crossOriginInjection=false] Controls if the `fin` API object is present for cross origin iframes.
- * @property {boolean} [api.iframe.sameOriginInjection=true] Controls if the `fin` API object is present for same origin iframes.
+ * [api.iframe.crossOriginInjection=false] Controls if the `fin` API object is present for cross origin iframes.
+ * [api.iframe.sameOriginInjection=true] Controls if the `fin` API object is present for same origin iframes.
  *
- * @property {object} [autoResize] AutoResize options
+ * [autoResize] AutoResize options
  *
- * @property {object} [bounds] initial bounds
+ * [bounds] initial bounds
  *
  * @property {string} [backgroundColor="#FFF"] - _Updatable._
  * The view’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color
@@ -154,7 +153,6 @@ export default class ViewModule extends Base {
  * To change that behavior, see the processAffinity {@link View~options view option}.
  *
  * A View's lifecycle is tied to its owning window and can be re-attached to a different window at any point during its lifecycle.
- * @class
  * @alias View
  * @hideconstructor
  */
@@ -176,7 +174,7 @@ export declare class View extends WebContents<ViewEvents> {
      * @return {Promise.<void>}
      * @function focus
      * @memberof View
-     * @emits focused
+     * @fires focused
      * @instance
      * @tutorial View.focus
      * @experimental

--- a/types/openfin/v50/_v2/api/window/window.d.ts
+++ b/types/openfin/v50/_v2/api/window/window.d.ts
@@ -120,32 +120,29 @@ export interface FindInPageOptions {
     medialCapitalAsWordStart?: boolean | undefined;
 }
 /**
- * @typedef { object } Margins
- * @property { string } [marginType]
+ * [marginType]
  * Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen,
  * you will also need to specify `top`, `bottom`, `left`, and `right`.
  *
- * @property { number } [top] The top margin of the printed web page, in pixels.
- * @property { number } [bottom] The bottom margin of the printed web page, in pixels.
- * @property { number } [left] The left margin of the printed web page, in pixels.
- * @property { number } [right] The right margin of the printed web page, in pixels.
+ * [top] The top margin of the printed web page, in pixels.
+ * [bottom] The bottom margin of the printed web page, in pixels.
+ * [left] The left margin of the printed web page, in pixels.
+ * [right] The right margin of the printed web page, in pixels.
 */
 /**
- * @typedef { object } Dpi
- * @property { number } [horizontal] The horizontal dpi
- * @property { number } [vertical] The vertical dpi
+ * [horizontal] The horizontal dpi
+ * [vertical] The vertical dpi
 */
 /**
- * @typedef { object } PrintOptions
- * @property { boolean } [silent=false] Don't ask user for print settings.
- * @property { boolean } [printBackground=false] Prints the background color and image of the web page.
- * @property { string } [deviceName=''] Set the printer device name to use.
- * @property { boolean } [color=true] Set whether the printed web page will be in color or grayscale.
- * @property { Margins } [margins] Set margins for the printed web page
- * @property { boolean } [landscape=false] Whether the web page should be printed in landscape mode.
- * @property { number } [scaleFactor] The scale factor of the web page.
- * @property { number } [pagesPerSheet] The number of pages to print per page sheet.
- * @property { boolean } [collate] Whether the web page should be collated.
+ * [silent=false] Don't ask user for print settings.
+ * [printBackground=false] Prints the background color and image of the web page.
+ * [deviceName=''] Set the printer device name to use.
+ * [color=true] Set whether the printed web page will be in color or grayscale.
+ * [margins] Set margins for the printed web page
+ * [landscape=false] Whether the web page should be printed in landscape mode.
+ * [scaleFactor] The scale factor of the web page.
+ * [pagesPerSheet] The number of pages to print per page sheet.
+ * [collate] Whether the web page should be collated.
  * @property { number } [copies] The number of copies of the web page to print.
  * @property { Record<string, number> } [pageRanges] The page range to print. Should have two keys: from and to.
  * @property { string } [duplexMode] Set the duplex mode of the printed web page. Can be simplex, shortEdge, or longEdge.
@@ -153,42 +150,40 @@ export interface FindInPageOptions {
  */
 /**
 * PrinterInfo interface
-* @typedef { object } PrinterInfo
-* @property { string } name Printer Name
-* @property { string } description Printer Description
-* @property { number } status Printer Status
-* @property { boolean } isDefault Indicates that system's default printer
+* name Printer Name
+* description Printer Description
+* status Printer Status
+* isDefault Indicates that system's default printer
 */
 /**
- * @typedef {object} Window~options
  * @summary Window creation options.
- * @desc This is the options object required by {@link Window.create Window.create}.
+ * @description This is the options object required by {@link Window.create Window.create}.
  *
  * Note that `name` is the only required property — albeit the `url` property is usually provided as well
  * (defaults to `"about:blank"` when omitted).
  *
  * _This jsdoc typedef mirrors the `WindowOptions` TypeScript interface in `@types/openfin`._
  *
- * @property {object} [accelerator]
+ * [accelerator]
  * Enable keyboard shortcuts for devtools, zoom, reload, and reload ignoring cache.
  *
- * @property {boolean} [accelerator.devtools=false]
+ * [accelerator.devtools=false]
  * If `true`, enables the devtools keyboard shortcut:<br>
  * `Ctrl` + `Shift` + `I` _(Toggles Devtools)_
  *
- * @property {boolean} [accelerator.reload=false]
+ * [accelerator.reload=false]
  * If `true`, enables the reload keyboard shortcuts:<br>
  * `Ctrl` + `R` _(Windows)_<br>
  * `F5` _(Windows)_<br>
  * `Command` + `R` _(Mac)_
  *
- * @property {boolean} [accelerator.reloadIgnoringCache=false]
+ * [accelerator.reloadIgnoringCache=false]
  * If `true`, enables the reload-from-source keyboard shortcuts:<br>
  * `Ctrl` + `Shift` + `R` _(Windows)_<br>
  * `Shift` + `F5` _(Windows)_<br>
  * `Command` + `Shift` + `R` _(Mac)_
  *
- * @property {boolean} [accelerator.zoom=false]
+ * [accelerator.zoom=false]
  * If `true`, enables the zoom keyboard shortcuts:<br>
  * `Ctrl` + `+` _(Zoom In)_<br>
  * `Ctrl` + `Shift` + `+` _(Zoom In)_<br>
@@ -197,7 +192,7 @@ export interface FindInPageOptions {
  * `Ctrl` + `Scroll` _(Zoom In & Out)_<br>
  * `Ctrl` + `0` _(Restore to 100%)_
  *
- * @property {object} [alphaMask] - _Experimental._  _Updatable._
+ * [alphaMask] - _Experimental._  _Updatable._
  * <br>
  * alphaMask turns anything of matching RGB value transparent.
  * <br>
@@ -208,8 +203,8 @@ export interface FindInPageOptions {
  * * Windows Aero must be enabled
  * * Won't make visual sense on Pixel-pushed environments such as Citrix
  * * Not supported on rounded corner windows
- * @property {number} [alphaMask.red=-1] 0-255
- * @property {number} [alphaMask.green=-1] 0-255
+ * [alphaMask.red=-1] 0-255
+ * [alphaMask.green=-1] 0-255
  * @property {number} [alphaMask.blue=-1] 0-255
  *
  * @property {boolean} [alwaysOnTop=false] - _Updatable._
@@ -403,68 +398,59 @@ export interface FindInPageOptions {
  * When set to `false`, the window will appear immediately without waiting for content to be loaded.
  */
 /**
- * @typedef { object } Area
- * @property { number } height Area's height
- * @property { number } width Area's width
- * @property { number } x X coordinate of area's starting point
- * @property { number } y Y coordinate of area's starting point
+ * height Area's height
+ * width Area's width
+ * x X coordinate of area's starting point
+ * y Y coordinate of area's starting point
  */
 /**
- * @typedef { object } WindowMovementOptions
- * @property { boolean } moveIndependently - Move a window independently of its group or along with its group. Defaults to false.
+ * moveIndependently - Move a window independently of its group or along with its group. Defaults to false.
  */
 /**
- * @typedef {object} FindInPageOptions
- * @property {boolean} [forward=true] Whether to search forward or backward.
- * @property {boolean} [findNext=false] Whether the operation is first request or a follow up.
- * @property {boolean} [matchCase=false] Whether search should be case-sensitive.
- * @property {boolean} [wordStart=false] Whether to look only at the start of words.
- * @property {boolean} [medialCapitalAsWordStart=false]
+ * [forward=true] Whether to search forward or backward.
+ * [findNext=false] Whether the operation is first request or a follow up.
+ * [matchCase=false] Whether search should be case-sensitive.
+ * [wordStart=false] Whether to look only at the start of words.
+ * [medialCapitalAsWordStart=false]
  * When combined with wordStart, accepts a match in the middle of a word if the match begins with an uppercase letter followed by a<br>
  * lowercase or non-letter. Accepts several other intra-word matches.
  */
 /**
- * @typedef {object} Transition
- * @property {Opacity} opacity - The Opacity transition
- * @property {Position} position - The Position transition
- * @property {Size} size - The Size transition
+ * opacity - The Opacity transition
+ * position - The Position transition
+ * size - The Size transition
 */
 /**
- * @typedef {object} TransitionOptions
- * @property {boolean} interrupt - This option interrupts the current animation. When false it pushes
+ * interrupt - This option interrupts the current animation. When false it pushes
 this animation onto the end of the animation queue.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
  */
 /**
- * @typedef {object} Size
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} width - Optional if height is present. Defaults to the window's current width.
- * @property {number} height - Optional if width is present. Defaults to the window's current height.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * width - Optional if height is present. Defaults to the window's current width.
+ * height - Optional if width is present. Defaults to the window's current height.
  */
 /**
- * @typedef {object} Position
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} left - Defaults to the window's current left position in virtual screen coordinates.
- * @property {number} top - Defaults to the window's current top position in virtual screen coordinates.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * left - Defaults to the window's current left position in virtual screen coordinates.
+ * top - Defaults to the window's current top position in virtual screen coordinates.
  */
 /**
- * @typedef {object} Opacity
- * @property {number} duration - The total time in milliseconds this transition should take.
- * @property {boolean} relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
- * @property {number} opacity - This value is clamped from 0.0 to 1.0.
+ * duration - The total time in milliseconds this transition should take.
+ * relative - Treat 'opacity' as absolute or as a delta. Defaults to false.
+ * opacity - This value is clamped from 0.0 to 1.0.
 */
 /**
  * Bounds is a interface that has the properties of height,
  * width, left, top which are all numbers
- * @typedef { object } Bounds
- * @property { number } height Get the application height bound
- * @property { number } width Get the application width bound
- * @property { number } top Get the application top bound
- * @property { number } left Get the application left bound
- * @property { number } right Get the application right bound
- * @property { number } bottom Get the application bottom bound
+ * height Get the application height bound
+ * width Get the application width bound
+ * top Get the application top bound
+ * left Get the application left bound
+ * right Get the application right bound
+ * bottom Get the application bottom bound
  */
 /**
  * @classdesc A basic window that wraps a native HTML window. Provides more fine-grained
@@ -472,7 +458,6 @@ this animation onto the end of the animation queue.
  * By default a window does not show upon instantiation; instead the window's show() method
  * must be invoked manually. The new window appears in the same process as the parent window.
  * It has the ability to listen for <a href="tutorial-Window.EventEmitter.html">window specific events</a>.
- * @class
  * @alias Window
  * @hideconstructor
  */
@@ -570,7 +555,7 @@ export declare class _Window extends WebContents<WindowEvents> {
      * Gives focus to the window.
      * @return {Promise.<void>}
      * @function focus
-     * @emits focused
+     * @fires focused
      * @memberOf Window
      * @instance
      * @tutorial Window.focus
@@ -921,7 +906,7 @@ export declare class _Window extends WebContents<WindowEvents> {
     setAsForeground(): Promise<void>;
     /**
      * Sets the window's size and position.
-     * @property { Bounds } bounds This is a * @type {string} name - name of the window.object that holds the propertys of
+     * bounds This is a * @type {string} name - name of the window.object that holds the propertys of
      * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.setBounds

--- a/types/openfin/v50/index.d.ts
+++ b/types/openfin/v50/index.d.ts
@@ -1172,7 +1172,7 @@ declare namespace fin {
         /**
          * Gives focus to the external window.
          * @return {Promise.<void>}
-         * @emits ExternalWindow#focused
+         * @fires ExternalWindow#focused
          * @experimental
          */
         focus(): Promise<void>;
@@ -1335,7 +1335,6 @@ declare namespace fin {
 
         /**
          * Sets the external window's size and position.
-         * @property { Bounds } bounds
          * @return {Promise.<void>}
          * @experimental
          */
@@ -1647,7 +1646,7 @@ declare namespace fin {
          * @return {Promise.<void>}
          * @function focus
          * @memberof View
-         * @emits focused
+         * @fires focused
          * @instance
          * @tutorial View.focus
          * @experimental

--- a/types/packery/index.d.ts
+++ b/types/packery/index.d.ts
@@ -12,79 +12,66 @@ declare module 'packery' {
     export interface PackeryOptions {
         /**
          * [itemSelector Specifies which child elements to be used as item elements. Setting itemSelector is always recommended. itemSelector is useful to exclude sizing elements]
-         * @type {string}
          */
         itemSelector?: string | undefined;
 
         /**
          * [columnWidth The width of a column of a horizontal grid. When set, Packery will align item elements horizontally to this grid]
-         * @type {number}
          */
         columnWidth?: number | undefined;
 
         /**
          * [rowHeight Height of a row of a vertical grid. When set, Packery will align item elements vertically to this grid]
-         * @type {number}
          */
         rowHeight?: number | undefined;
 
         /**
          * [gutter The space between item elements, both vertically and horizontally]
-         * @type {number}
          */
         gutter?: number | undefined;
 
         /**
          * [percentPosition Will set item position in percent values, rather than pixel values. percentPosition works well with percent-width items, as items will not transition their position on resize]
-         * @type {boolean}
          */
         percentPosition?: boolean | undefined;
 
         /**
          * [stamp Specifies which elements are stamped within the layout. These are special layout elements which will not be laid out by Packery. Rather, Packery will layout item elements around stamped elements]
-         * @type {string}
          */
         stamp?: string | undefined;
 
         /**
          * [isHorizontal Arranges items horizontally instead of vertically]
-         * @type {boolean}
          */
         isHorizontal?: boolean | undefined;
 
         /**
          * [isOriginLeft Controls the horizontal flow of the layout. By default, item elements start positioning at the left. Set to false for right-to-left layouts]
-         * @type {boolean}
          */
         isOriginLeft?: boolean | undefined;
 
         /**
          * [isOriginTop Controls the vertical flow of the layout. By default, item elements start positioning at the top. Set to false for bottom-up layouts. It’s like Tetris!]
-         * @type {boolean}
          */
         isOriginTop?: boolean | undefined;
 
         /**
          * [transitionDuration The time duration of transitions for item elements]
-         * @type {string}
          */
         transitionDuration?: string | undefined;
 
         /**
          * [containerStyle CSS styles that are applied to the container element. To disable Packery from setting any CSS to the container element, set containerStyle: null]
-         * @type {Object}
          */
         containerStyle?: Object | undefined;
 
         /**
          * [isResizeBound Binds layout to window resizing]
-         * @type {boolean}
          */
         isResizeBound?: boolean | undefined;
 
         /**
          * [isInitLayout Enables layout on initialization. Set this to false to disable layout on initialization, so you can use methods or add events before the initial layout]
-         * @type {boolean}
          */
         isInitLayout?: boolean | undefined;
     }

--- a/types/page/index.d.ts
+++ b/types/page/index.d.ts
@@ -10,12 +10,10 @@ declare namespace PageJS {
         create(options?: Partial<Options>): Static;
         /**
          * Expose Route
-         * @type {Route}
          */
         Route: Route;
         /**
          * Export Context
-         * @type {Context}
          */
         Context: Context;
         /**
@@ -216,12 +214,10 @@ declare namespace PageJS {
     interface RouteOptions {
         /**
          * enable case-sensitive routes
-         * @type {[type]}
          */
         sensitive?: boolean | undefined;
         /**
          * enable strict matching for trailing slashes
-         * @type {[type]}
          */
         strict?: boolean | undefined;
     }

--- a/types/parse/v1/index.d.ts
+++ b/types/parse/v1/index.d.ts
@@ -78,7 +78,6 @@ declare namespace Parse {
      * </pre></p>
      *
      * @see Parse.Promise.prototype.then
-     * @class
      */
 
     interface IPromise<T> {
@@ -134,7 +133,6 @@ declare namespace Parse {
      * If the argument is any other JSON object, that object will be interpretted
      *   as a serialized ACL created with toJSON().
      * @see Parse.Object#setACL
-     * @class
      *
      * <p>An ACL, or Access Control List can be added to any
      * <code>Parse.Object</code> to restrict access to only a subset of users
@@ -176,7 +174,6 @@ declare namespace Parse {
     /**
      * A Parse.File is a local representation of a file that is saved to the Parse
      * cloud.
-     * @class
      * @param name {String} The file's name. This will be prefixed by a unique
      *     value once the file has finished saving. The file name must begin with
      *     an alphanumeric character, and consist of alphanumeric characters,
@@ -218,7 +215,6 @@ declare namespace Parse {
      *   new GeoPoint({latitude: 30, longitude: 30})
      *   new GeoPoint()  // defaults to (0, 0)
      *   </pre>
-     * @class
      *
      * <p>Represents a latitude / longitude point that may be associated
      * with a key in a ParseObject or used as a reference point for geo queries.
@@ -251,7 +247,6 @@ declare namespace Parse {
      * — you should use the reference to <code>Parse.history</code>
      * that will be created for you automatically if you make use of
      * Routers with routes.
-     * @class
      *
      * <p>A fork of Backbone.History, provided for your convenience.  If you
      * use this class, you must also include jQuery, or another library
@@ -318,7 +313,6 @@ declare namespace Parse {
      *     object.  The only option currently supported is "collection".
      * @see Parse.Object.extend
      *
-     * @class
      *
      * <p>The fundamental unit of Parse data, which implements the Backbone Model
      * interface.</p>
@@ -435,7 +429,6 @@ declare namespace Parse {
      *
      * @see Parse.Collection.extend
      *
-     * @class
      *
      * <p>Provides a standard collection class for our sets of models, ordered
      * or unordered.  For more information, see the
@@ -493,7 +486,6 @@ declare namespace Parse {
     }
 
     /**
-     * @class
      *
      * <p>Parse.Events is a fork of Backbone's Events module, provided for your
      * convenience.</p>
@@ -532,7 +524,6 @@ declare namespace Parse {
      * Creates a new parse Parse.Query for the given Parse.Object subclass.
      * @param objectClass -
      *   An instance of a subclass of Parse.Object, or a Parse className string.
-     * @class
      *
      * <p>Parse.Query defines a query that is used to fetch Parse.Objects. The
      * most common use case is finding all objects that match a query through the
@@ -688,7 +679,7 @@ declare namespace Parse {
      *
      * <p>Roles must have a name (which cannot be changed after creation of the
      * role), and must specify an ACL.</p>
-     * @class
+     *
      * A Parse.Role is a local representation of a role persisted to the Parse
      * cloud.
      */
@@ -719,7 +710,6 @@ declare namespace Parse {
     /**
      * Routers map faux-URLs to actions, and fire events when routes are
      * matched. Creating a new one sets its `routes` hash, if not set statically.
-     * @class
      *
      * <p>A fork of Backbone.Router, provided for your convenience.
      * For more information, see the
@@ -754,7 +744,6 @@ declare namespace Parse {
     }
 
     /**
-     * @class
      *
      * <p>A Parse.User object is a local representation of a user persisted to the
      * Parse cloud. This class is a subclass of a Parse.Object, and retains the
@@ -790,7 +779,6 @@ declare namespace Parse {
     /**
      * Creating a Parse.View creates its initial element outside of the DOM,
      * if an existing element is not provided...
-     * @class
      *
      * <p>A fork of Backbone.View, provided for your convenience.  If you use this
      * class, you must also include jQuery, or another library that provides a
@@ -1087,7 +1075,6 @@ declare namespace Parse {
     }
 
     /**
-     * @class
      * A Parse.Op is an atomic operation that can be applied to a field in a
      * Parse.Object. For example, calling <code>object.set("foo", "bar")</code>
      * is an example of a Parse.Op.Set. Calling <code>object.unset("foo")</code>

--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -146,8 +146,6 @@ declare namespace plupload {
         /**
          * Unique id for the Uploader instance.
          *
-         * @property id
-         * @type String
          */
         id: string;
 
@@ -155,8 +153,6 @@ declare namespace plupload {
          * Current state of the total uploading progress. This one can either be plupload.STARTED or plupload.STOPPED.
          * These states are controlled by the stop/start methods. The default value is STOPPED.
          *
-         * @property state
-         * @type Number
          */
         state: number;
 
@@ -165,24 +161,18 @@ declare namespace plupload {
          * before the init event is called, these features can then be used to alter the UI for the end user.
          * Some of the current features that might be in this map is: dragdrop, chunks, jpgresize, pngresize.
          *
-         * @property features
-         * @type Object
          */
         features: any;
 
         /**
          * Current runtime name.
          *
-         * @property runtime
-         * @type String
          */
         runtime: string;
 
         /**
          * Current upload queue, an array of File instances.
          *
-         * @property files
-         * @type Array
          * @see plupload.File
          */
         files: Array<any>;
@@ -190,16 +180,12 @@ declare namespace plupload {
         /**
          * Object with name/value settings.
          *
-         * @property settings
-         * @type Object
          */
         settings: any;
 
         /**
          * Total progess information. How many files has been uploaded, total percent etc.
          *
-         * @property total
-         * @type plupload.QueueProgress
          */
         total: plupload_queue_progress;
 
@@ -321,7 +307,6 @@ declare namespace plupload {
     /**
      * The state of the queue before it has started and after it has finished
      *
-     * @property STOPPED
      * @static
      * @final
      */
@@ -330,7 +315,6 @@ declare namespace plupload {
     /**
      * Upload process is running
      *
-     * @property STARTED
      * @static
      * @final
      */
@@ -339,7 +323,6 @@ declare namespace plupload {
     /**
      * File is queued for upload
      *
-     * @property QUEUED
      * @static
      * @final
      */
@@ -348,7 +331,6 @@ declare namespace plupload {
     /**
      * File is being uploaded
      *
-     * @property UPLOADING
      * @static
      * @final
      */
@@ -357,7 +339,6 @@ declare namespace plupload {
     /**
      * File has failed to be uploaded
      *
-     * @property FAILED
      * @static
      * @final
      */
@@ -366,7 +347,6 @@ declare namespace plupload {
     /**
      * File has been uploaded successfully
      *
-     * @property DONE
      * @static
      * @final
      */
@@ -375,7 +355,6 @@ declare namespace plupload {
     /**
      * Generic error for example if an exception is thrown inside Silverlight.
      *
-     * @property GENERIC_ERROR
      * @static
      * @final
      */
@@ -384,7 +363,6 @@ declare namespace plupload {
     /**
      * HTTP transport error. For example if the server produces a HTTP status other than 200.
      *
-     * @property HTTP_ERROR
      * @static
      * @final
      */
@@ -393,14 +371,12 @@ declare namespace plupload {
     /**
      * Generic I/O error. For example if it wasn't possible to open the file stream on local machine.
      *
-     * @property IO_ERROR
      * @static
      * @final
      */
     export const IO_ERROR: number;
 
     /**
-     * @property SECURITY_ERROR
      * @static
      * @final
      */
@@ -409,7 +385,6 @@ declare namespace plupload {
     /**
      * Initialization error. Will be triggered if no runtime was initialized.
      *
-     * @property INIT_ERROR
      * @static
      * @final
      */
@@ -419,7 +394,6 @@ declare namespace plupload {
      * File size error. If the user selects a file that is too large or is empty it will be blocked and
      * an error of this type will be triggered.
      *
-     * @property FILE_SIZE_ERROR
      * @static
      * @final
      */
@@ -428,7 +402,6 @@ declare namespace plupload {
     /**
      * File extension error. If the user selects a file that isn't valid according to the filters setting.
      *
-     * @property FILE_EXTENSION_ERROR
      * @static
      * @final
      */
@@ -437,7 +410,6 @@ declare namespace plupload {
     /**
      * Duplicate file error. If prevent_duplicates is set to true and user selects the same file again.
      *
-     * @property FILE_DUPLICATE_ERROR
      * @static
      * @final
      */
@@ -446,7 +418,6 @@ declare namespace plupload {
     /**
      * Runtime will try to detect if image is proper one. Otherwise will throw this error.
      *
-     * @property IMAGE_FORMAT_ERROR
      * @static
      * @final
      */
@@ -456,7 +427,6 @@ declare namespace plupload {
      * While working on files runtime may run out of memory and will throw this error.
      *
      * @since 2.1.2
-     * @property MEMORY_ERROR
      * @static
      * @final
      */
@@ -465,7 +435,6 @@ declare namespace plupload {
     /**
      * Each runtime has an upper limit on a dimension of the image it can handle. If bigger, will throw this error.
      *
-     * @property IMAGE_DIMENSIONS_ERROR
      * @static
      * @final
      */

--- a/types/progressbar.js/index.d.ts
+++ b/types/progressbar.js/index.d.ts
@@ -103,7 +103,7 @@ declare namespace main {
         /**
          * Width of the stroke.
          * Unit is percentage of SVG canvas' size.
-         * @desc In Line shape, you should control
+         * @description In Line shape, you should control
          * the stroke width by setting container's height.
          * WARNING: IE doesn't support values over 6, see this bug:
          * @see {@link https://github.com/kimmobrunfeldt/progressbar.js/issues/79}

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -584,7 +584,7 @@ declare global {
          *
          * `QUnit.begin()` is called once before running any tests.
          *
-         * @callback callback Callback to execute.
+         * callback Callback to execute.
          */
         begin(callback: (details: QUnit.BeginDetails) => void | Promise<void>): void;
 

--- a/types/react-foundation/enums.d.ts
+++ b/types/react-foundation/enums.d.ts
@@ -153,7 +153,6 @@ export declare const VerticalAlignments: {
 /**
  * Menu alignment enumerable.
  *
- * @type {{RIGHT = string, CENTER = string}}
  */
 export declare type MenuAlignments = 'right' | 'center';
 export declare const MenuAlignments: {

--- a/types/redux-optimistic-ui/index.d.ts
+++ b/types/redux-optimistic-ui/index.d.ts
@@ -51,13 +51,11 @@ declare module "redux-optimistic-ui" {
                 /**
                  * Type, BEGIN, COMMIT or REVERT
                  *
-                 * @type {string}
                  */
                 type: string;
                 /**
                  * Transaction id. Id should be unique for each optimistic action
                  *
-                 * @type {number}
                  */
                 id: number;
             }

--- a/types/ref-struct-di/index.d.ts
+++ b/types/ref-struct-di/index.d.ts
@@ -158,7 +158,6 @@ declare namespace struct {
      * Pass in an Object containing the struct fields to auto-populate the
      * struct with the data.
      *
-     * @constructor
      */
     interface StructType<TDefinition extends StructTypeDefinitionBase = any> extends ref.Type<StructObject<StructObjectProperties<TDefinition>>> {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */

--- a/types/ref-struct/index.d.ts
+++ b/types/ref-struct/index.d.ts
@@ -14,7 +14,6 @@ import ref = require('ref');
  * Pass in an Object containing the struct fields to auto-populate the
  * struct with the data.
  *
- * @constructor
  */
 interface StructType extends ref.Type {
     /** Pass it an existing Buffer instance to use that as the backing buffer. */

--- a/types/ref-union-di/index.d.ts
+++ b/types/ref-union-di/index.d.ts
@@ -117,7 +117,6 @@ declare namespace union {
      * Pass in an Object containing the union fields to auto-populate the
      * union with the data.
      *
-     * @constructor
      */
     interface UnionType<TDefinition extends UnionTypeDefinitionBase = any> extends ref.Type<UnionObject<UnionObjectProperties<TDefinition>>> {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */

--- a/types/ref-union/index.d.ts
+++ b/types/ref-union/index.d.ts
@@ -13,7 +13,6 @@ import ref = require('ref');
  * Pass in an Object containing the union fields to auto-populate the
  * union with the data.
  *
- * @constructor
  */
 interface UnionType extends ref.Type {
     /** Pass it an existing Buffer instance to use that as the backing buffer. */

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -813,7 +813,7 @@ export interface Response extends http.ServerResponse {
      * @param    code the status code
      * @param    url to redirect to
      * @param    next - mandatory, to complete the response and trigger audit logger
-     * @emits    redirect
+     * @fires    redirect
      */
     redirect(code: number, url: string, next: Next): void;
 
@@ -823,7 +823,7 @@ export interface Response extends http.ServerResponse {
      * `next` is mandatory, to complete the response and trigger audit logger.
      * @param    url to redirect to or options object to configure a redirect or
      * @param    next - mandatory, to complete the response and trigger audit logger
-     * @emits    redirect
+     * @fires    redirect
      */
     redirect(opts: string | RedirectOptions, next: Next): void;
 

--- a/types/restify/v5/index.d.ts
+++ b/types/restify/v5/index.d.ts
@@ -708,7 +708,7 @@ export interface Response extends http.ServerResponse {
      * @param      code the status code
      * @param      url to redirect to
      * @param    next fn
-     * @emits    redirect
+     * @fires    redirect
      */
     redirect(code: number, url: string, next: Next): void;
 
@@ -718,7 +718,7 @@ export interface Response extends http.ServerResponse {
      * `next` is mandatory, to complete the response and trigger audit logger.
      * @param      options the options or url to redirect to
      * @param    next fn
-     * @emits    redirect
+     * @fires    redirect
      */
     redirect(options: object | string, next: Next): void;
 

--- a/types/restler/index.d.ts
+++ b/types/restler/index.d.ts
@@ -121,104 +121,87 @@ declare module "restler" {
     interface RestlerOptions {
         /**
          * OAuth Bearer Token.
-         * @type {string}
          */
         accessToken?: string | undefined;
 
         /**
          *  HTTP Agent instance to use. If not defined globalAgent will be used. If false opts out of connection pooling with an Agent, defaults request to Connection: close.
-         * @type {any}
          */
         agent?: any;
 
         /**
          * A http.Client instance if you want to reuse or implement some kind of connection pooling.
-         * @type {any}
          */
         client?: any;
 
         /**
          * Data to be added to the body of the request.
-         * @type {any}
          */
         data?: any;
 
         /**
          * Encoding of the response body
-         * @type {string}
          */
         decoding?: string | undefined;
 
         /**
          * Encoding of the request body.
-         * @type {string}
          */
         encoding?: string | undefined;
 
         /**
          * If set will recursively follow redirects.
-         * @type {boolean}
          */
         followRedirects?: boolean | undefined;
 
         /**
          * A hash of HTTP headers to be sent.
-         * @type {RestlerOptionsHeader}
          */
         headers?: RestlerOptionsHeader | undefined;
 
         /**
          * Request method
-         * @type {string}
          */
         method?: string | undefined;
 
         /**
          * If set the data passed will be formatted as <code>multipart/form-encoded</code>.
-         * @type {boolean}
          */
         multipart?: boolean | undefined;
 
         /**
          * A function that will be called on the returned data. Use any of predefined <code>restler.parsers</code>.
-         * @type {any}
          */
         parser?: any;
 
         /**
          * Basic auth password.
-         * @type {string}
          */
         password?: string | undefined;
 
         /**
          * Query string variables as a javascript object, will override the querystring in the URL.
-         * @type {any}
          */
         query?: any;
 
         /**
          * If true, the server certificate is verified against the list of supplied CAs.
          * An 'error' event is emitted if verification fails. Verification happens at the connection level, before the HTTP request is sent.
-         * @type {boolean}
          */
         rejectUnauthorized?: boolean | undefined;
 
         /**
          * Emit the timeout event when the response does not return within the said value (in ms).
-         * @type {number}
          */
         timeout?: number | undefined;
 
         /**
          * Basic auth username.
-         * @type {string}
          */
         username?: string | undefined;
 
         /**
          * Options for xml2js.
-         * @type {any}
          */
         xml2js?: any;
     }

--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -240,7 +240,6 @@ declare namespace rosie {
         /**
          * Generates values for all the registered options using the values given.
          *
-         * @private
          * @param {object} options
          * @return {object}
          */

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -40,7 +40,6 @@ declare namespace ROSLIB {
          *  * &#60;topicName&#62; - A message came from rosbridge with the given topic name.
          *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
          *
-         * @constructor
          * @param {Object} options
          * @param {string} [options.url] - The WebSocket URL for rosbridge or the node server URL to connect using socket.io (if socket.io exists in the page). Can be specified later with `connect`.
          * @param {boolean} [options.groovyCompatibility=true] - Don't use interfaces that changed after the last groovy release or rosbridge_suite and related tools.
@@ -337,7 +336,6 @@ declare namespace ROSLIB {
         /**
          * Message objects are used for publishing and subscribing to and from topics.
          *
-         * @constructor
          * @param {any} values - An object matching the fields defined in the .msg definition file.
          */
         constructor(values: any);
@@ -347,7 +345,6 @@ declare namespace ROSLIB {
         /**
          * A ROS parameter.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.name - The param name, like max_vel_x.
@@ -382,7 +379,6 @@ declare namespace ROSLIB {
         /**
          * A ROS service client.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.name - The service name, like '/add_two_ints'.
@@ -434,7 +430,6 @@ declare namespace ROSLIB {
         /**
          * A ServiceRequest is passed into the service call.
          *
-         * @constructor
          * @param {any} values - Object matching the fields defined in the .srv definition file.
          */
         constructor(values: any);
@@ -444,7 +439,6 @@ declare namespace ROSLIB {
         /**
          * A ServiceResponse is returned from the service call.
          *
-         * @constructor
          * @param {any} values - Object matching the fields defined in the .srv definition file.
          */
         constructor(values: any);
@@ -458,7 +452,6 @@ declare namespace ROSLIB {
          *  * 'warning' - If there are any warning during the Topic creation.
          *  * 'message' - The message data from rosbridge.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.name - The topic name, like '/cmd_vel'.
@@ -529,7 +522,6 @@ declare namespace ROSLIB {
         /**
          * A TF Client that listens to TFs from tf2_web_republisher.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} [options.fixedFrame=base_link] - The fixed frame.
@@ -603,7 +595,6 @@ declare namespace ROSLIB {
         /**
          * A Transform in 3-space. Values are copied into this object.
          *
-         * @constructor
          * @param {Object} options
          * @param {Vector3Like} options.translation - The ROSLIB.Vector3 describing the translation.
          * @param {QuaternionLike} options.rotation - The ROSLIB.Quaternion describing the rotation.
@@ -628,7 +619,6 @@ declare namespace ROSLIB {
         /**
          * A 3D vector.
          *
-         * @constructor
          * @param {Object} options
          * @param {number} [options.x=0] - The x value.
          * @param {number} [options.y=0] - The y value.
@@ -680,7 +670,6 @@ declare namespace ROSLIB {
         /**
          * A Quaternion.
          *
-         * @constructor
          * @param {Object} options
          * @param {number} [options.x=0] - The x value.
          * @param {number} [options.y=0] - The y value.
@@ -746,7 +735,6 @@ declare namespace ROSLIB {
         /**
          * A Pose in 3D space. Values are copied into this object.
          *
-         * @constructor
          * @param {Object} options
          * @param {Vector3Like} options.position - The ROSLIB.Vector3 describing the position.
          * @param {QuaternionLike} options.orientation - The ROSLIB.Quaternion describing the orientation.
@@ -797,7 +785,6 @@ declare namespace ROSLIB {
          *  * 'feedback' - The feedback messages received from the action server.
          *  * 'result' - The result returned from the action server.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.serverName - The action server name, like '/fibonacci'.
@@ -829,7 +816,6 @@ declare namespace ROSLIB {
          *  * 'feedback' - The feedback messages received from the action server.
          *  * 'result' - The result returned from the action server.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.serverName - The action server name, like '/fibonacci'.
@@ -845,7 +831,6 @@ declare namespace ROSLIB {
          * Emits the following events:
          *  * 'timeout' - If a timeout occurred while sending a goal.
          *
-         * @constructor
          * @param {Object} options
          * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
          * @param {any} options.goalMessage - The JSON object containing the goal for the action server.
@@ -881,7 +866,6 @@ declare namespace ROSLIB {
          *  * 'goal' - Goal sent by action client.
          *  * 'cancel' - Action client has canceled the request.
          *
-         * @constructor
          * @param {Object} options
          * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
          * @param {string} options.serverName - The action server name, like '/fibonacci'.
@@ -924,7 +908,6 @@ declare namespace ROSLIB {
         /**
          * A Color element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -939,7 +922,6 @@ declare namespace ROSLIB {
         /**
          * A Material element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -961,7 +943,6 @@ declare namespace ROSLIB {
         /**
          * A Joint element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -982,7 +963,6 @@ declare namespace ROSLIB {
         /**
          * A Sphere element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -996,7 +976,6 @@ declare namespace ROSLIB {
         /**
          * A Box element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -1011,7 +990,6 @@ declare namespace ROSLIB {
         /**
          * A Cylinder element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -1026,7 +1004,6 @@ declare namespace ROSLIB {
         /**
          * A Box element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -1041,7 +1018,6 @@ declare namespace ROSLIB {
         /**
          * A Visual element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -1055,7 +1031,6 @@ declare namespace ROSLIB {
         /**
          * A Link element in a URDF.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          */
@@ -1070,7 +1045,6 @@ declare namespace ROSLIB {
         /**
          * A URDF Model can be used to parse a given URDF into the appropriate elements.
          *
-         * @constructor
          * @param {Object} options
          * @param {Node} options.xml - The XML element to parse.
          * @param {string} options.string - The XML element to parse as a string.

--- a/types/russian-nouns-js/src/Engine.d.ts
+++ b/types/russian-nouns-js/src/Engine.d.ts
@@ -7,7 +7,6 @@ import StressDictionary from './StressDictionary';
 export default class Engine {
     /**
      * @description Словарь ударений. Его можно редактировать в рантайме.
-     * @type {API.StressDictionary}
      */
     readonly sd: StressDictionary;
 

--- a/types/sass-graph/index.d.ts
+++ b/types/sass-graph/index.d.ts
@@ -19,7 +19,6 @@ declare namespace SassGraph {
   }
 
   /**
-   * @class Graph
    */
   export interface Graph {
     dir: string;

--- a/types/sat/index.d.ts
+++ b/types/sat/index.d.ts
@@ -10,7 +10,7 @@ declare namespace SAT {
      */
     export class Vector {
         /**
-         * @class Vector has two properties
+         * Vector has two properties
          * @param {number} x The x-coordinate of the Vector.
          * @param {number} y The y-coordinate of the Vector.
          */

--- a/types/selenium-webdriver/chrome.d.ts
+++ b/types/selenium-webdriver/chrome.d.ts
@@ -5,7 +5,6 @@ import * as remote from './remote';
 /**
  * Creates a new WebDriver client for Chrome.
  *
- * @extends {webdriver.WebDriver}
  */
 export class Driver extends webdriver.ChromiumWebDriver {
   /**
@@ -47,7 +46,6 @@ export interface IPerfLoggingPrefs {
  */
 export class Options extends webdriver.Capabilities {
   /**
-   * @constructor
    */
   constructor();
 
@@ -307,7 +305,6 @@ export class ServiceBuilder extends remote.DriverService.Builder {
    *     PATH.
    * @throws {Error} If provided executable does not exist, or the chromedriver
    *     cannot be found on the PATH.
-   * @constructor
    */
   constructor(opt_exe?: string);
 

--- a/types/selenium-webdriver/edge.d.ts
+++ b/types/selenium-webdriver/edge.d.ts
@@ -38,7 +38,6 @@ export interface IPerfLoggingPrefs {
  */
 export class Options extends webdriver.Capabilities {
   /**
-   * @constructor
    */
   constructor();
 

--- a/types/selenium-webdriver/http.d.ts
+++ b/types/selenium-webdriver/http.d.ts
@@ -95,7 +95,6 @@ export function sendRequest(
  * [json]: https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
  * [w3c]: https://w3c.github.io/webdriver/webdriver-spec.html
  *
- * @implements {cmd.Executor}
  */
 export class Executor {
   /**

--- a/types/selenium-webdriver/ie.d.ts
+++ b/types/selenium-webdriver/ie.d.ts
@@ -3,7 +3,6 @@ import * as remote from './remote';
 
 /**
  * IEDriverServer logging levels.
- * @enum {string}
  */
 export type Level = 'FATAL' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE';
 

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -325,21 +325,18 @@ export class Condition<T> {
    *     sentence 'Waiting [...]'
    * @param {function(!WebDriver): OUT} fn The condition function to
    *     evaluate on each iteration of the wait loop.
-   * @constructor
    */
   constructor(message: string, fn: ConditionFn<T>);
 
   /** @return {string} A description of this condition. */
   description(): string;
 
-  /** @type {function(!WebDriver): OUT} */
   fn(webdriver: WebDriver): ConditionFn<T>;
 }
 
 /**
  * Defines a condition that will result in a {@link WebElement}.
  *
- * @extends {Condition<!(WebElement|IThenable<!WebElement>)>}
  */
 export class WebElementCondition extends Condition<WebElement> {
   // add an unused private member so the compiler treats this
@@ -575,7 +572,6 @@ export class Alert {
  *       return alert.dismiss();
  *     });
  *
- * @implements {promise.Thenable.<!Alert>}
  * @final
  */
 export interface AlertPromise extends Promise<Alert> {}
@@ -651,7 +647,6 @@ export class Builder {
   // region Constructors
 
   /**
-   * @constructor
    */
   constructor();
 
@@ -929,7 +924,6 @@ export class EventEmitter {
   // region Constructors
 
   /**
-   * @constructor
    */
   constructor();
 
@@ -961,7 +955,6 @@ export class EventEmitter {
    *     after
    *    the first event is fired.
    * @return {!EventEmitter} A self reference.
-   * @private
    */
   addListener(type: string, fn: Function, opt_scope?: any, opt_oneshot?: boolean): EventEmitter;
 
@@ -1103,7 +1096,6 @@ export interface IWebDriverOptionsCookie {
    * The expiry is always returned in seconds since epoch when
    * {@linkplain Options#getCookies() retrieving cookies} from the browser.
    *
-   * @type {(!Date|number|undefined)}
    */
   expiry?: number|Date | undefined;
 }
@@ -1115,7 +1107,6 @@ export interface IWebDriverCookie extends IWebDriverOptionsCookie {
    * The expiry is always returned in seconds since epoch when
    * {@linkplain Options#getCookies() retrieving cookies} from the browser.
    *
-   * @type {(!number|undefined)}
    */
   expiry?: number | undefined;
 }
@@ -1128,7 +1119,6 @@ export class Options {
 
   /**
    * @param {!WebDriver} driver The parent driver.
-   * @constructor
    */
   constructor(driver: WebDriver);
 
@@ -1218,7 +1208,6 @@ export class Window {
 
   /**
    * @param {!WebDriver} driver The parent driver.
-   * @constructor
    */
   constructor(driver: WebDriver);
 
@@ -1315,7 +1304,6 @@ export class Logs {
 
   /**
    * @param {!WebDriver} driver The parent driver.
-   * @constructor
    */
   constructor(driver: WebDriver);
 
@@ -1357,7 +1345,6 @@ export class TargetLocator {
 
   /**
    * @param {!WebDriver} driver The parent driver.
-   * @constructor
    */
   constructor(driver: WebDriver);
 
@@ -1466,7 +1453,6 @@ export class TargetLocator {
  * [Selenium Server](http://docs.seleniumhq.org/download/).
  */
 export class FileDetector {
-  /** @constructor */
   constructor();
 
   /**
@@ -2024,7 +2010,6 @@ export class WebDriver {
    * @param {!(WebDriver|WebElement)} context The search context.
    * @return {!Promise<!WebElement>} A promise that will resolve to a list of
    *     WebElements.
-   * @private
    */
   findElementInternal_(locatorFn: Function, context: WebDriver | WebElement): Promise<WebElement>;
 
@@ -2033,7 +2018,6 @@ export class WebDriver {
    * @param {!(WebDriver|WebElement)} context The search context.
    * @return {!Promise<!Array<!WebElement>>} A promise that will resolve to an
    *     array of WebElements.
-   * @private
    */
   findElementsInternal_(locatorFn: Function, context: WebDriver | WebElement): Promise<WebElement[]>;
 
@@ -2254,8 +2238,6 @@ export class ChromiumWebDriver extends WebDriver {
  * If the driver instance fails to resolve (e.g. the session cannot be created),
  * every issued command will fail.
  *
- * @extends {webdriver.IWebDriver}
- * @extends {Promise<!webdriver.IWebDriver>}
  * @interface
  */
 export interface ThenableWebDriver extends WebDriver, Promise<WebDriver> {}
@@ -2544,7 +2526,6 @@ export interface IWebElementFinders {
  * Defines an object that can be asynchronously serialized to its WebDriver
  * wire representation.
  *
- * @constructor
  * @template T
  */
 export interface Serializable<T> {
@@ -2581,7 +2562,6 @@ export interface Serializable<T> {
  *       alert('The element was not found, as expected');
  *     });
  *
- * @extends {Serializable.<WebElement.Id>}
  */
 export class WebElement implements Serializable<IWebElementId> {
   /**
@@ -2917,9 +2897,6 @@ export class WebElement implements Serializable<IWebElementId> {
  *     element.
  * @param {!Promise.<!WebElement>} el A promise
  *     that will resolve to the promised element.
- * @constructor
- * @extends {WebElement}
- * @implements {promise.Thenable.<!WebElement>}
  * @final
  */
 export interface WebElementPromise extends Promise<WebElement> {}
@@ -2947,7 +2924,6 @@ export class Session {
    * @param {string} id The session ID.
    * @param {!(Object|Capabilities)} capabilities The session
    *     capabilities.
-   * @constructor
    */
   constructor(id: string, capabilities: Capabilities|{});
 

--- a/types/selenium-webdriver/lib/by.d.ts
+++ b/types/selenium-webdriver/lib/by.d.ts
@@ -180,16 +180,6 @@ export class RelativeBy {
  * Closure compiler), as locator hashes will always be parsed using
  * the un-obfuscated properties listed.
  *
- * @typedef {(
- *     {className: string}|
- *     {css: string}|
- *     {id: string}|
- *     {js: string}|
- *     {linkText: string}|
- *     {name: string}|
- *     {partialLinkText: string}|
- *     {tagName: string}|
- *     {xpath: string})}
  */
 export type ByHash =
     | { className: string }

--- a/types/selenium-webdriver/lib/capabilities.d.ts
+++ b/types/selenium-webdriver/lib/capabilities.d.ts
@@ -3,7 +3,6 @@ import { logging, ProxyConfig } from '../';
 
 /**
  * Recognized browser names.
- * @enum {string}
  */
 export interface IBrowser {
     CHROME: 'chrome';
@@ -22,7 +21,6 @@ export const Browser: IBrowser;
  * Common platform names. These platforms are not explicitly defined by the
  * WebDriver spec, however, their use is encouraged for interoperability.
  *
- * @enum {string}
  * @see <https://w3c.github.io/webdriver/webdriver-spec.html>
  */
 export interface IPlatform {
@@ -38,7 +36,6 @@ export const Platform: IPlatform;
  *
  * [document readiness]: https://html.spec.whatwg.org/#current-document-readiness
  *
- * @enum {string}
  */
 export interface IPageLoadStrategy {
     /**
@@ -67,7 +64,6 @@ export const PageLoadStrategy: IPageLoadStrategy;
  * unhandled user prompts (`window.alert()`, `window.confirm()`, and
  * `window.prompt()`).
  *
- * @enum {string}
  */
 export interface IUserPromptHandler {
     /** All prompts should be silently accepted. */
@@ -92,7 +88,6 @@ export const UserPromptHandler: IUserPromptHandler;
 
 /**
  * Common webdriver capability keys.
- * @enum {string}
  */
 export interface ICapability {
     /**

--- a/types/selenium-webdriver/lib/command.d.ts
+++ b/types/selenium-webdriver/lib/command.d.ts
@@ -155,14 +155,12 @@ export const Name: ICommandName;
 /**
  * Describes a command to be executed by the WebDriverJS framework.
  * @param {!CommandName} name The name of this command.
- * @constructor
  */
 export class Command {
     // region Constructors
 
     /**
      * @param {!CommandName} name The name of this command.
-     * @constructor
      */
     constructor(name: string);
 

--- a/types/selenium-webdriver/lib/error.d.ts
+++ b/types/selenium-webdriver/lib/error.d.ts
@@ -3,7 +3,6 @@
  * TODO: remove this when all code paths have been switched to the new error
  * types.
  * @deprecated
- * @enum {number}
  */
 export const ErrorCode: {
     SUCCESS: 0;

--- a/types/selenium-webdriver/lib/input.d.ts
+++ b/types/selenium-webdriver/lib/input.d.ts
@@ -106,7 +106,6 @@ export interface IKey {
  * the Unicode PUA (Private Use Area) code points, 0xE000-0xF8FF.  Refer to
  * http://www.google.com.au/search?&q=unicode+pua&btnG=Search
  *
- * @enum {string}
  */
 export const Key: IKey;
 

--- a/types/selenium-webdriver/lib/logging.d.ts
+++ b/types/selenium-webdriver/lib/logging.d.ts
@@ -97,20 +97,15 @@ export class Entry {
      *     milliseconds since 0:00:00, January 1, 1970 UTC. If omitted, the
      *     current time will be used.
      * @param {string=} opt_type The log type, if known.
-     * @constructor
      */
     constructor(level: Level | string | number, message: string, opt_timestamp?: number, opt_type?: string | IType);
 
-    /** @type {!logging.Level} */
     level: Level;
 
-    /** @type {string} */
     message: string;
 
-    /** @type {number} */
     timestamp: number;
 
-    /** @type {string} */
     type: string;
 
     /**
@@ -143,13 +138,9 @@ export class Logger {
      */
     constructor(name: string, opt_level?: Level);
 
-    /** @private {string} */
     name_: string;
-    /** @private {Level} */
     level_: Level;
-    /** @private {Logger} */
     parent_: Logger;
-    /** @private {Set<function(!Entry)>} */
     handlers_: any;
 
     /** @return {string} the name of this logger. */
@@ -277,7 +268,6 @@ export class LogManager {
      * @param {string} name the logger's name.
      * @param {!Logger} parent the logger's parent.
      * @return {!Logger} the new logger.
-     * @private
      */
     createLogger_(name: string, parent: Logger): Logger;
 }
@@ -330,7 +320,6 @@ export interface IType {
 
 /**
  * Common log types.
- * @enum {string}
  */
 export const Type: IType;
 

--- a/types/selenium-webdriver/lib/virtual_authenticator.d.ts
+++ b/types/selenium-webdriver/lib/virtual_authenticator.d.ts
@@ -1,6 +1,5 @@
 /**
  * Protocol for virtual authenticators
- * @enum {string}
  */
  export enum Protocol {
     CTAP2 = 'ctap2',
@@ -9,7 +8,6 @@
 
 /**
  * AuthenticatorTransport values
- * @enum {string}
  */
 export enum Transport {
     BLE = 'ble',

--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -35,7 +35,6 @@ export class ShadowRoot implements Serializable<IWebElementId> {
      * @return {!Promise<T>} A promise that will be resolved with the result.
      * @template T
      * @see WebDriver#schedule
-     * @private
      */
     execute_<T>(command: Command): Promise<T>;
 
@@ -95,7 +94,6 @@ export class ShadowRoot implements Serializable<IWebElementId> {
  * scheduled without directly on this instance before the underlying
  * ShadowRoot has been fulfilled.
  *
- * @implements { IThenable<!ShadowRoot>}
  * @final
  */
 export interface ShadowRootPromise extends Promise<ShadowRoot> {}

--- a/types/selenium-webdriver/safari.d.ts
+++ b/types/selenium-webdriver/safari.d.ts
@@ -26,7 +26,6 @@ export function cleanSession(desiredCapabilities: webdriver.Capabilities): any[]
 export function getRandomString(): string;
 
 /**
- * @implements {command.Executor}
  */
 export class CommandExecutor {}
 

--- a/types/selenium-webdriver/v2/chrome.d.ts
+++ b/types/selenium-webdriver/v2/chrome.d.ts
@@ -4,7 +4,6 @@ import * as remote from './remote';
 /**
  * Creates a new WebDriver client for Chrome.
  *
- * @extends {webdriver.WebDriver}
  */
 export class Driver extends webdriver.WebDriver {
     /**
@@ -14,7 +13,6 @@ export class Driver extends webdriver.WebDriver {
      *     the {@link getDefaultService default service} by default.
      * @param {webdriver.promise.ControlFlow=} opt_flow The control flow to use, or
      *     {@code null} to use the currently active flow.
-     * @constructor
      */
     constructor(
         opt_config?: Options | webdriver.Capabilities,
@@ -46,7 +44,6 @@ interface IPerfLoggingPrefs {
  */
 export class Options {
     /**
-     * @constructor
      */
     constructor();
 
@@ -297,7 +294,6 @@ export class ServiceBuilder {
      *     PATH.
      * @throws {Error} If provided executable does not exist, or the chromedriver
      *     cannot be found on the PATH.
-     * @constructor
      */
     constructor(opt_exe?: string);
 

--- a/types/selenium-webdriver/v2/firefox.d.ts
+++ b/types/selenium-webdriver/v2/firefox.d.ts
@@ -8,7 +8,6 @@ export class Binary {
     /**
      * @param {string=} opt_exe Path to the Firefox binary to use. If not
      *     specified, will attempt to locate Firefox on the current system.
-     * @constructor
      */
     constructor(opt_exe?: string);
 
@@ -45,7 +44,6 @@ export class Profile {
      * @param {string=} opt_dir Path to an existing Firefox profile directory to
      *     use a template for this profile. If not specified, a blank profile will
      *     be used.
-     * @constructor
      */
     constructor(opt_dir?: string);
 

--- a/types/selenium-webdriver/v2/http.d.ts
+++ b/types/selenium-webdriver/v2/http.d.ts
@@ -94,7 +94,6 @@ export function sendRequest(options: Object, onOk: any, onError: any, opt_data?:
  * [json]: https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
  * [w3c]: https://w3c.github.io/webdriver/webdriver-spec.html
  *
- * @implements {cmd.Executor}
  */
 export class Executor {
     /**

--- a/types/selenium-webdriver/v2/index.d.ts
+++ b/types/selenium-webdriver/v2/index.d.ts
@@ -242,7 +242,6 @@ export namespace error {
 export namespace logging {
     /**
      * A hash describing log preferences.
-     * @typedef {Object.<logging.Type, logging.LevelName>}
      */
     class Preferences {
         setLevel(type: string, level: Level | string | number): void;
@@ -264,7 +263,6 @@ export namespace logging {
 
     /**
      * Common log types.
-     * @enum {string}
      */
     var Type: IType;
 
@@ -366,20 +364,15 @@ export namespace logging {
          *     milliseconds since 0:00:00, January 1, 1970 UTC. If omitted, the
          *     current time will be used.
          * @param {string=} opt_type The log type, if known.
-         * @constructor
          */
         constructor(level: Level | string | number, message: string, opt_timestamp?: number, opt_type?: string | IType);
 
-        /** @type {!logging.Level} */
         level: Level;
 
-        /** @type {string} */
         message: string;
 
-        /** @type {number} */
         timestamp: number;
 
-        /** @type {string} */
         type: string;
 
         /**
@@ -412,13 +405,9 @@ export namespace logging {
          */
         constructor(name: string, opt_level?: Level);
 
-        /** @private {string} */
         name_: string;
-        /** @private {Level} */
         level_: Level;
-        /** @private {Logger} */
         parent_: Logger;
-        /** @private {Set<function(!Entry)>} */
         handlers_: any;
 
         /** @return {string} the name of this logger. */
@@ -546,7 +535,6 @@ export namespace logging {
          * @param {string} name the logger's name.
          * @param {!Logger} parent the logger's parent.
          * @return {!Logger} the new logger.
-         * @private
          */
         createLogger_(name: string, parent: Logger): Logger;
     }
@@ -1008,7 +996,6 @@ export namespace promise {
      * fulfilled or rejected state, at which point the promise is considered
      * resolved.
      *
-     * @implements {promise.Thenable<T>}
      * @template T
      * @see http://promises-aplus.github.io/promises-spec/
      */
@@ -1167,7 +1154,6 @@ export namespace promise {
      * the Deferred's canceller function (if provided). The canceller may return a
      * truth-y value to override the reason provided for rejection.
      *
-     * @extends {promise.Promise}
      */
     class Deferred<T> extends Promise<T> {
         // region Constructors
@@ -1177,7 +1163,6 @@ export namespace promise {
          * @param {promise.ControlFlow=} opt_flow The control flow
          *     this instance was created under. This should only be provided during
          *     unit tests.
-         * @constructor
          */
         constructor(opt_flow?: ControlFlow);
 
@@ -1195,7 +1180,6 @@ export namespace promise {
         /**
          * The consumer promise for this instance. Provides protected access to the
          * callback registering functions.
-         * @type {!promise.Promise}
          */
         promise: Promise<T>;
 
@@ -1281,18 +1265,15 @@ export namespace promise {
      * UNCAUGHT_EXCEPTION} event. If there are no listeners registered with the
      * flow, the error will be rethrown to the global error handler.
      *
-     * @extends {EventEmitter}
      * @final
      */
     class ControlFlow extends EventEmitter {
         /**
-         * @constructor
          */
         constructor();
 
         /**
          * Events that may be emitted by an {@link promise.ControlFlow}.
-         * @enum {string}
          */
         static EventType: IEventType;
 
@@ -1398,14 +1379,12 @@ export namespace until {
          *     sentence 'Waiting [...]'
          * @param {function(!WebDriver): OUT} fn The condition function to
          *     evaluate on each iteration of the wait loop.
-         * @constructor
          */
         constructor(message: string, fn: (webdriver: WebDriver) => any);
 
         /** @return {string} A description of this condition. */
         description(): string;
 
-        /** @type {function(!WebDriver): OUT} */
         fn(webdriver: WebDriver): any;
     }
 
@@ -1611,7 +1590,6 @@ interface IButton {
  * the Unicode PUA (Private Use Area) code points, 0xE000-0xF8FF.  Refer to
  * http://www.google.com.au/search?&q=unicode+pua&btnG=Search
  *
- * @enum {string}
  */
 export var Button: IButton;
 
@@ -1700,7 +1678,6 @@ interface IKey {
  * the Unicode PUA (Private Use Area) code points, 0xE000-0xF8FF.  Refer to
  * http://www.google.com.au/search?&q=unicode+pua&btnG=Search
  *
- * @enum {string}
  */
 export var Key: IKey;
 
@@ -1724,7 +1701,6 @@ export class ActionSequence {
 
     /**
      * @param {!WebDriver} driver The driver instance to use.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -2090,7 +2066,6 @@ export class Alert {
  *       return alert.dismiss();
  *     });
  *
- * @implements {promise.Thenable.<!Alert>}
  * @final
  */
 export class AlertPromise extends Alert implements promise.IThenable<Alert> {
@@ -2229,7 +2204,6 @@ export class UnhandledAlertError extends error.UnexpectedAlertOpenError {}
 
 /**
  * Recognized browser names.
- * @enum {string}
  */
 interface IBrowser {
     ANDROID: string;
@@ -2300,7 +2274,6 @@ export class Builder {
     // region Constructors
 
     /**
-     * @constructor
      */
     constructor();
 
@@ -2652,16 +2625,6 @@ export class By {
  * Closure compiler), as locator hashes will always be parsed using
  * the un-obfuscated properties listed.
  *
- * @typedef {(
- *     {className: string}|
- *     {css: string}|
- *     {id: string}|
- *     {js: string}|
- *     {linkText: string}|
- *     {name: string}|
- *     {partialLinkText: string}|
- *     {tagName: string}|
- *     {xpath: string})}
  */
 type ByHash =
     | { className: string }
@@ -2676,7 +2639,6 @@ type ByHash =
 
 /**
  * Common webdriver capability keys.
- * @enum {string}
  */
 interface ICapability {
     /**
@@ -2774,7 +2736,6 @@ export class Capabilities {
     /**
      * @param {(Capabilities|Object)=} opt_other Another set of
      *     capabilities to merge into this instance.
-     * @constructor
      */
     constructor(opt_other?: Capabilities | Object);
 
@@ -3057,14 +3018,12 @@ export var CommandName: ICommandName;
 /**
  * Describes a command to be executed by the WebDriverJS framework.
  * @param {!CommandName} name The name of this command.
- * @constructor
  */
 export class Command {
     // region Constructors
 
     /**
      * @param {!CommandName} name The name of this command.
-     * @constructor
      */
     constructor(name: string);
 
@@ -3128,7 +3087,6 @@ export class Executor {
 /**
  * Wraps a promised {@link Executor}, ensuring no commands are executed until
  * the wrapped executor has been fully resolved.
- * @implements {Executor}
  */
 export class DeferredExecutor {
     /**
@@ -3160,7 +3118,6 @@ export class EventEmitter {
     // region Constructors
 
     /**
-     * @constructor
      */
     constructor();
 
@@ -3191,7 +3148,6 @@ export class EventEmitter {
      * @param {boolean=} opt_oneshot Whether the listener should b (e removed after
      *    the first event is fired.
      * @return {!EventEmitter} A self reference.
-     * @private
      */
     addListener(type: string, fn: Function, opt_scope?: any, opt_oneshot?: boolean): EventEmitter;
 
@@ -3304,7 +3260,6 @@ export class Options {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3401,7 +3356,6 @@ export class Timeouts {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3463,7 +3417,6 @@ export class Window {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3525,7 +3478,6 @@ export class Logs {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3567,7 +3519,6 @@ export class TargetLocator {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3654,7 +3605,6 @@ export class TargetLocator {
  * [Selenium Server](http://docs.seleniumhq.org/download/).
  */
 export class FileDetector {
-    /** @constructor */
     constructor();
 
     /**
@@ -4472,7 +4422,6 @@ interface IWebElementFinders {
  * Defines an object that can be asynchronously serialized to its WebDriver
  * wire representation.
  *
- * @constructor
  * @template T
  */
 interface Serializable<T> {
@@ -4509,7 +4458,6 @@ interface Serializable<T> {
  *       alert('The element was not found, as expected');
  *     });
  *
- * @extends {Serializable.<WebElement.Id>}
  */
 export class WebElement implements Serializable<IWebElementId> {
     /**
@@ -4863,9 +4811,6 @@ export class WebElement implements Serializable<IWebElementId> {
  *     element.
  * @param {!promise.Promise.<!WebElement>} el A promise
  *     that will resolve to the promised element.
- * @constructor
- * @extends {WebElement}
- * @implements {promise.Thenable.<!WebElement>}
  * @final
  */
 export class WebElementPromise extends WebElement implements promise.IThenable<WebElement> {
@@ -5022,7 +4967,6 @@ export class Session {
      * @param {string} id The session ID.
      * @param {!(Object|Capabilities)} capabilities The session
      *     capabilities.
-     * @constructor
      */
     constructor(id: string, capabilities: Capabilities | Object);
 

--- a/types/selenium-webdriver/v2/remote.d.ts
+++ b/types/selenium-webdriver/v2/remote.d.ts
@@ -84,7 +84,6 @@ export class DriverService {
  */
 export class FileDetector extends webdriver.FileDetector {
     /**
-     * @constructor
      **/
     constructor();
 

--- a/types/selenium-webdriver/v2/safari.d.ts
+++ b/types/selenium-webdriver/v2/safari.d.ts
@@ -26,7 +26,6 @@ export function cleanSession(desiredCapabilities: webdriver.Capabilities): any[]
 export function getRandomString(): string;
 
 /**
- * @implements {command.Executor}
  */
 export class CommandExecutor {}
 

--- a/types/selenium-webdriver/v3/chrome.d.ts
+++ b/types/selenium-webdriver/v3/chrome.d.ts
@@ -5,7 +5,6 @@ import * as http from './http';
 /**
  * Creates a new WebDriver client for Chrome.
  *
- * @extends {webdriver.WebDriver}
  */
 export class Driver extends webdriver.WebDriver {
     /**
@@ -51,7 +50,6 @@ export interface IPerfLoggingPrefs {
  */
 export class Options {
     /**
-     * @constructor
      */
     constructor();
 
@@ -313,7 +311,6 @@ export class ServiceBuilder extends remote.DriverService.Builder {
      *     PATH.
      * @throws {Error} If provided executable does not exist, or the chromedriver
      *     cannot be found on the PATH.
-     * @constructor
      */
     constructor(opt_exe?: string);
 

--- a/types/selenium-webdriver/v3/firefox.d.ts
+++ b/types/selenium-webdriver/v3/firefox.d.ts
@@ -9,7 +9,6 @@ export class Binary {
     /**
      * @param {string=} opt_exe Path to the Firefox binary to use. If not
      *     specified, will attempt to locate Firefox on the current system.
-     * @constructor
      */
     constructor(opt_exe?: string);
 
@@ -46,7 +45,6 @@ export class Profile {
      * @param {string=} opt_dir Path to an existing Firefox profile directory to
      *     use a template for this profile. If not specified, a blank profile will
      *     be used.
-     * @constructor
      */
     constructor(opt_dir?: string);
 

--- a/types/selenium-webdriver/v3/http.d.ts
+++ b/types/selenium-webdriver/v3/http.d.ts
@@ -103,7 +103,6 @@ export function sendRequest(options: Object, onOk: any, onError: any, opt_data?:
  * [json]: https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
  * [w3c]: https://w3c.github.io/webdriver/webdriver-spec.html
  *
- * @implements {cmd.Executor}
  */
 export class Executor {
     /**

--- a/types/selenium-webdriver/v3/index.d.ts
+++ b/types/selenium-webdriver/v3/index.d.ts
@@ -245,7 +245,6 @@ export namespace error {
 export namespace logging {
     /**
      * A hash describing log preferences.
-     * @typedef {Object.<logging.Type, logging.LevelName>}
      */
     class Preferences {
         setLevel(type: string, level: Level | string | number): void;
@@ -267,7 +266,6 @@ export namespace logging {
 
     /**
      * Common log types.
-     * @enum {string}
      */
     const Type: IType;
 
@@ -369,20 +367,15 @@ export namespace logging {
          *     milliseconds since 0:00:00, January 1, 1970 UTC. If omitted, the
          *     current time will be used.
          * @param {string=} opt_type The log type, if known.
-         * @constructor
          */
         constructor(level: Level | string | number, message: string, opt_timestamp?: number, opt_type?: string | IType);
 
-        /** @type {!logging.Level} */
         level: Level;
 
-        /** @type {string} */
         message: string;
 
-        /** @type {number} */
         timestamp: number;
 
-        /** @type {string} */
         type: string;
 
         /**
@@ -415,13 +408,9 @@ export namespace logging {
          */
         constructor(name: string, opt_level?: Level);
 
-        /** @private {string} */
         name_: string;
-        /** @private {Level} */
         level_: Level;
-        /** @private {Logger} */
         parent_: Logger;
-        /** @private {Set<function(!Entry)>} */
         handlers_: any;
 
         /** @return {string} the name of this logger. */
@@ -549,7 +538,6 @@ export namespace logging {
          * @param {string} name the logger's name.
          * @param {!Logger} parent the logger's parent.
          * @return {!Logger} the new logger.
-         * @private
          */
         createLogger_(name: string, parent: Logger): Logger;
     }
@@ -981,7 +969,6 @@ export namespace promise {
      * fulfilled or rejected state, at which point the promise is considered
      * resolved.
      *
-     * @implements {promise.Thenable<T>}
      * @template T
      * @see http://promises-aplus.github.io/promises-spec/
      */
@@ -1081,7 +1068,6 @@ export namespace promise {
          * @param {promise.ControlFlow=} opt_flow The control flow
          *     this instance was created under. This should only be provided during
          *     unit tests.
-         * @constructor
          */
         constructor(opt_flow?: ControlFlow);
 
@@ -1099,7 +1085,6 @@ export namespace promise {
         /**
          * The consumer promise for this instance. Provides protected access to the
          * callback registering functions.
-         * @type {!promise.Promise}
          */
         promise: Promise<T>;
 
@@ -1185,18 +1170,15 @@ export namespace promise {
      * UNCAUGHT_EXCEPTION} event. If there are no listeners registered with the
      * flow, the error will be rethrown to the global error handler.
      *
-     * @extends {EventEmitter}
      * @final
      */
     class ControlFlow extends EventEmitter {
         /**
-         * @constructor
          */
         constructor();
 
         /**
          * Events that may be emitted by an {@link promise.ControlFlow}.
-         * @enum {string}
          */
         static EventType: IEventType;
 
@@ -1301,21 +1283,18 @@ export class Condition<T> {
      *     sentence 'Waiting [...]'
      * @param {function(!WebDriver): OUT} fn The condition function to
      *     evaluate on each iteration of the wait loop.
-     * @constructor
      */
     constructor(message: string, fn: (webdriver: WebDriver) => any);
 
     /** @return {string} A description of this condition. */
     description(): string;
 
-    /** @type {function(!WebDriver): OUT} */
     fn(webdriver: WebDriver): any;
 }
 
 /**
  * Defines a condition that will result in a {@link WebElement}.
  *
- * @extends {Condition<!(WebElement|IThenable<!WebElement>)>}
  */
 export class WebElementCondition extends Condition<WebElement> {
     // add an unused private member so the compiler treats this
@@ -1554,7 +1533,6 @@ export interface IButton {
  * the Unicode PUA (Private Use Area) code points, 0xE000-0xF8FF.  Refer to
  * http://www.google.com.au/search?&q=unicode+pua&btnG=Search
  *
- * @enum {string}
  */
 export const Button: IButton;
 
@@ -1643,7 +1621,6 @@ export interface IKey {
  * the Unicode PUA (Private Use Area) code points, 0xE000-0xF8FF.  Refer to
  * http://www.google.com.au/search?&q=unicode+pua&btnG=Search
  *
- * @enum {string}
  */
 export const Key: IKey;
 
@@ -1667,7 +1644,6 @@ export class ActionSequence {
 
     /**
      * @param {!WebDriver} driver The driver instance to use.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -2033,7 +2009,6 @@ export class Alert {
  *       return alert.dismiss();
  *     });
  *
- * @implements {promise.Thenable.<!Alert>}
  * @final
  */
 export interface AlertPromise extends promise.IThenable<Alert> {}
@@ -2049,7 +2024,6 @@ export class AlertPromise extends Alert {
 
 /**
  * Recognized browser names.
- * @enum {string}
  */
 export interface IBrowser {
     ANDROID: string;
@@ -2123,7 +2097,6 @@ export class Builder {
     // region Constructors
 
     /**
-     * @constructor
      */
     constructor();
 
@@ -2513,16 +2486,6 @@ export class By {
  * Closure compiler), as locator hashes will always be parsed using
  * the un-obfuscated properties listed.
  *
- * @typedef {(
- *     {className: string}|
- *     {css: string}|
- *     {id: string}|
- *     {js: string}|
- *     {linkText: string}|
- *     {name: string}|
- *     {partialLinkText: string}|
- *     {tagName: string}|
- *     {xpath: string})}
  */
 export type ByHash =
     | { className: string }
@@ -2539,7 +2502,6 @@ export type Locator = By | Function | ByHash;
 
 /**
  * Common webdriver capability keys.
- * @enum {string}
  */
 export interface ICapability {
     /**
@@ -2637,7 +2599,6 @@ export class Capabilities {
     /**
      * @param {(Capabilities|Object)=} opt_other Another set of
      *     capabilities to merge into this instance.
-     * @constructor
      */
     constructor(opt_other?: Capabilities | Object);
 
@@ -2920,14 +2881,12 @@ export const CommandName: ICommandName;
 /**
  * Describes a command to be executed by the WebDriverJS framework.
  * @param {!CommandName} name The name of this command.
- * @constructor
  */
 export class Command {
     // region Constructors
 
     /**
      * @param {!CommandName} name The name of this command.
-     * @constructor
      */
     constructor(name: string);
 
@@ -3010,7 +2969,6 @@ export class EventEmitter {
     // region Constructors
 
     /**
-     * @constructor
      */
     constructor();
 
@@ -3041,7 +2999,6 @@ export class EventEmitter {
      * @param {boolean=} opt_oneshot Whether the listener should b (e removed after
      *    the first event is fired.
      * @return {!EventEmitter} A self reference.
-     * @private
      */
     addListener(type: string, fn: Function, opt_scope?: any, opt_oneshot?: boolean): EventEmitter;
 
@@ -3181,7 +3138,6 @@ export interface IWebDriverOptionsCookie {
      * The expiry is always returned in seconds since epoch when
      * {@linkplain Options#getCookies() retrieving cookies} from the browser.
      *
-     * @type {(!Date|number|undefined)}
      */
     expiry?: number | Date | undefined;
 }
@@ -3193,7 +3149,6 @@ export interface IWebDriverCookie extends IWebDriverOptionsCookie {
      * The expiry is always returned in seconds since epoch when
      * {@linkplain Options#getCookies() retrieving cookies} from the browser.
      *
-     * @type {(!number|undefined)}
      */
     expiry?: number | undefined;
 }
@@ -3206,7 +3161,6 @@ export class Options {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3292,7 +3246,6 @@ export class Timeouts {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3354,7 +3307,6 @@ export class Window {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3416,7 +3368,6 @@ export class Logs {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3458,7 +3409,6 @@ export class TargetLocator {
 
     /**
      * @param {!WebDriver} driver The parent driver.
-     * @constructor
      */
     constructor(driver: WebDriver);
 
@@ -3545,7 +3495,6 @@ export class TargetLocator {
  * [Selenium Server](http://docs.seleniumhq.org/download/).
  */
 export class FileDetector {
-    /** @constructor */
     constructor();
 
     /**
@@ -4154,8 +4103,6 @@ export class WebDriver {
  * If the driver instance fails to resolve (e.g. the session cannot be created),
  * every issued command will fail.
  *
- * @extends {webdriver.IWebDriver}
- * @extends {promise.IThenable<!webdriver.IWebDriver>}
  * @interface
  */
 export interface ThenableWebDriver extends WebDriver, promise.IThenable<WebDriver> {}
@@ -4441,7 +4388,6 @@ export interface IWebElementFinders {
  * Defines an object that can be asynchronously serialized to its WebDriver
  * wire representation.
  *
- * @constructor
  * @template T
  */
 export interface Serializable<T> {
@@ -4478,7 +4424,6 @@ export interface Serializable<T> {
  *       alert('The element was not found, as expected');
  *     });
  *
- * @extends {Serializable.<WebElement.Id>}
  */
 export class WebElement implements Serializable<IWebElementId> {
     /**
@@ -4797,9 +4742,6 @@ export class WebElement implements Serializable<IWebElementId> {
  *     element.
  * @param {!promise.Promise.<!WebElement>} el A promise
  *     that will resolve to the promised element.
- * @constructor
- * @extends {WebElement}
- * @implements {promise.Thenable.<!WebElement>}
  * @final
  */
 export interface WebElementPromise extends promise.IThenable<WebElement> {}
@@ -4823,7 +4765,6 @@ export class Session {
      * @param {string} id The session ID.
      * @param {!(Object|Capabilities)} capabilities The session
      *     capabilities.
-     * @constructor
      */
     constructor(id: string, capabilities: Capabilities | Object);
 

--- a/types/selenium-webdriver/v3/remote.d.ts
+++ b/types/selenium-webdriver/v3/remote.d.ts
@@ -84,7 +84,6 @@ export namespace DriverService {
          *
          * @param {...CommandLineFlag} var_args The arguments to include.
          * @return {!THIS} A self reference.
-         * @this {THIS}
          * @template THIS
          */
         addArguments(...var_args: string[]): this;
@@ -221,7 +220,6 @@ export namespace SeleniumServer {
  */
 export class FileDetector extends webdriver.FileDetector {
     /**
-     * @constructor
      **/
     constructor();
 

--- a/types/selenium-webdriver/v3/safari.d.ts
+++ b/types/selenium-webdriver/v3/safari.d.ts
@@ -26,7 +26,6 @@ export function cleanSession(desiredCapabilities: webdriver.Capabilities): any[]
 export function getRandomString(): string;
 
 /**
- * @implements {command.Executor}
  */
 export class CommandExecutor {}
 

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5974,8 +5974,6 @@ declare namespace sequelize {
         /**
          * Instantiate sequelize with an URI
          * @name Sequelize
-         * @constructor
-         *
          * @param uri A full database URI
          * @param options See above for possible options
          */
@@ -5984,8 +5982,6 @@ declare namespace sequelize {
         /**
          * Instantiate sequelize with an options object which containing username, password, database
          * @name Sequelize
-         * @constructor
-         *
          * @param options An object with options. See above for possible options
          */
         new (options: Options): Sequelize;

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -5446,8 +5446,6 @@ declare namespace sequelize {
         /**
          * Instantiate sequelize with an URI
          * @name Sequelize
-         * @constructor
-         *
          * @param uri A full database URI
          * @param options See above for possible options
          */
@@ -5456,8 +5454,6 @@ declare namespace sequelize {
         /**
          * Instantiate sequelize with an options object which containing username, password, database
          * @name Sequelize
-         * @constructor
-         *
          * @param options An object with options. See above for possible options
          */
         new (options: Options): Sequelize;

--- a/types/showdown/index.d.ts
+++ b/types/showdown/index.d.ts
@@ -1041,7 +1041,6 @@ declare namespace Showdown {
 
     interface ConverterStatic {
         /**
-         * @constructor
          * @param converterOptions - Configuration object, describes which extensions to apply.
          */
         new(converterOptions?: ConverterOptions): Converter;

--- a/types/simplesmtp/index.d.ts
+++ b/types/simplesmtp/index.d.ts
@@ -69,7 +69,6 @@ export interface SmtpServerOptions {
 /**
  * <p>Constructs a SMTP server</p>
  *
- * @constructor
  * @namespace SMTP Server module
  * @param {Object} [options] Options object
  */

--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -43,8 +43,6 @@ declare namespace Slick {
     /**
     * An event object for passing data to event handlers and letting them control propagation.
     * <p>This is pretty much identical to how W3C and jQuery implement events.</p>
-    * @class EventData
-    * @constructor
     **/
     export class EventData {
 
@@ -141,7 +139,6 @@ declare namespace Slick {
 
         /**
         * A structure containing a range of cells.
-        * @constructor
         * @param fromRow {Integer} Starting row.
         * @param fromCell {Integer} Starting cell.
         * @param toRow {Integer} Optional. Ending row. Defaults to <code>fromRow</code>.
@@ -226,8 +223,6 @@ declare namespace Slick {
 
         /**
         * Grouping level, starting with 0.
-        * @property level
-        * @type {Number}
         */
         public level: number;
 
@@ -268,23 +263,17 @@ declare namespace Slick {
 
         /**
         * Rows that are part of the group.
-        * @property rows
-        * @type {Array}
         */
         public rows: T[];
 
         /**
         * Sub-groups that are part of the group.
-        * @property groups
-        * @type {Array}
         */
         public groups: Group<T>[];
 
         /**
         * A unique key used to identify the group.  This key can be used in calls to DataView
         * collapseGroup() or expandGroup().
-        * @property groupingKey
-        * @type {Object}
         */
         public groupingKey: any;
 
@@ -379,9 +368,7 @@ declare namespace Slick {
 
     /**
     * A global singleton editor lock.
-    * @class GlobalEditorLock
     * @static
-    * @constructor
     **/
     export var GlobalEditorLock: EditorLock<Slick.SlickData>;
 

--- a/types/smart-fox-server/index.d.ts
+++ b/types/smart-fox-server/index.d.ts
@@ -22,11 +22,11 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Data.Vec3D.html
             export class Vec3D {
 
-                /** @type {number} Returns the position along the X axis. */
+                /** Returns the position along the X axis. */
                 px: number;
-                /** @type {number} Returns the position along the Y axis. */
+                /** Returns the position along the Y axis. */
                 py: number;
-                /** @type {number} Returns the position along the Z axis. */
+                /** Returns the position along the Z axis. */
                 pz: number;
 
                 /**
@@ -56,9 +56,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Invitation.InvitationReply.html
             export class InvitationReply {
 
-                /** @type {number} Invitation is accepted. */
+                /** Invitation is accepted. */
                 static ACCEPT: number;
-                /** @type {number} Invitation is refused. */
+                /** Invitation is refused. */
                 static REFUSE: number;
 
             }
@@ -70,15 +70,15 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Invitation.SFSInvitation.html
             export class SFSInvitation {
 
-                /** @type {number} Indicates the id of the invitation. */
+                /** Indicates the id of the invitation. */
                 id: number;
-                /** @type {SFSUser} Returns the SFSUser object corresponding to the user who received the invitation. */
+                /** Returns the SFSUser object corresponding to the user who received the invitation. */
                 invitee: SFSUser;
-                /** @type {SFSUser} Returns the SFSUser object corresponding to the user who sent the invitation. */
+                /** Returns the SFSUser object corresponding to the user who sent the invitation. */
                 inviter: SFSUser;
-                /** @type {Object} Returns an object containing a custom set of parameters. */
+                /** Returns an object containing a custom set of parameters. */
                 params: Object;
-                /** @type {number} Returns the number of seconds available to the invitee to reply to the invitation, after which the invitation expires. */
+                /** Returns the number of seconds available to the invitee to reply to the invitation, after which the invitation expires. */
                 secondsForAnswer: number;
 
                 /**
@@ -105,9 +105,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.BoolMatch.html
             export class BoolMatch {
 
-                /** @type {BoolMatch} An instance of BoolMatch representing the following condition: bool1 == bool2. */
+                /** An instance of BoolMatch representing the following condition: bool1 == bool2. */
                 static EQUALS: BoolMatch;
-                /** @type {BoolMatch} An instance of BoolMatch representing the following condition: bool1 != bool2. */
+                /** An instance of BoolMatch representing the following condition: bool1 != bool2. */
                 static NOT_EQUALS: BoolMatch;
 
             }
@@ -118,9 +118,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.LogicOperator.html
             export class LogicOperator {
 
-                /** @type {LogicOperator} An instance of LogicOperator representing the AND logical operator. */
+                /** An instance of LogicOperator representing the AND logical operator. */
                 static AND: LogicOperator;
-                /** @type {LogicOperator} An instance of LogicOperator representing the OR logical operator. */
+                /** An instance of LogicOperator representing the OR logical operator. */
                 static OR: LogicOperator;
 
             }
@@ -131,15 +131,15 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.MatchExpression.html
             export class MatchExpression {
 
-                /** @type {(RoomProperties | UserProperties | BoolMatch | NumberMatch | StringMatch | Requests.Game.CreateSFSGameRequest | Requests.System.FindRoomsRequest | Requests.System.FindUsersRequest)} Returns the matching criteria used during values comparison among those provided by the BoolMatch, NumberMatch and StringMatch classes. */
+                /** Returns the matching criteria used during values comparison among those provided by the BoolMatch, NumberMatch and StringMatch classes. */
                 condition: RoomProperties | UserProperties | BoolMatch | NumberMatch | StringMatch | Requests.Game.CreateSFSGameRequest | Requests.System.FindRoomsRequest | Requests.System.FindUsersRequest;
-                /** @type {LogicOperator} In case of concatenated expressions, returns the current logical operator. */
+                /** In case of concatenated expressions, returns the current logical operator. */
                 loginOp: LogicOperator;
-                /** @type {MatchExpression} Returns the next matching expression concatenated to the current one, if existing. */
+                /** Returns the next matching expression concatenated to the current one, if existing. */
                 next: MatchExpression;
-                /** @type {any} Returns the value against which the variable or property corresponding to varName is compared. */
+                /** Returns the value against which the variable or property corresponding to varName is compared. */
                 value: any;
-                /** @type {string} Returns the name of the variable or property against which the comparison is made. */
+                /** Returns the name of the variable or property against which the comparison is made. */
                 varName: string;
 
                 /**
@@ -189,17 +189,17 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.NumberMatch.html
             export class NumberMatch {
 
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 == number2. */
+                /** An instance of NumberMatch representing the following condition: number1 == number2. */
                 static EQUALS: NumberMatch;
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 > number2. */
+                /** An instance of NumberMatch representing the following condition: number1 > number2. */
                 static GREATER_THAN: NumberMatch;
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 >= number2. */
+                /** An instance of NumberMatch representing the following condition: number1 >= number2. */
                 static GREATER_THAN_OR_EQUAL_TO: NumberMatch;
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 < number2. */
+                /** An instance of NumberMatch representing the following condition: number1 < number2. */
                 static LESS_THAN: NumberMatch;
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 <= number2. */
+                /** An instance of NumberMatch representing the following condition: number1 <= number2. */
                 static LESS_THAN_OR_EQUAL_TO: NumberMatch;
-                /** @type {NumberMatch} An instance of NumberMatch representing the following condition: number1 != number2. */
+                /** An instance of NumberMatch representing the following condition: number1 != number2. */
                 static NOT_EQUALS: NumberMatch;
 
             }
@@ -210,25 +210,25 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.RoomProperties.html
             export class RoomProperties {
 
-                /** @type {string} The name of the Group to which the Room belongs. */
+                /** The name of the Group to which the Room belongs. */
                 static GROUP_ID: string;
-                /** @type {string} The Room has at least one free player slot. */
+                /** The Room has at least one free player slot. */
                 static HAS_FREE_PLAYER_SLOTS: string;
-                /** @type {string} The Room is a Game Room. */
+                /** The Room is a Game Room. */
                 static IS_GAME: string;
-                /** @type {string} The Room is private. */
+                /** The Room is private. */
                 static IS_PRIVATE: string;
-                /** @type {string} The Room is an SFSGame on the server-side. */
+                /** The Room is an SFSGame on the server-side. */
                 static IS_TYPE_SFSGAME: string;
-                /** @type {string} The maximum number of spectators allowed in the Room (Game Rooms only). */
+                /** The maximum number of spectators allowed in the Room (Game Rooms only). */
                 static MAX_SPECTATORS: string;
-                /** @type {string} The maximum number of users allowed in the Room (players in Game Rooms). */
+                /** The maximum number of users allowed in the Room (players in Game Rooms). */
                 static MAX_USERS: string;
-                /** @type {string} The Room name. */
+                /** The Room name. */
                 static NAME: string;
-                /** @type {string} The Room spectators count (Game Rooms only). */
+                /** The Room spectators count (Game Rooms only). */
                 static SPECTATOR_COUNT: string;
-                /** @type {string} The Room users count (players in Game Rooms). */
+                /** The Room users count (players in Game Rooms). */
                 static USER_COUNT: string;
 
             }
@@ -239,15 +239,15 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.StringMatch.html
             export class StringMatch {
 
-                /** @type {StringMatch} An instance of StringMatch representing the following condition: string1.indexOf(string2) != -1 */
+                /** An instance of StringMatch representing the following condition: string1.indexOf(string2) != -1 */
                 static CONTAINS: StringMatch;
-                /** @type {StringMatch} An instance of StringMatch representing the following condition: string1 ends with characters contained in string2. */
+                /** An instance of StringMatch representing the following condition: string1 ends with characters contained in string2. */
                 static ENDS_WITH: StringMatch;
-                /** @type {StringMatch} An instance of StringMatch representing the following condition: string1 == string2. */
+                /** An instance of StringMatch representing the following condition: string1 == string2. */
                 static EQUALS: StringMatch;
-                /** @type {StringMatch} An instance of StringMatch representing the following condition: string1 != string2. */
+                /** An instance of StringMatch representing the following condition: string1 != string2. */
                 static NOT_EQUALS: StringMatch;
-                /** @type {StringMatch} An instance of StringMatch representing the following condition: string1 starts with characters contained in string2. */
+                /** An instance of StringMatch representing the following condition: string1 starts with characters contained in string2. */
                 static STARTS_WITH: StringMatch;
 
             }
@@ -258,17 +258,17 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Match.UserProperties.html
             export class UserProperties {
 
-                /** @type {string} The user joined at least one Room. */
+                /** The user joined at least one Room. */
                 static IS_IN_ANY_ROOM: string;
-                /** @type {string} The user is a Non-Player Character (NPC). */
+                /** The user is a Non-Player Character (NPC). */
                 static IS_NPC: string;
-                /** @type {string} The user is a player in a Game Room. */
+                /** The user is a player in a Game Room. */
                 static IS_PLAYER: string;
-                /** @type {string} The user is a spectator in a Game Room. */
+                /** The user is a spectator in a Game Room. */
                 static IS_SPECTATOR: string;
-                /** @type {string} The user name. */
+                /** The user name. */
                 static NAME: string;
-                /** @type {string} The user privilege id. */
+                /** The user privilege id. */
                 static PRIVILEGE_ID: string;
 
             }
@@ -282,9 +282,9 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.MMOItem.html
         export class MMOItem {
 
-            /** @type {Data.Vec3D} Returns the entry point of this item in the current user's AoI. */
+            /** Returns the entry point of this item in the current user's AoI. */
             aoiEnteryPoint: Data.Vec3D;
-            /** @type {number} Indicates the id of this item. */
+            /** Indicates the id of this item. */
             id: number;
 
             /**
@@ -323,11 +323,11 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.MMORoom.html
         export class MMORoom extends SFSRoom {
 
-            /** @type {Data.Vec3D} Returns the default Area of Interest (AoI) of this MMORoom. */
+            /** Returns the default Area of Interest (AoI) of this MMORoom. */
             defaultAOI: Data.Vec3D;
-            /** @type {Requests.MMO.MapLimits} Returns the higher coordinates limit of the virtual environment represented by the MMORoom along the X,Y,Z axes. If null is returned, no limits were set at Room creation time. */
+            /** Returns the higher coordinates limit of the virtual environment represented by the MMORoom along the X,Y,Z axes. If null is returned, no limits were set at Room creation time. */
             higherMapLimit: Requests.MMO.MapLimits;
-            /** @type {Requests.MMO.MapLimits} Returns the lower coordinates limit of the virtual environment represented by the MMORoom along the X,Y,Z axes. If null is returned, no limits were set at Room creation time. */
+            /** Returns the lower coordinates limit of the virtual environment represented by the MMORoom along the X,Y,Z axes. If null is returned, no limits were set at Room creation time. */
             lowerMapLimit: Requests.MMO.MapLimits;
 
             /**
@@ -357,9 +357,9 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.SFSBuddy.html
         export class SFSBuddy {
 
-            /** @type {number} Indicates the id of this buddy. */
+            /** Indicates the id of this buddy. */
             id: number;
-            /** @type {string} Indicates the name of this buddy. */
+            /** Indicates the name of this buddy. */
             name: string;
 
             /**
@@ -436,25 +436,25 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.SFSRoom.html
         export class SFSRoom {
 
-            /** @type {string} Returns the Room Group name. */
+            /** Returns the Room Group name. */
             groupId: string;
-            /** @type {number} Indicates the id of this Room. */
+            /** Indicates the id of this Room. */
             id: number;
-            /** @type {boolean} Indicates whether this is a Game Room or not. */
+            /** Indicates whether this is a Game Room or not. */
             isGame: boolean;
-            /** @type {boolean} Indicates whether this Room is hidden or not. */
+            /** Indicates whether this Room is hidden or not. */
             isHidden: boolean;
-            /** @type {boolean} Indicates whether the client joined this Room or not. */
+            /** Indicates whether the client joined this Room or not. */
             isJoined: boolean;
-            /** @type {boolean} Indicates whether this Room requires a password to be joined or not. */
+            /** Indicates whether this Room requires a password to be joined or not. */
             isPasswordProtected: boolean;
-            /** @type {number} Returns the maximum number of spectators allowed in this Room (Game Rooms only). */
+            /** Returns the maximum number of spectators allowed in this Room (Game Rooms only). */
             maxSpectators: number;
-            /** @type {number} Returns the maximum number of users allowed in this Room. */
+            /** Returns the maximum number of users allowed in this Room. */
             maxUsers: number;
-            /** @type {string} Indicates the name of this Room. */
+            /** Indicates the name of this Room. */
             name: string;
-            /** @type {Object} Defines a generic utility object that can be used to store custom Room data. */
+            /** Defines a generic utility object that can be used to store custom Room data. */
             properties: Object;
 
             /**
@@ -548,17 +548,17 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.SFSUser.html
         export class SFSUser {
 
-            /** @type {Data.Vec3D} Returns the entry point of this user in the current user's AoI. */
+            /** Returns the entry point of this user in the current user's AoI. */
             aoiEntryPoint: Data.Vec3D;
-            /** @type {number} Indicates the id of this user. It is unique and it is generated by the server when the user is created. */
+            /** Indicates the id of this user. It is unique and it is generated by the server when the user is created. */
             id: number;
-            /** @type {boolean} Indicates if this SFSUser object represents the current client. */
+            /** Indicates if this SFSUser object represents the current client. */
             isItMe: boolean;
-            /** @type {string} Indicates the name of this user. Two users in the same Zone can't have the same name. */
+            /** Indicates the name of this user. Two users in the same Zone can't have the same name. */
             name: string;
-            /** @type {number} Returns the id which identifies the privilege level of this user. */
+            /** Returns the id which identifies the privilege level of this user. */
             privilegeId: number;
-            /** @type {Object} Defines a generic utility object that can be used to store custom user data. The values added to this object are for client-side use only and are never transmitted to the server or to the other clients. */
+            /** Defines a generic utility object that can be used to store custom user data. The values added to this object are for client-side use only and are never transmitted to the server or to the other clients. */
             properties: Object;
 
             /**
@@ -658,13 +658,13 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.UserPrivileges.html
         export class UserPrivileges {
 
-            /** @type {number} The administrator user can send dedicated "administrator messages", kick and ban users. */
+            /** The administrator user can send dedicated "administrator messages", kick and ban users. */
             static ADMINISTRATOR: number;
-            /** @type {number} The Guest user is usually the lowest level in the privilege profiles scale. */
+            /** The Guest user is usually the lowest level in the privilege profiles scale. */
             static GUEST: number;
-            /** @type {number} The moderator user can send dedicated "moderator messages", kick and ban users. */
+            /** The moderator user can send dedicated "moderator messages", kick and ban users. */
             static MODERATOR: number;
-            /** @type {number} The standard user is usually registered in the application custom login system; uses a unique name and password to login. */
+            /** The standard user is usually registered in the application custom login system; uses a unique name and password to login. */
             static STANDARD: number;
 
         }
@@ -700,11 +700,11 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.ReservedBuddyVariables.html
             export class ReservedBuddyVariables {
 
-                /** @type {string} The Buddy Variable with this name stores the optional nickname of the user in a buddy list. This variable is persistent, which means that the nickname is preserved upon disconnection. */
+                /** The Buddy Variable with this name stores the optional nickname of the user in a buddy list. This variable is persistent, which means that the nickname is preserved upon disconnection. */
                 static BV_NICKNAME: string;
-                /** @type {string} The Buddy Variable with this name keeps track of the online/offline state of the user in a buddy list. This variable is persistent, which means that the online/offline state is preserved upon disconnection. */
+                /** The Buddy Variable with this name keeps track of the online/offline state of the user in a buddy list. This variable is persistent, which means that the online/offline state is preserved upon disconnection. */
                 static BV_ONLINE: string;
-                /** @type {string} The Buddy Variable with this name stores the custom state of the user in a buddy list. This variable is persistent, which means that the custom state is preserved upon disconnection. */
+                /** The Buddy Variable with this name stores the custom state of the user in a buddy list. This variable is persistent, which means that the custom state is preserved upon disconnection. */
                 static BV_STATE: string;
 
             }
@@ -714,7 +714,7 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.ReservedRoomVariables.html
             export class ReservedRoomVariables {
 
-                /** @type {string} The Room Variable with this name keeps track of the state (started or stopped) of a game created with the CreateSFSGameRequest request. */
+                /** The Room Variable with this name keeps track of the state (started or stopped) of a game created with the CreateSFSGameRequest request. */
                 static RV_GAME_STARTED: string;
 
             }
@@ -724,7 +724,7 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.SFSBuddyVariable.html
             export class SFSBuddyVariable extends SFSUserVariable {
 
-                /** @type {string} The prefix to be added to a Buddy Variable name to make it persistent. */
+                /** The prefix to be added to a Buddy Variable name to make it persistent. */
                 static OFFLINE_PREFIX: string;
 
                 /**
@@ -752,9 +752,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.SFSRoomVariable.html
             export class SFSRoomVariable extends SFSUserVariable {
 
-                /** @type {boolean} Indicates whether this Room Variable is persistent or not. */
+                /** Indicates whether this Room Variable is persistent or not. */
                 isPersistent: boolean;
-                /** @type {boolean} Indicates whether this Room Variable is private or not. */
+                /** Indicates whether this Room Variable is private or not. */
                 isPrivate: boolean;
 
                 /**
@@ -777,9 +777,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.SFSUserVariable.html
             export class SFSUserVariable {
 
-                /** @type {string} Indicates the name of this variable. */
+                /** Indicates the name of this variable. */
                 name: string;
-                /** @type {number} Returns the value of this variable. */
+                /** Returns the value of this variable. */
                 value: number;
 
                 /**
@@ -812,19 +812,19 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Entities.Variables.VariableType.html
             export class VariableType {
 
-                /** @type {number} The type of the User/Room Variable is array. */
+                /** The type of the User/Room Variable is array. */
                 static ARRAY: number;
-                /** @type {number} The type of the User/Room Variable is boolean. */
+                /** The type of the User/Room Variable is boolean. */
                 static BOOL: number;
-                /** @type {number} The type of the User/Room Variable is number (specifically a double). */
+                /** The type of the User/Room Variable is number (specifically a double). */
                 static DOUBLE: number;
-                /** @type {number} The type of the User/Room Variable is number (specifically an integer). */
+                /** The type of the User/Room Variable is number (specifically an integer). */
                 static INT: number;
-                /** @type {number} The User/Room Variable is null. */
+                /** The User/Room Variable is null. */
                 static NULL: number;
-                /** @type {number} The type of the User/Room Variable is object. */
+                /** The type of the User/Room Variable is object. */
                 static OBJECT: number;
-                /** @type {number} The type of the User/Room Variable is string. */
+                /** The type of the User/Room Variable is string. */
                 static STRING: number;
 
             }
@@ -867,13 +867,13 @@ declare namespace SFS2X {
     // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.LogLevel.html
     export class LogLevel {
 
-        /** @type {number} A DEBUG message is a fine-grained information on the client activity. */
+        /** A DEBUG message is a fine-grained information on the client activity. */
         static DEBUG: number;
-        /** @type {number} An ERROR message contains informations on a problem that occurred during the client activities. Client operations might be compromised when an error is raised. */
+        /** An ERROR message contains informations on a problem that occurred during the client activities. Client operations might be compromised when an error is raised. */
         static ERROR: number;
-        /** @type {number} An INFO message contains informations on the standard client activities. */
+        /** An INFO message contains informations on the standard client activities. */
         static INFO: number;
-        /** @type {number} A WARN message is a warning caused by an unexpected behavior of the client. Client operations are not compromised when a warning is raised. */
+        /** A WARN message is a warning caused by an unexpected behavior of the client. Client operations are not compromised when a warning is raised. */
         static WARN: number;
 
     }
@@ -1113,9 +1113,9 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.BanMode.html
         export class BanMode {
 
-            /** @type {number} User is banned by IP address. */
+            /** User is banned by IP address. */
             static BY_ADDRESS: number;
-            /** @type {number} User is banned by name. */
+            /** User is banned by name. */
             static BY_NAME: number;
 
         }
@@ -1295,25 +1295,25 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.Game.SFSGameSettings.html
             export class SFSGameSettings extends RoomSettings {
 
-                /** @type {number} In private games, defines the number of seconds that users have to reply to the invitation to join a game. The suggested range is 10 to 40 seconds. */
+                /** In private games, defines the number of seconds that users have to reply to the invitation to join a game. The suggested range is 10 to 40 seconds. */
                 invitationExpiryTime: number;
-                /** @type {Object} In private games, defines a list of SFSUser objects representing players to be invited to join the game. */
+                /** In private games, defines a list of SFSUser objects representing players to be invited to join the game. */
                 invitiationParams: Object;
-                /** @type {Entities.SFSUser[]} In private games, defines a list of SFSUser objects representing players to be invited to join the game.. */
+                /** In private games, defines a list of SFSUser objects representing players to be invited to join the game.. */
                 invitiedPlayers: Entities.SFSUser[];
-                /** @type {boolean} Indicates whether the game is public or private. */
+                /** Indicates whether the game is public or private. */
                 isPublic: boolean;
-                /** @type {boolean} In private games, indicates whether the players must leave the previous Room when joining the game or not. */
+                /** In private games, indicates whether the players must leave the previous Room when joining the game or not. */
                 leaveLastJoinedRoom: boolean;
-                /** @type {number} Defines the minimum number of players required to start the game. If the notifyGameStarted property is set to true, when this number is reached, the game start is notified. */
+                /** Defines the minimum number of players required to start the game. If the notifyGameStarted property is set to true, when this number is reached, the game start is notified. */
                 minPlayersToStartGame: number;
-                /** @type {boolean} Indicates if a game state change must be notified when the minimum number of players is reached. */
+                /** Indicates if a game state change must be notified when the minimum number of players is reached. */
                 notifyGameStarted: boolean;
-                /** @type {Entities.Match.MatchExpression} Defines the game matching expression to be used to filters players. */
+                /** Defines the game matching expression to be used to filters players. */
                 playerMatchExpression: Entities.Match.MatchExpression;
-                /** @type {string[]} In private games, defines a list of Groups names where to search players to invite. */
+                /** In private games, defines a list of Groups names where to search players to invite. */
                 serachableRooms: string[]; // Might need any
-                /** @type {Entities.Match.MatchExpression} Defines the game matching expression to be used to filters spectators. */
+                /** Defines the game matching expression to be used to filters spectators. */
                 spectatorMatchExpression: Entities.Match.MatchExpression;
 
                 /**
@@ -1332,17 +1332,17 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.MessageRecipientMode.html
         export class MessageRecipientMode {
 
-            /** @type {number} Returns the selected recipient mode. */
+            /** Returns the selected recipient mode. */
             mode: number;
-            /** @type {any} Returns the moderator/administrator message target, according to the selected recipient mode. */
+            /** Returns the moderator/administrator message target, according to the selected recipient mode. */
             target: any;
-            /** @type {number} The moderator/administrator message will be sent to all the clients who subscribed a specific Room Group. */
+            /** The moderator/administrator message will be sent to all the clients who subscribed a specific Room Group. */
             static TO_GROUP: number;
-            /** @type {number} The moderator/administrator message will be sent to all the users in a specific Room. */
+            /** The moderator/administrator message will be sent to all the users in a specific Room. */
             static TO_ROOM: number;
-            /** @type {number} The moderator/administrator message will be sent to a specific user. */
+            /** The moderator/administrator message will be sent to a specific user. */
             static TO_USER: number;
-            /** @type {number} The moderator/administrator message will be sent to all the users in the Zone. */
+            /** The moderator/administrator message will be sent to all the users in the Zone. */
             static TO_ZONE: number;
 
             /**
@@ -1364,9 +1364,9 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.MMO.MapLimits.html
             export class MapLimits {
 
-                /** @type {Entities.Data.Vec3D} Returns the higher coordinates limit of the virtual environment along the X,Y,Z axes. */
+                /** Returns the higher coordinates limit of the virtual environment along the X,Y,Z axes. */
                 higherLimit: Entities.Data.Vec3D;
-                /** @type {Entities.Data.Vec3D} Returns the lower coordinates limit of the virtual environment along the X,Y,Z axes. */
+                /** Returns the lower coordinates limit of the virtual environment along the X,Y,Z axes. */
                 lowerLimit: Entities.Data.Vec3D;
 
                 /**
@@ -1383,15 +1383,15 @@ declare namespace SFS2X {
             // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.MMO.MMORoomSettings.html
             export class MMORoomSettings {
 
-                /** @type {Entities.Data.Vec3D} Defines the Area of Interest (AoI) for the MMORoom. */
+                /** Defines the Area of Interest (AoI) for the MMORoom. */
                 defaultAOI: Entities.Data.Vec3D;
-                /** @type {MapLimits} Defines the limits of the virtual environment represented by the MMORoom. */
+                /** Defines the limits of the virtual environment represented by the MMORoom. */
                 mapLimits: MapLimits;
-                /** @type {number} Configures the speed at which the SFSEvent.PROXIMITY_LIST_UPDATE event is sent by the server. */
+                /** Configures the speed at which the SFSEvent.PROXIMITY_LIST_UPDATE event is sent by the server. */
                 proximityListUpdateMillis: number;
-                /** @type {boolean} Sets if the users entry points in the current user's Area of Interest should be transmitted in the SFSEvent.PROXIMITY_LIST_UPDATE event. */
+                /** Sets if the users entry points in the current user's Area of Interest should be transmitted in the SFSEvent.PROXIMITY_LIST_UPDATE event. */
                 sendAOIEntryPoint: boolean;
-                /** @type {number} Defines the time limit before a user without a physical position set inside the MMORoom is kicked from the Room. */
+                /** Defines the time limit before a user without a physical position set inside the MMORoom is kicked from the Room. */
                 userMaxLimboSeconds: number;
 
                 /**
@@ -1424,13 +1424,13 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.RoomEvents.html
         export class RoomEvents {
 
-            /** @type {boolean} Sets whether or not the userCountChange event should be dispatched whenever the users (or players+spectators) count changes in the Room. */
+            /** Sets whether or not the userCountChange event should be dispatched whenever the users (or players+spectators) count changes in the Room. */
             allowUserCountChance: boolean;
-            /** @type {boolean} Sets whether the userEnterRoom event should be dispatched whenever a user joins the Room or not. */
+            /** Sets whether the userEnterRoom event should be dispatched whenever a user joins the Room or not. */
             allowUserEnter: boolean;
-            /** @type {boolean} Sets whether the userExitRoom event should be dispatched whenever a user leaves the Room or not. */
+            /** Sets whether the userExitRoom event should be dispatched whenever a user leaves the Room or not. */
             allowUserExit: boolean;
-            /** @type {boolean} Sets whether or not the userVariablesUpdate event should be dispatched whenever a user in the Room updates their User Variables */
+            /** Sets whether or not the userVariablesUpdate event should be dispatched whenever a user in the Room updates their User Variables */
             allowUserVariablesUpdate: boolean;
 
             /**
@@ -1445,11 +1445,11 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.RoomExtension.html
         export class RoomExtension {
 
-            /** @type {string} Returns the fully qualified name of the main class of the Extension. */
+            /** Returns the fully qualified name of the main class of the Extension. */
             className: string;
-            /** @type {string} Returns the name of the Extension to be attached to the Room. */
+            /** Returns the name of the Extension to be attached to the Room. */
             id: string;
-            /** @type {string} Sets the name of an optional properties file that should be loaded on the server-side during the Extension initialization. */
+            /** Sets the name of an optional properties file that should be loaded on the server-side during the Extension initialization. */
             propertiesFile: string;
 
             /**
@@ -1466,13 +1466,13 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.RoomPermissions.html
         export class RoomPermissions {
 
-            /** @type {boolean} Sets whether changing the Room name after its creation is allowed or not. */
+            /** Sets whether changing the Room name after its creation is allowed or not. */
             allowNameChange: boolean;
-            /** @type {boolean} Sets whether changing (or removing) the Room password after its creation is allowed or not. */
+            /** Sets whether changing (or removing) the Room password after its creation is allowed or not. */
             allowPasswordStateChange: boolean;
-            /** @type {boolean} Sets whether users inside the Room are allowed to send public messages or not. */
+            /** Sets whether users inside the Room are allowed to send public messages or not. */
             allowPublicMessages: boolean;
-            /** @type {boolean} Sets whether the Room capacity can be changed after its creation or not. */
+            /** Sets whether the Room capacity can be changed after its creation or not. */
             aloowResizing: boolean;
 
             /**
@@ -1487,27 +1487,27 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Requests.RoomSettings.html
         export class RoomSettings {
 
-            /** @type {RoomEvents} Sets the flags indicating which events related to the Room are dispatched by the SmartFox client. */
+            /** Sets the flags indicating which events related to the Room are dispatched by the SmartFox client. */
             events: RoomEvents;
-            /** @type {RoomExtension} Sets the Extension that must be attached to the Room on the server-side, and its settings. */
+            /** Sets the Extension that must be attached to the Room on the server-side, and its settings. */
             extension: RoomExtension;
-            /** @type {string} Sets the id of the Group to which the Room should belong. */
+            /** Sets the id of the Group to which the Room should belong. */
             groupId: string;
-            /** @type {boolean} Sets whether the Room is a Game Room or not. */
+            /** Sets whether the Room is a Game Room or not. */
             isGame: boolean;
-            /** @type {number} Sets the maximum number of spectators allowed in the Room (only for Game Rooms). */
+            /** Sets the maximum number of spectators allowed in the Room (only for Game Rooms). */
             maxSpectators: number;
-            /** @type {number} Sets the maximum number of users allowed in the Room. */
+            /** Sets the maximum number of users allowed in the Room. */
             maxUsers: number;
-            /** @type {number} Sets the maximum number of Room Variables allowed for the Room. */
+            /** Sets the maximum number of Room Variables allowed for the Room. */
             maxVariables: number;
-            /** @type {string} Defines the name of the Room. */
+            /** Defines the name of the Room. */
             name: string;
-            /** @type {string} Sets the password of the Room. */
+            /** Sets the password of the Room. */
             password: string;
-            /** @type {RoomPermissions} Sets the flags indicating which operations are permitted on the Room. */
+            /** Sets the flags indicating which operations are permitted on the Room. */
             permissions: RoomPermissions;
-            /** @type {Entities.Variables.ReservedRoomVariables[]} Sets a list of SFSRooomVariable objects to be attached to the Room. */
+            /** Sets a list of SFSRooomVariable objects to be attached to the Room. */
             variables: Entities.Variables.ReservedRoomVariables[];
 
             /**
@@ -1880,21 +1880,21 @@ declare namespace SFS2X {
     // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.SFSBuddyEvent.html
     export class SFSBuddyEvent {
 
-        /** @type {string} The buddyAdd event type, dispatched when a buddy is added successfully to the current user's buddy list. */
+        /** The buddyAdd event type, dispatched when a buddy is added successfully to the current user's buddy list. */
         static BUDDY_ADD: string;
-        /** @type {string} The buddyBlock event type, dispatched when a buddy is blocked or unblocked successfully by the current user. */
+        /** The buddyBlock event type, dispatched when a buddy is blocked or unblocked successfully by the current user. */
         static BUDDY_BLOCK: string;
-        /** @type {string} The buddyError event type, dispatched if an error occurs while executing a request related to the Buddy List system. */
+        /** The buddyError event type, dispatched if an error occurs while executing a request related to the Buddy List system. */
         static BUDDY_ERROR: string;
-        /** @type {string} The buddyListInit event type, dispatched if the Buddy List system is successfully initialized. */
+        /** The buddyListInit event type, dispatched if the Buddy List system is successfully initialized. */
         static BUDDY_LIST_INIT: string;
-        /** @type {string} The buddyMessage event type, dispatched when a message from a buddy is received by the current user. */
+        /** The buddyMessage event type, dispatched when a message from a buddy is received by the current user. */
         static BUDDY_MESSAGE: string;
-        /** @type {string} The buddyOnlineStateChange event type, dispatched when a buddy in the current user's buddy list changes their online state in the Buddy List system. */
+        /** The buddyOnlineStateChange event type, dispatched when a buddy in the current user's buddy list changes their online state in the Buddy List system. */
         static BUDDY_ONLINE_STATE_CHANGE: string;
-        /** @type {string} The buddyRemove event type, dispatched when a buddy is removed successfully from the current user's buddy list. */
+        /** The buddyRemove event type, dispatched when a buddy is removed successfully from the current user's buddy list. */
         static BUDDY_REMOVE: string;
-        /** @type {string} The buddyVariablesUpdate event type, dispatched when a buddy in the current user's buddies list updates one or more Buddy Variables. */
+        /** The buddyVariablesUpdate event type, dispatched when a buddy in the current user's buddies list updates one or more Buddy Variables. */
         static BUDDY_VARIABLES_UPDATE: string;
 
     }
@@ -1945,93 +1945,93 @@ declare namespace SFS2X {
     // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.SFSEvent.html
     export class SFSEvent {
 
-        /** @type {string} The adminMessage event type, dispatched when the current user receives a message from an administrator user. */
+        /** The adminMessage event type, dispatched when the current user receives a message from an administrator user. */
         static ADMIN_MESSAGE: string;
-        /** @type {string} The connection event type, dispatched when a connection between the client and a SmartFoxServer 2X instance is attempted. */
+        /** The connection event type, dispatched when a connection between the client and a SmartFoxServer 2X instance is attempted. */
         static CONNECTION: string;
-        /** @type {string} The connectionLost event type, dispatched when the connection between the client and the SmartFoxServer 2X instance is interrupted. */
+        /** The connectionLost event type, dispatched when the connection between the client and the SmartFoxServer 2X instance is interrupted. */
         static CONNECTION_LOST: string;
-        /** @type {string} The extensionResponse event type, dispatched when data coming from a server-side Extension is received by the current user. */
+        /** The extensionResponse event type, dispatched when data coming from a server-side Extension is received by the current user. */
         static EXTENSION_RESPONSE: string;
-        /** @type {string} The invitation event type, dispatched when the current user receives an invitation from another user. */
+        /** The invitation event type, dispatched when the current user receives an invitation from another user. */
         static INVITATION: string;
-        /** @type {string} The invitationReply event type, dispatched when the current user receives a reply to an invitation they sent previously. */
+        /** The invitationReply event type, dispatched when the current user receives a reply to an invitation they sent previously. */
         static INVITATION_REPLY: string;
-        /** @type {string} The invitationReplyError event type, dispatched when an error occurs while the current user is sending a reply to an invitation they received. */
+        /** The invitationReplyError event type, dispatched when an error occurs while the current user is sending a reply to an invitation they received. */
         static INVITATION_REPLY_ERROR: string;
-        /** @type {string} The login event type, dispatched when the current user performs a successful login in a server Zone. */
+        /** The login event type, dispatched when the current user performs a successful login in a server Zone. */
         static LOGIN: string;
-        /** @type {string} The loginError event type, dispatched if an error occurs while the user login is being performed. */
+        /** The loginError event type, dispatched if an error occurs while the user login is being performed. */
         static LOGIN_ERROR: string;
-        /** @type {string} The logout event type, dispatched when the current user performs logs out of the server Zone. */
+        /** The logout event type, dispatched when the current user performs logs out of the server Zone. */
         static LOGOUT: string;
-        /** @type {string} The mmoItemVariablesUpdate event type, dispatched when an MMOItem Variable is updated in an MMORoom. */
+        /** The mmoItemVariablesUpdate event type, dispatched when an MMOItem Variable is updated in an MMORoom. */
         static MMOITEM_VARIABLES_UPDATE: string;
-        /** @type {string} The moderatorMessage event type, dispatched when the current user receives a message from a moderator user. */
+        /** The moderatorMessage event type, dispatched when the current user receives a message from a moderator user. */
         static MODERATOR_MESSAGE: string;
-        /** @type {string} The objectMessage event type, dispatched when an object containing custom data is received by the current user. */
+        /** The objectMessage event type, dispatched when an object containing custom data is received by the current user. */
         static OBJECT_MESSAGE: string;
-        /** @type {string} The pingPong event type, dispatched when a new lag value measurement is available. */
+        /** The pingPong event type, dispatched when a new lag value measurement is available. */
         static PING_PONG: string;
-        /** @type {string} The playerToSpectator event type, dispatched when a player is turned to a spectator inside a Game Room. */
+        /** The playerToSpectator event type, dispatched when a player is turned to a spectator inside a Game Room. */
         static PLAYER_TO_SPECTATOR: string;
-        /** @type {string} The playerToSpectatorError event type, dispatched when an error occurs while the current user is being turned from player to spectator in a Game Room. */
+        /** The playerToSpectatorError event type, dispatched when an error occurs while the current user is being turned from player to spectator in a Game Room. */
         static PLAYER_TO_SPECTATOR_ERROR: string;
-        /** @type {string} The privateMessage event type, dispatched when a private message is received by the current user. */
+        /** The privateMessage event type, dispatched when a private message is received by the current user. */
         static PRIVATE_MESSAGE: string;
-        /** @type {string} The proximityListUpdate event type, dispatched when one more users or one or more MMOItem objects enter/leave the current user's Area of Interest in MMORooms. */
+        /** The proximityListUpdate event type, dispatched when one more users or one or more MMOItem objects enter/leave the current user's Area of Interest in MMORooms. */
         static PROXIMITY_LIST_UPDATE: string;
-        /** @type {string} The publicMessage event type, dispatched when a public message is received by the current user. */
+        /** The publicMessage event type, dispatched when a public message is received by the current user. */
         static PUBLIC_MESSAGE: string;
-        /** @type {string} The roomAdd event type, dispatched when a new Room is created inside the Zone under any of the Room Groups that the client subscribed. */
+        /** The roomAdd event type, dispatched when a new Room is created inside the Zone under any of the Room Groups that the client subscribed. */
         static ROOM_ADD: string;
-        /** @type {string} The roomCapacityChange event type, dispatched when the capacity of a Room is changed. */
+        /** The roomCapacityChange event type, dispatched when the capacity of a Room is changed. */
         static ROOM_CAPACITY_CHANGE: string;
-        /** @type {string} The roomCapacityChangeError event type, dispatched when an error occurs while attempting to change the capacity of a Room. */
+        /** The roomCapacityChangeError event type, dispatched when an error occurs while attempting to change the capacity of a Room. */
         static ROOM_CAPACITY_CHANGE_ERROR: string;
-        /** @type {string} The roomCreationError event type, dispatched if an error occurs while creating a new Room. */
+        /** The roomCreationError event type, dispatched if an error occurs while creating a new Room. */
         static ROOM_CREATION_ERROR: string;
-        /** @type {string} The roomFindResult event type, dispatched when a Rooms search is completed. */
+        /** The roomFindResult event type, dispatched when a Rooms search is completed. */
         static ROOM_FIND_RESULT: string;
-        /** @type {string} The roomGroupSubscribe event type, dispatched when a Group is subscribed by the current user. */
+        /** The roomGroupSubscribe event type, dispatched when a Group is subscribed by the current user. */
         static ROOM_GROUP_SUBSCRIBE: string;
-        /** @type {string} The roomGroupSubscribeError event type, dispatched when an error occurs while a Room Group is being subscribed. */
+        /** The roomGroupSubscribeError event type, dispatched when an error occurs while a Room Group is being subscribed. */
         static ROOM_GROUP_SUBSCRIBE_ERROR: string;
-        /** @type {string} The roomGroupUnsubscribe event type, dispatched when a Group is unsubscribed by the current user. */
+        /** The roomGroupUnsubscribe event type, dispatched when a Group is unsubscribed by the current user. */
         static ROOM_GROUP_UNSUBSCRIBE: string;
-        /** @type {string} The roomGroupUnsubscribeError event type, dispatched when an error occurs while a Room Group is being unsubscribed. */
+        /** The roomGroupUnsubscribeError event type, dispatched when an error occurs while a Room Group is being unsubscribed. */
         static ROOM_GROUP_UNSUBSCRIBE_ERROR: string;
-        /** @type {string} The roomJoin event type, dispatched when a Room is joined by the current user. */
+        /** The roomJoin event type, dispatched when a Room is joined by the current user. */
         static ROOM_JOIN: string;
-        /** @type {string} The roomJoinError event type, dispatched when an error occurs while the current user is trying to join a Room. */
+        /** The roomJoinError event type, dispatched when an error occurs while the current user is trying to join a Room. */
         static ROOM_JOIN_ERROR: string;
-        /** @type {string} The roomNameChange event type, dispatched when the name of a Room is changed. */
+        /** The roomNameChange event type, dispatched when the name of a Room is changed. */
         static ROOM_NAME_CHANGE: string;
-        /** @type {string} The roomNameChangeError event type, dispatched when an error occurs while attempting to change the name of a Room. */
+        /** The roomNameChangeError event type, dispatched when an error occurs while attempting to change the name of a Room. */
         static ROOM_NAME_CHANGE_ERROR: string;
-        /** @type {string} The roomPasswordStateChange event type, dispatched when the password of a Room is set, changed or removed. */
+        /** The roomPasswordStateChange event type, dispatched when the password of a Room is set, changed or removed. */
         static ROOM_PASSWORD_STATE_CHANGE: string;
-        /** @type {string} The roomPasswordStateChangeError event type, dispatched when an error occurs while attempting to set, change or remove the password of a Room. */
+        /** The roomPasswordStateChangeError event type, dispatched when an error occurs while attempting to set, change or remove the password of a Room. */
         static ROOM_PASSWORD_STATE_CHANGE_ERROR: string;
-        /** @type {string} The roomRemove event type, dispatched when a Room belonging to one of the Groups subscribed by the client is removed from the Zone. */
+        /** The roomRemove event type, dispatched when a Room belonging to one of the Groups subscribed by the client is removed from the Zone. */
         static ROOM_REMOVE: string;
-        /** @type {string} The roomVariablesUpdate event type, dispatched when a Room Variable is updated. */
+        /** The roomVariablesUpdate event type, dispatched when a Room Variable is updated. */
         static ROOM_VARIABLES_UPDATE: string;
-        /** @type {string} The socketError event type, dispatched when a low level socket error is detected, for example bad/inconsistent data. */
+        /** The socketError event type, dispatched when a low level socket error is detected, for example bad/inconsistent data. */
         static SOCKET_ERROR: string;
-        /** @type {string} The spectatorToPlayer event type, dispatched when a spectator is turned to a player inside a Game Room. */
+        /** The spectatorToPlayer event type, dispatched when a spectator is turned to a player inside a Game Room. */
         static SPECTATOR_TO_PLAYER: string;
-        /** @type {string} The spectatorToPlayerError event type, dispatched when an error occurs while the current user is being turned from spectator to player in a Game Room. */
+        /** The spectatorToPlayerError event type, dispatched when an error occurs while the current user is being turned from spectator to player in a Game Room. */
         static SPECTATOR_TO_PLAYER_ERROR: string;
-        /** @type {string} The userCountChange event type, dispatched when the number of users/players or spectators inside a Room changes. */
+        /** The userCountChange event type, dispatched when the number of users/players or spectators inside a Room changes. */
         static USER_COUNT_CHANGE: string;
-        /** @type {string} The userEnterRoom event type, dispatched when one of the Rooms joined by the current user is entered by another user. */
+        /** The userEnterRoom event type, dispatched when one of the Rooms joined by the current user is entered by another user. */
         static USER_ENTER_ROOM: string;
-        /** @type {string} The userExitRoom event type, dispatched when one of the Rooms joined by the current user is left by another user, or by the current user themselves. */
+        /** The userExitRoom event type, dispatched when one of the Rooms joined by the current user is left by another user, or by the current user themselves. */
         static USER_EXIT_ROOM: string;
-        /** @type {string} The userFindResult event type, dispatched when a users search is completed. */
+        /** The userFindResult event type, dispatched when a users search is completed. */
         static USER_FIND_RESULT: string;
-        /** @type {string} The userVariablesUpdate event type, dispatched when a User Variable is updated. */
+        /** The userVariablesUpdate event type, dispatched when a User Variable is updated. */
         static USER_VARIABLES_UPDATE: string;
 
     }
@@ -2259,25 +2259,25 @@ declare namespace SFS2X {
     // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.SmartFox.html
     export class SmartFox {
 
-        /** @type {Managers.BuddyManager} Returns a reference to the Buddy Manager. */
+        /** Returns a reference to the Buddy Manager. */
         buddyManager: Managers.BuddyManager;
-        /** @type {IconfigObj} Returns the client configuration object passed during the SmartFox instance creation. */
+        /** Returns the client configuration object passed during the SmartFox instance creation. */
         config: IconfigObj;
-        /** @type {boolean} Indicates whether the client-server messages console debug is enabled or not. */
+        /** Indicates whether the client-server messages console debug is enabled or not. */
         debug: boolean;
-        /** @type {Entities.SFSRoom} Returns the object representing the last Room joined by the client, if any. */
+        /** Returns the object representing the last Room joined by the client, if any. */
         lastJoinedRoom: Entities.SFSRoom;
-        /** @type {Logger} Returns a reference to the internal Logger instance used by SmartFoxServer 2X. */
+        /** Returns a reference to the internal Logger instance used by SmartFoxServer 2X. */
         logger: Logger;
-        /** @type {Entities.SFSUser} Returns the SFSUser object representing the client itself when connected to a SmartFoxServer 2X instance. */
+        /** Returns the SFSUser object representing the client itself when connected to a SmartFoxServer 2X instance. */
         mySelf: Entities.SFSUser;
-        /** @type {Managers.RoomManager} Returns a reference to the Room Manager. */
+        /** Returns a reference to the Room Manager. */
         roomManager: Managers.RoomManager;
-        /** @type {string} Returns the unique session token of the client. */
+        /** Returns the unique session token of the client. */
         sessionToken: string;
-        /** @type {Managers.UserManager} Returns a reference to the User Manager. */
+        /** Returns a reference to the User Manager. */
         userManager: Managers.UserManager;
-        /** @type {string} Returns the current version of the SmartFoxServer 2X JavaScript API. */
+        /** Returns the current version of the SmartFoxServer 2X JavaScript API. */
         version: string;
 
         /**
@@ -2368,15 +2368,15 @@ declare namespace SFS2X {
     }
 
     export interface IconfigObj {
-        /** @type {string} The IP address or host name of the SmartFoxServer 2X instance to connect to. */
+        /** The IP address or host name of the SmartFoxServer 2X instance to connect to. */
         host?: string | undefined;
-        /** @type {number} The TCP port of the SmartFoxServer 2X instance to connect to. */
+        /** The TCP port of the SmartFoxServer 2X instance to connect to. */
         port?: number | undefined;
-        /** @type {boolean} Use an encrypted SSL connection. */
+        /** Use an encrypted SSL connection. */
         useSSL?: boolean | undefined;
-        /** @type {string} The Zone of the SmartFoxServer 2X instance to join during the login process. */
+        /** The Zone of the SmartFoxServer 2X instance to join during the login process. */
         zone?: string | undefined;
-        /** @type {boolean} Indicates whether the client-server messages console debug should be enabled or not. */
+        /** Indicates whether the client-server messages console debug should be enabled or not. */
         debug?: boolean | undefined;
     }
     //#endregion
@@ -2390,15 +2390,15 @@ declare namespace SFS2X {
         // http://docs2x.smartfoxserver.com/api-docs/jsdoc/symbols/SFS2X.Utils.ClientDisconnectionReason.html
         export class ClientDisconnectionReason {
 
-            /** @type {string} Client was banned from the server. */
+            /** Client was banned from the server. */
             static BAN: string;
-            /** @type {string} Client was disconnected because it was idle for too long. */
+            /** Client was disconnected because it was idle for too long. */
             static IDLE: string;
-            /** @type {string} Client was kicked out of the server. */
+            /** Client was kicked out of the server. */
             static KICK: string;
-            /** @type {string} The client manually disconnected from the server. */
+            /** The client manually disconnected from the server. */
             static MANUAL: string;
-            /** @type {string} A generic network error occurred, and the client is unable to determine the cause of the disconnection. */
+            /** A generic network error occurred, and the client is unable to determine the cause of the disconnection. */
             static UNKNOWN: string;
 
         }

--- a/types/smtp-server/v1/index.d.ts
+++ b/types/smtp-server/v1/index.d.ts
@@ -28,7 +28,6 @@ export interface SMTPServerOptions {
      * If secure is true, additional tls options for tls.
      * createServer can be added directly onto this options object.
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     secure?: boolean | undefined;
@@ -39,7 +38,6 @@ export interface SMTPServerOptions {
      * optional hostname of the server,
      *  used for identifying to the client (defaults to os.hostname())
      * 
-     * @type {string}
      * @memberOf SMTPServerOptions
      */
     name?: string | undefined;
@@ -47,7 +45,6 @@ export interface SMTPServerOptions {
      * optional greeting message.
      *  This message is appended to the default ESMTP response.
      * 
-     * @type {string}
      * @memberOf SMTPServerOptions
      */
     banner?: string | undefined;
@@ -55,7 +52,6 @@ export interface SMTPServerOptions {
      * optional maximum allowed message size in bytes, 
      * see details:https://github.com/andris9/smtp-server#using-size-extension
      * 
-     * @type {number}
      * @memberOf SMTPServerOptions
      */
     size?: number | undefined;
@@ -67,14 +63,12 @@ export interface SMTPServerOptions {
      * Authentication is only allowed in secure mode 
      * (either the server is started with secure: true option or STARTTLS command is used)
      * 
-     * @type {string[]}
      * @memberOf SMTPServerOptions
      */
     authMethods?: string[] | undefined;
     /**
      * allow authentication, but do not require it
      * 
-     * @type {*}
      * @memberOf SMTPServerOptions
      */
     authOptional?: any;
@@ -84,7 +78,6 @@ export interface SMTPServerOptions {
      * use ['AUTH'] as this value. 
      * If you want to allow authentication in clear text, set it to ['STARTTLS'].
      * 
-     * @type {*}
      * @memberOf SMTPServerOptions
      */
     disabledCommands?: string[] | undefined;
@@ -94,49 +87,42 @@ export interface SMTPServerOptions {
      * when creating integration test servers for testing the scenario 
      * where you want to try STARTTLS even when it is not advertised
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     hideSTARTTLS?: boolean | undefined;
     /**
      * optional boolean, if set to true then does not show PIPELINING in feature list
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     hidePIPELINING?: boolean | undefined;
     /**
      * optional boolean, if set to true then does not show 8BITMIME in features list
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     hide8BITMIME?: boolean | undefined;
     /**
      * optional boolean, if set to true then does not show SMTPUTF8 in features list
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     hideSMTPUTF8?: boolean | undefined;
     /**
      * optional boolean, if set to true allows authentication even if connection is not secured first
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     allowInsecureAuth?: boolean | undefined;
     /**
      * optional boolean, if set to true then does not try to reverse resolve client hostname
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     disableReverseLookup?: boolean | undefined;
     /**
      * optional Map or an object of TLS options for SNI where servername is the key. Overrided by SNICallback.
      * 
-     * @type {Object}
      * @memberOf SMTPServerOptions
      */
     sniOptions?: Object | undefined;
@@ -145,14 +131,12 @@ export interface SMTPServerOptions {
      * If set to true then logs to console. 
      * If value is not set or is false then nothing is logged
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     logger?: boolean | undefined;
     /**
      * sets the maximum number of concurrently connected clients, defaults to Infinity
      * 
-     * @type {number}
      * @memberOf SMTPServerOptions
      */
     maxClients?: number | undefined;//defaults to Infinity
@@ -160,7 +144,6 @@ export interface SMTPServerOptions {
      * boolean, if set to true expects to be behind a proxy that emits a 
      * PROXY header{http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt} (version 1 only)
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     useProxy?: boolean | undefined;
@@ -169,7 +152,6 @@ export interface SMTPServerOptions {
      * XCLIENT{http://www.postfix.org/XCLIENT_README.html} extension to override connection properties. 
      * See session.xClient (Map object) for the details provided by the client
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     useXClient?: boolean | undefined;
@@ -177,21 +159,18 @@ export interface SMTPServerOptions {
      * boolean, if set to true, enables usage of XFORWARD{http://www.postfix.org/XFORWARD_README.html} extension. 
      * See session.xForward (Map object) for the details provided by the client
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     useXForward?: boolean | undefined;
     /**
      * boolean, if set to true use LMTP protocol instead of SMTP
      * 
-     * @type {boolean}
      * @memberOf SMTPServerOptions
      */
     lmtp?: boolean | undefined;
     /**
      * How many milliseconds of inactivity to allow before disconnecting the client (defaults to 1 minute)
      * 
-     * @type {number}
      * @memberOf SMTPServerOptions
      */
     socketTimeout?: number | undefined;//millisceonds
@@ -199,7 +178,6 @@ export interface SMTPServerOptions {
      * How many millisceonds to wait before disconnecting pending 
      * connections once server.close() has been called (defaults to 30 seconds)
      * 
-     * @type {number}
      * @memberOf SMTPServerOptions
      */
     closeTimeout?: number | undefined;//millisceonds
@@ -251,28 +229,24 @@ export interface Authentication {
     /**
      * indicates the authentication method used, 'PLAIN', 'LOGIN' or 'XOAUTH2'
      * 
-     * @type {string}
      * @memberOf Authentication
      */
     method: "PLAIN" | "LOGIN" | "XOAUTH2";//'PLAIN', 'LOGIN' or 'XOAUTH2'
     /**
      * the username of the user
      * 
-     * @type {string}
      * @memberOf Authentication
      */
     username?: string | undefined;
     /**
      * the password if LOGIN or PLAIN was used
      * 
-     * @type {string}
      * @memberOf Authentication
      */
     password?: string | undefined;
     /**
      *  the OAuth2 bearer access token if 'XOAUTH2' was used as the authentication method
      * 
-     * @type {string}
      * @memberOf Authentication
      */
     accessToken?: string | undefined;
@@ -292,7 +266,6 @@ export interface AuthenticationResponse {
      * and this value is used later with the session data to identify the user. 
      * If this value is empty, then the authentication is considered failed
      * 
-     * @type {*}
      * @memberOf AuthenticationResponse
      */
     user: any;
@@ -300,7 +273,6 @@ export interface AuthenticationResponse {
      * an object to return if XOAUTH2 authentication failed (do not set the error object in this case). 
      * This value is serialized to JSON and base64 encoded automatically, so you can just return the object
      * 
-     * @type {{}}
      * @memberOf AuthenticationResponse
      */
     data?: {} | undefined;
@@ -310,42 +282,36 @@ export interface Session {
     /**
      * random string identificator generated when the client connected
      * 
-     * @type {string}
      * @memberOf Session
      */
     id: string;
     /**
      * the IP address for the connected client
      * 
-     * @type {Address}
      * @memberOf Session
      */
     remoteAddress: Address;
     /**
      * reverse resolved hostname for remoteAddress
      * 
-     * @type {string}
      * @memberOf Session
      */
     clientHostname: string;
     /**
      * the opening SMTP command (HELO/EHLO/LHLO)
      * 
-     * @type {string}
      * @memberOf Session
      */
     openingCommand: string;
     /**
      * hostname the client provided with HELO/EHLO call
      * 
-     * @type {string}
      * @memberOf Session
      */
     hostNameApearsAs: string;
     /**
      * Envelope Object
      * 
-     * @type {Envelope}
      * @memberOf Session
      */
     envelope: Envelope;
@@ -355,14 +321,12 @@ export interface Envelope {
     /**
      * includes an address object or is set to false
      * 
-     * @type {Address}
      * @memberOf Envelope
      */
     mailFrom: Address;
     /**
      * includes an array of address objects
      * 
-     * @type {Address[]}
      * @memberOf Envelope
      */
     rcptTo: Address[];
@@ -372,14 +336,12 @@ export interface Address {
     /**
      * the address provided with the MAIL FROM or RCPT TO command
      * 
-     * @type {string}
      * @memberOf Address
      */
     address: string;
     /**
      * an object with additional arguments (all key names are uppercase)
      * 
-     * @type {Object}
      * @memberOf Address
      */
     args: Object;

--- a/types/sparkpost/v1/index.d.ts
+++ b/types/sparkpost/v1/index.d.ts
@@ -569,7 +569,6 @@ declare namespace SparkPost {
          * At a minimum, address or multichannel_addresses is required.
          * If both address and multichannel_addresses are specified only multichannel_addresses will be used.
          *
-         * @type {(Address | string)}
          * @memberOf RecipientWithMultichannelAddresses
          */
         address?: Address | string | undefined;
@@ -578,7 +577,6 @@ declare namespace SparkPost {
          * At a minimum, address or multichannel_addresses is required.
          * If both address and multichannel_addresses are specified only multichannel_addresses will be used.
          *
-         * @type {MultichannelAddress[]}
          * @memberOf RecipientWithMultichannelAddresses
          */
         multichannel_addresses: MultichannelAddress[];
@@ -823,7 +821,6 @@ declare namespace SparkPost {
          * Address “from” : "deals@company.com" or JSON object composed of the “name” and “email” fields
          * “from” : { “name” : “My Company”, “email” : "deals@company.com" } used to compose the email’s “From” header.
          *
-         * @type {(Address | string)}
          * @memberOf CreateTemplateContent
          */
         from: Address | string;
@@ -844,7 +841,6 @@ declare namespace SparkPost {
          * Address “from” : "deals@company.com" or JSON object composed of the “name” and “email” fields
          * “from” : { “name” : “My Company”, “email” : "deals@company.com" } used to compose the email’s “From” header.
          *
-         * @type {(Address | string)}
          * @memberOf CreateTemplateContent
          */
         from: Address | string;
@@ -871,7 +867,6 @@ declare namespace SparkPost {
          * At a minimum, id or name is required upon creation. It is auto generated if not provided.
          * After a template has been created, this property cannot be changed. Maximum length - 64 bytes
          *
-         * @type {string}
          * @memberOf CreateTemplate
          */
         id: string;
@@ -897,7 +892,6 @@ declare namespace SparkPost {
          * At a minimum, id or name is required upon creation. It is auto generated if not provided.
          * After a template has been created, this property cannot be changed. Maximum length - 64 bytes
          *
-         * @type {string}
          * @memberOf CreateTemplate
          */
         id?: string | undefined;
@@ -1056,7 +1050,6 @@ declare namespace SparkPost {
          * including the “charset” parameter (text/html; charset=“UTF-8”) if needed.
          * The value will apply “as-is” to the “Content-Type” header of the generated MIME part for the attachment.
          *
-         * @type {string}
          * @memberOf Attachment
          */
         type: string;
@@ -1067,7 +1060,6 @@ declare namespace SparkPost {
          * The string should not contain \r\n line breaks.
          * The SparkPost systems will add line breaks as necessary to ensure the Base64 encoded lines contain no more than 76 characters each.
          *
-         * @type {string}
          * @memberOf Attachment
          */
         data: string;

--- a/types/suitescript/index.d.ts
+++ b/types/suitescript/index.d.ts
@@ -2440,8 +2440,6 @@ declare interface AccountingBook {
  *
  * @classDescription Class definition for business records in the system.
  * @return {nlobjRecord}
- * @constructor
- *
  * @since 2008.2
  */
 declare interface nlobjRecord {
@@ -3174,8 +3172,6 @@ declare interface nlobjRecord {
  *
  * @classDescription Class definition for interacting with setup/configuration pages
  * @return {nlobjConfiguration}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjConfiguration {
@@ -3361,8 +3357,6 @@ declare interface nlobjConfiguration {
  *
  * @classDescription Encapsulation of files (media items) in the file cabinet.
  * @return {nlobjFile}
- * @constructor
- *
  * @since 2009.1
  */
 declare interface nlobjFile {
@@ -3582,7 +3576,6 @@ declare interface nlobjFile {
  * Return a new instance of nlobjSearchFilter filter objects used to define search criteria.
  *
  * @classDescription search filter
- * @constructor
  * @param {string} name filter name.
  * @param {string} join internal ID for joined search where this filter is defined
  * @param {string} operator operator name (i.e. anyOf, contains, lessThan, etc..)
@@ -3647,7 +3640,6 @@ declare interface nlobjSearchFilter {
  *
  * @classDescription search column.
  * @return {nlobjSearchColumn}
- * @constructor
  * @param {string} name column name.
  * @param {string} join internal ID for joined search where this column is defined
  * @param {string} summary
@@ -3748,7 +3740,6 @@ declare class nlobjSearchColumn {
  *
  * @classDescription Class definition for interacting with the results of a search operation
  * @return {nlobjSearchResult}
- * @constructor
  */
 declare interface nlobjSearchResult {
 
@@ -3829,7 +3820,6 @@ declare interface nlobjSearchResult {
  *
  * @classDescription Utility class providing information about the current user and the script runtime.
  * @return {nlobjContext}
- * @constructor
  */
 declare interface nlobjContext {
 
@@ -4208,7 +4198,6 @@ declare interface nlobjContext {
  *
  * @classDescription Encapsulation of errors thrown during script execution.
  * @return {nlobjError}
- * @constructor
  */
 declare interface nlobjError {
 
@@ -4299,8 +4288,6 @@ declare class nlobjError {
  *
  * @classDescription Contains the results of a server response to an outbound Http(s) call.
  * @return {nlobjServerResponse}
- * @constructor
- *
  * @since 2008.1
  */
 declare interface nlobjServerResponse {
@@ -4403,7 +4390,6 @@ declare interface nlobjServerResponse {
  *
  * @classDescription Accessor to Http response made available to Suitelets.
  * @return {nlobjResponse}
- * @constructor
  */
 declare interface nlobjResponse {
 
@@ -4601,7 +4587,6 @@ declare interface nlobjResponse {
  *
  * @classDescription Accessor to Http request data made available to Suitelets
  * @return {nlobjRequest}
- * @constructor
  */
 declare interface nlobjRequest {
 
@@ -4772,7 +4757,6 @@ declare interface nlobjRequest {
  *
  * @classDescription UI Object used for building portlets that are displayed on dashboard pages
  * @return {nlobjPortlet}
- * @constructor
  */
 declare interface nlobjPortlet {
 
@@ -4897,7 +4881,6 @@ declare interface nlobjPortlet {
  *
  * @classDescription UI Object page type used for building lists
  * @return {nlobjList}
- * @constructor
  */
 declare interface nlobjList {
 
@@ -5018,7 +5001,6 @@ declare interface nlobjList {
  *
  * @classDescription UI Object page type used for building basic data entry forms.
  * @return {nlobjForm}
- * @constructor
  */
 declare interface nlobjForm {
 
@@ -5352,8 +5334,6 @@ declare interface nlobjForm {
  * throughout the user's session up until completion of the assistant.
  *
  * @return {nlobjAssistant}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjAssistant {
@@ -5789,7 +5769,6 @@ declare interface nlobjAssistant {
  *
  * @classDescription Core descriptor for fields used to define records and also used to build pages and portlets.
  * @return {nlobjField}
- * @constructor
  */
 declare interface nlobjField {
 
@@ -6074,7 +6053,6 @@ declare interface nlobjField {
  *
  * @classDescription high level container for defining sublist (many to one) relationships on a record or multi-line data entry UIs on pages.
  * @return {nlobjSubList}
- * @constructor
  */
 declare interface nlobjSubList {
 
@@ -6255,7 +6233,6 @@ declare interface nlobjSubList {
  *
  * @classDescription Class definition for columns used on lists and list portlets.
  * @return {nlobjColumn}
- * @constructor
  */
 declare interface nlobjColumn {
 
@@ -6316,7 +6293,6 @@ declare interface nlobjColumn {
  *
  * @classDescription high level grouping for fields on a data entry form (nlobjForm).
  * @return {nlobjTab}
- * @constructor
  */
 declare interface nlobjTab {
 
@@ -6356,8 +6332,6 @@ declare interface nlobjTab {
  *
  * @classDescription assistant step definition. Used to define individual steps/pages in multi-step workflows.
  * @return {nlobjAssistantStep}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjAssistantStep {
@@ -6508,8 +6482,6 @@ declare interface nlobjAssistantStep {
  *
  * @classDescription object used for grouping fields on pages (currently only supported on assistant pages).
  * @return {nlobjFieldGroup}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjFieldGroup {
@@ -6587,8 +6559,6 @@ declare interface nlobjFieldGroup {
  *
  * @classDescription buttons used for triggering custom behaviors on pages.
  * @return {nlobjButton}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjButton {
@@ -6635,8 +6605,6 @@ declare interface nlobjButton {
  *
  * @classDescription select|radio option used for building select fields via the UI Object API and for describing select|radio fields.
  * @return {nlobjSelectOption}
- * @constructor
- *
  * @since 2009.2
  */
 declare interface nlobjSelectOption {

--- a/types/trunk8/index.d.ts
+++ b/types/trunk8/index.d.ts
@@ -37,7 +37,6 @@ interface Trunk8Options {
 interface JQuery {
     /**
     Creates a trunk8 instance and calls a method.
-    @constructor
     @param {string} method
     @param {string} value
     */
@@ -45,7 +44,6 @@ interface JQuery {
 
     /**
     Creates a trunk8 instance with default options.
-    @constructor
     @param {Trunk8Options} options
     */
     trunk8(options?: Trunk8Options): any;

--- a/types/tuya-panel-kit/index.d.ts
+++ b/types/tuya-panel-kit/index.d.ts
@@ -11110,7 +11110,7 @@ export interface DevInfo<S = Record<string, DpType>> {
     appId: number;
     appKey: string;
     /**
-     * @desc 网络是否在线
+     * @description 网络是否在线
      */
     appOnline: boolean;
     attribute: number;
@@ -11124,7 +11124,7 @@ export interface DevInfo<S = Record<string, DpType>> {
     communication: Record<string, any>;
     devAttribute: number;
     /**
-     * @desc 设备是否在线
+     * @description 设备是否在线
      */
     deviceOnline: boolean;
     deviceType: number;
@@ -11148,7 +11148,7 @@ export interface DevInfo<S = Record<string, DpType>> {
     isAdmin: boolean;
     isCloudOnline: boolean;
     /**
-     * @desc 局域网是否在线
+     * @description 局域网是否在线
      */
     isLocalOnline: boolean;
     isMeshBleOnline: boolean;
@@ -11303,7 +11303,7 @@ export interface NavigationOptions {
      */
     enablePopGesture?: boolean | undefined;
     /**
-     * @desc 蓝牙离线提示是否覆盖整个面板(除头部栏外)
+     * @description 蓝牙离线提示是否覆盖整个面板(除头部栏外)
      * @defaultValueValue true
      */
     isBleOfflineOverlay?: boolean | undefined;
@@ -11399,7 +11399,7 @@ export let TYSdk: {
         getDpCodeById(id: string | number): string;
         getDpCodes(): string[];
         /**
-         * @desc 主动从设备获取 dp 点状态
+         * @description 主动从设备获取 dp 点状态
          */
         getDpDataFromDevice(idOrCode: string | number): Promise<void>;
         getDpIdByCode(code: string): string;
@@ -11423,11 +11423,11 @@ export let TYSdk: {
         isSigMeshDevice(): boolean;
         isWifiDevice(): boolean;
         /**
-         * @desc 下发 dp 点
+         * @description 下发 dp 点
          */
         putDeviceData(cmd: Record<string, any>): Promise<{ success: boolean }>;
         /**
-         * @desc 局域网下发 dp 点
+         * @description 局域网下发 dp 点
          */
         putLocalDpData(cmd: Record<string, any>): Promise<void>;
         setDevState(state: Record<string, DpValue>): DevInfo;
@@ -11449,7 +11449,7 @@ export let TYSdk: {
         // eslint-disable-next-line no-unnecessary-generics
         on<T>(event: string, callback: (args: T) => void): void;
         /**
-         * @desc
+         * @description
          * type: dpData 设备状态变更通知，payload 为更新的 DP 状态
          * type: devInfo 设备信息变更通知，payload 为 devInfo
          * type: deviceOnline 设备是否在线通知，payload 为 boolean
@@ -11462,19 +11462,19 @@ export let TYSdk: {
             }) => void,
         ): void;
         /**
-         * @desc app 网络状态变更通知
+         * @description app 网络状态变更通知
          */
         on(event: 'networkStateChange', callback: (data: { appOnline: boolean }) => void): void;
         /**
-         * @desc 云定时状态变更通知
+         * @description 云定时状态变更通知
          */
         on(event: 'linkageTimeUpdate', callback: (data: {}) => void): void;
         /**
-         * @desc 设备局域网在线状态变更通知
+         * @description 设备局域网在线状态变更通知
          */
         on(event: 'deviceLocalStateChange', callback: (data: { state: boolean }) => void): void;
         /**
-         * @desc 蓝牙状态变更通知
+         * @description 蓝牙状态变更通知
          */
         on(event: 'bluetoothChange', callback: (value: boolean) => void): void;
         once(event: string, callback: AnyFunction): void;
@@ -11518,11 +11518,11 @@ export let TYSdk: {
         };
 
         /**
-         * @desc 根据 uiId 跳转二级页面
+         * @description 根据 uiId 跳转二级页面
          */
         jumpSubPage(uiIdParams: { uiId: string }, pageParams: any): void;
         /**
-         * @desc 跳转到 app 内置路由页面或网页
+         * @description 跳转到 app 内置路由页面或网页
          * @param routeId app 路由 url 或网页链接
          */
         jumpTo(routeId: string): void;

--- a/types/twitter-stream-channels/index.d.ts
+++ b/types/twitter-stream-channels/index.d.ts
@@ -90,7 +90,6 @@ declare module 'twitter-stream-channels' {
   }
 
   /**
-   * @class TwitterStreamChannels
    * @param {object} credentials
    * @param {String} credentials.consumer_key
    * @param {String} credentials.consumer_secret

--- a/types/typeahead.js/index.d.ts
+++ b/types/typeahead.js/index.d.ts
@@ -10,7 +10,6 @@ interface JQuery {
     /**
      * For a given input[type="text"], enables typeahead functionality.
      *
-     * @constructor
      * @param options Options hash that's used for configuration
      * @param datasets Array of datasets
      */
@@ -19,7 +18,6 @@ interface JQuery {
     /**
       * For a given input[type="text"], enables typeahead functionality.
       *
-      * @constructor
       * @param options Options hash that's used for configuration
       * @param dataset At least one dataset is required
       * @param datasets Rest of the datasets.
@@ -30,7 +28,6 @@ interface JQuery {
      * Returns the current value of the typeahead.
      * The value is the text the user has entered into the input element.
      *
-     * @constructor
      * @param methodName Method 'val'
      */
     typeahead(methodName: 'val'): string;
@@ -38,7 +35,6 @@ interface JQuery {
     /**
      * Accommodates the val overload.
      *
-     * @constructor
      * @param methodName Method 'val'
      */
     typeahead(methodName: string): string;
@@ -46,7 +42,6 @@ interface JQuery {
     /**
      * Sets the value of the typeahead. This should be used in place of jQuery#val.
      *
-     * @constructor
      * @param methodName Method 'val'
      * @param val The value to be set
      */
@@ -55,7 +50,6 @@ interface JQuery {
     /**
      * Accommodates the set val overload.
      *
-     * @constructor
      * @param methodName Method 'val'
      * @param val The value to be set
      */
@@ -64,7 +58,6 @@ interface JQuery {
     /**
      * Opens the suggestion menu.
      *
-     * @constructor
      * @param methodName Method 'open'
      */
     typeahead(methodName: 'open'): JQuery;
@@ -72,7 +65,6 @@ interface JQuery {
     /**
      * Closes the suggestion menu.
      *
-     * @constructor
      * @param methodName Method 'close'
      */
     typeahead(methodName: 'close'): JQuery;
@@ -80,7 +72,6 @@ interface JQuery {
     /**
      * Removes typeahead functionality and reverts the input element back to its original state.
      *
-     * @constructor
      * @param methodName Method 'destroy'
      */
     typeahead(methodName: 'destroy'): JQuery;
@@ -1123,7 +1114,6 @@ declare class Bloodhound<T> {
     /**
      * The constructor function.
      *
-     * @constructor
      * @param options Options hash.
      */
     constructor(options: Bloodhound.BloodhoundOptions<T>);

--- a/types/vitalsigns/index.d.ts
+++ b/types/vitalsigns/index.d.ts
@@ -18,31 +18,26 @@ declare module "vitalsigns" {
             /**
              * The comparator to use when comparing the field's value with the constraint value.
              * Valid comparators are: 'equal', 'greater', and 'less'.
-             * @type {string}
              */
             comparator: string;
 
             /**
              * The name of the field to be constrained.
-             * @type {string}
              */
             field: string;
 
             /**
              * The name of the monitor containing the field to be constrained.
-             * @type {string}
              */
             monitor: string;
 
             /**
              * true to negate the outcome of the comparison; false or omitted to use the comparison result.
-             * @type {boolean}
              */
             negate?: boolean | undefined;
 
             /**
              * The value against which the field should be compared.
-             * @type {any}
              */
             value: any;
         }
@@ -68,19 +63,16 @@ declare module "vitalsigns" {
         export interface Options {
             /**
              * Number of milliseconds to wait between automatic health checks.
-             * @type {number|boolean}
              */
             autoCheck?: number | boolean | undefined;
 
             /**
              * HTTP response code to send back in the VitalSigns.
-             * @type {number}
              */
             httpHealthy?: number | undefined;
 
             /**
              * HTTP response code to send back in the VitalSigns.
-             * @type {number}
              */
             httpUnhealthy?: number | undefined;
         }
@@ -88,7 +80,6 @@ declare module "vitalsigns" {
         export interface Monitor {
             /**
              * Connections.
-             * @type {any}
              */
             connections: any;
         }
@@ -100,13 +91,11 @@ declare module "vitalsigns" {
         export interface MonitorField {
             /**
              * Name.
-             * @type {string}
              */
             name?: string | undefined;
 
             /**
              * Units.
-             * @type {string}
              */
             units?: string | undefined;
         }
@@ -118,13 +107,11 @@ declare module "vitalsigns" {
         interface ReportOptions {
             /**
              * true to flatten the report object down to a single level by concatenating nested key names; false to keep the default hierarchical format.
-             * @type {boolean}
              */
             flatten?: boolean | undefined;
 
             /**
              * If flatten is true, this string will be used to separate key names when they are concatenated together.
-             * @type {boolean}
              */
             separator?: string | undefined;
         }
@@ -155,7 +142,6 @@ declare module "vitalsigns" {
 
         /**
          * Gets a request handler.
-         * @type {RequestHandler}
          */
         express: RequestHandler;
 

--- a/types/wallabyjs/index.d.ts
+++ b/types/wallabyjs/index.d.ts
@@ -9,17 +9,17 @@ declare module 'wallabyjs' {
    *
    * @interface
    *
-   * @property {IWallabyCompiler=}     compilers - File patterns as keys and compiler functions as values.
-   * @property {boolean=}              debug - Flag if debug messages written to Wallaby console (default=false).
-   * @property {IWallabyEnvironment=} env - Specify a different test runner or change the runner settings.
-   * @property {string[] | IWallabyFilePattern[]}   files - Specifies an array of source files or file name patterns to copy
+   * compilers - File patterns as keys and compiler functions as values.
+   * debug - Flag if debug messages written to Wallaby console (default=false).
+   * env - Specify a different test runner or change the runner settings.
+   * files - Specifies an array of source files or file name patterns to copy
    *                                                        to the local cache.
-   * @property {Function=}             postprocessor - Function that runs for every batch of file changes after all compilers and preprocessors.
-   * @property {Function=}             preprocessors - Function that runs for every batch of file changes after all compilers.
-   * @property {string=}               testFramework - Specifies the name and version of the testing framework you are using for your tests.
-   * @property {string[] | IWallabyFilePattern[]}   tests - Specifies an array of test files or test file name patterns to copy
+   * postprocessor - Function that runs for every batch of file changes after all compilers and preprocessors.
+   * preprocessors - Function that runs for every batch of file changes after all compilers.
+   * testFramework - Specifies the name and version of the testing framework you are using for your tests.
+   * tests - Specifies an array of test files or test file name patterns to copy
    *                                                        to the local cache.
-   * @property {IWallabyWorkers=}      workers - Degree of parallelism used to run your tests and controls the way wallaby re-uses workers.
+   * workers - Degree of parallelism used to run your tests and controls the way wallaby re-uses workers.
    *
    * @see {@link https://wallabyjs.com/docs/config/overview.html} for details.
    */
@@ -79,9 +79,9 @@ declare module 'wallabyjs' {
    * @export
    * @interface IWallabyCompilerResult
    *
-   * @property  {string}  map - Source map.
-   * @property  {string}  code - Code transformed to JavaScript.
-   * @property  {any}  ranges - All converable ranges of the original file.
+   * map - Source map.
+   * code - Code transformed to JavaScript.
+   * ranges - All converable ranges of the original file.
    *
    * @see {@link https://wallabyjs.com/docs/config/compilers.html} for details.
    */
@@ -107,8 +107,8 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyFile
    *
-   * @property {string=}  content - The current content of the file.
-   * @property {string=}  path - The current path to the file.
+   * content - The current content of the file.
+   * path - The current path to the file.
    * @function rename - Allows you to rename/move the file to newPath.
    * @function changeExt - Shortcut for the rename function allowing you to change the file extension.
    *
@@ -126,10 +126,10 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyFilePattern
    *
-   * @property {string}   pattern - File name or file pattern.
-   * @property {boolean=}   ignore - Used to completely exclude the file from Wallaby (default=false).
-   * @property {boolean=}   instrument - Determines if file is instrumented (default=true).
-   * @property {boolean=}   load - Determines if the file is loaded to sandbox HTML via script tag .(default=true).
+   * pattern - File name or file pattern.
+   * ignore - Used to completely exclude the file from Wallaby (default=false).
+   * instrument - Determines if file is instrumented (default=true).
+   * load - Determines if the file is loaded to sandbox HTML via script tag .(default=true).
    *
    * @see {@link https://wallabyjs.com/docs/config/files.html} for details.
    */
@@ -145,9 +145,9 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyEnvironment
    *
-   * @property  {IWallabyEnvironmentParameters=}  params - set parameters on environment.
-   * @property  {string=}  runner - Path of local Node / PhantomJs / Electron.
-   * @property  {string=}  type - Specify a different test runner or change the runner settings.
+   * params - set parameters on environment.
+   * runner - Path of local Node / PhantomJs / Electron.
+   * type - Specify a different test runner or change the runner settings.
    *
    * @see {@link https://wallabyjs.com/docs/config/runner.html} for details.
    */
@@ -163,8 +163,8 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyEnvironmentParameters
    *
-   * @property  {string=}  env - Semicolon-separated spawed runner process env variables.
-   * @property  {string=}  runner - Space-separated spawed runner process flags.
+   * env - Semicolon-separated spawed runner process env variables.
+   * runner - Space-separated spawed runner process flags.
    *
    * @see {@link https://wallabyjs.com/docs/config/runner.html} for details.
    */
@@ -178,8 +178,8 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyEnvironmentViewportSize
    *
-   * @property  {number=} width - Width in pixels for the viewport size in PhantomJs/Electron.
-   * @property  {number=} height - height in pixels for the viewport size in PhantomJs/Electron.
+   * width - Width in pixels for the viewport size in PhantomJs/Electron.
+   * height - height in pixels for the viewport size in PhantomJs/Electron.
    */
   export interface IWallabyEnvironmentViewportSize {
     width?: number | undefined;
@@ -191,7 +191,7 @@ declare module 'wallabyjs' {
    *
    * @interface IWallabyWorkers
    *
-   * @property  {boolean=}  recycle - Specifies the degree of parallelism used to run your tests and
+   * recycle - Specifies the degree of parallelism used to run your tests and
    *                                  controls the way wallaby re-uses workers.
    *
    * @see {@link https://wallabyjs.com/docs/config/workers.html} for details.
@@ -205,10 +205,10 @@ declare module 'wallabyjs' {
    *
    * @interface IWallaby
    *
-   * @property  {string=} localProjectDir - String property which returns the project local folder.
-   * @property  {string=} projectCacheDir - String property which returns the project cache folder.
-   * @property  {IWallabyBuiltInCompilers=} compilers - Property which allows you to access the built-in TypeScript, CoffeeScript and Babel compilers.
-   * @property  {object=} defaults - Property which allows you to set the default values for file object properties.
+   * localProjectDir - String property which returns the project local folder.
+   * projectCacheDir - String property which returns the project cache folder.
+   * compilers - Property which allows you to access the built-in TypeScript, CoffeeScript and Babel compilers.
+   * defaults - Property which allows you to set the default values for file object properties.
    *
    * @see {@link https://wallabyjs.com/docs/config/overview.html} for details.
    */

--- a/types/winjs/index.d.ts
+++ b/types/winjs/index.d.ts
@@ -386,7 +386,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a List object.
-         * @constructor
          * @param list The array containing the elements to initalize the list.
          * @param options You can set two Boolean options: binding and proxy. If options.binding is true, the list contains the result of calling as on the element values. If options.proxy is true, the list specified as the first parameter is used as the storage for the List. This option should be used with care, because uncoordinated edits to the data storage may result in errors.
         **/
@@ -1195,7 +1194,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a template that provides a reusable declarative binding element.
-         * @constructor
          * @param element The DOM element to convert to a template.
          * @param options If this parameter is supplied, the template is loaded from the URI and the content of the element parameter is ignored. You can add the following options: href.
         **/
@@ -1470,7 +1468,6 @@ declare namespace WinJS {
 
         /**
          * Creates an Error object with the specified name and message properties.
-         * @constructor
          * @param name The name of this error. The name is meant to be consumed programmatically and should not be localized.
          * @param message The message for this error. The message is meant to be consumed by humans and should be localized.
         **/
@@ -1511,7 +1508,6 @@ declare namespace WinJS {
 
         /**
          * A promise provides a mechanism to schedule work to be done on a value that has not yet been computed. It is a convenient abstraction for managing interactions with asynchronous APIs. For more information about asynchronous programming, see Asynchronous programming. For more information about promises in JavaScript, see Asynchronous programming in JavaScript. For more information about using promises, see the WinJS Promise sample.
-         * @constructor
          * @param init The function that is called during construction of the Promise that contains the implementation of the operation that the Promise will represent. This can be synchronous or asynchronous, depending on the nature of the operation. Note that placing code within this function does not automatically run it asynchronously; that must be done explicitly with other asynchronous APIs such as setImmediate, setTimeout, requestAnimationFrame, and the Windows Runtime asynchronous APIs. The init function is given three arguments: completeDispatch, errorDispatch, progressDispatch. This parameter is optional.
          * @param onCancel The function to call if a consumer of this promise wants to cancel its undone work. Promises are not required to support cancellation.
         **/
@@ -3942,7 +3938,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBar object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBar.
         **/
@@ -4119,7 +4114,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBarCommand object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBarCommand.
         **/
@@ -4251,7 +4245,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AutoSuggestBox.
-         * @constructor
          * @param element The DOM element hosts the new AutoSuggestBox.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -4386,7 +4379,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new BackButton.
-         * @constructor
          * @param element The DOM element hosts the new BackButton.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -4456,7 +4448,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new CellSpanningLayout.
-         * @constructor
          * @param options An object that contains one or more property/value pairs to apply to the new CellSpanningLayout. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
         constructor(options?: any);
@@ -4627,7 +4618,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ContentDialog control.
-         * @constructor
          * @param The DOM element that hosts the ContentDialog control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -4742,7 +4732,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of the DatePicker control.
-         * @constructor
          * @param element The DOM element associated with the DatePicker control.
          * @param options The set of options to be applied initially to the DatePicker control. The options are the following: calendar, current, datePattern, disabled, maxYear, minYear, monthPattern, yearPattern.
         **/
@@ -4895,7 +4884,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new FlipView.
-         * @constructor
          * @param element The DOM element that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the pageselected event, add a property named "onpageselected" and set its value to the event handler.
         **/
@@ -5062,7 +5050,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Flyout object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new Flyout.
         **/
@@ -5205,7 +5192,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new GridLayout object.
-         * @constructor
          * @param options The set of properties and values to apply to the new GridLayout.
         **/
         constructor(options?: any);
@@ -5343,7 +5329,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Hub control.
-         * @constructor
          * @param element The DOM element that will host the Hub control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the contentanimating event, add a property named "oncontentanimating" to the options object and set its value to the event handler.
         **/
@@ -5517,7 +5502,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new HubSection.
-         * @constructor
          * @param element The DOM element hosts the new HubSection.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -5578,7 +5562,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of HtmlControl to define a new page control.
-         * @constructor
          * @param element The element that hosts the HtmlControl.
          * @param options The options for configuring the page. The uri option is required in order to specify the source document for the content of the page. Other options are the ones used by the WinJS.Pages.render method.
         **/
@@ -5605,7 +5588,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ItemContainer.
-         * @constructor
          * @param element The DOM element hosts the new ItemContainer. For the ItemContainer to be accessible, this element must have its role attribute set to "list" or "listbox". If tapBehavior is set to none and selectionDisabled is true, then use the "list" role; otherwise, use the "listbox" role.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -5737,7 +5719,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListLayout.
-         * @constructor
          * @param options An object that contains one or more property/value pairs to apply to the new ListLayout. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
         constructor(options?: any);
@@ -5853,7 +5834,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListView.
-         * @constructor
          * @param element The DOM element that hosts the ListView control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the selectionchanged event, add a property named "onselectionchanged" to the options object and set its value to the event handler.
         **/
@@ -6244,7 +6224,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Pivot.
-         * @constructor
          * @param element The DOM element hosts the new Pivot.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -6371,7 +6350,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new PivotItem.
-         * @constructor
          * @param element The DOM element hosts the new PivotItem.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -6426,7 +6404,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Menu object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new Menu.
         **/
@@ -6603,7 +6580,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new MenuCommand object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new MenuCommand.
         **/
@@ -6705,7 +6681,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new NavBar.
-         * @constructor
          * @param element The DOM element that will host the new NavBar.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -6872,7 +6847,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new NavBarCommand.
-         * @constructor
          * @param element The DOM element hosts the new NavBarCommand.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -6982,7 +6956,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new NavBarContainer.
-         * @constructor
          * @param element The DOM element hosts the new NavBarContainer.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -7098,7 +7071,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Rating.
-         * @constructor
          * @param element The DOM element hosts the new Rating.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -7207,7 +7179,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Repeater control.
-         * @constructor
          * @param elemnt The DOM element that will host the new control. The Repeater will create an element if this value is null.
          * @param options An object that contains one or more property/value pairs to apply to the new Repeater. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
@@ -7369,7 +7340,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SearchBox.
-         * @constructor
          * @param element The DOM element hosts the new SearchBox.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -7505,7 +7475,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SemanticZoom.
-         * @constructor
          * @param element The DOM element that hosts the SemanticZoom.
          * @param options An object that contains one or more property/value pairs to apply to the new control. This object can contain these properties: initiallyZoomedOut Boolean, zoomFactor 0.2–0.85.
         **/
@@ -7620,7 +7589,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SettingsFlyout object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new SettingsFlyout.
         **/
@@ -7813,7 +7781,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SplitView.
-         * @constructor
          * @param element The DOM element hosts the new SplitView.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -7924,7 +7891,6 @@ declare namespace WinJS.UI {
     class SplitViewPaneToggle {
         /**
          * Creates a new SplitViewPaneToggle.
-         * @constructor
          * @param element The DOM element hosts the new SplitViewPaneToggle.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -7991,7 +7957,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SplitViewCommand.
-         * @constructor
          * @param element The DOM element hosts the new SplitViewCommand.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -8080,7 +8045,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new StorageDataSource object.
-         * @constructor
          * @param query The IStorageQueryResultBase that the StorageDataSource obtains its items from. Instead of IStorageQueryResultBase, you can also pass one of these string values: Music, Pictures, Videos, Documents.
          * @param options The set of properties and values to apply to the new StorageDataSource. Properties on this object may include: mode , requestedThumbnailSize , thumbnailOptions , synchronous .
         **/
@@ -8139,7 +8103,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new TabContainer.
-         * @constructor
          * @param element The DOM element that hosts the TabContainer control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties.
         **/
@@ -8185,7 +8148,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of a TimePicker control.
-         * @constructor
          * @param element The DOM element associated with the TimePicker control.
          * @param options The set of options to be applied initially to the TimePicker control. The options are the following: clock.
         **/
@@ -8300,7 +8262,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ToggleSwitch.
-         * @constructor
          * @param element The DOM that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the change event, add a property named "onchange" to the options object and set its value to the event handler.
         **/
@@ -8533,7 +8494,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Tooltip.
-         * @constructor
          * @param element The DOM element associated that hosts the Tooltip.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the opened event, add a property named "onopened" to the options object and set its value to the event handler.
         **/
@@ -8654,7 +8614,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of the ViewBox control.
-         * @constructor
          * @param element The DOM element that functions as the scaling box. This element fills 100% of the width and height allotted to it.
          * @param options The set of options to be applied initially to the ViewBox control. There are currently no options on this control, and any options included in this parameter are ignored.
         **/
@@ -8731,7 +8690,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes the VirtualizedDataSource base class of a custom data source.
-         * @constructor
          * @param listDataAdapter The object that supplies data to the VirtualizedDataSource.
          * @param options An object that can contain properties that specify additional options for the VirtualizedDataSource. It supports these properties: cacheSize.
         **/

--- a/types/winjs/v1/index.d.ts
+++ b/types/winjs/v1/index.d.ts
@@ -378,7 +378,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a List object.
-         * @constructor
          * @param list The array containing the elements to initalize the list.
          * @param options You can set two Boolean options: binding and proxy. If options.binding is true, the list contains the result of calling as on the element values. If options.proxy is true, the list specified as the first parameter is used as the storage for the List. This option should be used with care, because uncoordinated edits to the data storage may result in errors.
         **/
@@ -938,7 +937,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a template that provides a reusable declarative binding element.
-         * @constructor
          * @param element The DOM element to convert to a template.
          * @param options If this parameter is supplied, the template is loaded from the URI and the content of the element parameter is ignored. You can add the following options: href.
         **/
@@ -1159,7 +1157,6 @@ declare namespace WinJS {
 
         /**
          * Creates an Error object with the specified name and message properties.
-         * @constructor
          * @param name The name of this error. The name is meant to be consumed programmatically and should not be localized.
          * @param message The message for this error. The message is meant to be consumed by humans and should be localized.
         **/
@@ -1191,7 +1188,6 @@ declare namespace WinJS {
 
         /**
          * A promise provides a mechanism to schedule work to be done on a value that has not yet been computed. It is a convenient abstraction for managing interactions with asynchronous APIs. For more information about asynchronous programming, see Asynchronous programming. For more information about promises in JavaScript, see Asynchronous programming in JavaScript. For more information about using promises, see the WinJS Promise sample.
-         * @constructor
          * @param init The function that is called during construction of the Promise that contains the implementation of the operation that the Promise will represent. This can be synchronous or asynchronous, depending on the nature of the operation. Note that placing code within this function does not automatically run it asynchronously; that must be done explicitly with other asynchronous APIs such as setImmediate, setTimeout, requestAnimationFrame, and the Windows Runtime asynchronous APIs. The init function is given three arguments: completeDispatch, errorDispatch, progressDispatch. This parameter is optional.
          * @param onCancel The function to call if a consumer of this promise wants to cancel its undone work. Promises are not required to support cancellation.
         **/
@@ -3284,7 +3280,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBar object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBar.
         **/
@@ -3435,7 +3430,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBarCommand object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBarCommand.
         **/
@@ -3542,7 +3536,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of the DatePicker control.
-         * @constructor
          * @param element The DOM element associated with the DatePicker control.
          * @param options The set of options to be applied initially to the DatePicker control. The options are the following: calendar, current, datePattern, disabled, maxYear, minYear, monthPattern, yearPattern.
         **/
@@ -3696,7 +3689,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new FlipView.
-         * @constructor
          * @param element The DOM element that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the pageselected event, add a property named "onpageselected" and set its value to the event handler.
         **/
@@ -3833,7 +3825,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Flyout object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new Flyout.
         **/
@@ -3941,7 +3932,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new GridLayout object.
-         * @constructor
          * @param options The set of properties and values to apply to the new GridLayout.
         **/
         constructor(options?: any);
@@ -4135,7 +4125,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of HtmlControl to define a new page control.
-         * @constructor
          * @param element The element that hosts the HtmlControl.
          * @param options The options for configuring the page. The uri option is required in order to specify the source document for the content of the page. Other options are the ones used by the WinJS.Pages.render method.
         **/
@@ -4159,7 +4148,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListLayout.
-         * @constructor
          * @param options An object that contains one or more property/value pairs to apply to the new ListLayout. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
         constructor(options?: any);
@@ -4348,7 +4336,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListView.
-         * @constructor
          * @param element The DOM element that hosts the ListView control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the selectionchanged event, add a property named "onselectionchanged" to the options object and set its value to the event handler.
         **/
@@ -4588,7 +4575,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Menu object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new Menu.
         **/
@@ -4729,7 +4715,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new MenuCommand object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new MenuCommand.
         **/
@@ -4821,7 +4806,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Rating.
-         * @constructor
          * @param element The DOM element hosts the new Rating.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -4920,7 +4904,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SemanticZoom.
-         * @constructor
          * @param element The DOM element that hosts the SemanticZoom.
          * @param options An object that contains one or more property/value pairs to apply to the new control. This object can contain these properties: initiallyZoomedOut Boolean, zoomFactor 0.2–0.85.
         **/
@@ -5015,7 +4998,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SettingsFlyout object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new SettingsFlyout.
         **/
@@ -5141,7 +5123,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new StorageDataSource object.
-         * @constructor
          * @param query The IStorageQueryResultBase that the StorageDataSource obtains its items from. Instead of IStorageQueryResultBase, you can also pass one of these string values: Music, Pictures, Videos, Documents.
          * @param options The set of properties and values to apply to the new StorageDataSource. Properties on this object may include: mode , requestedThumbnailSize , thumbnailOptions , synchronous .
         **/
@@ -5171,7 +5152,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new TabContainer.
-         * @constructor
          * @param element The DOM element that hosts the TabContainer control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties.
         **/
@@ -5203,7 +5183,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of a TimePicker control.
-         * @constructor
          * @param element The DOM element associated with the TimePicker control.
          * @param options The set of options to be applied initially to the TimePicker control. The options are the following: clock.
         **/
@@ -5311,7 +5290,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ToggleSwitch.
-         * @constructor
          * @param element The DOM that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the change event, add a property named "onchange" to the options object and set its value to the event handler.
         **/
@@ -5415,7 +5393,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Tooltip.
-         * @constructor
          * @param element The DOM element associated that hosts the Tooltip.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the opened event, add a property named "onopened" to the options object and set its value to the event handler.
         **/
@@ -5526,7 +5503,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of the ViewBox control.
-         * @constructor
          * @param element The DOM element that functions as the scaling box. This element fills 100% of the width and height allotted to it.
          * @param options The set of options to be applied initially to the ViewBox control. There are currently no options on this control, and any options included in this parameter are ignored.
         **/
@@ -5585,7 +5561,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes the VirtualizedDataSource base class of a custom data source.
-         * @constructor
          * @param listDataAdapter The object that supplies data to the VirtualizedDataSource.
          * @param options An object that can contain properties that specify additional options for the VirtualizedDataSource. It supports these properties: cacheSize.
         **/

--- a/types/winjs/v2/index.d.ts
+++ b/types/winjs/v2/index.d.ts
@@ -394,7 +394,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a List object.
-         * @constructor
          * @param list The array containing the elements to initalize the list.
          * @param options You can set two Boolean options: binding and proxy. If options.binding is true, the list contains the result of calling as on the element values. If options.proxy is true, the list specified as the first parameter is used as the storage for the List. This option should be used with care, because uncoordinated edits to the data storage may result in errors.
         **/
@@ -954,7 +953,6 @@ declare namespace WinJS.Binding {
 
         /**
          * Creates a template that provides a reusable declarative binding element.
-         * @constructor
          * @param element The DOM element to convert to a template.
          * @param options If this parameter is supplied, the template is loaded from the URI and the content of the element parameter is ignored. You can add the following options: href.
         **/
@@ -1217,7 +1215,6 @@ declare namespace WinJS {
 
         /**
          * Creates an Error object with the specified name and message properties.
-         * @constructor
          * @param name The name of this error. The name is meant to be consumed programmatically and should not be localized.
          * @param message The message for this error. The message is meant to be consumed by humans and should be localized.
         **/
@@ -1249,7 +1246,6 @@ declare namespace WinJS {
 
         /**
          * A promise provides a mechanism to schedule work to be done on a value that has not yet been computed. It is a convenient abstraction for managing interactions with asynchronous APIs. For more information about asynchronous programming, see Asynchronous programming. For more information about promises in JavaScript, see Asynchronous programming in JavaScript. For more information about using promises, see the WinJS Promise sample.
-         * @constructor
          * @param init The function that is called during construction of the Promise that contains the implementation of the operation that the Promise will represent. This can be synchronous or asynchronous, depending on the nature of the operation. Note that placing code within this function does not automatically run it asynchronously; that must be done explicitly with other asynchronous APIs such as setImmediate, setTimeout, requestAnimationFrame, and the Windows Runtime asynchronous APIs. The init function is given three arguments: completeDispatch, errorDispatch, progressDispatch. This parameter is optional.
          * @param onCancel The function to call if a consumer of this promise wants to cancel its undone work. Promises are not required to support cancellation.
         **/
@@ -3634,7 +3630,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBar object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBar.
         **/
@@ -3795,7 +3790,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new AppBarCommand object.
-         * @constructor
          * @param element The DOM element that will host the control.
          * @param options The set of properties and values to apply to the new AppBarCommand.
         **/
@@ -3953,7 +3947,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new FlipView.
-         * @constructor
          * @param element The DOM element that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the pageselected event, add a property named "onpageselected" and set its value to the event handler.
         **/
@@ -4094,7 +4087,6 @@ declare namespace WinJS.UI {
        //#region Constructors
        /**
          * Creates a new FlipView.
-         * @constructor
          * @param element The DOM element that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the pageselected event, add a property named "onpageselected" and set its value to the event handler.
         **/
@@ -4212,7 +4204,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new GridLayout object.
-         * @constructor
          * @param options The set of properties and values to apply to the new GridLayout.
         **/
         constructor(options?: any);
@@ -4470,7 +4461,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of HtmlControl to define a new page control.
-         * @constructor
          * @param element The element that hosts the HtmlControl.
          * @param options The options for configuring the page. The uri option is required in order to specify the source document for the content of the page. Other options are the ones used by the WinJS.Pages.render method.
         **/
@@ -4488,7 +4478,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ItemContainer.
-         * @constructor
          * @param element The DOM element hosts the new ItemContainer. For the ItemContainer to be accessible, this element must have its role attribute set to "list" or "listbox". If tapBehavior is set to none and selectionDisabled is true, then use the "list" role; otherwise, use the "listbox" role.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events.
         **/
@@ -4606,7 +4595,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListLayout.
-         * @constructor
          * @param options An object that contains one or more property/value pairs to apply to the new ListLayout. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
         constructor(options?: any);
@@ -4852,7 +4840,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ListView.
-         * @constructor
          * @param element The DOM element that hosts the ListView control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the selectionchanged event, add a property named "onselectionchanged" to the options object and set its value to the event handler.
         **/
@@ -5113,7 +5100,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Pivot.
-         * @constructor
          * @param element The DOM element hosts the new Pivot.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -5219,7 +5205,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new PivotItem.
-         * @constructor
          * @param element The DOM element hosts the new PivotItem.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the cancel event, add a property named "oncancel" to the options object and set its value to the event handler.
         **/
@@ -5264,7 +5249,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new Repeater control.
-         * @constructor
          * @param elemnt The DOM element that will host the new control. The Repeater will create an element if this value is null.
          * @param options An object that contains one or more property/value pairs to apply to the new Repeater. Each property of the options object corresponds to one of the object's properties or events. Event names must begin with "on".
         **/
@@ -5416,7 +5400,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new SemanticZoom.
-         * @constructor
          * @param element The DOM element that hosts the SemanticZoom.
          * @param options An object that contains one or more property/value pairs to apply to the new control. This object can contain these properties: initiallyZoomedOut Boolean, zoomFactor 0.2–0.85.
         **/
@@ -5511,7 +5494,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new StorageDataSource object.
-         * @constructor
          * @param query The IStorageQueryResultBase that the StorageDataSource obtains its items from. Instead of IStorageQueryResultBase, you can also pass one of these string values: Music, Pictures, Videos, Documents.
          * @param options The set of properties and values to apply to the new StorageDataSource. Properties on this object may include: mode , requestedThumbnailSize , thumbnailOptions , synchronous .
         **/
@@ -5541,7 +5523,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new TabContainer.
-         * @constructor
          * @param element The DOM element that hosts the TabContainer control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties.
         **/
@@ -5582,7 +5563,6 @@ declare namespace WinJS.UI {
 
         /**
          * Creates a new ToggleSwitch.
-         * @constructor
          * @param element The DOM that hosts the control.
          * @param options An object that contains one or more property/value pairs to apply to the new control. Each property of the options object corresponds to one of the control's properties or events. Event names must begin with "on". For example, to provide a handler for the change event, add a property named "onchange" to the options object and set its value to the event handler.
         **/
@@ -5691,7 +5671,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes a new instance of the ViewBox control.
-         * @constructor
          * @param element The DOM element that functions as the scaling box. This element fills 100% of the width and height allotted to it.
          * @param options The set of options to be applied initially to the ViewBox control. There are currently no options on this control, and any options included in this parameter are ignored.
         **/
@@ -5755,7 +5734,6 @@ declare namespace WinJS.UI {
 
         /**
          * Initializes the VirtualizedDataSource base class of a custom data source.
-         * @constructor
          * @param listDataAdapter The object that supplies data to the VirtualizedDataSource.
          * @param options An object that can contain properties that specify additional options for the VirtualizedDataSource. It supports these properties: cacheSize.
         **/

--- a/types/winreg/index.d.ts
+++ b/types/winreg/index.d.ts
@@ -10,9 +10,6 @@ interface WinregStatic {
      * Creates a registry object, which provides access to a single registry key.
      * Note: This class is returned by a call to ```require('winreg')```.
      *
-     * @public
-     * @class
-     *
      * @param {@link Options} options - the options
      *
      * @example
@@ -147,37 +144,31 @@ declare namespace Winreg {
     export interface Registry {
         /**
          * The hostname.
-         * @readonly
          */
         host: string;
 
         /**
          * The hive id.
-         * @readonly
          */
         hive: string;
 
         /**
          * The registry key name.
-         * @readonly
          */
         key: string;
 
         /**
          * The full path to the registry key.
-         * @readonly
          */
         path: string;
 
         /**
          * The registry hive architecture ('x86' or 'x64').
-         * @readonly
          */
         arch: string;
 
         /**
          * Creates a new {@link Registry} instance that points to the parent registry key.
-         * @readonly
          */
         parent: Registry;
 
@@ -291,43 +282,36 @@ declare namespace Winreg {
     export interface RegistryItem {
         /**
          * The hostname.
-         * @readonly
          */
         host: string;
 
         /**
          * The hive id.
-         * @readonly
          */
         hive: string;
 
         /**
          * The registry key.
-         * @readonly
          */
         key: string;
 
         /**
          * The value name.
-         * @readonly
          */
         name: string;
 
         /**
          * The value type.
-         * @readonly
          */
         type: string;
 
         /**
          * The value.
-         * @readonly
          */
         value: string;
 
         /**
          * The hive architecture.
-         * @readonly
          */
         arch: string;
     }

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -805,7 +805,7 @@ declare namespace Xrm {
              * @param T Generic type parameter.
              * @param key The key.
              * @returns The shared variable.
-             * @desc Gets the shared variable with the specified key.
+             * @description Gets the shared variable with the specified key.
              * Used to pass values between handlers of an event.
              */
             getSharedVariable<T>(key: string): T;
@@ -815,7 +815,7 @@ declare namespace Xrm {
              * @param T Generic type parameter.
              * @param key The key.
              * @param value The value.
-             * @desc Sets the shared variable with the specified key.
+             * @description Sets the shared variable with the specified key.
              * Used to pass values between handlers of an event.
              */
             setSharedVariable<T>(key: string, value: T): void;

--- a/types/ydn-db/ydn-db-tests.ts
+++ b/types/ydn-db/ydn-db-tests.ts
@@ -11,7 +11,6 @@ var schema = {
 /**
  * Create and initialize the database. Depending on platform, this will
  * create IndexedDB or WebSql or even localStorage storage mechanism.
- * @type {ydn.db.Storage}
  */
 var db = new ydn.db.Storage('todo_2', schema);
 

--- a/types/zeroclipboard/index.d.ts
+++ b/types/zeroclipboard/index.d.ts
@@ -20,7 +20,6 @@ declare namespace ZC {
 
     /**
      * The version of the ZeroClipboard library being used, e.g. "2.0.0".
-     * @type {string}
      */
     version: string;
     /**
@@ -59,7 +58,6 @@ declare namespace ZC {
     /**
      * Create the Flash bridge SWF object.
      * IMPORTANT: This method should be considered private.
-     * @private
      */
     create(): void;
     /**
@@ -102,7 +100,6 @@ declare namespace ZC {
      * Indicates if Flash Player is definitely unusable (disabled, outdated, unavailable, or deactivated).
      * IMPORTANT: This method should be considered private.
      * @return {boolean}
-     * @private
      */
     isFlashUnusable(): boolean;
   }
@@ -110,7 +107,6 @@ declare namespace ZC {
   interface ZeroClipboardClient extends ZeroClipboardCommon {
     /**
      * A unique identifier for this ZeroClipboard client instance.
-     * @type {string}
      */
     id: string;
     /**
@@ -411,91 +407,75 @@ declare namespace ZC {
   interface ZeroClipboardConfig {
     /**
      * SWF URL, relative to the page. Default value will be "ZeroClipboard.swf" under the same path as the ZeroClipboard JS file.
-     * @type {string}
      */
     swfPath?: string | undefined;
     /**
      * SWF inbound scripting policy: page domains that the SWF should trust. (single string, or array of strings)
-     * @type {SingleOrList<string>}
      */
     trustedDomains?: string[] | undefined;
     /**
      * Include a "noCache" query parameter on requests for the SWF.
-     * @type {boolean}
      */
     cacheBust?: boolean | undefined;
     /**
      * Enable use of the fancy "Desktop" clipboard, even on Linux where it is known to suck.
-     * @type {boolean}
      */
     forceEnhancedClipboard?: boolean | undefined;
     /**
      * How many milliseconds to wait for the Flash SWF to load and respond before assuming that
      * Flash is deactivated (e.g. click-to-play) in the user's browser. If you don't care about
      * how long it takes to load the SWF, you can set this to `null`.
-     * @type {number}
      */
     flashLoadTimeout?: number | undefined;
     /**
      * Setting this to `false` would allow users to handle calling `ZeroClipboard.focus(...);`
      * themselves instead of relying on our per-element `mouseover` handler.
-     * @type {boolean}
      */
     autoActivate?: boolean | undefined;
     /**
      * Bubble synthetic events in JavaScript after they are received by the Flash object.
-     * @type {boolean}
      */
     bubbleEvents?: boolean | undefined;
     /**
      * Ensure OS-compliant line endings, i.e. "\r\n" on Windows, "\n" elsewhere
-     * @type {boolean}
      */
     fixLineEndings?: boolean | undefined;
     /**
      * Sets the ID of the `div` encapsulating the Flash object.
      * Value is validated against the [HTML4 spec for `ID` tokens][valid_ids].
-     * @type {string}
      */
     containerId?: string | undefined;
     /**
      * Sets the class of the `div` encapsulating the Flash object.
-     * @type {string}
      */
     containerClass?: string | undefined;
     /**
      * Sets the ID and name of the Flash `object` element.
      * Value is validated against the [HTML4 spec for `ID` and `Name` tokens][valid_ids].
-     * @type {string}
      */
     swfObjectId?: string | undefined;
     /**
      * The class used to indicate that a clipped element is being hovered over.
-     * @type {string}
      */
     hoverClass?: string | undefined;
     /**
      * The class used to indicate that a clipped element is active (is being clicked).
-     * @type {string}
      */
     activeClass?: string | undefined;
     /**
      * Forcibly set the hand cursor ("pointer") for all clipped elements.
      * IMPORTANT: This configuration value CAN be modified while a SWF is actively embedded.
-     * @type {boolean}
      */
     forceHandCursor?: boolean | undefined;
     /**
      * Sets the title of the `div` encapsulating the Flash object.
      * IMPORTANT: This configuration value CAN be modified while a SWF is actively embedded.
-     * @type {string}
      */
     title?: string | undefined;
     /**
      * The z-index used by the Flash object.
      * Max value (32-bit): 2147483647.
      * IMPORTANT: This configuration value CAN be modified while a SWF is actively embedded.
-     * @type {number}
      */
     zIndex?: number | undefined;
   }
@@ -503,7 +483,6 @@ declare namespace ZC {
 
 /**
  * [ZeroClipboard description]
- * @type {ZC.ZeroClipboardStatic}
  */
 declare var ZeroClipboard: ZC.ZeroClipboardStatic;
 


### PR DESCRIPTION
**Context**: Part of part of #648, porting old [TSLint](https://palantir.github.io/tslint) rules to [ESLint](https://eslint.org/) equivalents. Within migrating `no-redundant-jsdoc2`, this runs the auto-fixer from [jsdoc/check-tag-names](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-tag-names.md#user-content-check-tag-names-options-typed).

`jsdoc/check-tag-names` reports on JSDoc tags that are unnecessary. Here, we're using its `{ typed: true }` option to look for JSDoc tags that are redundant in TypeScript.

<details>
<summary>I used a <em>very</em> permissive ESLint config to avoid flagging library-specific tags or switching tag names unnecessarily (e.g. <code>@return</code> to <code>@returns</code>)</summary>

```json
{
    "root": true,
    "extends": [],
    "parser": "@typescript-eslint/parser",
    "plugins": ["@typescript-eslint", "jsdoc"],
    "rules": {
      "jsdoc/check-tag-names": [
        "error",
        {
          "definedTags": [
            "addVersion",
            "api",
            "author",
            "beta",
            "brief",
            "category",
            "cfg",
            "chainable",
            "check",
            "classDescription",
            "condparamprivilege",
            "constraint",
            "credits",
            "declaration",
            "defApiFeature",
            "defaultValue",
            "detail",
            "end",
            "eventproperty",
            "experimental",
            "export",
            "expose",
            "extendscript",
            "factory",
            "field",
            "final",
            "fixme",
            "fluent",
            "for",
            "governance",
            "header",
            "hidden-property",
            "hidden",
            "id",
            "label",
            "language",
            "link",
            "listen",
            "locus",
            "methodOf",
            "minVersion",
            "ngdoc",
            "nonstandard",
            "note",
            "npm",
            "observable",
            "option",
            "optionobject",
            "options",
            "packageDocumentation",
            "param",
            "parent",
            "platform",
            "plugin",
            "preserve",
            "privateRemarks",
            "privilegeLevel",
            "privilegeName",
            "proposed",
            "range",
            "readOnly",
            "related",
            "remark",
            "remarks",
            "required",
            "requires",
            "restriction",
            "returnType",
            "section",
            "see",
            "since",
            "const",
            "singleton",
            "source",
            "struct",
            "suppress",
            "targetfolder",
            "enum",
            "title",
            "record",
            "title",
            "TODO",
            "trigger",
            "triggers",
            "typeparam",
            "typeParam",
            "unsupported",
            "url",
            "usage",
            "warn",
            "warning",
            "version"
          ],
          "typed": true
        }
      ]
    },
    "settings": {
        "jsdoc": {
            "tagNamePreference": {
                "argument": "argument",
                "exception": "exception",
                "function": "function",
                "method": "method",
                "param": "param",
                "return": "return",
                "returns": "returns"
            }
        }
    }
  }
```

</details>

Starting off as a draft so we can discuss what changes might need to be made to `check-tag-names`. Each classification of change has a comment thread inline.