### PR TITLE
fix(react-lazy-load-image-component): change Omit key in LazyLoadImageProps

### DIFF
--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -45,7 +45,7 @@ export interface CommonProps {
     scrollPosition?: ScrollPosition | undefined;
 }
 
-export interface LazyLoadImageProps extends CommonProps, Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onload'>  {
+export interface LazyLoadImageProps extends CommonProps, Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onLoad'>  {
     /** Name of the effect to use. Requires importing CSS, see README.md. */
     effect?: Effect | undefined;
     /** Image src to display while the image is not visible or loaded. */


### PR DESCRIPTION
I modified `react-lazy-load-image-component` package.
I think `onLoad` rather than `onload` would be more appropriate.

package url : https://github.com/Aljullu/react-lazy-load-image-component


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

