### PR TITLE
Remove dotenv, package.json from oracledb

### DIFF
--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -1,10 +1,7 @@
 import * as oracledb from 'oracledb';
 
 import defaultOracledb from 'oracledb';
-// import dotenv from 'dotenv';
 import assert from 'assert';
-
-// dotenv.config();
 
 /*
 

--- a/types/oracledb/package.json
+++ b/types/oracledb/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "dotenv": "^8.2.0"
-    }
-}

--- a/types/oracledb/v3/oracledb-tests.ts
+++ b/types/oracledb/v3/oracledb-tests.ts
@@ -1,8 +1,5 @@
 import * as oracledb from 'oracledb';
-import * as dotenv from 'dotenv';
 import * as assert from 'assert';
-
-dotenv.config();
 
 /*
 


### PR DESCRIPTION
This package does not depend on dotenv at all. It was only there for a random test in which it didn't matter.