### PR TITLE
Fix bad imports in hapi/v16 tests

### DIFF
--- a/types/hapi/v16/test/request/set-url.ts
+++ b/types/hapi/v16/test/request/set-url.ts
@@ -16,14 +16,12 @@ server.ext('onRequest', onRequest);
 
 // Example 2
 
-const Url = require('url');
-const Qs = require('hapi../../qs');
+import * as Url from 'url';
 
 onRequest = function (request, reply) {
 
     const uri = request.raw.req.url;
-    const parsed = Url.parse(uri, false);
-    parsed.query = Qs.parse(parsed.query);
+    const parsed = Url.parse(uri!, false);
     request.setUrl(parsed);
 
     return reply.continue();

--- a/types/hapi/v16/test/response/error.ts
+++ b/types/hapi/v16/test/response/error.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#error-response
 
 import * as Hapi from 'hapi';
-const Boom = require('hapi../../boom');
+import * as Boom from 'boom';
 
 const server = new Hapi.Server();
 

--- a/types/hapi/v16/test/route/validate.ts
+++ b/types/hapi/v16/test/route/validate.ts
@@ -2,7 +2,7 @@
 // Added from: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16065#issuecomment-302216131
 
 import * as Hapi from 'hapi';
-import * as Joi from 'hapi../../joi';
+import * as Joi from 'joi';
 
 const validate: Hapi.RouteValidationConfigurationObject = {
     headers: true,

--- a/types/hapi/v16/test/server/auth.ts
+++ b/types/hapi/v16/test/server/auth.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#serverauthapi
 
 import * as Hapi from 'hapi';
-import * as Boom from 'hapi../../boom';
+import * as Boom from 'boom';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/initialize.ts
+++ b/types/hapi/v16/test/server/initialize.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#serverinitializecallback
 
 import * as Hapi from 'hapi';
-const Hoek = require('hapi../../hoek');
+import * as Hoek from 'hoek';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/start.ts
+++ b/types/hapi/v16/test/server/start.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#serverstartcallback
 
 import * as Hapi from 'hapi';
-import * as Hoek from 'hapi../../hoek';
+import * as Hoek from 'hoek';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 


### PR DESCRIPTION
Noticed during the monorepo refactor. These tests have been broken for a few years.