### PR TITLE
Fix casing of references in testing-library__cyprus

### DIFF
--- a/types/testing-library__cypress/testing-library__cypress-tests.ts
+++ b/types/testing-library__cypress/testing-library__cypress-tests.ts
@@ -1,4 +1,4 @@
-/// <reference types="Cypress" />
+/// <reference types="cypress" />
 import { configure } from '@testing-library/cypress';
 import '@testing-library/cypress/add-commands';
 


### PR DESCRIPTION
I have no idea how this is legal, but apparently it is. But, it confuses my script that's converting DT to a monorepo and I feel like this should be written in its canonical form anyhow.