### PR TITLE
Remove unused references clause from jasmine-expect-jsx test

### DIFF
--- a/types/jasmine-expect-jsx/jasmine-expect-jsx-tests.tsx
+++ b/types/jasmine-expect-jsx/jasmine-expect-jsx-tests.tsx
@@ -1,5 +1,3 @@
-/// <reference types="./index"/>
-
 describe('test suite', () => {
   it('tests toEqualJSX method', () => {
     const component = (


### PR DESCRIPTION
There's no need for this `references` comment. Not sure why the bot didn't complain originally; maybe it did.