### PR TITLE
[sinon] allow partial arguments in withArgs and calledOnceWith

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -10,7 +10,7 @@
 //                 Mathias Schreck <https://github.com/lo1tuma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as FakeTimers from "@sinonjs/fake-timers";
+import * as FakeTimers from '@sinonjs/fake-timers';
 
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
@@ -19,13 +19,17 @@ interface Event {} // tslint:disable-line no-empty-interface
 interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
-    type DeepPartialOrMatcher<T> = {
-        [K in keyof T]?: SinonMatcher | (T[K] extends object ? DeepPartialOrMatcher<T[K]> : T[K]);
+    type MatchProvidedArguments<T> = {
+        [K in keyof T]?: SinonMatcher | (T[K] extends object ? MatchProvidedArguments<T[K]> : T[K]);
     };
+    // Alias for backward compatibility, remove on next major release
+    type DeepPartialOrMatcher<T> = MatchProvidedArguments<T>;
 
-    type MatchArguments<T> = {
-        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
+    type MatchExactlyArguments<T> = {
+        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchExactlyArguments<T[K]> : T[K]);
     };
+    // Alias for backward compatibility, remove on next major release
+    type MatchArguments<T> = MatchExactlyArguments<T>;
 
     interface SinonSpyCallApi<TArgs extends readonly any[] = any[], TReturnValue = any> {
         // Properties
@@ -47,11 +51,11 @@ declare namespace Sinon {
          * so a call that received the provided arguments (in the same spots) and possibly others as well will return true.
          * @param args
          */
-        calledWith(...args: Partial<MatchArguments<TArgs>>): boolean;
+        calledWith(...args: MatchProvidedArguments<TArgs>): boolean;
         /**
          * Returns true if spy was called at least once with the provided arguments and no others.
          */
-        calledWithExactly(...args: MatchArguments<TArgs>): boolean;
+        calledWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if spy/stub was called the new operator.
          * Beware that this is inferred based on the value of the this object and the spy function’s prototype,
@@ -62,25 +66,25 @@ declare namespace Sinon {
          * Returns true if spy was called at exactly once with the provided arguments.
          * @param args
          */
-        calledOnceWith(...args: MatchArguments<TArgs>): boolean;
-        calledOnceWithExactly(...args: MatchArguments<TArgs>): boolean;
+        calledOnceWith(...args: MatchExactlyArguments<TArgs>): boolean;
+        calledOnceWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if spy was called with matching arguments (and possibly others).
          * This behaves the same as spy.calledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        calledWithMatch(...args: DeepPartialOrMatcher<TArgs>): boolean;
+        calledWithMatch(...args: MatchProvidedArguments<TArgs>): boolean;
         /**
          * Returns true if call did not receive provided arguments.
          * @param args
          */
-        notCalledWith(...args: MatchArguments<TArgs>): boolean;
+        notCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if call did not receive matching arguments.
          * This behaves the same as spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        notCalledWithMatch(...args: DeepPartialOrMatcher<TArgs>): boolean;
+        notCalledWithMatch(...args: MatchProvidedArguments<TArgs>): boolean;
         /**
          * Returns true if spy returned the provided value at least once.
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
@@ -173,7 +177,7 @@ declare namespace Sinon {
     interface SinonSpy<TArgs extends readonly any[] = any[], TReturnValue = any>
         extends Pick<
             SinonSpyCallApi<TArgs, TReturnValue>,
-            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, "args">
+            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
         > {
         // Properties
         /**
@@ -269,7 +273,7 @@ declare namespace Sinon {
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
          * @param args Expected args
          */
-        withArgs(...args: MatchArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
+        withArgs(...args: MatchProvidedArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
         /**
          * Returns true if the spy was always called with @param obj as this.
          * @param obj
@@ -278,12 +282,12 @@ declare namespace Sinon {
         /**
          * Returns true if spy was always called with the provided arguments (and possibly others).
          */
-        alwaysCalledWith(...args: MatchArguments<TArgs>): boolean;
+        alwaysCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with the exact provided arguments.
          * @param args
          */
-        alwaysCalledWithExactly(...args: MatchArguments<TArgs>): boolean;
+        alwaysCalledWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with matching arguments (and possibly others).
          * This behaves the same as spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
@@ -294,7 +298,7 @@ declare namespace Sinon {
          * Returns true if the spy/stub was never called with the provided arguments.
          * @param args
          */
-        neverCalledWith(...args: MatchArguments<TArgs>): boolean;
+        neverCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
         /**
          * Returns true if the spy/stub was never called with matching arguments.
          * This behaves the same as spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
@@ -386,7 +390,7 @@ declare namespace Sinon {
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
 
-        <T, K extends keyof T>(obj: T, method: K, types: Array<"get" | "set">): PropertyDescriptor & {
+        <T, K extends keyof T>(obj: T, method: K, types: Array<'get' | 'set'>): PropertyDescriptor & {
             get: SinonSpy<[], T[K]>;
             set: SinonSpy<[T[K]], void>;
         };
@@ -400,7 +404,8 @@ declare namespace Sinon {
         ? SinonSpy<TArgs, TReturnValue>
         : T;
 
-    interface SinonStub<TArgs extends readonly any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
+    interface SinonStub<TArgs extends readonly any[] = any[], TReturnValue = any>
+        extends SinonSpy<TArgs, TReturnValue> {
         /**
          * Resets the stub’s behaviour to the default behaviour
          * You can reset behaviour of all stubs using sinon.resetBehavior()
@@ -654,7 +659,7 @@ declare namespace Sinon {
          * It is also useful to create a stub that can act differently in response to different arguments.
          * @param args
          */
-        withArgs(...args: MatchArguments<TArgs>): SinonStub<TArgs, TReturnValue>;
+        withArgs(...args: MatchProvidedArguments<TArgs>): SinonStub<TArgs, TReturnValue>;
     }
 
     interface SinonStubStatic {
@@ -1114,20 +1119,20 @@ declare namespace Sinon {
          */
         calledWith<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: Partial<MatchArguments<TArgs>>
+            ...args: MatchProvidedArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
          * @param args
          */
-        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: Partial<MatchArguments<TArgs>>): void;
+        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
         /**
          * Passes if spy was never called with the provided arguments.
          * @param spy
          * @param args
          */
-        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: Partial<MatchArguments<TArgs>>): void;
+        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
         /**
          * Passes if spy was called with the provided arguments and no others.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);.
@@ -1136,7 +1141,7 @@ declare namespace Sinon {
          */
         calledWithExactly<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchArguments<TArgs>
+            ...args: MatchExactlyArguments<TArgs>
         ): void;
         /**
          * Passes if spy was called at exactly once with the provided arguments and no others.
@@ -1145,12 +1150,12 @@ declare namespace Sinon {
          */
         calledOnceWithExactly<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchArguments<TArgs>
+            ...args: MatchExactlyArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments and no others.
          */
-        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;
+        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchExactlyArguments<TArgs>): void;
         /**
          * Passes if spy was called with matching arguments.
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
@@ -1158,7 +1163,7 @@ declare namespace Sinon {
          */
         calledWithMatch<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: DeepPartialOrMatcher<TArgs>
+            ...args: MatchProvidedArguments<TArgs>
         ): void;
         /**
          * Passes if spy was called once with matching arguments.
@@ -1173,14 +1178,14 @@ declare namespace Sinon {
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          */
-        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: DeepPartialOrMatcher<TArgs>): void;
+        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
         /**
          * Passes if spy was never called with matching arguments.
          * This behaves the same way as sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * @param spy
          * @param args
          */
-        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: DeepPartialOrMatcher<TArgs>): void;
+        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
         /**
          * Passes if spy was called with the new operator.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.
@@ -1493,13 +1498,17 @@ declare namespace Sinon {
          * Creates a fake that returns the val argument
          * @param val Returned value
          */
-        returns<TArgs extends readonly any[] = any[], TReturnValue = any>(val: TReturnValue): SinonSpy<TArgs, TReturnValue>;
+        returns<TArgs extends readonly any[] = any[], TReturnValue = any>(
+            val: TReturnValue,
+        ): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that throws an Error with the provided value as the message property.
          * If an Error is passed as the val argument, then that will be the thrown value. If any other value is passed, then that will be used for the message property of the thrown Error.
          * @param val Returned value or throw value if an Error
          */
-        throws<TArgs extends readonly any[] = any[], TReturnValue = any>(val: Error | string): SinonSpy<TArgs, TReturnValue>;
+        throws<TArgs extends readonly any[] = any[], TReturnValue = any>(
+            val: Error | string,
+        ): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that returns a resolved Promise for the passed value.
          * @param val Resolved promise
@@ -1521,7 +1530,9 @@ declare namespace Sinon {
         /**
          * fake expects the last argument to be a callback and will invoke it asynchronously with the given arguments.
          */
-        yieldsAsync<TArgs extends readonly any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
+        yieldsAsync<TArgs extends readonly any[] = any[], TReturnValue = any>(
+            ...args: any[]
+        ): SinonSpy<TArgs, TReturnValue>;
     }
 
     interface SinonSandbox {
@@ -1659,7 +1670,7 @@ declare namespace Sinon {
     }
 
     type SinonPromise<T> = Promise<T> & {
-        status: 'pending'|'resolved'|'rejected';
+        status: 'pending' | 'resolved' | 'rejected';
         resolve(val: unknown): Promise<T>;
         reject(reason: unknown): Promise<void>;
         resolvedValue?: T;
@@ -1702,7 +1713,7 @@ declare namespace Sinon {
         setFormatter: (customFormatter: (...args: any[]) => string) => void;
 
         promise<T = unknown>(
-            executor?: (resolve: (value: T) => void, reject: (reason?: unknown) => void) => void
+            executor?: (resolve: (value: T) => void, reject: (reason?: unknown) => void) => void,
         ): SinonPromise<T>;
     }
 

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -19,17 +19,17 @@ interface Event {} // tslint:disable-line no-empty-interface
 interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
-    type MatchProvidedArguments<T> = {
-        [K in keyof T]?: SinonMatcher | (T[K] extends object ? MatchProvidedArguments<T[K]> : T[K]);
+    type MatchPartialArguments<T> = {
+        [K in keyof T]?: SinonMatcher | (T[K] extends object ? MatchPartialArguments<T[K]> : T[K]);
     };
-    // Alias for backward compatibility, remove on next major release
-    type DeepPartialOrMatcher<T> = MatchProvidedArguments<T>;
+    // TODO: Alias for backward compatibility, remove on next major release
+    type DeepPartialOrMatcher<T> = MatchPartialArguments<T>;
 
-    type MatchExactlyArguments<T> = {
-        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchExactlyArguments<T[K]> : T[K]);
+    type MatchExactArguments<T> = {
+        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchExactArguments<T[K]> : T[K]);
     };
-    // Alias for backward compatibility, remove on next major release
-    type MatchArguments<T> = MatchExactlyArguments<T>;
+    // TODO: Alias for backward compatibility, remove on next major release
+    type MatchArguments<T> = MatchExactArguments<T>;
 
     interface SinonSpyCallApi<TArgs extends readonly any[] = any[], TReturnValue = any> {
         // Properties
@@ -51,11 +51,11 @@ declare namespace Sinon {
          * so a call that received the provided arguments (in the same spots) and possibly others as well will return true.
          * @param args
          */
-        calledWith(...args: MatchProvidedArguments<TArgs>): boolean;
+        calledWith(...args: MatchPartialArguments<TArgs>): boolean;
         /**
          * Returns true if spy was called at least once with the provided arguments and no others.
          */
-        calledWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
+        calledWithExactly(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if spy/stub was called the new operator.
          * Beware that this is inferred based on the value of the this object and the spy function’s prototype,
@@ -66,25 +66,25 @@ declare namespace Sinon {
          * Returns true if spy was called at exactly once with the provided arguments.
          * @param args
          */
-        calledOnceWith(...args: MatchExactlyArguments<TArgs>): boolean;
-        calledOnceWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
+        calledOnceWith(...args: MatchPartialArguments<TArgs>): boolean;
+        calledOnceWithExactly(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if spy was called with matching arguments (and possibly others).
          * This behaves the same as spy.calledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        calledWithMatch(...args: MatchProvidedArguments<TArgs>): boolean;
+        calledWithMatch(...args: MatchPartialArguments<TArgs>): boolean;
         /**
          * Returns true if call did not receive provided arguments.
          * @param args
          */
-        notCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
+        notCalledWith(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if call did not receive matching arguments.
          * This behaves the same as spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        notCalledWithMatch(...args: MatchProvidedArguments<TArgs>): boolean;
+        notCalledWithMatch(...args: MatchPartialArguments<TArgs>): boolean;
         /**
          * Returns true if spy returned the provided value at least once.
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
@@ -273,7 +273,7 @@ declare namespace Sinon {
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
          * @param args Expected args
          */
-        withArgs(...args: MatchProvidedArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
+        withArgs(...args: MatchPartialArguments<TArgs>): SinonSpy<TArgs, TReturnValue>;
         /**
          * Returns true if the spy was always called with @param obj as this.
          * @param obj
@@ -282,12 +282,12 @@ declare namespace Sinon {
         /**
          * Returns true if spy was always called with the provided arguments (and possibly others).
          */
-        alwaysCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
+        alwaysCalledWith(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with the exact provided arguments.
          * @param args
          */
-        alwaysCalledWithExactly(...args: MatchExactlyArguments<TArgs>): boolean;
+        alwaysCalledWithExactly(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if spy was always called with matching arguments (and possibly others).
          * This behaves the same as spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
@@ -298,7 +298,7 @@ declare namespace Sinon {
          * Returns true if the spy/stub was never called with the provided arguments.
          * @param args
          */
-        neverCalledWith(...args: MatchExactlyArguments<TArgs>): boolean;
+        neverCalledWith(...args: MatchExactArguments<TArgs>): boolean;
         /**
          * Returns true if the spy/stub was never called with matching arguments.
          * This behaves the same as spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
@@ -659,7 +659,7 @@ declare namespace Sinon {
          * It is also useful to create a stub that can act differently in response to different arguments.
          * @param args
          */
-        withArgs(...args: MatchProvidedArguments<TArgs>): SinonStub<TArgs, TReturnValue>;
+        withArgs(...args: MatchPartialArguments<TArgs>): SinonStub<TArgs, TReturnValue>;
     }
 
     interface SinonStubStatic {
@@ -1119,20 +1119,20 @@ declare namespace Sinon {
          */
         calledWith<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchProvidedArguments<TArgs>
+            ...args: MatchPartialArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
          * @param args
          */
-        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
+        alwaysCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchPartialArguments<TArgs>): void;
         /**
          * Passes if spy was never called with the provided arguments.
          * @param spy
          * @param args
          */
-        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
+        neverCalledWith<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchPartialArguments<TArgs>): void;
         /**
          * Passes if spy was called with the provided arguments and no others.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);.
@@ -1141,7 +1141,7 @@ declare namespace Sinon {
          */
         calledWithExactly<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchExactlyArguments<TArgs>
+            ...args: MatchExactArguments<TArgs>
         ): void;
         /**
          * Passes if spy was called at exactly once with the provided arguments and no others.
@@ -1150,12 +1150,12 @@ declare namespace Sinon {
          */
         calledOnceWithExactly<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchExactlyArguments<TArgs>
+            ...args: MatchExactArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with the provided arguments and no others.
          */
-        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchExactlyArguments<TArgs>): void;
+        alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchExactArguments<TArgs>): void;
         /**
          * Passes if spy was called with matching arguments.
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
@@ -1163,7 +1163,7 @@ declare namespace Sinon {
          */
         calledWithMatch<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchProvidedArguments<TArgs>
+            ...args: MatchPartialArguments<TArgs>
         ): void;
         /**
          * Passes if spy was called once with matching arguments.
@@ -1178,14 +1178,14 @@ declare namespace Sinon {
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          */
-        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
+        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchPartialArguments<TArgs>): void;
         /**
          * Passes if spy was never called with matching arguments.
          * This behaves the same way as sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * @param spy
          * @param args
          */
-        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchProvidedArguments<TArgs>): void;
+        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchPartialArguments<TArgs>): void;
         /**
          * Passes if spy was called with the new operator.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -663,6 +663,7 @@ function testSpy() {
     fnSpy('a', 1); // $ExpectType boolean
     fnSpy.args; // $ExpectType [string, number][] || [arg: string, arg2: number][]
     fnSpy.returnValues; // $ExpectType boolean[]
+    fnSpy.withArgs('a').returned(true);
 
     spy(1, 2);
     spy(true);
@@ -731,7 +732,7 @@ function testSpy() {
 
 function testStub() {
     const obj = class {
-        foo(arg: string): number {
+        foo(arg: string, arg2: number): number {
             return 1;
         }
         promiseFunc() {
@@ -824,17 +825,20 @@ function testStub() {
     stub2.returns(5);
     // @ts-expect-error
     stub2.returns('foo');
-    stub2.callsFake((arg: string) => 1);
+    stub2.callsFake((arg: string, arg2: number) => 1);
     // @ts-expect-error
     stub2.callsFake((arg: number) => 1);
+    // @ts-expect-error
+    stub2.callsFake((arg: string, arg2: string) => 1);
     // @ts-expect-error
     stub2.callsFake((arg: string) => 'a');
     stub2.onCall(1).returns(2);
     // @ts-expect-error
-    stub2.withArgs('a', 2).returns('true');
+    stub2.withArgs('a', 2, 3).returns(1);
+    stub2.withArgs('a', 2).returns(1);
     stub2.withArgs('a').returns(1);
     // @ts-expect-error
-    stub2.withArgs('a').returns('a');
+    stub2.withArgs('a', 2).returns('a');
 
     const stub3 = sinon.stub(instance, 'fooDeep').named('namedStubDeep');
     stub3.calledWith({ s: sinon.match.string });

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -664,6 +664,9 @@ function testSpy() {
     fnSpy.args; // $ExpectType [string, number][] || [arg: string, arg2: number][]
     fnSpy.returnValues; // $ExpectType boolean[]
     fnSpy.withArgs('a').returned(true);
+    fnSpy.calledOnceWith('a');
+    // @ts-expect-error
+    fnSpy.calledOnceWithExactly('a');
 
     spy(1, 2);
     spy(true);


### PR DESCRIPTION
Follows up from:
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58362 (introduces `DeepPartialOrMatcher`)
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53467 (adds more `Partial<MatchArguments>`)
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34048 (introduces `Partial<MatchArguments>`)

In this PR I do these things:
1. Unify `DeepPartialOrMatcher` and `Partial<MatchArguments>` since both express the same.
2. Create type names closer to what it is expressed in the API documentation/code: "match arguments exactly" and "match the arguments partially". I also leave the previous ones for compatibility.
3. Fix `withArgs` in spy and stubs, the API supports "matching the arguments partially".
4. Fix `spy.calledOnceWith`, it uses "matching the arguments partially".

Checks
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://sinonjs.org/releases/v15/spies/#spywithargsarg1-arg2-
  * https://sinonjs.org/releases/v15/stubs/#stubwithargsarg1-arg2-
- n/a If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
