### PR TITLE
Remove stray import from leaflet.pm tests

### DIFF
--- a/types/leaflet.pm/leaflet.pm-tests.ts
+++ b/types/leaflet.pm/leaflet.pm-tests.ts
@@ -1,5 +1,4 @@
 import * as L from 'leaflet';
-import 'leaflet-pm';
 
 const toolbarOptions: L.PM.ToolbarOptions = {
     position: 'topleft',


### PR DESCRIPTION
This import doesn't mean anything and can be removed.