### PR TITLE
[react] Add v18 fork for TS 5.0 and below

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -29,5 +29,12 @@
         "default": "./jsx-dev-runtime.d.ts"
       }
     }
+  },
+  "typesVersions": {
+    "<=5.0": {
+      "*": [
+        "ts5.0/*"
+      ]
+    }
   }
 }

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "csstype": "^3.0.2"
   },
+  "types": "index",
   "exports": {
     ".": {
       "types": {

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -6,26 +6,41 @@
   "types": "index",
   "exports": {
     ".": {
+      "types@<=5.0": {
+        "default": "./ts5.0/index.d.ts"
+      },
       "types": {
         "default": "./index.d.ts"
       }
     },
     "./next": {
+      "types@<=5.0": {
+        "default": "./ts5.0/next.d.ts"
+      },
       "types": {
         "default": "./next.d.ts"
       }
     },
     "./experimental": {
+      "types@<=5.0": {
+        "default": "./ts5.0/experimental.d.ts"
+      },
       "types": {
         "default": "./experimental.d.ts"
       }
     },
     "./jsx-runtime": {
+      "types@<=5.0": {
+        "default": "./ts5.0/jsx-runtime.d.ts"
+      },
       "types": {
         "default": "./jsx-runtime.d.ts"
       }
     },
     "./jsx-dev-runtime": {
+      "types@<=5.0": {
+        "default": "./ts5.0/jsx-dev-runtime.d.ts"
+      },
       "types": {
         "default": "./jsx-dev-runtime.d.ts"
       }

--- a/types/react/ts5.0/.eslintrc.json
+++ b/types/react/ts5.0/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "dt-header": "off",
+        "no-unnecessary-generics": "off"
+    }
+}

--- a/types/react/ts5.0/OTHER_FILES.txt
+++ b/types/react/ts5.0/OTHER_FILES.txt
@@ -1,0 +1,4 @@
+next.d.ts
+experimental.d.ts
+jsx-dev-runtime.d.ts
+jsx-runtime.d.ts

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -1,0 +1,108 @@
+/**
+ * These are types for things that are present in the `experimental` builds of React but not yet
+ * on a stable build.
+ *
+ * Once they are promoted to stable they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/experimental"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/experimental'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/experimental" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/master/packages/react/src/React.js to see how the exports are declared,
+// and https://github.com/facebook/react/blob/master/packages/shared/ReactFeatureFlags.js to verify which APIs are
+// flagged experimental or not. Experimental APIs will be tagged with `__EXPERIMENTAL__`.
+//
+// For the inputs of types exported as simply a fiber tag, the `beginWork` function of ReactFiberBeginWork.js
+// is a good place to start looking for details; it generally calls prop validation functions or delegates
+// all tasks done as part of the render phase (the concurrent part of the React update cycle).
+//
+// Suspense-related handling can be found in ReactFiberThrow.js.
+
+import React = require('./next');
+
+export {};
+
+declare module '.' {
+    export interface SuspenseProps {
+        /**
+         * The presence of this prop indicates that the content is computationally expensive to render.
+         * In other words, the tree is CPU bound and not I/O bound (e.g. due to fetching data).
+         * @see {@link https://github.com/facebook/react/pull/19936}
+         */
+        unstable_expectedLoadTime?: number | undefined;
+    }
+
+    export type SuspenseListRevealOrder = 'forwards' | 'backwards' | 'together';
+    export type SuspenseListTailMode = 'collapsed' | 'hidden';
+
+    export interface SuspenseListCommonProps {
+        /**
+         * Note that SuspenseList require more than one child;
+         * it is a runtime warning to provide only a single child.
+         *
+         * It does, however, allow those children to be wrapped inside a single
+         * level of `<React.Fragment>`.
+         */
+        children: ReactElement | Iterable<ReactElement>;
+    }
+
+    interface DirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder: 'forwards' | 'backwards';
+        /**
+         * Dictates how unloaded items in a SuspenseList is shown.
+         *
+         * - By default, `SuspenseList` will show all fallbacks in the list.
+         * - `collapsed` shows only the next fallback in the list.
+         * - `hidden` doesn’t show any unloaded items.
+         */
+        tail?: SuspenseListTailMode | undefined;
+    }
+
+    interface NonDirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder?: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps['revealOrder']> | undefined;
+        /**
+         * The tail property is invalid when not using the `forwards` or `backwards` reveal orders.
+         */
+        tail?: never | undefined;
+    }
+
+    export type SuspenseListProps = DirectionalSuspenseListProps | NonDirectionalSuspenseListProps;
+
+    /**
+     * `SuspenseList` helps coordinate many components that can suspend by orchestrating the order
+     * in which these components are revealed to the user.
+     *
+     * When multiple components need to fetch data, this data may arrive in an unpredictable order.
+     * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
+     * until previous items have been displayed (this behavior is adjustable).
+     *
+     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
+     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     */
+    export const SuspenseList: ExoticComponent<SuspenseListProps>;
+
+    // tslint:disable-next-line ban-types
+    export function experimental_useEffectEvent<T extends Function>(event: T): T;
+}

--- a/types/react/ts5.0/global.d.ts
+++ b/types/react/ts5.0/global.d.ts
@@ -1,0 +1,157 @@
+/*
+React projects that don't include the DOM library need these interfaces to compile.
+React Native applications use React, but there is no DOM available. The JavaScript runtime
+is ES6/ES2015 only. These definitions allow such projects to compile with only `--lib ES6`.
+
+Warning: all of these interfaces are empty. If you want type definitions for various properties
+(such as HTMLInputElement.prototype.value), you need to add `--lib DOM` (via command line or tsconfig.json).
+*/
+
+interface Event { }
+interface AnimationEvent extends Event { }
+interface ClipboardEvent extends Event { }
+interface CompositionEvent extends Event { }
+interface DragEvent extends Event { }
+interface FocusEvent extends Event { }
+interface KeyboardEvent extends Event { }
+interface MouseEvent extends Event { }
+interface TouchEvent extends Event { }
+interface PointerEvent extends Event { }
+interface TransitionEvent extends Event { }
+interface UIEvent extends Event { }
+interface WheelEvent extends Event { }
+
+interface EventTarget { }
+interface Document { }
+interface DataTransfer { }
+interface StyleMedia { }
+
+interface Element { }
+interface DocumentFragment { }
+
+interface HTMLElement extends Element { }
+interface HTMLAnchorElement extends HTMLElement { }
+interface HTMLAreaElement extends HTMLElement { }
+interface HTMLAudioElement extends HTMLElement { }
+interface HTMLBaseElement extends HTMLElement { }
+interface HTMLBodyElement extends HTMLElement { }
+interface HTMLBRElement extends HTMLElement { }
+interface HTMLButtonElement extends HTMLElement { }
+interface HTMLCanvasElement extends HTMLElement { }
+interface HTMLDataElement extends HTMLElement { }
+interface HTMLDataListElement extends HTMLElement { }
+interface HTMLDetailsElement extends HTMLElement { }
+interface HTMLDialogElement extends HTMLElement { }
+interface HTMLDivElement extends HTMLElement { }
+interface HTMLDListElement extends HTMLElement { }
+interface HTMLEmbedElement extends HTMLElement { }
+interface HTMLFieldSetElement extends HTMLElement { }
+interface HTMLFormElement extends HTMLElement { }
+interface HTMLHeadingElement extends HTMLElement { }
+interface HTMLHeadElement extends HTMLElement { }
+interface HTMLHRElement extends HTMLElement { }
+interface HTMLHtmlElement extends HTMLElement { }
+interface HTMLIFrameElement extends HTMLElement { }
+interface HTMLImageElement extends HTMLElement { }
+interface HTMLInputElement extends HTMLElement { }
+interface HTMLModElement extends HTMLElement { }
+interface HTMLLabelElement extends HTMLElement { }
+interface HTMLLegendElement extends HTMLElement { }
+interface HTMLLIElement extends HTMLElement { }
+interface HTMLLinkElement extends HTMLElement { }
+interface HTMLMapElement extends HTMLElement { }
+interface HTMLMetaElement extends HTMLElement { }
+interface HTMLMeterElement extends HTMLElement { }
+interface HTMLObjectElement extends HTMLElement { }
+interface HTMLOListElement extends HTMLElement { }
+interface HTMLOptGroupElement extends HTMLElement { }
+interface HTMLOptionElement extends HTMLElement { }
+interface HTMLOutputElement extends HTMLElement { }
+interface HTMLParagraphElement extends HTMLElement { }
+interface HTMLParamElement extends HTMLElement { }
+interface HTMLPreElement extends HTMLElement { }
+interface HTMLProgressElement extends HTMLElement { }
+interface HTMLQuoteElement extends HTMLElement { }
+interface HTMLSlotElement extends HTMLElement { }
+interface HTMLScriptElement extends HTMLElement { }
+interface HTMLSelectElement extends HTMLElement { }
+interface HTMLSourceElement extends HTMLElement { }
+interface HTMLSpanElement extends HTMLElement { }
+interface HTMLStyleElement extends HTMLElement { }
+interface HTMLTableElement extends HTMLElement { }
+interface HTMLTableColElement extends HTMLElement { }
+interface HTMLTableDataCellElement extends HTMLElement { }
+interface HTMLTableHeaderCellElement extends HTMLElement { }
+interface HTMLTableRowElement extends HTMLElement { }
+interface HTMLTableSectionElement extends HTMLElement { }
+interface HTMLTemplateElement extends HTMLElement { }
+interface HTMLTextAreaElement extends HTMLElement { }
+interface HTMLTimeElement extends HTMLElement { }
+interface HTMLTitleElement extends HTMLElement { }
+interface HTMLTrackElement extends HTMLElement { }
+interface HTMLUListElement extends HTMLElement { }
+interface HTMLVideoElement extends HTMLElement { }
+interface HTMLWebViewElement extends HTMLElement { }
+
+interface SVGElement extends Element { }
+interface SVGSVGElement extends SVGElement { }
+interface SVGCircleElement extends SVGElement { }
+interface SVGClipPathElement extends SVGElement { }
+interface SVGDefsElement extends SVGElement { }
+interface SVGDescElement extends SVGElement { }
+interface SVGEllipseElement extends SVGElement { }
+interface SVGFEBlendElement extends SVGElement { }
+interface SVGFEColorMatrixElement extends SVGElement { }
+interface SVGFEComponentTransferElement extends SVGElement { }
+interface SVGFECompositeElement extends SVGElement { }
+interface SVGFEConvolveMatrixElement extends SVGElement { }
+interface SVGFEDiffuseLightingElement extends SVGElement { }
+interface SVGFEDisplacementMapElement extends SVGElement { }
+interface SVGFEDistantLightElement extends SVGElement { }
+interface SVGFEDropShadowElement extends SVGElement { }
+interface SVGFEFloodElement extends SVGElement { }
+interface SVGFEFuncAElement extends SVGElement { }
+interface SVGFEFuncBElement extends SVGElement { }
+interface SVGFEFuncGElement extends SVGElement { }
+interface SVGFEFuncRElement extends SVGElement { }
+interface SVGFEGaussianBlurElement extends SVGElement { }
+interface SVGFEImageElement extends SVGElement { }
+interface SVGFEMergeElement extends SVGElement { }
+interface SVGFEMergeNodeElement extends SVGElement { }
+interface SVGFEMorphologyElement extends SVGElement { }
+interface SVGFEOffsetElement extends SVGElement { }
+interface SVGFEPointLightElement extends SVGElement { }
+interface SVGFESpecularLightingElement extends SVGElement { }
+interface SVGFESpotLightElement extends SVGElement { }
+interface SVGFETileElement extends SVGElement { }
+interface SVGFETurbulenceElement extends SVGElement { }
+interface SVGFilterElement extends SVGElement { }
+interface SVGForeignObjectElement extends SVGElement { }
+interface SVGGElement extends SVGElement { }
+interface SVGImageElement extends SVGElement { }
+interface SVGLineElement extends SVGElement { }
+interface SVGLinearGradientElement extends SVGElement { }
+interface SVGMarkerElement extends SVGElement { }
+interface SVGMaskElement extends SVGElement { }
+interface SVGMetadataElement extends SVGElement { }
+interface SVGPathElement extends SVGElement { }
+interface SVGPatternElement extends SVGElement { }
+interface SVGPolygonElement extends SVGElement { }
+interface SVGPolylineElement extends SVGElement { }
+interface SVGRadialGradientElement extends SVGElement { }
+interface SVGRectElement extends SVGElement { }
+interface SVGStopElement extends SVGElement { }
+interface SVGSwitchElement extends SVGElement { }
+interface SVGSymbolElement extends SVGElement { }
+interface SVGTextElement extends SVGElement { }
+interface SVGTextPathElement extends SVGElement { }
+interface SVGTSpanElement extends SVGElement { }
+interface SVGUseElement extends SVGElement { }
+interface SVGViewElement extends SVGElement { }
+
+interface Text { }
+interface TouchList { }
+interface WebGLRenderingContext { }
+interface WebGL2RenderingContext { }
+
+interface TrustedHTML { }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1,0 +1,3297 @@
+// NOTE: Users of the `experimental` builds of React should add a reference
+// to 'react/experimental' in their project. See experimental.d.ts's top comment
+// for reference and documentation on how exactly to do it.
+
+/// <reference path="global.d.ts" />
+
+import * as CSS from 'csstype';
+import * as PropTypes from 'prop-types';
+import { Interaction as SchedulerInteraction } from 'scheduler/tracing';
+
+type NativeAnimationEvent = AnimationEvent;
+type NativeClipboardEvent = ClipboardEvent;
+type NativeCompositionEvent = CompositionEvent;
+type NativeDragEvent = DragEvent;
+type NativeFocusEvent = FocusEvent;
+type NativeKeyboardEvent = KeyboardEvent;
+type NativeMouseEvent = MouseEvent;
+type NativeTouchEvent = TouchEvent;
+type NativePointerEvent = PointerEvent;
+type NativeTransitionEvent = TransitionEvent;
+type NativeUIEvent = UIEvent;
+type NativeWheelEvent = WheelEvent;
+type Booleanish = boolean | 'true' | 'false';
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// Destructors are only allowed to return void.
+type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+// eslint-disable-next-line export-just-namespace
+export = React;
+export as namespace React;
+
+declare namespace React {
+    //
+    // React Elements
+    // ----------------------------------------------------------------------
+
+    type ElementType<P = any> =
+        {
+            [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
+        }[keyof JSX.IntrinsicElements] |
+        ComponentType<P>;
+    type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+
+    type JSXElementConstructor<P> =
+        | ((props: P) => ReactElement<any, any> | null)
+        | (new (props: P) => Component<any, any>);
+
+    interface RefObject<T> {
+        readonly current: T | null;
+    }
+    // Bivariance hack for consistent unsoundness with RefObject
+    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type Ref<T> = RefCallback<T> | RefObject<T> | null;
+    type LegacyRef<T> = string | Ref<T>;
+    /**
+     * Gets the instance type for a React element. The instance will be different for various component types:
+     *
+     * - React class components will be the class instance. So if you had `class Foo extends React.Component<{}> {}`
+     *   and used `React.ElementRef<typeof Foo>` then the type would be the instance of `Foo`.
+     * - React stateless functional components do not have a backing instance and so `React.ElementRef<typeof Bar>`
+     *   (when `Bar` is `function Bar() {}`) will give you the `undefined` type.
+     * - JSX intrinsics like `div` will give you their DOM instance. For `React.ElementRef<'div'>` that would be
+     *   `HTMLDivElement`. For `React.ElementRef<'input'>` that would be `HTMLInputElement`.
+     * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
+     *   to component.
+     *
+     * `C` must be the type _of_ a React component so you need to use typeof as in `React.ElementRef<typeof MyComponent>`.
+     *
+     * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
+     *       `React.forwardRef()` returns.
+     */
+    type ElementRef<
+        C extends
+            | ForwardRefExoticComponent<any>
+            | { new (props: any): Component<any> }
+            | ((props: any, context?: any) => ReactElement | null)
+            | keyof JSX.IntrinsicElements
+    > =
+        // need to check first if `ref` is a valid prop for ts@3.0
+        // otherwise it will infer `{}` instead of `never`
+        "ref" extends keyof ComponentPropsWithRef<C>
+            ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
+                infer Instance
+            >
+                ? Instance
+                : never
+            : never;
+
+    type ComponentState = any;
+
+    type Key = string | number;
+
+    /**
+     * @internal You shouldn't need to use this type since you never see these attributes
+     * inside your component or have to validate them.
+     */
+    interface Attributes {
+        key?: Key | null | undefined;
+    }
+    interface RefAttributes<T> extends Attributes {
+        /**
+         * Allows getting a ref to the component instance.
+         * Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref).
+         * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
+         */
+        ref?: Ref<T> | undefined;
+    }
+    interface ClassAttributes<T> extends Attributes {
+        /**
+         * Allows getting a ref to the component instance.
+         * Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref).
+         * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
+         */
+        ref?: LegacyRef<T> | undefined;
+    }
+
+    interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
+        type: T;
+        props: P;
+        key: Key | null;
+    }
+
+    interface ReactComponentElement<
+        T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
+    > extends ReactElement<P, Exclude<T, number>> { }
+
+    interface FunctionComponentElement<P> extends ReactElement<P, FunctionComponent<P>> {
+        ref?: ('ref' extends keyof P ? P extends { ref?: infer R | undefined } ? R : never : never) | undefined;
+    }
+
+    type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
+    interface ComponentElement<P, T extends Component<P, ComponentState>> extends ReactElement<P, ComponentClass<P>> {
+        ref?: LegacyRef<T> | undefined;
+    }
+
+    type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
+
+    // string fallback for custom web-components
+    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P, string> {
+        ref: LegacyRef<T>;
+    }
+
+    // ReactHTML for ReactHTMLElement
+    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> { }
+
+    interface DetailedReactHTMLElement<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMElement<P, T> {
+        type: keyof ReactHTML;
+    }
+
+    // ReactSVG for ReactSVGElement
+    interface ReactSVGElement extends DOMElement<SVGAttributes<SVGElement>, SVGElement> {
+        type: keyof ReactSVG;
+    }
+
+    interface ReactPortal extends ReactElement {
+        key: Key | null;
+        children: ReactNode;
+    }
+
+    //
+    // Factories
+    // ----------------------------------------------------------------------
+
+    type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
+
+    /**
+     * @deprecated Please use `FunctionComponentFactory`
+     */
+    type SFCFactory<P> = FunctionComponentFactory<P>;
+
+    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
+
+    type ComponentFactory<P, T extends Component<P, ComponentState>> =
+        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
+
+    type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
+    type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
+
+    type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
+
+    interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
+
+    interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    }
+
+    interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
+        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
+    }
+
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
+    type ReactText = string | number;
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
+    type ReactChild = ReactElement | string | number;
+
+    /**
+     * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
+     */
+    interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+    type ReactFragment = Iterable<ReactNode>;
+    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
+
+    //
+    // Top Level API
+    // ----------------------------------------------------------------------
+
+    // DOM Elements
+    function createFactory<T extends HTMLElement>(
+        type: keyof ReactHTML): HTMLFactory<T>;
+    function createFactory(
+        type: keyof ReactSVG): SVGFactory;
+    function createFactory<P extends DOMAttributes<T>, T extends Element>(
+        type: string): DOMFactory<P, T>;
+
+    // Custom components
+    function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
+    function createFactory<P>(
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
+    function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
+        type: ClassType<P, T, C>): CFactory<P, T>;
+    function createFactory<P>(type: ComponentClass<P>): Factory<P>;
+
+    // DOM Elements
+    // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
+    function createElement(
+        type: "input",
+        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+    function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        type: keyof ReactHTML,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
+        type: keyof ReactSVG,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): ReactSVGElement;
+    function createElement<P extends DOMAttributes<T>, T extends Element>(
+        type: string,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DOMElement<P, T>;
+
+    // Custom components
+
+    function createElement<P extends {}>(
+        type: FunctionComponent<P>,
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): FunctionComponentElement<P>;
+    function createElement<P extends {}>(
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
+        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
+        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
+    function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
+        type: ClassType<P, T, C>,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): CElement<P, T>;
+    function createElement<P extends {}>(
+        type: FunctionComponent<P> | ComponentClass<P> | string,
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    // DOM Elements
+    // ReactHTMLElement
+    function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        element: DetailedReactHTMLElement<P, T>,
+        props?: P,
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    // ReactHTMLElement, less specific
+    function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        element: ReactHTMLElement<T>,
+        props?: P,
+        ...children: ReactNode[]): ReactHTMLElement<T>;
+    // SVGElement
+    function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
+        element: ReactSVGElement,
+        props?: P,
+        ...children: ReactNode[]): ReactSVGElement;
+    // DOM Element (has to be the last, because type checking stops at first overload that fits)
+    function cloneElement<P extends DOMAttributes<T>, T extends Element>(
+        element: DOMElement<P, T>,
+        props?: DOMAttributes<T> & P,
+        ...children: ReactNode[]): DOMElement<P, T>;
+
+    // Custom components
+    function cloneElement<P>(
+        element: FunctionComponentElement<P>,
+        props?: Partial<P> & Attributes,
+        ...children: ReactNode[]): FunctionComponentElement<P>;
+    function cloneElement<P, T extends Component<P, ComponentState>>(
+        element: CElement<P, T>,
+        props?: Partial<P> & ClassAttributes<T>,
+        ...children: ReactNode[]): CElement<P, T>;
+    function cloneElement<P>(
+        element: ReactElement<P>,
+        props?: Partial<P> & Attributes,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    // Context via RenderProps
+    interface ProviderProps<T> {
+        value: T;
+        children?: ReactNode | undefined;
+    }
+
+    interface ConsumerProps<T> {
+        children: (value: T) => ReactNode;
+    }
+
+    // TODO: similar to how Fragment is actually a symbol, the values returned from createContext,
+    // forwardRef and memo are actually objects that are treated specially by the renderer; see:
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/ReactContext.js#L35-L48
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/forwardRef.js#L42-L45
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/memo.js#L27-L31
+    // However, we have no way of telling the JSX parser that it's a JSX element type or its props other than
+    // by pretending to be a normal component.
+    //
+    // We don't just use ComponentType or FunctionComponent types because you are not supposed to attach statics to this
+    // object, but rather to the original function.
+    interface ExoticComponent<P = {}> {
+        /**
+         * **NOTE**: Exotic components are not callable.
+         */
+        (props: P): (ReactElement|null);
+        readonly $$typeof: symbol;
+    }
+
+    interface NamedExoticComponent<P = {}> extends ExoticComponent<P> {
+        displayName?: string | undefined;
+    }
+
+    interface ProviderExoticComponent<P> extends ExoticComponent<P> {
+        propTypes?: WeakValidationMap<P> | undefined;
+    }
+
+    type ContextType<C extends Context<any>> = C extends Context<infer T> ? T : never;
+
+    // NOTE: only the Context object itself can get a displayName
+    // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
+    type Provider<T> = ProviderExoticComponent<ProviderProps<T>>;
+    type Consumer<T> = ExoticComponent<ConsumerProps<T>>;
+    interface Context<T> {
+        Provider: Provider<T>;
+        Consumer: Consumer<T>;
+        displayName?: string | undefined;
+    }
+    function createContext<T>(
+        // If you thought this should be optional, see
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106
+        defaultValue: T,
+    ): Context<T>;
+
+    function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
+
+    // Sync with `ReactChildren` until `ReactChildren` is removed.
+    const Children: {
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+        count(children: any): number;
+        only<C>(children: C): C extends any[] ? never : C;
+        toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | null | undefined>>;
+    };
+    const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+    const StrictMode: ExoticComponent<{ children?: ReactNode | undefined }>;
+
+    interface SuspenseProps {
+        children?: ReactNode | undefined;
+
+        /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
+        fallback?: ReactNode;
+    }
+
+    const Suspense: ExoticComponent<SuspenseProps>;
+    const version: string;
+
+    /**
+     * {@link https://react.dev/reference/react/Profiler#onrender-callback Profiler API}
+     */
+    type ProfilerOnRenderCallback = (
+        id: string,
+        phase: "mount" | "update",
+        actualDuration: number,
+        baseDuration: number,
+        startTime: number,
+        commitTime: number,
+        interactions: Set<SchedulerInteraction>,
+    ) => void;
+    interface ProfilerProps {
+        children?: ReactNode | undefined;
+        id: string;
+        onRender: ProfilerOnRenderCallback;
+    }
+
+    const Profiler: ExoticComponent<ProfilerProps>;
+
+    //
+    // Component API
+    // ----------------------------------------------------------------------
+
+    type ReactInstance = Component<any> | Element;
+
+    // Base component for plain JS classes
+    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
+    class Component<P, S> {
+        // tslint won't let me format the sample code in a way that vscode likes it :(
+        /**
+         * If set, `this.context` will be set at runtime to the current value of the given Context.
+         *
+         * Usage:
+         *
+         * ```ts
+         * type MyContext = number
+         * const Ctx = React.createContext<MyContext>(0)
+         *
+         * class Foo extends React.Component {
+         *   static contextType = Ctx
+         *   context!: React.ContextType<typeof Ctx>
+         *   render () {
+         *     return <>My context's value: {this.context}</>;
+         *   }
+         * }
+         * ```
+         *
+         * @see https://react.dev/reference/react/Component#static-contexttype
+         */
+        static contextType?: Context<any> | undefined;
+
+        /**
+         * If using the new style context, re-declare this in your class to be the
+         * `React.ContextType` of your `static contextType`.
+         * Should be used with type annotation or static contextType.
+         *
+         * ```ts
+         * static contextType = MyContext
+         * // For TS pre-3.7:
+         * context!: React.ContextType<typeof MyContext>
+         * // For TS 3.7 and above:
+         * declare context: React.ContextType<typeof MyContext>
+         * ```
+         *
+         * @see https://react.dev/reference/react/Component#context
+         */
+        context: unknown;
+
+        constructor(props: Readonly<P> | P);
+        /**
+         * @deprecated
+         * @see https://legacy.reactjs.org/docs/legacy-context.html
+         */
+        constructor(props: P, context: any);
+
+        // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+        // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+        // Also, the ` | S` allows intellisense to not be dumbisense
+        setState<K extends keyof S>(
+            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+            callback?: () => void
+        ): void;
+
+        forceUpdate(callback?: () => void): void;
+        render(): ReactNode;
+
+        readonly props: Readonly<P>;
+        state: Readonly<S>;
+        /**
+         * @deprecated
+         * https://legacy.reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
+         */
+        refs: {
+            [key: string]: ReactInstance
+        };
+    }
+
+    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
+
+    interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
+        replaceState(nextState: S, callback?: () => void): void;
+        isMounted(): boolean;
+        getInitialState?(): S;
+    }
+
+    interface ChildContextProvider<CC> {
+        getChildContext(): CC;
+    }
+
+    //
+    // Class Interfaces
+    // ----------------------------------------------------------------------
+
+    type FC<P = {}> = FunctionComponent<P>;
+
+    interface FunctionComponent<P = {}> {
+        (props: P, context?: any): ReactElement<any, any> | null;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    /**
+     * @deprecated - Equivalent with `React.FC`.
+     */
+    type VFC<P = {}> = VoidFunctionComponent<P>;
+
+    /**
+     * @deprecated - Equivalent with `React.FunctionComponent`.
+     */
+    interface VoidFunctionComponent<P = {}> {
+        (props: P, context?: any): ReactElement<any, any> | null;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
+
+    interface ForwardRefRenderFunction<T, P = {}> {
+        (props: P, ref: ForwardedRef<T>): ReactElement | null;
+        displayName?: string | undefined;
+        // explicit rejected with `never` required due to
+        // https://github.com/microsoft/TypeScript/issues/36826
+        /**
+         * defaultProps are not supported on render functions
+         */
+        defaultProps?: never | undefined;
+        /**
+         * propTypes are not supported on render functions
+         */
+        propTypes?: never | undefined;
+    }
+
+    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
+        new (props: P, context?: any): Component<P, S>;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextType?: Context<any> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        childContextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
+        new (props: P, context?: any): ClassicComponent<P, ComponentState>;
+        getDefaultProps?(): P;
+    }
+
+    /**
+     * We use an intersection type to infer multiple type parameters from
+     * a single argument, which is useful for many top-level API defs.
+     * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
+     */
+    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
+        C &
+        (new (props: P, context?: any) => T);
+
+    //
+    // Component Specs and Lifecycle
+    // ----------------------------------------------------------------------
+
+    // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
+    // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
+    // methods are present.
+    interface ComponentLifecycle<P, S, SS = any> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
+        /**
+         * Called immediately after a component is mounted. Setting state here will trigger re-rendering.
+         */
+        componentDidMount?(): void;
+        /**
+         * Called to determine whether the change in props and state should trigger a re-render.
+         *
+         * `Component` always returns true.
+         * `PureComponent` implements a shallow comparison on props and state and returns true if any
+         * props or states have changed.
+         *
+         * If false is returned, `Component#render`, `componentWillUpdate`
+         * and `componentDidUpdate` will not be called.
+         */
+        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean;
+        /**
+         * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
+         * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
+         */
+        componentWillUnmount?(): void;
+        /**
+         * Catches exceptions generated in descendant components. Unhandled exceptions will cause
+         * the entire component tree to unmount.
+         */
+        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+    }
+
+    // Unfortunately, we have no way of declaring that the component constructor must implement this
+    interface StaticLifecycle<P, S> {
+        getDerivedStateFromProps?: GetDerivedStateFromProps<P, S> | undefined;
+        getDerivedStateFromError?: GetDerivedStateFromError<P, S> | undefined;
+    }
+
+    type GetDerivedStateFromProps<P, S> =
+        /**
+         * Returns an update to a component's state based on its new props and old state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        (nextProps: Readonly<P>, prevState: S) => Partial<S> | null;
+
+    type GetDerivedStateFromError<P, S> =
+        /**
+         * This lifecycle is invoked after an error has been thrown by a descendant component.
+         * It receives the error that was thrown as a parameter and should return a value to update state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        (error: any) => Partial<S> | null;
+
+    // This should be "infer SS" but can't use it yet
+    interface NewLifecycle<P, S, SS> {
+        /**
+         * Runs before React applies the result of `render` to the document, and
+         * returns an object to be given to componentDidUpdate. Useful for saving
+         * things such as scroll position before `render` causes changes to it.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
+         * lifecycle events from running.
+         */
+        getSnapshotBeforeUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>): SS | null;
+        /**
+         * Called immediately after updating occurs. Not called for the initial render.
+         *
+         * The snapshot is only present if getSnapshotBeforeUpdate is present and returns non-null.
+         */
+        componentDidUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>, snapshot?: SS): void;
+    }
+
+    interface DeprecatedLifecycle<P, S> {
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillMount?(): void;
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillMount?(): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
+    }
+
+    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+        mixins?: Array<Mixin<P, S>> | undefined;
+        statics?: {
+            [key: string]: any;
+        } | undefined;
+
+        displayName?: string | undefined;
+        propTypes?: ValidationMap<any> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        childContextTypes?: ValidationMap<any> | undefined;
+
+        getDefaultProps?(): P;
+        getInitialState?(): S;
+    }
+
+    interface ComponentSpec<P, S> extends Mixin<P, S> {
+        render(): ReactNode;
+
+        [propertyName: string]: any;
+    }
+
+    function createRef<T>(): RefObject<T>;
+
+    // will show `ForwardRef(${Component.displayName || Component.name})` in devtools by default,
+    // but can be given its own specific name
+    interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
+        defaultProps?: Partial<P> | undefined;
+        propTypes?: WeakValidationMap<P> | undefined;
+    }
+
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+
+    /** Ensures that the props do not include ref at all */
+    type PropsWithoutRef<P> =
+        // Omit would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
+        // see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+        // https://github.com/Microsoft/TypeScript/issues/28339
+        P extends any ? ('ref' extends keyof P ? Omit<P, 'ref'> : P) : P;
+    /** Ensures that the props do not include string ref, which cannot be forwarded */
+    type PropsWithRef<P> =
+        // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.
+        'ref' extends keyof P
+            ? P extends { ref?: infer R | undefined }
+                ? string extends R
+                    ? PropsWithoutRef<P> & { ref?: Exclude<R, string> | undefined }
+                    : P
+                : P
+            : P;
+
+    type PropsWithChildren<P = unknown> = P & { children?: ReactNode | undefined };
+
+    /**
+     * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
+     * or ComponentPropsWithoutRef when refs are not supported.
+     */
+    type ComponentProps<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =
+        T extends JSXElementConstructor<infer P>
+            ? P
+            : T extends keyof JSX.IntrinsicElements
+                ? JSX.IntrinsicElements[T]
+                : {};
+    type ComponentPropsWithRef<T extends ElementType> =
+        T extends (new (props: infer P) => Component<any, any>)
+            ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+            : PropsWithRef<ComponentProps<T>>;
+    type ComponentPropsWithoutRef<T extends ElementType> =
+        PropsWithoutRef<ComponentProps<T>>;
+
+    type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
+        ComponentPropsWithoutRef<T> & RefAttributes<infer Method>
+    >
+        ? Method
+        : ComponentPropsWithRef<T> extends RefAttributes<infer Method>
+            ? Method
+            : never;
+
+    // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
+    // but can be given its own specific name
+    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<ComponentPropsWithRef<T>> & {
+        readonly type: T;
+    };
+
+    function memo<P extends object>(
+        Component: FunctionComponent<P>,
+        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
+    ): NamedExoticComponent<P>;
+    function memo<T extends ComponentType<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
+
+    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
+        readonly _result: T;
+    };
+
+    function lazy<T extends ComponentType<any>>(
+        factory: () => Promise<{ default: T }>
+    ): LazyExoticComponent<T>;
+
+    //
+    // React Hooks
+    // ----------------------------------------------------------------------
+
+    // based on the code in https://github.com/facebook/react/pull/13968
+
+    // Unlike the class component setState, the updates are not allowed to be partial
+    type SetStateAction<S> = S | ((prevState: S) => S);
+    // this technically does accept a second argument, but it's already under a deprecation warning
+    // and it's not even released so probably better to not define it.
+    type Dispatch<A> = (value: A) => void;
+    // Since action _can_ be undefined, dispatch may be called without any parameters.
+    type DispatchWithoutAction = () => void;
+    // Unlike redux, the actions _can_ be anything
+    type Reducer<S, A> = (prevState: S, action: A) => S;
+    // If useReducer accepts a reducer without action, dispatch may be called without any parameters.
+    type ReducerWithoutAction<S> = (prevState: S) => S;
+    // types used to try and prevent the compiler from reducing S
+    // to a supertype common with the second argument to useReducer()
+    type ReducerState<R extends Reducer<any, any>> = R extends Reducer<infer S, any> ? S : never;
+    type ReducerAction<R extends Reducer<any, any>> = R extends Reducer<any, infer A> ? A : never;
+    // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
+    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
+        R extends ReducerWithoutAction<infer S> ? S : never;
+    type DependencyList = ReadonlyArray<unknown>;
+
+    // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
+    type EffectCallback = () => (void | Destructor);
+
+    interface MutableRefObject<T> {
+        current: T;
+    }
+
+    // This will technically work if you give a Consumer<T> or Provider<T> but it's deprecated and warns
+    /**
+     * Accepts a context object (the value returned from `React.createContext`) and returns the current
+     * context value, as given by the nearest context provider for the given context.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useContext
+     */
+    function useContext<T>(context: Context<T>/*, (not public API) observedBits?: number|boolean */): T;
+    /**
+     * Returns a stateful value, and a function to update it.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useState
+     */
+    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    // convenience overload when first argument is omitted
+    /**
+     * Returns a stateful value, and a function to update it.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useState
+     */
+    function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useReducer
+     */
+    // overload where dispatch could accept 0 arguments.
+    function useReducer<R extends ReducerWithoutAction<any>, I>(
+        reducer: R,
+        initializerArg: I,
+        initializer: (arg: I) => ReducerStateWithoutAction<R>
+    ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useReducer
+     */
+    // overload where dispatch could accept 0 arguments.
+    function useReducer<R extends ReducerWithoutAction<any>>(
+        reducer: R,
+        initializerArg: ReducerStateWithoutAction<R>,
+        initializer?: undefined
+    ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useReducer
+     */
+    // overload where "I" may be a subset of ReducerState<R>; used to provide autocompletion.
+    // If "I" matches ReducerState<R> exactly then the last overload will allow initializer to be omitted.
+    // the last overload effectively behaves as if the identity function (x => x) is the initializer.
+    function useReducer<R extends Reducer<any, any>, I>(
+        reducer: R,
+        initializerArg: I & ReducerState<R>,
+        initializer: (arg: I & ReducerState<R>) => ReducerState<R>
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useReducer
+     */
+    // overload for free "I"; all goes as long as initializer converts it into "ReducerState<R>".
+    function useReducer<R extends Reducer<any, any>, I>(
+        reducer: R,
+        initializerArg: I,
+        initializer: (arg: I) => ReducerState<R>
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useReducer
+     */
+
+    // I'm not sure if I keep this 2-ary or if I make it (2,3)-ary; it's currently (2,3)-ary.
+    // The Flow types do have an overload for 3-ary invocation with undefined initializer.
+
+    // NOTE: without the ReducerState indirection, TypeScript would reduce S to be the most common
+    // supertype between the reducer's return type and the initialState (or the initializer's return type),
+    // which would prevent autocompletion from ever working.
+
+    // TODO: double-check if this weird overload logic is necessary. It is possible it's either a bug
+    // in older versions, or a regression in newer versions of the typescript completion service.
+    function useReducer<R extends Reducer<any, any>>(
+        reducer: R,
+        initialState: ReducerState<R>,
+        initializer?: undefined
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useRef
+     */
+    function useRef<T>(initialValue: T): MutableRefObject<T>;
+    // convenience overload for refs given as a ref prop as they typically start with a null value
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
+     * of the generic argument.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useRef
+     */
+    function useRef<T>(initialValue: T|null): RefObject<T>;
+    // convenience overload for potentially undefined initialValue / call with 0 arguments
+    // has a default to stop it from defaulting to {} instead
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useRef
+     */
+    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    /**
+     * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
+     * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+     * `useLayoutEffect` will be flushed synchronously, before the browser has a chance to paint.
+     *
+     * Prefer the standard `useEffect` when possible to avoid blocking visual updates.
+     *
+     * If you’re migrating code from a class component, `useLayoutEffect` fires in the same phase as
+     * `componentDidMount` and `componentDidUpdate`.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useLayoutEffect
+     */
+    function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
+    /**
+     * Accepts a function that contains imperative, possibly effectful code.
+     *
+     * @param effect Imperative function that can return a cleanup function
+     * @param deps If present, effect will only activate if the values in the list change.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useEffect
+     */
+    function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+    // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
+    /**
+     * `useImperativeHandle` customizes the instance value that is exposed to parent components when using
+     * `ref`. As always, imperative code using refs should be avoided in most cases.
+     *
+     * `useImperativeHandle` should be used with `React.forwardRef`.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useImperativeHandle
+     */
+    function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, deps?: DependencyList): void;
+    // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
+    // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
+    /**
+     * `useCallback` will return a memoized version of the callback that only changes if one of the `inputs`
+     * has changed.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useCallback
+     */
+    // A specific function type would not trigger implicit any.
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873#issuecomment-845806435 for a comparison between `Function` and more specific types.
+    // tslint:disable-next-line ban-types
+    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
+    /**
+     * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useMemo
+     */
+    // allow undefined, but don't make it optional as that is very likely a mistake
+    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    /**
+     * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
+     *
+     * NOTE: We don’t recommend adding debug values to every custom hook.
+     * It’s most valuable for custom hooks that are part of shared libraries.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useDebugValue
+     */
+    // the name of the custom hook is itself derived from the function name at runtime:
+    // it's just the function name without the "use" prefix.
+    function useDebugValue<T>(value: T, format?: (value: T) => any): void;
+
+    // must be synchronous
+    export type TransitionFunction = () => VoidOrUndefinedOnly;
+    // strange definition to allow vscode to show documentation on the invocation
+    export interface TransitionStartFunction {
+        /**
+         * State updates caused inside the callback are allowed to be deferred.
+         *
+         * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
+         *
+         * @param callback A _synchronous_ function which causes state updates that can be deferred.
+         */
+        (callback: TransitionFunction): void;
+    }
+
+    /**
+     * Returns a deferred version of the value that may “lag behind” it.
+     *
+     * This is commonly used to keep the interface responsive when you have something that renders immediately
+     * based on user input and something that needs to wait for a data fetch.
+     *
+     * A good example of this is a text input.
+     *
+     * @param value The value that is going to be deferred
+     *
+     * @see https://react.dev/reference/react/useDeferredValue
+     */
+    export function useDeferredValue<T>(value: T): T;
+
+    /**
+     * Allows components to avoid undesirable loading states by waiting for content to load
+     * before transitioning to the next screen. It also allows components to defer slower,
+     * data fetching updates until subsequent renders so that more crucial updates can be
+     * rendered immediately.
+     *
+     * The `useTransition` hook returns two values in an array.
+     *
+     * The first is a boolean, React’s way of informing us whether we’re waiting for the transition to finish.
+     * The second is a function that takes a callback. We can use it to tell React which state we want to defer.
+     *
+     * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**`
+     *
+     * @see https://react.dev/reference/react/useTransition
+     */
+    export function useTransition(): [boolean, TransitionStartFunction];
+
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback A _synchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: TransitionFunction): void;
+
+    export function useId(): string;
+
+    /**
+     * @param effect Imperative function that can return a cleanup function
+     * @param deps If present, effect will only activate if the values in the list change.
+     *
+     * @see https://github.com/facebook/react/pull/21913
+     */
+     export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
+
+    /**
+     * @param subscribe
+     * @param getSnapshot
+     *
+     * @see https://github.com/reactwg/react-18/discussions/86
+     */
+    // keep in sync with `useSyncExternalStore` from `use-sync-external-store`
+    export function useSyncExternalStore<Snapshot>(
+        subscribe: (onStoreChange: () => void) => () => void,
+        getSnapshot: () => Snapshot,
+        getServerSnapshot?: () => Snapshot,
+    ): Snapshot;
+
+    //
+    // Event System
+    // ----------------------------------------------------------------------
+    // TODO: change any to unknown when moving to TS v3
+    interface BaseSyntheticEvent<E = object, C = any, T = any> {
+        nativeEvent: E;
+        currentTarget: C;
+        target: T;
+        bubbles: boolean;
+        cancelable: boolean;
+        defaultPrevented: boolean;
+        eventPhase: number;
+        isTrusted: boolean;
+        preventDefault(): void;
+        isDefaultPrevented(): boolean;
+        stopPropagation(): void;
+        isPropagationStopped(): boolean;
+        persist(): void;
+        timeStamp: number;
+        type: string;
+    }
+
+    /**
+     * currentTarget - a reference to the element on which the event listener is registered.
+     *
+     * target - a reference to the element from which the event was originally dispatched.
+     * This might be a child element to the element on which the event listener is registered.
+     * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
+     */
+    interface SyntheticEvent<T = Element, E = Event> extends BaseSyntheticEvent<E, EventTarget & T, EventTarget> {}
+
+    interface ClipboardEvent<T = Element> extends SyntheticEvent<T, NativeClipboardEvent> {
+        clipboardData: DataTransfer;
+    }
+
+    interface CompositionEvent<T = Element> extends SyntheticEvent<T, NativeCompositionEvent> {
+        data: string;
+    }
+
+    interface DragEvent<T = Element> extends MouseEvent<T, NativeDragEvent> {
+        dataTransfer: DataTransfer;
+    }
+
+    interface PointerEvent<T = Element> extends MouseEvent<T, NativePointerEvent> {
+        pointerId: number;
+        pressure: number;
+        tangentialPressure: number;
+        tiltX: number;
+        tiltY: number;
+        twist: number;
+        width: number;
+        height: number;
+        pointerType: 'mouse' | 'pen' | 'touch';
+        isPrimary: boolean;
+    }
+
+    interface FocusEvent<Target = Element, RelatedTarget = Element> extends SyntheticEvent<Target, NativeFocusEvent> {
+        relatedTarget: (EventTarget & RelatedTarget) | null;
+        target: EventTarget & Target;
+    }
+
+    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    }
+
+    interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
+        target: EventTarget & T;
+    }
+
+    interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
+        target: EventTarget & T;
+    }
+
+    export type ModifierKey = "Alt" | "AltGraph" | "CapsLock" | "Control" | "Fn" | "FnLock" | "Hyper" | "Meta" | "NumLock" | "ScrollLock" | "Shift" | "Super" | "Symbol" | "SymbolLock";
+
+    interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
+        altKey: boolean;
+        /** @deprecated */
+        charCode: number;
+        ctrlKey: boolean;
+        code: string;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: ModifierKey): boolean;
+        /**
+         * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
+         */
+        key: string;
+        /** @deprecated */
+        keyCode: number;
+        locale: string;
+        location: number;
+        metaKey: boolean;
+        repeat: boolean;
+        shiftKey: boolean;
+        /** @deprecated */
+        which: number;
+    }
+
+    interface MouseEvent<T = Element, E = NativeMouseEvent> extends UIEvent<T, E> {
+        altKey: boolean;
+        button: number;
+        buttons: number;
+        clientX: number;
+        clientY: number;
+        ctrlKey: boolean;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: ModifierKey): boolean;
+        metaKey: boolean;
+        movementX: number;
+        movementY: number;
+        pageX: number;
+        pageY: number;
+        relatedTarget: EventTarget | null;
+        screenX: number;
+        screenY: number;
+        shiftKey: boolean;
+    }
+
+    interface TouchEvent<T = Element> extends UIEvent<T, NativeTouchEvent> {
+        altKey: boolean;
+        changedTouches: TouchList;
+        ctrlKey: boolean;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: ModifierKey): boolean;
+        metaKey: boolean;
+        shiftKey: boolean;
+        targetTouches: TouchList;
+        touches: TouchList;
+    }
+
+    interface UIEvent<T = Element, E = NativeUIEvent> extends SyntheticEvent<T, E> {
+        detail: number;
+        view: AbstractView;
+    }
+
+    interface WheelEvent<T = Element> extends MouseEvent<T, NativeWheelEvent> {
+        deltaMode: number;
+        deltaX: number;
+        deltaY: number;
+        deltaZ: number;
+    }
+
+    interface AnimationEvent<T = Element> extends SyntheticEvent<T, NativeAnimationEvent> {
+        animationName: string;
+        elapsedTime: number;
+        pseudoElement: string;
+    }
+
+    interface TransitionEvent<T = Element> extends SyntheticEvent<T, NativeTransitionEvent> {
+        elapsedTime: number;
+        propertyName: string;
+        pseudoElement: string;
+    }
+
+    //
+    // Event Handler Types
+    // ----------------------------------------------------------------------
+
+    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
+
+    type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
+
+    type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
+    type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+    type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+    type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+    type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
+    type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+    type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+    type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
+    type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+    type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+    type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent<T>>;
+    type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent<T>>;
+
+    //
+    // Props / DOM Attributes
+    // ----------------------------------------------------------------------
+
+    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
+    }
+
+    type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = ClassAttributes<T> & E;
+
+    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {
+    }
+
+    interface DOMAttributes<T> {
+        children?: ReactNode | undefined;
+        dangerouslySetInnerHTML?: {
+            // Should be InnerHTML['innerHTML'].
+            // But unfortunately we're mixing renderer-specific type declarations.
+            __html: string | TrustedHTML;
+        } | undefined;
+
+        // Clipboard Events
+        onCopy?: ClipboardEventHandler<T> | undefined;
+        onCopyCapture?: ClipboardEventHandler<T> | undefined;
+        onCut?: ClipboardEventHandler<T> | undefined;
+        onCutCapture?: ClipboardEventHandler<T> | undefined;
+        onPaste?: ClipboardEventHandler<T> | undefined;
+        onPasteCapture?: ClipboardEventHandler<T> | undefined;
+
+        // Composition Events
+        onCompositionEnd?: CompositionEventHandler<T> | undefined;
+        onCompositionEndCapture?: CompositionEventHandler<T> | undefined;
+        onCompositionStart?: CompositionEventHandler<T> | undefined;
+        onCompositionStartCapture?: CompositionEventHandler<T> | undefined;
+        onCompositionUpdate?: CompositionEventHandler<T> | undefined;
+        onCompositionUpdateCapture?: CompositionEventHandler<T> | undefined;
+
+        // Focus Events
+        onFocus?: FocusEventHandler<T> | undefined;
+        onFocusCapture?: FocusEventHandler<T> | undefined;
+        onBlur?: FocusEventHandler<T> | undefined;
+        onBlurCapture?: FocusEventHandler<T> | undefined;
+
+        // Form Events
+        onChange?: FormEventHandler<T> | undefined;
+        onChangeCapture?: FormEventHandler<T> | undefined;
+        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInputCapture?: FormEventHandler<T> | undefined;
+        onInput?: FormEventHandler<T> | undefined;
+        onInputCapture?: FormEventHandler<T> | undefined;
+        onReset?: FormEventHandler<T> | undefined;
+        onResetCapture?: FormEventHandler<T> | undefined;
+        onSubmit?: FormEventHandler<T> | undefined;
+        onSubmitCapture?: FormEventHandler<T> | undefined;
+        onInvalid?: FormEventHandler<T> | undefined;
+        onInvalidCapture?: FormEventHandler<T> | undefined;
+
+        // Image Events
+        onLoad?: ReactEventHandler<T> | undefined;
+        onLoadCapture?: ReactEventHandler<T> | undefined;
+        onError?: ReactEventHandler<T> | undefined; // also a Media Event
+        onErrorCapture?: ReactEventHandler<T> | undefined; // also a Media Event
+
+        // Keyboard Events
+        onKeyDown?: KeyboardEventHandler<T> | undefined;
+        onKeyDownCapture?: KeyboardEventHandler<T> | undefined;
+        /** @deprecated */
+        onKeyPress?: KeyboardEventHandler<T> | undefined;
+        /** @deprecated */
+        onKeyPressCapture?: KeyboardEventHandler<T> | undefined;
+        onKeyUp?: KeyboardEventHandler<T> | undefined;
+        onKeyUpCapture?: KeyboardEventHandler<T> | undefined;
+
+        // Media Events
+        onAbort?: ReactEventHandler<T> | undefined;
+        onAbortCapture?: ReactEventHandler<T> | undefined;
+        onCanPlay?: ReactEventHandler<T> | undefined;
+        onCanPlayCapture?: ReactEventHandler<T> | undefined;
+        onCanPlayThrough?: ReactEventHandler<T> | undefined;
+        onCanPlayThroughCapture?: ReactEventHandler<T> | undefined;
+        onDurationChange?: ReactEventHandler<T> | undefined;
+        onDurationChangeCapture?: ReactEventHandler<T> | undefined;
+        onEmptied?: ReactEventHandler<T> | undefined;
+        onEmptiedCapture?: ReactEventHandler<T> | undefined;
+        onEncrypted?: ReactEventHandler<T> | undefined;
+        onEncryptedCapture?: ReactEventHandler<T> | undefined;
+        onEnded?: ReactEventHandler<T> | undefined;
+        onEndedCapture?: ReactEventHandler<T> | undefined;
+        onLoadedData?: ReactEventHandler<T> | undefined;
+        onLoadedDataCapture?: ReactEventHandler<T> | undefined;
+        onLoadedMetadata?: ReactEventHandler<T> | undefined;
+        onLoadedMetadataCapture?: ReactEventHandler<T> | undefined;
+        onLoadStart?: ReactEventHandler<T> | undefined;
+        onLoadStartCapture?: ReactEventHandler<T> | undefined;
+        onPause?: ReactEventHandler<T> | undefined;
+        onPauseCapture?: ReactEventHandler<T> | undefined;
+        onPlay?: ReactEventHandler<T> | undefined;
+        onPlayCapture?: ReactEventHandler<T> | undefined;
+        onPlaying?: ReactEventHandler<T> | undefined;
+        onPlayingCapture?: ReactEventHandler<T> | undefined;
+        onProgress?: ReactEventHandler<T> | undefined;
+        onProgressCapture?: ReactEventHandler<T> | undefined;
+        onRateChange?: ReactEventHandler<T> | undefined;
+        onRateChangeCapture?: ReactEventHandler<T> | undefined;
+        onResize?: ReactEventHandler<T> | undefined;
+        onResizeCapture?: ReactEventHandler<T> | undefined;
+        onSeeked?: ReactEventHandler<T> | undefined;
+        onSeekedCapture?: ReactEventHandler<T> | undefined;
+        onSeeking?: ReactEventHandler<T> | undefined;
+        onSeekingCapture?: ReactEventHandler<T> | undefined;
+        onStalled?: ReactEventHandler<T> | undefined;
+        onStalledCapture?: ReactEventHandler<T> | undefined;
+        onSuspend?: ReactEventHandler<T> | undefined;
+        onSuspendCapture?: ReactEventHandler<T> | undefined;
+        onTimeUpdate?: ReactEventHandler<T> | undefined;
+        onTimeUpdateCapture?: ReactEventHandler<T> | undefined;
+        onVolumeChange?: ReactEventHandler<T> | undefined;
+        onVolumeChangeCapture?: ReactEventHandler<T> | undefined;
+        onWaiting?: ReactEventHandler<T> | undefined;
+        onWaitingCapture?: ReactEventHandler<T> | undefined;
+
+        // MouseEvents
+        onAuxClick?: MouseEventHandler<T> | undefined;
+        onAuxClickCapture?: MouseEventHandler<T> | undefined;
+        onClick?: MouseEventHandler<T> | undefined;
+        onClickCapture?: MouseEventHandler<T> | undefined;
+        onContextMenu?: MouseEventHandler<T> | undefined;
+        onContextMenuCapture?: MouseEventHandler<T> | undefined;
+        onDoubleClick?: MouseEventHandler<T> | undefined;
+        onDoubleClickCapture?: MouseEventHandler<T> | undefined;
+        onDrag?: DragEventHandler<T> | undefined;
+        onDragCapture?: DragEventHandler<T> | undefined;
+        onDragEnd?: DragEventHandler<T> | undefined;
+        onDragEndCapture?: DragEventHandler<T> | undefined;
+        onDragEnter?: DragEventHandler<T> | undefined;
+        onDragEnterCapture?: DragEventHandler<T> | undefined;
+        onDragExit?: DragEventHandler<T> | undefined;
+        onDragExitCapture?: DragEventHandler<T> | undefined;
+        onDragLeave?: DragEventHandler<T> | undefined;
+        onDragLeaveCapture?: DragEventHandler<T> | undefined;
+        onDragOver?: DragEventHandler<T> | undefined;
+        onDragOverCapture?: DragEventHandler<T> | undefined;
+        onDragStart?: DragEventHandler<T> | undefined;
+        onDragStartCapture?: DragEventHandler<T> | undefined;
+        onDrop?: DragEventHandler<T> | undefined;
+        onDropCapture?: DragEventHandler<T> | undefined;
+        onMouseDown?: MouseEventHandler<T> | undefined;
+        onMouseDownCapture?: MouseEventHandler<T> | undefined;
+        onMouseEnter?: MouseEventHandler<T> | undefined;
+        onMouseLeave?: MouseEventHandler<T> | undefined;
+        onMouseMove?: MouseEventHandler<T> | undefined;
+        onMouseMoveCapture?: MouseEventHandler<T> | undefined;
+        onMouseOut?: MouseEventHandler<T> | undefined;
+        onMouseOutCapture?: MouseEventHandler<T> | undefined;
+        onMouseOver?: MouseEventHandler<T> | undefined;
+        onMouseOverCapture?: MouseEventHandler<T> | undefined;
+        onMouseUp?: MouseEventHandler<T> | undefined;
+        onMouseUpCapture?: MouseEventHandler<T> | undefined;
+
+        // Selection Events
+        onSelect?: ReactEventHandler<T> | undefined;
+        onSelectCapture?: ReactEventHandler<T> | undefined;
+
+        // Touch Events
+        onTouchCancel?: TouchEventHandler<T> | undefined;
+        onTouchCancelCapture?: TouchEventHandler<T> | undefined;
+        onTouchEnd?: TouchEventHandler<T> | undefined;
+        onTouchEndCapture?: TouchEventHandler<T> | undefined;
+        onTouchMove?: TouchEventHandler<T> | undefined;
+        onTouchMoveCapture?: TouchEventHandler<T> | undefined;
+        onTouchStart?: TouchEventHandler<T> | undefined;
+        onTouchStartCapture?: TouchEventHandler<T> | undefined;
+
+        // Pointer Events
+        onPointerDown?: PointerEventHandler<T> | undefined;
+        onPointerDownCapture?: PointerEventHandler<T> | undefined;
+        onPointerMove?: PointerEventHandler<T> | undefined;
+        onPointerMoveCapture?: PointerEventHandler<T> | undefined;
+        onPointerUp?: PointerEventHandler<T> | undefined;
+        onPointerUpCapture?: PointerEventHandler<T> | undefined;
+        onPointerCancel?: PointerEventHandler<T> | undefined;
+        onPointerCancelCapture?: PointerEventHandler<T> | undefined;
+        onPointerEnter?: PointerEventHandler<T> | undefined;
+        onPointerEnterCapture?: PointerEventHandler<T> | undefined;
+        onPointerLeave?: PointerEventHandler<T> | undefined;
+        onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
+        onPointerOver?: PointerEventHandler<T> | undefined;
+        onPointerOverCapture?: PointerEventHandler<T> | undefined;
+        onPointerOut?: PointerEventHandler<T> | undefined;
+        onPointerOutCapture?: PointerEventHandler<T> | undefined;
+        onGotPointerCapture?: PointerEventHandler<T> | undefined;
+        onGotPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+        onLostPointerCapture?: PointerEventHandler<T> | undefined;
+        onLostPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+
+        // UI Events
+        onScroll?: UIEventHandler<T> | undefined;
+        onScrollCapture?: UIEventHandler<T> | undefined;
+
+        // Wheel Events
+        onWheel?: WheelEventHandler<T> | undefined;
+        onWheelCapture?: WheelEventHandler<T> | undefined;
+
+        // Animation Events
+        onAnimationStart?: AnimationEventHandler<T> | undefined;
+        onAnimationStartCapture?: AnimationEventHandler<T> | undefined;
+        onAnimationEnd?: AnimationEventHandler<T> | undefined;
+        onAnimationEndCapture?: AnimationEventHandler<T> | undefined;
+        onAnimationIteration?: AnimationEventHandler<T> | undefined;
+        onAnimationIterationCapture?: AnimationEventHandler<T> | undefined;
+
+        // Transition Events
+        onTransitionEnd?: TransitionEventHandler<T> | undefined;
+        onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    export interface CSSProperties extends CSS.Properties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
+    // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
+    interface AriaAttributes {
+        /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+        'aria-activedescendant'?: string | undefined;
+        /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+        'aria-atomic'?: Booleanish | undefined;
+        /**
+         * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+         * presented if they are made.
+         */
+        'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined;
+        /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+        'aria-busy'?: Booleanish | undefined;
+        /**
+         * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+         * @see aria-pressed @see aria-selected.
+         */
+        'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        /**
+         * Defines the total number of columns in a table, grid, or treegrid.
+         * @see aria-colindex.
+         */
+        'aria-colcount'?: number | undefined;
+        /**
+         * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+         * @see aria-colcount @see aria-colspan.
+         */
+        'aria-colindex'?: number | undefined;
+        /**
+         * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+         * @see aria-colindex @see aria-rowspan.
+         */
+        'aria-colspan'?: number | undefined;
+        /**
+         * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+         * @see aria-owns.
+         */
+        'aria-controls'?: string | undefined;
+        /** Indicates the element that represents the current item within a container or set of related elements. */
+        'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined;
+        /**
+         * Identifies the element (or elements) that describes the object.
+         * @see aria-labelledby
+         */
+        'aria-describedby'?: string | undefined;
+        /**
+         * Identifies the element that provides a detailed, extended description for the object.
+         * @see aria-describedby.
+         */
+        'aria-details'?: string | undefined;
+        /**
+         * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+         * @see aria-hidden @see aria-readonly.
+         */
+        'aria-disabled'?: Booleanish | undefined;
+        /**
+         * Indicates what functions can be performed when a dragged object is released on the drop target.
+         * @deprecated in ARIA 1.1
+         */
+        'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined;
+        /**
+         * Identifies the element that provides an error message for the object.
+         * @see aria-invalid @see aria-describedby.
+         */
+        'aria-errormessage'?: string | undefined;
+        /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+        'aria-expanded'?: Booleanish | undefined;
+        /**
+         * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+         * allows assistive technology to override the general default of reading in document source order.
+         */
+        'aria-flowto'?: string | undefined;
+        /**
+         * Indicates an element's "grabbed" state in a drag-and-drop operation.
+         * @deprecated in ARIA 1.1
+         */
+        'aria-grabbed'?: Booleanish | undefined;
+        /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+        'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined;
+        /**
+         * Indicates whether the element is exposed to an accessibility API.
+         * @see aria-disabled.
+         */
+        'aria-hidden'?: Booleanish | undefined;
+        /**
+         * Indicates the entered value does not conform to the format expected by the application.
+         * @see aria-errormessage.
+         */
+        'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined;
+        /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+        'aria-keyshortcuts'?: string | undefined;
+        /**
+         * Defines a string value that labels the current element.
+         * @see aria-labelledby.
+         */
+        'aria-label'?: string | undefined;
+        /**
+         * Identifies the element (or elements) that labels the current element.
+         * @see aria-describedby.
+         */
+        'aria-labelledby'?: string | undefined;
+        /** Defines the hierarchical level of an element within a structure. */
+        'aria-level'?: number | undefined;
+        /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+        'aria-live'?: 'off' | 'assertive' | 'polite' | undefined;
+        /** Indicates whether an element is modal when displayed. */
+        'aria-modal'?: Booleanish | undefined;
+        /** Indicates whether a text box accepts multiple lines of input or only a single line. */
+        'aria-multiline'?: Booleanish | undefined;
+        /** Indicates that the user may select more than one item from the current selectable descendants. */
+        'aria-multiselectable'?: Booleanish | undefined;
+        /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
+        'aria-orientation'?: 'horizontal' | 'vertical' | undefined;
+        /**
+         * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+         * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+         * @see aria-controls.
+         */
+        'aria-owns'?: string | undefined;
+        /**
+         * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+         * A hint could be a sample value or a brief description of the expected format.
+         */
+        'aria-placeholder'?: string | undefined;
+        /**
+         * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+         * @see aria-setsize.
+         */
+        'aria-posinset'?: number | undefined;
+        /**
+         * Indicates the current "pressed" state of toggle buttons.
+         * @see aria-checked @see aria-selected.
+         */
+        'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        /**
+         * Indicates that the element is not editable, but is otherwise operable.
+         * @see aria-disabled.
+         */
+        'aria-readonly'?: Booleanish | undefined;
+        /**
+         * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+         * @see aria-atomic.
+         */
+        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined;
+        /** Indicates that user input is required on the element before a form may be submitted. */
+        'aria-required'?: Booleanish | undefined;
+        /** Defines a human-readable, author-localized description for the role of an element. */
+        'aria-roledescription'?: string | undefined;
+        /**
+         * Defines the total number of rows in a table, grid, or treegrid.
+         * @see aria-rowindex.
+         */
+        'aria-rowcount'?: number | undefined;
+        /**
+         * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+         * @see aria-rowcount @see aria-rowspan.
+         */
+        'aria-rowindex'?: number | undefined;
+        /**
+         * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+         * @see aria-rowindex @see aria-colspan.
+         */
+        'aria-rowspan'?: number | undefined;
+        /**
+         * Indicates the current "selected" state of various widgets.
+         * @see aria-checked @see aria-pressed.
+         */
+        'aria-selected'?: Booleanish | undefined;
+        /**
+         * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+         * @see aria-posinset.
+         */
+        'aria-setsize'?: number | undefined;
+        /** Indicates if items in a table or grid are sorted in ascending or descending order. */
+        'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined;
+        /** Defines the maximum allowed value for a range widget. */
+        'aria-valuemax'?: number | undefined;
+        /** Defines the minimum allowed value for a range widget. */
+        'aria-valuemin'?: number | undefined;
+        /**
+         * Defines the current value for a range widget.
+         * @see aria-valuetext.
+         */
+        'aria-valuenow'?: number | undefined;
+        /** Defines the human readable text alternative of aria-valuenow for a range widget. */
+        'aria-valuetext'?: string | undefined;
+    }
+
+    // All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+    type AriaRole =
+        | 'alert'
+        | 'alertdialog'
+        | 'application'
+        | 'article'
+        | 'banner'
+        | 'button'
+        | 'cell'
+        | 'checkbox'
+        | 'columnheader'
+        | 'combobox'
+        | 'complementary'
+        | 'contentinfo'
+        | 'definition'
+        | 'dialog'
+        | 'directory'
+        | 'document'
+        | 'feed'
+        | 'figure'
+        | 'form'
+        | 'grid'
+        | 'gridcell'
+        | 'group'
+        | 'heading'
+        | 'img'
+        | 'link'
+        | 'list'
+        | 'listbox'
+        | 'listitem'
+        | 'log'
+        | 'main'
+        | 'marquee'
+        | 'math'
+        | 'menu'
+        | 'menubar'
+        | 'menuitem'
+        | 'menuitemcheckbox'
+        | 'menuitemradio'
+        | 'navigation'
+        | 'none'
+        | 'note'
+        | 'option'
+        | 'presentation'
+        | 'progressbar'
+        | 'radio'
+        | 'radiogroup'
+        | 'region'
+        | 'row'
+        | 'rowgroup'
+        | 'rowheader'
+        | 'scrollbar'
+        | 'search'
+        | 'searchbox'
+        | 'separator'
+        | 'slider'
+        | 'spinbutton'
+        | 'status'
+        | 'switch'
+        | 'tab'
+        | 'table'
+        | 'tablist'
+        | 'tabpanel'
+        | 'term'
+        | 'textbox'
+        | 'timer'
+        | 'toolbar'
+        | 'tooltip'
+        | 'tree'
+        | 'treegrid'
+        | 'treeitem'
+        | (string & {});
+
+    interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // React-specific Attributes
+        defaultChecked?: boolean | undefined;
+        defaultValue?: string | number | ReadonlyArray<string> | undefined;
+        suppressContentEditableWarning?: boolean | undefined;
+        suppressHydrationWarning?: boolean | undefined;
+
+        // Standard HTML Attributes
+        accessKey?: string | undefined;
+        autoFocus?: boolean | undefined;
+        className?: string | undefined;
+        contentEditable?: Booleanish | "inherit" | undefined;
+        contextMenu?: string | undefined;
+        dir?: string | undefined;
+        draggable?: Booleanish | undefined;
+        hidden?: boolean | undefined;
+        id?: string | undefined;
+        lang?: string | undefined;
+        nonce?: string | undefined;
+        placeholder?: string | undefined;
+        slot?: string | undefined;
+        spellCheck?: Booleanish | undefined;
+        style?: CSSProperties | undefined;
+        tabIndex?: number | undefined;
+        title?: string | undefined;
+        translate?: 'yes' | 'no' | undefined;
+
+        // Unknown
+        radioGroup?: string | undefined; // <command>, <menuitem>
+
+        // WAI-ARIA
+        role?: AriaRole | undefined;
+
+        // RDFa Attributes
+        about?: string | undefined;
+        content?: string | undefined;
+        datatype?: string | undefined;
+        inlist?: any;
+        prefix?: string | undefined;
+        property?: string | undefined;
+        rel?: string | undefined;
+        resource?: string | undefined;
+        rev?: string | undefined;
+        typeof?: string | undefined;
+        vocab?: string | undefined;
+
+        // Non-standard Attributes
+        autoCapitalize?: string | undefined;
+        autoCorrect?: string | undefined;
+        autoSave?: string | undefined;
+        color?: string | undefined;
+        itemProp?: string | undefined;
+        itemScope?: boolean | undefined;
+        itemType?: string | undefined;
+        itemID?: string | undefined;
+        itemRef?: string | undefined;
+        results?: number | undefined;
+        security?: string | undefined;
+        unselectable?: 'on' | 'off' | undefined;
+
+        // Living Standard
+        /**
+         * Hints at the type of data that might be entered by the user while editing the element or its contents
+         * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+         */
+        inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' | undefined;
+        /**
+         * Specify that a standard HTML element should behave like a defined custom built-in element
+         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+         */
+        is?: string | undefined;
+    }
+
+    interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
+        // Standard HTML Attributes
+        accept?: string | undefined;
+        acceptCharset?: string | undefined;
+        action?: string | undefined;
+        allowFullScreen?: boolean | undefined;
+        allowTransparency?: boolean | undefined;
+        alt?: string | undefined;
+        as?: string | undefined;
+        async?: boolean | undefined;
+        autoComplete?: string | undefined;
+        autoPlay?: boolean | undefined;
+        capture?: boolean | 'user' | 'environment' | undefined;
+        cellPadding?: number | string | undefined;
+        cellSpacing?: number | string | undefined;
+        charSet?: string | undefined;
+        challenge?: string | undefined;
+        checked?: boolean | undefined;
+        cite?: string | undefined;
+        classID?: string | undefined;
+        cols?: number | undefined;
+        colSpan?: number | undefined;
+        controls?: boolean | undefined;
+        coords?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        data?: string | undefined;
+        dateTime?: string | undefined;
+        default?: boolean | undefined;
+        defer?: boolean | undefined;
+        disabled?: boolean | undefined;
+        download?: any;
+        encType?: string | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        frameBorder?: number | string | undefined;
+        headers?: string | undefined;
+        height?: number | string | undefined;
+        high?: number | undefined;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        htmlFor?: string | undefined;
+        httpEquiv?: string | undefined;
+        integrity?: string | undefined;
+        keyParams?: string | undefined;
+        keyType?: string | undefined;
+        kind?: string | undefined;
+        label?: string | undefined;
+        list?: string | undefined;
+        loop?: boolean | undefined;
+        low?: number | undefined;
+        manifest?: string | undefined;
+        marginHeight?: number | undefined;
+        marginWidth?: number | undefined;
+        max?: number | string | undefined;
+        maxLength?: number | undefined;
+        media?: string | undefined;
+        mediaGroup?: string | undefined;
+        method?: string | undefined;
+        min?: number | string | undefined;
+        minLength?: number | undefined;
+        multiple?: boolean | undefined;
+        muted?: boolean | undefined;
+        name?: string | undefined;
+        noValidate?: boolean | undefined;
+        open?: boolean | undefined;
+        optimum?: number | undefined;
+        pattern?: string | undefined;
+        placeholder?: string | undefined;
+        playsInline?: boolean | undefined;
+        poster?: string | undefined;
+        preload?: string | undefined;
+        readOnly?: boolean | undefined;
+        required?: boolean | undefined;
+        reversed?: boolean | undefined;
+        rows?: number | undefined;
+        rowSpan?: number | undefined;
+        sandbox?: string | undefined;
+        scope?: string | undefined;
+        scoped?: boolean | undefined;
+        scrolling?: string | undefined;
+        seamless?: boolean | undefined;
+        selected?: boolean | undefined;
+        shape?: string | undefined;
+        size?: number | undefined;
+        sizes?: string | undefined;
+        span?: number | undefined;
+        src?: string | undefined;
+        srcDoc?: string | undefined;
+        srcLang?: string | undefined;
+        srcSet?: string | undefined;
+        start?: number | undefined;
+        step?: number | string | undefined;
+        summary?: string | undefined;
+        target?: string | undefined;
+        type?: string | undefined;
+        useMap?: string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        width?: number | string | undefined;
+        wmode?: string | undefined;
+        wrap?: string | undefined;
+    }
+
+    type HTMLAttributeReferrerPolicy =
+        | ''
+        | 'no-referrer'
+        | 'no-referrer-when-downgrade'
+        | 'origin'
+        | 'origin-when-cross-origin'
+        | 'same-origin'
+        | 'strict-origin'
+        | 'strict-origin-when-cross-origin'
+        | 'unsafe-url';
+
+    type HTMLAttributeAnchorTarget =
+        | '_self'
+        | '_blank'
+        | '_parent'
+        | '_top'
+        | (string & {});
+
+    interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
+        download?: any;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        media?: string | undefined;
+        ping?: string | undefined;
+        target?: HTMLAttributeAnchorTarget | undefined;
+        type?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    }
+
+    interface AudioHTMLAttributes<T> extends MediaHTMLAttributes<T> {}
+
+    interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
+        alt?: string | undefined;
+        coords?: string | undefined;
+        download?: any;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        media?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        shape?: string | undefined;
+        target?: string | undefined;
+    }
+
+    interface BaseHTMLAttributes<T> extends HTMLAttributes<T> {
+        href?: string | undefined;
+        target?: string | undefined;
+    }
+
+    interface BlockquoteHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+    }
+
+    interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        name?: string | undefined;
+        type?: 'submit' | 'reset' | 'button' | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ColHTMLAttributes<T> extends HTMLAttributes<T> {
+        span?: number | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ColgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+        span?: number | undefined;
+    }
+
+    interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
+        open?: boolean | undefined;
+        onToggle?: ReactEventHandler<T> | undefined;
+    }
+
+    interface DelHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+        dateTime?: string | undefined;
+    }
+
+    interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
+        onCancel?: ReactEventHandler<T> |  undefined;
+        onClose?: ReactEventHandler<T> |  undefined;
+        open?: boolean | undefined;
+    }
+
+    interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        src?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface FieldsetHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
+        acceptCharset?: string | undefined;
+        action?: string | undefined;
+        autoComplete?: string | undefined;
+        encType?: string | undefined;
+        method?: string | undefined;
+        name?: string | undefined;
+        noValidate?: boolean | undefined;
+        target?: string | undefined;
+    }
+
+    interface HtmlHTMLAttributes<T> extends HTMLAttributes<T> {
+        manifest?: string | undefined;
+    }
+
+    interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
+        allow?: string | undefined;
+        allowFullScreen?: boolean | undefined;
+        allowTransparency?: boolean | undefined;
+        /** @deprecated */
+        frameBorder?: number | string | undefined;
+        height?: number | string | undefined;
+        loading?: "eager" | "lazy" | undefined;
+        /** @deprecated */
+        marginHeight?: number | undefined;
+        /** @deprecated */
+        marginWidth?: number | undefined;
+        name?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        sandbox?: string | undefined;
+        /** @deprecated */
+        scrolling?: string | undefined;
+        seamless?: boolean | undefined;
+        src?: string | undefined;
+        srcDoc?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+        alt?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        decoding?: "async" | "auto" | "sync" | undefined;
+        height?: number | string | undefined;
+        loading?: "eager" | "lazy" | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        sizes?: string | undefined;
+        src?: string | undefined;
+        srcSet?: string | undefined;
+        useMap?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface InsHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+        dateTime?: string | undefined;
+    }
+
+    type HTMLInputTypeAttribute =
+        | 'button'
+        | 'checkbox'
+        | 'color'
+        | 'date'
+        | 'datetime-local'
+        | 'email'
+        | 'file'
+        | 'hidden'
+        | 'image'
+        | 'month'
+        | 'number'
+        | 'password'
+        | 'radio'
+        | 'range'
+        | 'reset'
+        | 'search'
+        | 'submit'
+        | 'tel'
+        | 'text'
+        | 'time'
+        | 'url'
+        | 'week'
+        | (string & {});
+
+    interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
+        accept?: string | undefined;
+        alt?: string | undefined;
+        autoComplete?: string | undefined;
+        capture?: boolean | 'user' | 'environment' | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+        checked?: boolean | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        disabled?: boolean | undefined;
+        enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        height?: number | string | undefined;
+        list?: string | undefined;
+        max?: number | string | undefined;
+        maxLength?: number | undefined;
+        min?: number | string | undefined;
+        minLength?: number | undefined;
+        multiple?: boolean | undefined;
+        name?: string | undefined;
+        pattern?: string | undefined;
+        placeholder?: string | undefined;
+        readOnly?: boolean | undefined;
+        required?: boolean | undefined;
+        size?: number | undefined;
+        src?: string | undefined;
+        step?: number | string | undefined;
+        type?: HTMLInputTypeAttribute | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        width?: number | string | undefined;
+
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
+        challenge?: string | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        keyType?: string | undefined;
+        keyParams?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface LabelHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        htmlFor?: string | undefined;
+    }
+
+    interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
+        as?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        integrity?: string | undefined;
+        media?: string | undefined;
+        imageSrcSet?: string | undefined;
+        imageSizes?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        sizes?: string | undefined;
+        type?: string | undefined;
+        charSet?: string | undefined;
+    }
+
+    interface MapHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+    }
+
+    interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
+        type?: string | undefined;
+    }
+
+    interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoPlay?: boolean | undefined;
+        controls?: boolean | undefined;
+        controlsList?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        loop?: boolean | undefined;
+        mediaGroup?: string | undefined;
+        muted?: boolean | undefined;
+        playsInline?: boolean | undefined;
+        preload?: string | undefined;
+        src?: string | undefined;
+    }
+
+    interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
+        charSet?: string | undefined;
+        httpEquiv?: string | undefined;
+        name?: string | undefined;
+        media?: string | undefined;
+    }
+
+    interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        high?: number | undefined;
+        low?: number | undefined;
+        max?: number | string | undefined;
+        min?: number | string | undefined;
+        optimum?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+    }
+
+    interface ObjectHTMLAttributes<T> extends HTMLAttributes<T> {
+        classID?: string | undefined;
+        data?: string | undefined;
+        form?: string | undefined;
+        height?: number | string | undefined;
+        name?: string | undefined;
+        type?: string | undefined;
+        useMap?: string | undefined;
+        width?: number | string | undefined;
+        wmode?: string | undefined;
+    }
+
+    interface OlHTMLAttributes<T> extends HTMLAttributes<T> {
+        reversed?: boolean | undefined;
+        start?: number | undefined;
+        type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
+    }
+
+    interface OptgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        label?: string | undefined;
+    }
+
+    interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        label?: string | undefined;
+        selected?: boolean | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        htmlFor?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
+        max?: number | string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface SlotHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+    }
+
+    interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
+        async?: boolean | undefined;
+        /** @deprecated */
+        charSet?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        defer?: boolean | undefined;
+        integrity?: string | undefined;
+        noModule?: boolean | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        src?: string | undefined;
+        type?: string | undefined;
+    }
+
+    interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoComplete?: string | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        multiple?: boolean | undefined;
+        name?: string | undefined;
+        required?: boolean | undefined;
+        size?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        media?: string | undefined;
+        sizes?: string | undefined;
+        src?: string | undefined;
+        srcSet?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+        media?: string | undefined;
+        scoped?: boolean | undefined;
+        type?: string | undefined;
+    }
+
+    interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | undefined;
+        bgcolor?: string | undefined;
+        border?: number | undefined;
+        cellPadding?: number | string | undefined;
+        cellSpacing?: number | string | undefined;
+        frame?: boolean | undefined;
+        rules?: "none" | "groups" | "rows" | "columns" | "all" | undefined;
+        summary?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoComplete?: string | undefined;
+        cols?: number | undefined;
+        dirName?: string | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        maxLength?: number | undefined;
+        minLength?: number | undefined;
+        name?: string | undefined;
+        placeholder?: string | undefined;
+        readOnly?: boolean | undefined;
+        required?: boolean | undefined;
+        rows?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        wrap?: string | undefined;
+
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        colSpan?: number | undefined;
+        headers?: string | undefined;
+        rowSpan?: number | undefined;
+        scope?: string | undefined;
+        abbr?: string | undefined;
+        height?: number | string | undefined;
+        width?: number | string | undefined;
+        valign?: "top" | "middle" | "bottom" | "baseline" | undefined;
+    }
+
+    interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        colSpan?: number | undefined;
+        headers?: string | undefined;
+        rowSpan?: number | undefined;
+        scope?: string | undefined;
+        abbr?: string | undefined;
+    }
+
+    interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
+        dateTime?: string | undefined;
+    }
+
+    interface TrackHTMLAttributes<T> extends HTMLAttributes<T> {
+        default?: boolean | undefined;
+        kind?: string | undefined;
+        label?: string | undefined;
+        src?: string | undefined;
+        srcLang?: string | undefined;
+    }
+
+    interface VideoHTMLAttributes<T> extends MediaHTMLAttributes<T> {
+        height?: number | string | undefined;
+        playsInline?: boolean | undefined;
+        poster?: string | undefined;
+        width?: number | string | undefined;
+        disablePictureInPicture?: boolean | undefined;
+        disableRemotePlayback?: boolean | undefined;
+    }
+
+    // this list is "complete" in that it contains every SVG attribute
+    // that React supports, but the types can be improved.
+    // Full list here: https://facebook.github.io/react/docs/dom-elements.html
+    //
+    // The three broad type categories are (in order of restrictiveness):
+    //   - "number | string"
+    //   - "string"
+    //   - union of string literals
+    interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // Attributes which also defined in HTMLAttributes
+        // See comment in SVGDOMPropertyConfig.js
+        className?: string | undefined;
+        color?: string | undefined;
+        height?: number | string | undefined;
+        id?: string | undefined;
+        lang?: string | undefined;
+        max?: number | string | undefined;
+        media?: string | undefined;
+        method?: string | undefined;
+        min?: number | string | undefined;
+        name?: string | undefined;
+        style?: CSSProperties | undefined;
+        target?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+
+        // Other HTML properties supported by SVG elements in browsers
+        role?: AriaRole | undefined;
+        tabIndex?: number | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+
+        // SVG Specific attributes
+        accentHeight?: number | string | undefined;
+        accumulate?: "none" | "sum" | undefined;
+        additive?: "replace" | "sum" | undefined;
+        alignmentBaseline?: "auto" | "baseline" | "before-edge" | "text-before-edge" | "middle" | "central" | "after-edge" |
+        "text-after-edge" | "ideographic" | "alphabetic" | "hanging" | "mathematical" | "inherit" | undefined;
+        allowReorder?: "no" | "yes" | undefined;
+        alphabetic?: number | string | undefined;
+        amplitude?: number | string | undefined;
+        arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined;
+        ascent?: number | string | undefined;
+        attributeName?: string | undefined;
+        attributeType?: string | undefined;
+        autoReverse?: Booleanish | undefined;
+        azimuth?: number | string | undefined;
+        baseFrequency?: number | string | undefined;
+        baselineShift?: number | string | undefined;
+        baseProfile?: number | string | undefined;
+        bbox?: number | string | undefined;
+        begin?: number | string | undefined;
+        bias?: number | string | undefined;
+        by?: number | string | undefined;
+        calcMode?: number | string | undefined;
+        capHeight?: number | string | undefined;
+        clip?: number | string | undefined;
+        clipPath?: string | undefined;
+        clipPathUnits?: number | string | undefined;
+        clipRule?: number | string | undefined;
+        colorInterpolation?: number | string | undefined;
+        colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit" | undefined;
+        colorProfile?: number | string | undefined;
+        colorRendering?: number | string | undefined;
+        contentScriptType?: number | string | undefined;
+        contentStyleType?: number | string | undefined;
+        cursor?: number | string | undefined;
+        cx?: number | string | undefined;
+        cy?: number | string | undefined;
+        d?: string | undefined;
+        decelerate?: number | string | undefined;
+        descent?: number | string | undefined;
+        diffuseConstant?: number | string | undefined;
+        direction?: number | string | undefined;
+        display?: number | string | undefined;
+        divisor?: number | string | undefined;
+        dominantBaseline?: number | string | undefined;
+        dur?: number | string | undefined;
+        dx?: number | string | undefined;
+        dy?: number | string | undefined;
+        edgeMode?: number | string | undefined;
+        elevation?: number | string | undefined;
+        enableBackground?: number | string | undefined;
+        end?: number | string | undefined;
+        exponent?: number | string | undefined;
+        externalResourcesRequired?: Booleanish | undefined;
+        fill?: string | undefined;
+        fillOpacity?: number | string | undefined;
+        fillRule?: "nonzero" | "evenodd" | "inherit" | undefined;
+        filter?: string | undefined;
+        filterRes?: number | string | undefined;
+        filterUnits?: number | string | undefined;
+        floodColor?: number | string | undefined;
+        floodOpacity?: number | string | undefined;
+        focusable?: Booleanish | "auto" | undefined;
+        fontFamily?: string | undefined;
+        fontSize?: number | string | undefined;
+        fontSizeAdjust?: number | string | undefined;
+        fontStretch?: number | string | undefined;
+        fontStyle?: number | string | undefined;
+        fontVariant?: number | string | undefined;
+        fontWeight?: number | string | undefined;
+        format?: number | string | undefined;
+        fr?: number | string | undefined;
+        from?: number | string | undefined;
+        fx?: number | string | undefined;
+        fy?: number | string | undefined;
+        g1?: number | string | undefined;
+        g2?: number | string | undefined;
+        glyphName?: number | string | undefined;
+        glyphOrientationHorizontal?: number | string | undefined;
+        glyphOrientationVertical?: number | string | undefined;
+        glyphRef?: number | string | undefined;
+        gradientTransform?: string | undefined;
+        gradientUnits?: string | undefined;
+        hanging?: number | string | undefined;
+        horizAdvX?: number | string | undefined;
+        horizOriginX?: number | string | undefined;
+        href?: string | undefined;
+        ideographic?: number | string | undefined;
+        imageRendering?: number | string | undefined;
+        in2?: number | string | undefined;
+        in?: string | undefined;
+        intercept?: number | string | undefined;
+        k1?: number | string | undefined;
+        k2?: number | string | undefined;
+        k3?: number | string | undefined;
+        k4?: number | string | undefined;
+        k?: number | string | undefined;
+        kernelMatrix?: number | string | undefined;
+        kernelUnitLength?: number | string | undefined;
+        kerning?: number | string | undefined;
+        keyPoints?: number | string | undefined;
+        keySplines?: number | string | undefined;
+        keyTimes?: number | string | undefined;
+        lengthAdjust?: number | string | undefined;
+        letterSpacing?: number | string | undefined;
+        lightingColor?: number | string | undefined;
+        limitingConeAngle?: number | string | undefined;
+        local?: number | string | undefined;
+        markerEnd?: string | undefined;
+        markerHeight?: number | string | undefined;
+        markerMid?: string | undefined;
+        markerStart?: string | undefined;
+        markerUnits?: number | string | undefined;
+        markerWidth?: number | string | undefined;
+        mask?: string | undefined;
+        maskContentUnits?: number | string | undefined;
+        maskUnits?: number | string | undefined;
+        mathematical?: number | string | undefined;
+        mode?: number | string | undefined;
+        numOctaves?: number | string | undefined;
+        offset?: number | string | undefined;
+        opacity?: number | string | undefined;
+        operator?: number | string | undefined;
+        order?: number | string | undefined;
+        orient?: number | string | undefined;
+        orientation?: number | string | undefined;
+        origin?: number | string | undefined;
+        overflow?: number | string | undefined;
+        overlinePosition?: number | string | undefined;
+        overlineThickness?: number | string | undefined;
+        paintOrder?: number | string | undefined;
+        panose1?: number | string | undefined;
+        path?: string | undefined;
+        pathLength?: number | string | undefined;
+        patternContentUnits?: string | undefined;
+        patternTransform?: number | string | undefined;
+        patternUnits?: string | undefined;
+        pointerEvents?: number | string | undefined;
+        points?: string | undefined;
+        pointsAtX?: number | string | undefined;
+        pointsAtY?: number | string | undefined;
+        pointsAtZ?: number | string | undefined;
+        preserveAlpha?: Booleanish | undefined;
+        preserveAspectRatio?: string | undefined;
+        primitiveUnits?: number | string | undefined;
+        r?: number | string | undefined;
+        radius?: number | string | undefined;
+        refX?: number | string | undefined;
+        refY?: number | string | undefined;
+        renderingIntent?: number | string | undefined;
+        repeatCount?: number | string | undefined;
+        repeatDur?: number | string | undefined;
+        requiredExtensions?: number | string | undefined;
+        requiredFeatures?: number | string | undefined;
+        restart?: number | string | undefined;
+        result?: string | undefined;
+        rotate?: number | string | undefined;
+        rx?: number | string | undefined;
+        ry?: number | string | undefined;
+        scale?: number | string | undefined;
+        seed?: number | string | undefined;
+        shapeRendering?: number | string | undefined;
+        slope?: number | string | undefined;
+        spacing?: number | string | undefined;
+        specularConstant?: number | string | undefined;
+        specularExponent?: number | string | undefined;
+        speed?: number | string | undefined;
+        spreadMethod?: string | undefined;
+        startOffset?: number | string | undefined;
+        stdDeviation?: number | string | undefined;
+        stemh?: number | string | undefined;
+        stemv?: number | string | undefined;
+        stitchTiles?: number | string | undefined;
+        stopColor?: string | undefined;
+        stopOpacity?: number | string | undefined;
+        strikethroughPosition?: number | string | undefined;
+        strikethroughThickness?: number | string | undefined;
+        string?: number | string | undefined;
+        stroke?: string | undefined;
+        strokeDasharray?: string | number | undefined;
+        strokeDashoffset?: string | number | undefined;
+        strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined;
+        strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined;
+        strokeMiterlimit?: number | string | undefined;
+        strokeOpacity?: number | string | undefined;
+        strokeWidth?: number | string | undefined;
+        surfaceScale?: number | string | undefined;
+        systemLanguage?: number | string | undefined;
+        tableValues?: number | string | undefined;
+        targetX?: number | string | undefined;
+        targetY?: number | string | undefined;
+        textAnchor?: string | undefined;
+        textDecoration?: number | string | undefined;
+        textLength?: number | string | undefined;
+        textRendering?: number | string | undefined;
+        to?: number | string | undefined;
+        transform?: string | undefined;
+        u1?: number | string | undefined;
+        u2?: number | string | undefined;
+        underlinePosition?: number | string | undefined;
+        underlineThickness?: number | string | undefined;
+        unicode?: number | string | undefined;
+        unicodeBidi?: number | string | undefined;
+        unicodeRange?: number | string | undefined;
+        unitsPerEm?: number | string | undefined;
+        vAlphabetic?: number | string | undefined;
+        values?: string | undefined;
+        vectorEffect?: number | string | undefined;
+        version?: string | undefined;
+        vertAdvY?: number | string | undefined;
+        vertOriginX?: number | string | undefined;
+        vertOriginY?: number | string | undefined;
+        vHanging?: number | string | undefined;
+        vIdeographic?: number | string | undefined;
+        viewBox?: string | undefined;
+        viewTarget?: number | string | undefined;
+        visibility?: number | string | undefined;
+        vMathematical?: number | string | undefined;
+        widths?: number | string | undefined;
+        wordSpacing?: number | string | undefined;
+        writingMode?: number | string | undefined;
+        x1?: number | string | undefined;
+        x2?: number | string | undefined;
+        x?: number | string | undefined;
+        xChannelSelector?: string | undefined;
+        xHeight?: number | string | undefined;
+        xlinkActuate?: string | undefined;
+        xlinkArcrole?: string | undefined;
+        xlinkHref?: string | undefined;
+        xlinkRole?: string | undefined;
+        xlinkShow?: string | undefined;
+        xlinkTitle?: string | undefined;
+        xlinkType?: string | undefined;
+        xmlBase?: string | undefined;
+        xmlLang?: string | undefined;
+        xmlns?: string | undefined;
+        xmlnsXlink?: string | undefined;
+        xmlSpace?: string | undefined;
+        y1?: number | string | undefined;
+        y2?: number | string | undefined;
+        y?: number | string | undefined;
+        yChannelSelector?: string | undefined;
+        z?: number | string | undefined;
+        zoomAndPan?: string | undefined;
+    }
+
+    interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
+        allowFullScreen?: boolean | undefined;
+        allowpopups?: boolean | undefined;
+        autosize?: boolean | undefined;
+        blinkfeatures?: string | undefined;
+        disableblinkfeatures?: string | undefined;
+        disableguestresize?: boolean | undefined;
+        disablewebsecurity?: boolean | undefined;
+        guestinstance?: string | undefined;
+        httpreferrer?: string | undefined;
+        nodeintegration?: boolean | undefined;
+        partition?: string | undefined;
+        plugins?: boolean | undefined;
+        preload?: string | undefined;
+        src?: string | undefined;
+        useragent?: string | undefined;
+        webpreferences?: string | undefined;
+    }
+
+    //
+    // React.DOM
+    // ----------------------------------------------------------------------
+
+    interface ReactHTML {
+        a: DetailedHTMLFactory<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+        abbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        address: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        area: DetailedHTMLFactory<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
+        article: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        aside: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        audio: DetailedHTMLFactory<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
+        b: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        base: DetailedHTMLFactory<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
+        bdi: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        bdo: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        big: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        blockquote: DetailedHTMLFactory<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+        body: DetailedHTMLFactory<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+        br: DetailedHTMLFactory<HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+        button: DetailedHTMLFactory<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+        canvas: DetailedHTMLFactory<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
+        caption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        center: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        cite: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        code: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        col: DetailedHTMLFactory<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+        colgroup: DetailedHTMLFactory<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+        data: DetailedHTMLFactory<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
+        datalist: DetailedHTMLFactory<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
+        dd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        del: DetailedHTMLFactory<DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+        details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
+        dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        dialog: DetailedHTMLFactory<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+        div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+        dl: DetailedHTMLFactory<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+        dt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        em: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        embed: DetailedHTMLFactory<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
+        fieldset: DetailedHTMLFactory<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
+        figcaption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        figure: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        footer: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        form: DetailedHTMLFactory<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
+        h1: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h2: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h3: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h4: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h5: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h6: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        head: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLHeadElement>;
+        header: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        hgroup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        hr: DetailedHTMLFactory<HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+        html: DetailedHTMLFactory<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
+        i: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        iframe: DetailedHTMLFactory<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
+        img: DetailedHTMLFactory<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
+        input: DetailedHTMLFactory<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+        ins: DetailedHTMLFactory<InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+        kbd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        keygen: DetailedHTMLFactory<KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+        label: DetailedHTMLFactory<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
+        legend: DetailedHTMLFactory<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
+        li: DetailedHTMLFactory<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+        link: DetailedHTMLFactory<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
+        main: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        map: DetailedHTMLFactory<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+        mark: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        menu: DetailedHTMLFactory<MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+        menuitem: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        meta: DetailedHTMLFactory<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
+        meter: DetailedHTMLFactory<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
+        nav: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        noscript: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        object: DetailedHTMLFactory<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
+        ol: DetailedHTMLFactory<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
+        optgroup: DetailedHTMLFactory<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
+        option: DetailedHTMLFactory<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
+        output: DetailedHTMLFactory<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
+        p: DetailedHTMLFactory<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
+        param: DetailedHTMLFactory<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
+        picture: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        pre: DetailedHTMLFactory<HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+        progress: DetailedHTMLFactory<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
+        q: DetailedHTMLFactory<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+        rp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        rt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        ruby: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        s: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        samp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        slot: DetailedHTMLFactory<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
+        script: DetailedHTMLFactory<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
+        section: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        select: DetailedHTMLFactory<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
+        small: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        source: DetailedHTMLFactory<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
+        span: DetailedHTMLFactory<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+        strong: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        style: DetailedHTMLFactory<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
+        sub: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        summary: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        sup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        table: DetailedHTMLFactory<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+        template: DetailedHTMLFactory<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
+        tbody: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        td: DetailedHTMLFactory<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
+        textarea: DetailedHTMLFactory<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
+        tfoot: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        th: DetailedHTMLFactory<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+        thead: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        time: DetailedHTMLFactory<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
+        title: DetailedHTMLFactory<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
+        tr: DetailedHTMLFactory<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+        track: DetailedHTMLFactory<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
+        u: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        ul: DetailedHTMLFactory<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+        "var": DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        video: DetailedHTMLFactory<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
+        wbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+    }
+
+    interface ReactSVG {
+        animate: SVGFactory;
+        circle: SVGFactory;
+        clipPath: SVGFactory;
+        defs: SVGFactory;
+        desc: SVGFactory;
+        ellipse: SVGFactory;
+        feBlend: SVGFactory;
+        feColorMatrix: SVGFactory;
+        feComponentTransfer: SVGFactory;
+        feComposite: SVGFactory;
+        feConvolveMatrix: SVGFactory;
+        feDiffuseLighting: SVGFactory;
+        feDisplacementMap: SVGFactory;
+        feDistantLight: SVGFactory;
+        feDropShadow: SVGFactory;
+        feFlood: SVGFactory;
+        feFuncA: SVGFactory;
+        feFuncB: SVGFactory;
+        feFuncG: SVGFactory;
+        feFuncR: SVGFactory;
+        feGaussianBlur: SVGFactory;
+        feImage: SVGFactory;
+        feMerge: SVGFactory;
+        feMergeNode: SVGFactory;
+        feMorphology: SVGFactory;
+        feOffset: SVGFactory;
+        fePointLight: SVGFactory;
+        feSpecularLighting: SVGFactory;
+        feSpotLight: SVGFactory;
+        feTile: SVGFactory;
+        feTurbulence: SVGFactory;
+        filter: SVGFactory;
+        foreignObject: SVGFactory;
+        g: SVGFactory;
+        image: SVGFactory;
+        line: SVGFactory;
+        linearGradient: SVGFactory;
+        marker: SVGFactory;
+        mask: SVGFactory;
+        metadata: SVGFactory;
+        path: SVGFactory;
+        pattern: SVGFactory;
+        polygon: SVGFactory;
+        polyline: SVGFactory;
+        radialGradient: SVGFactory;
+        rect: SVGFactory;
+        stop: SVGFactory;
+        svg: SVGFactory;
+        switch: SVGFactory;
+        symbol: SVGFactory;
+        text: SVGFactory;
+        textPath: SVGFactory;
+        tspan: SVGFactory;
+        use: SVGFactory;
+        view: SVGFactory;
+    }
+
+    interface ReactDOM extends ReactHTML, ReactSVG { }
+
+    //
+    // React.PropTypes
+    // ----------------------------------------------------------------------
+
+    type Validator<T> = PropTypes.Validator<T>;
+
+    type Requireable<T> = PropTypes.Requireable<T>;
+
+    type ValidationMap<T> = PropTypes.ValidationMap<T>;
+
+    type WeakValidationMap<T> = {
+        [K in keyof T]?: null extends T[K]
+            ? Validator<T[K] | null | undefined>
+            : undefined extends T[K]
+            ? Validator<T[K] | null | undefined>
+            : Validator<T[K]>
+    };
+
+    interface ReactPropTypes {
+        any: typeof PropTypes.any;
+        array: typeof PropTypes.array;
+        bool: typeof PropTypes.bool;
+        func: typeof PropTypes.func;
+        number: typeof PropTypes.number;
+        object: typeof PropTypes.object;
+        string: typeof PropTypes.string;
+        node: typeof PropTypes.node;
+        element: typeof PropTypes.element;
+        instanceOf: typeof PropTypes.instanceOf;
+        oneOf: typeof PropTypes.oneOf;
+        oneOfType: typeof PropTypes.oneOfType;
+        arrayOf: typeof PropTypes.arrayOf;
+        objectOf: typeof PropTypes.objectOf;
+        shape: typeof PropTypes.shape;
+        exact: typeof PropTypes.exact;
+    }
+
+    //
+    // React.Children
+    // ----------------------------------------------------------------------
+
+    /**
+     * @deprecated - Use `typeof React.Children` instead.
+     */
+    // Sync with type of `const Children`.
+    interface ReactChildren {
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+        count(children: any): number;
+        only<C>(children: C): C extends any[] ? never : C;
+        toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | null | undefined>>;
+    }
+
+    //
+    // Browser Interfaces
+    // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
+    // ----------------------------------------------------------------------
+
+    interface AbstractView {
+        styleMedia: StyleMedia;
+        document: Document;
+    }
+
+    interface Touch {
+        identifier: number;
+        target: EventTarget;
+        screenX: number;
+        screenY: number;
+        clientX: number;
+        clientY: number;
+        pageX: number;
+        pageY: number;
+    }
+
+    interface TouchList {
+        [index: number]: Touch;
+        length: number;
+        item(index: number): Touch;
+        identifiedTouch(identifier: number): Touch;
+    }
+
+    //
+    // Error Interfaces
+    // ----------------------------------------------------------------------
+    interface ErrorInfo {
+        /**
+         * Captures which component contained the exception, and its ancestors.
+         */
+        componentStack: string;
+    }
+}
+
+// naked 'any' type in a conditional type will short circuit and union both the then/else branches
+// so boolean is only resolved for T = any
+type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+
+type ExactlyAnyPropertyKeys<T> = { [K in keyof T]: IsExactlyAny<T[K]> extends true ? K : never }[keyof T];
+type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
+
+// Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+type MergePropTypes<P, T> =
+    // Distribute over P in case it is a union type
+    P extends any
+        // If props is type any, use propTypes definitions
+        ? IsExactlyAny<P> extends true ? T :
+            // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+            string extends keyof P ? P :
+                // Prefer declared types which are not exactly any
+                & Pick<P, NotExactlyAnyPropertyKeys<P>>
+                // For props which are exactly any, use the type inferred from propTypes if present
+                & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
+                // Keep leftover props not specified in propTypes
+                & Pick<P, Exclude<keyof P, keyof T>>
+        : never;
+
+type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
+
+// Any prop that has a default prop becomes optional, but its type is unchanged
+// Undeclared default props are augmented into the resulting allowable attributes
+// If declared props have indexed properties, ignore default props entirely as keyof gets widened
+// Wrap in an outer-level conditional type to allow distribution over props that are unions
+type Defaultize<P, D> = P extends any
+    ? string extends keyof P ? P :
+        & Pick<P, Exclude<keyof P, keyof D>>
+        & InexactPartial<Pick<P, Extract<keyof P, keyof D>>>
+        & InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D; }
+    ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
+    : C extends { propTypes: infer T; }
+        ? MergePropTypes<P, PropTypes.InferProps<T>>
+        : C extends { defaultProps: infer D; }
+            ? Defaultize<P, D>
+            : P;
+
+declare global {
+    namespace JSX {
+        interface Element extends React.ReactElement<any, any> { }
+        interface ElementClass extends React.Component<any> {
+            render(): React.ReactNode;
+        }
+        interface ElementAttributesProperty { props: {}; }
+        interface ElementChildrenAttribute { children: {}; }
+
+        // We can't recurse forever because `type` can't be self-referential;
+        // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
+        type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
+            ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
+                ? ReactManagedAttributes<U, P>
+                : ReactManagedAttributes<T, P>
+            : ReactManagedAttributes<C, P>;
+
+        interface IntrinsicAttributes extends React.Attributes { }
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
+
+        interface IntrinsicElements {
+            // HTML
+            a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+            abbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            address: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            area: React.DetailedHTMLProps<React.AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
+            article: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            aside: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            audio: React.DetailedHTMLProps<React.AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
+            b: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            base: React.DetailedHTMLProps<React.BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
+            bdi: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            bdo: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            big: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            blockquote: React.DetailedHTMLProps<React.BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+            body: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+            br: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+            button: React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+            canvas: React.DetailedHTMLProps<React.CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
+            caption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            center: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            cite: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            code: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            col: React.DetailedHTMLProps<React.ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            colgroup: React.DetailedHTMLProps<React.ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            data: React.DetailedHTMLProps<React.DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
+            datalist: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
+            dd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
+            dfn: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            dialog: React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+            div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+            dl: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+            dt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            em: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            embed: React.DetailedHTMLProps<React.EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
+            fieldset: React.DetailedHTMLProps<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
+            figcaption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            figure: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            footer: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            form: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
+            h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h2: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h3: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h4: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h5: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h6: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            head: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadElement>, HTMLHeadElement>;
+            header: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            hgroup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            hr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+            html: React.DetailedHTMLProps<React.HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
+            i: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            iframe: React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
+            img: React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
+            input: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+            ins: React.DetailedHTMLProps<React.InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            kbd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            keygen: React.DetailedHTMLProps<React.KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+            label: React.DetailedHTMLProps<React.LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
+            legend: React.DetailedHTMLProps<React.HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
+            li: React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+            link: React.DetailedHTMLProps<React.LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
+            main: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            map: React.DetailedHTMLProps<React.MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+            mark: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            menu: React.DetailedHTMLProps<React.MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+            menuitem: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            meta: React.DetailedHTMLProps<React.MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
+            meter: React.DetailedHTMLProps<React.MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
+            nav: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            noindex: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            noscript: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            object: React.DetailedHTMLProps<React.ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
+            ol: React.DetailedHTMLProps<React.OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
+            optgroup: React.DetailedHTMLProps<React.OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
+            option: React.DetailedHTMLProps<React.OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
+            output: React.DetailedHTMLProps<React.OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
+            p: React.DetailedHTMLProps<React.HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
+            param: React.DetailedHTMLProps<React.ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
+            picture: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            pre: React.DetailedHTMLProps<React.HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+            progress: React.DetailedHTMLProps<React.ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
+            q: React.DetailedHTMLProps<React.QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+            rp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            rt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            ruby: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            s: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            samp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            slot: React.DetailedHTMLProps<React.SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
+            script: React.DetailedHTMLProps<React.ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
+            section: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            select: React.DetailedHTMLProps<React.SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
+            small: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            source: React.DetailedHTMLProps<React.SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
+            span: React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+            strong: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            style: React.DetailedHTMLProps<React.StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
+            sub: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            summary: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            sup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            table: React.DetailedHTMLProps<React.TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+            template: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
+            tbody: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            td: React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
+            textarea: React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
+            tfoot: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            th: React.DetailedHTMLProps<React.ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+            thead: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            time: React.DetailedHTMLProps<React.TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
+            title: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
+            tr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+            track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
+            u: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            ul: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+            "var": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
+            wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+
+            // SVG
+            svg: React.SVGProps<SVGSVGElement>;
+
+            animate: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
+            animateMotion: React.SVGProps<SVGElement>;
+            animateTransform: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateTransformElement but is not in TypeScript's lib.dom.d.ts for now.
+            circle: React.SVGProps<SVGCircleElement>;
+            clipPath: React.SVGProps<SVGClipPathElement>;
+            defs: React.SVGProps<SVGDefsElement>;
+            desc: React.SVGProps<SVGDescElement>;
+            ellipse: React.SVGProps<SVGEllipseElement>;
+            feBlend: React.SVGProps<SVGFEBlendElement>;
+            feColorMatrix: React.SVGProps<SVGFEColorMatrixElement>;
+            feComponentTransfer: React.SVGProps<SVGFEComponentTransferElement>;
+            feComposite: React.SVGProps<SVGFECompositeElement>;
+            feConvolveMatrix: React.SVGProps<SVGFEConvolveMatrixElement>;
+            feDiffuseLighting: React.SVGProps<SVGFEDiffuseLightingElement>;
+            feDisplacementMap: React.SVGProps<SVGFEDisplacementMapElement>;
+            feDistantLight: React.SVGProps<SVGFEDistantLightElement>;
+            feDropShadow: React.SVGProps<SVGFEDropShadowElement>;
+            feFlood: React.SVGProps<SVGFEFloodElement>;
+            feFuncA: React.SVGProps<SVGFEFuncAElement>;
+            feFuncB: React.SVGProps<SVGFEFuncBElement>;
+            feFuncG: React.SVGProps<SVGFEFuncGElement>;
+            feFuncR: React.SVGProps<SVGFEFuncRElement>;
+            feGaussianBlur: React.SVGProps<SVGFEGaussianBlurElement>;
+            feImage: React.SVGProps<SVGFEImageElement>;
+            feMerge: React.SVGProps<SVGFEMergeElement>;
+            feMergeNode: React.SVGProps<SVGFEMergeNodeElement>;
+            feMorphology: React.SVGProps<SVGFEMorphologyElement>;
+            feOffset: React.SVGProps<SVGFEOffsetElement>;
+            fePointLight: React.SVGProps<SVGFEPointLightElement>;
+            feSpecularLighting: React.SVGProps<SVGFESpecularLightingElement>;
+            feSpotLight: React.SVGProps<SVGFESpotLightElement>;
+            feTile: React.SVGProps<SVGFETileElement>;
+            feTurbulence: React.SVGProps<SVGFETurbulenceElement>;
+            filter: React.SVGProps<SVGFilterElement>;
+            foreignObject: React.SVGProps<SVGForeignObjectElement>;
+            g: React.SVGProps<SVGGElement>;
+            image: React.SVGProps<SVGImageElement>;
+            line: React.SVGProps<SVGLineElement>;
+            linearGradient: React.SVGProps<SVGLinearGradientElement>;
+            marker: React.SVGProps<SVGMarkerElement>;
+            mask: React.SVGProps<SVGMaskElement>;
+            metadata: React.SVGProps<SVGMetadataElement>;
+            mpath: React.SVGProps<SVGElement>;
+            path: React.SVGProps<SVGPathElement>;
+            pattern: React.SVGProps<SVGPatternElement>;
+            polygon: React.SVGProps<SVGPolygonElement>;
+            polyline: React.SVGProps<SVGPolylineElement>;
+            radialGradient: React.SVGProps<SVGRadialGradientElement>;
+            rect: React.SVGProps<SVGRectElement>;
+            stop: React.SVGProps<SVGStopElement>;
+            switch: React.SVGProps<SVGSwitchElement>;
+            symbol: React.SVGProps<SVGSymbolElement>;
+            text: React.SVGProps<SVGTextElement>;
+            textPath: React.SVGProps<SVGTextPathElement>;
+            tspan: React.SVGProps<SVGTSpanElement>;
+            use: React.SVGProps<SVGUseElement>;
+            view: React.SVGProps<SVGViewElement>;
+        }
+    }
+}

--- a/types/react/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/ts5.0/jsx-dev-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';

--- a/types/react/ts5.0/jsx-runtime.d.ts
+++ b/types/react/ts5.0/jsx-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';

--- a/types/react/ts5.0/next.d.ts
+++ b/types/react/ts5.0/next.d.ts
@@ -1,0 +1,86 @@
+/**
+ * These are types for things that are present in the React `next` release channel.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/next"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/next'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/next" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react/src/React.js to see how the exports are declared,
+
+import React = require('.');
+
+export {};
+
+declare module '.' {
+    interface ThenableImpl<T> {
+        then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
+    }
+    interface UntrackedThenable<T> extends ThenableImpl<T> {
+        status?: void;
+    }
+
+    export interface PendingThenable<T> extends ThenableImpl<T> {
+        status: 'pending';
+    }
+
+    export interface FulfilledThenable<T> extends ThenableImpl<T> {
+        status: 'fulfilled';
+        value: T;
+    }
+
+    export interface RejectedThenable<T> extends ThenableImpl<T> {
+        status: 'rejected';
+        reason: unknown;
+    }
+
+    export type Thenable<T> = UntrackedThenable<T> | PendingThenable<T> | FulfilledThenable<T> | RejectedThenable<T>;
+
+    export type Usable<T> = Thenable<T> | Context<T>;
+
+    export function use<T>(usable: Usable<T>): T;
+
+    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONArray> {}
+    export type ServerContextJSONValue =
+        | string
+        | boolean
+        | number
+        | null
+        | ServerContextJSONArray
+        | { [key: string]: ServerContextJSONValue };
+    export interface ServerContext<T extends ServerContextJSONValue> {
+        Provider: Provider<T>;
+    }
+    /**
+     * Accepts a context object (the value returned from `React.createContext` or `React.createServerContext`) and returns the current
+     * context value, as given by the nearest context provider for the given context.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useContext
+     */
+    function useContext<T extends ServerContextJSONValue>(context: ServerContext<T>): T;
+    export function createServerContext<T extends ServerContextJSONValue>(
+        globalName: string,
+        defaultValue: T,
+    ): ServerContext<T>;
+
+    // tslint:disable-next-line ban-types
+    export function cache<CachedFunction extends Function>(fn: CachedFunction): CachedFunction;
+
+    export function unstable_useCacheRefresh(): () => void;
+}

--- a/types/react/ts5.0/next.d.ts
+++ b/types/react/ts5.0/next.d.ts
@@ -55,7 +55,7 @@ declare module '.' {
 
     export function use<T>(usable: Usable<T>): T;
 
-    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONArray> {}
+    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONValue> {}
     export type ServerContextJSONValue =
         | string
         | boolean

--- a/types/react/ts5.0/test/cssProperties.tsx
+++ b/types/react/ts5.0/test/cssProperties.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+const initialStyle: React.CSSProperties = { fontWeight: 'initial' };
+const initialStyleTest = <div style={initialStyle} />;
+
+const borderRadiusStyle: React.CSSProperties = { borderRadius: 5, borderTopRightRadius: '20%' };
+const borderRadiusStyleTest = <div style={borderRadiusStyle} />;
+
+const backgroundAttachmentStyle: React.CSSProperties = { backgroundAttachment: 'fixed' };
+const backgroundAttachmentStyleTest = <div style={backgroundAttachmentStyle} />;
+
+const columnCountStyle: React.CSSProperties = { columnCount: 'auto' };
+const columnCountStyleTest = <div style={columnCountStyle} />;
+
+const fontSizeAdjustStyle: React.CSSProperties = { fontSizeAdjust: 'none' };
+const fontSizeAdjustStyleTest = <div style={fontSizeAdjustStyle} />;
+
+const fontStretchStyle: React.CSSProperties = { fontStretch: 'condensed' };
+const fontStretchStyleTest = <div style={fontStretchStyle} />;
+
+const fontStyleStyle: React.CSSProperties = { fontStyle: 'italic' };
+const fontStyleStyleTest = <div style={fontStyleStyle} />;
+
+const fontWeightStyle: React.CSSProperties = { fontWeight: 400 };
+const fontWeightStyleTest = <div style={fontWeightStyle} />;
+
+const justifyContentStyle: React.CSSProperties = { justifyContent: 'space-evenly' };
+const justifyContentStyleTest = <div style={justifyContentStyle} />;
+
+const boxShadowStyle: React.CSSProperties = { boxShadow: '2px 2px 2px 1px rgba(0, 0, 0, 0.2)' };
+const boxShadowStyleTest = <div style={boxShadowStyle} />;
+
+const overflowStyle: React.CSSProperties = { overflow: 'auto', overflowX: 'visible', overflowY: 'scroll' };
+const overflowStyleTest = <div style={overflowStyle} />;
+
+const positionStyle: React.CSSProperties = { position: 'relative' };
+const positionStyleTest = <div style={positionStyle} />;
+
+// SVG specific style attribute declarations
+
+const fillOpacityStyle: React.CSSProperties = { fillOpacity: 0.3 };
+const fillOpacityStyleTest = <svg style={fillOpacityStyle} />;
+
+const strokeOpacityStyle: React.CSSProperties = { strokeOpacity: 0.3 };
+const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
+
+const strokeWidthStyle: React.CSSProperties = { strokeWidth: '10px' };
+const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+
+const testCases = [
+    <span />,
+    <span accessKey="s" />,
+    <span autoFocus />,
+    <span className="klass" />,
+    <span contentEditable />,
+    <span contextMenu="menuId" />,
+    <span dir="rtl" />,
+    <span draggable />,
+    <span hidden />,
+    <span id="s" />,
+    <span lang="art-x-tokipona" />,
+    <input placeholder="placeholder" />,
+    <span slot="my-text" />,
+    <span spellCheck />,
+    <span tabIndex={0} />,
+    <span title="title" />,
+    <span role="button" />,
+    <span autoCapitalize="off" />,
+    <span autoCapitalize="none" />,
+    <span autoCapitalize="on" />,
+    <span autoCapitalize="words" />,
+    <span autoCapitalize="sentences" />,
+    <span autoCorrect="off" />,
+    <span autoCorrect="on" />,
+    <span translate="no" />,
+    <span translate="yes" />,
+    <svg>
+        <image crossOrigin="anonymous" />
+    </svg>,
+    <details open={true} onToggle={() => {}} />,
+    <input value={['one', 'two'] as ReadonlyArray<string>} />,
+    <input value={['one', 'two'] as string[]} />,
+    <input value={['one', 'two']} />,
+    <input enterKeyHint="done" />,
+    <input accept="image/*" capture="user" />,
+    <input accept="image/*" capture="environment" />,
+    <input accept="image/*" capture />,
+    <input accept="video/*" capture="user" />,
+    <input accept="video/*" capture="environment" />,
+    // @ts-expect-error
+    <input accept="video/*" capture="haha" />,
+    <input accept="video/*" capture />,
+    <input accept="audio/*" capture />,
+
+    <div role="dialog" />,
+    <div role="none presentation" />,
+    <svg role="treeitem" />,
+    <a target="_blank"></a>,
+    <a target="some-frame"></a>,
+    <input type="button" />,
+    <input type="some-type" />,
+    // @ts-expect-error
+    <input enterKeyHint="don" />,
+    <video disableRemotePlayback onResize={() => {}} />,
+    <picture>
+        <source media="test" srcSet="test" width={50} height={50} />
+        <img src="test" width={100} height={100} />
+    </picture>,
+    <dialog
+        onCancel={event => {
+            // $ExpectType SyntheticEvent<HTMLDialogElement, Event>
+            event;
+        }}
+        onClose={event => {
+            // $ExpectType SyntheticEvent<HTMLDialogElement, Event>
+            event;
+        }}
+    ></dialog>,
+    <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
+    <center></center>
+];
+
+// Needed to check these HTML elements in event callbacks.
+// "Imported" from typescript's lib.dom.d.ts.
+declare global {
+    interface HTMLDetailsElement {
+        open: boolean;
+    }
+
+    interface HTMLMeterElement {
+        optimum: number;
+    }
+
+    interface HTMLModElement {
+        cite: string;
+    }
+
+    interface HTMLOutputElement {
+        value: string;
+    }
+
+    interface HTMLQuoteElement {
+        cite: string;
+    }
+
+    interface HTMLTimeElement {
+        dateTime: string;
+    }
+}
+
+const eventCallbacksTestCases = [
+    <blockquote onClick={e => e.currentTarget.cite} />,
+    <del onClick={e => e.currentTarget.cite} />,
+    <details onClick={e => e.currentTarget.open} />,
+    <meter onClick={e => e.currentTarget.optimum} />,
+    <output onClick={e => e.currentTarget.value} />,
+    <time onClick={e => e.currentTarget.dateTime} />,
+];

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -1,0 +1,73 @@
+/// <reference types="../experimental"/>
+
+import React = require('react');
+
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+function suspenseTest() {
+    function DisplayData() {
+        return null;
+    }
+
+    function FlameChart() {
+        return (
+            <React.Suspense fallback="computing..." unstable_expectedLoadTime={2000}>
+                <DisplayData />
+            </React.Suspense>
+        );
+    }
+}
+
+// Unsupported `revealOrder` triggers a runtime warning
+// @ts-expect-error
+<React.SuspenseList revealOrder="something">
+    <React.Suspense fallback="Loading">Content</React.Suspense>
+</React.SuspenseList>;
+
+<React.SuspenseList revealOrder="backwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.SuspenseList>;
+
+<React.SuspenseList revealOrder="forwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.SuspenseList>;
+
+<React.SuspenseList revealOrder="together">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.SuspenseList>;
+
+function useEvent() {
+    // Implicit any
+    // @ts-expect-error
+    const anyEvent = React.experimental_useEffectEvent(value => {
+        // $ExpectType any
+        return value;
+    });
+    // $ExpectType any
+    anyEvent({});
+    // $ExpectType (value: string) => number
+    const typedEvent = React.experimental_useEffectEvent((value: string) => {
+        return Number(value);
+    });
+    // $ExpectType number
+    typedEvent('1');
+    // Argument of type '{}' is not assignable to parameter of type 'string'.
+    // @ts-expect-error
+    typedEvent({});
+
+    function useContextuallyTypedEvent(fn: (event: Event) => string) {}
+    useContextuallyTypedEvent(
+        React.experimental_useEffectEvent(event => {
+            // $ExpectType Event
+            event;
+            return String(event);
+        }),
+    );
+}

--- a/types/react/ts5.0/test/hooks.tsx
+++ b/types/react/ts5.0/test/hooks.tsx
@@ -1,0 +1,417 @@
+import * as React from "react";
+
+const {useSyncExternalStore} = React;
+
+interface PersonProps {
+    name: string;
+    age: number;
+}
+export function Person(props: PersonProps) {
+    return <div>
+        hello! I'm {props.name} and I'm {props.age} years old!
+    </div>;
+}
+
+export interface FancyButtonProps {
+    onClick: () => void;
+    children?: React.ReactNode | undefined;
+}
+export interface FancyButtonMethod {
+    fancyClick(): void;
+}
+export const FancyButton = React.forwardRef((props: FancyButtonProps, ref: React.Ref<FancyButtonMethod>) => {
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+    const [count, setCount] = React.useState(0);
+
+    React.useImperativeHandle(ref, () => ({
+        fancyClick() {
+            buttonRef.current!; // $ExpectType HTMLButtonElement
+        },
+        getClickCount() {
+            return count;
+        }
+    }));
+
+    return <button onClick={() => { setCount(count + 1); props.onClick(); }}>
+        {props.children}
+    </button>;
+});
+
+interface AppState {
+    name: string;
+    age: number;
+}
+
+type AppActions =
+    | { type: "getOlder" }
+    | { type: "resetAge" };
+
+function reducer(s: AppState, action: AppActions): AppState {
+    switch (action.type) {
+        case "getOlder":
+            return { ...s, age: s.age + 1 };
+        case "resetAge":
+            return { ...s, age: 0 };
+    }
+}
+
+const initialState = {
+    name: "Daniel",
+    age: 26
+};
+
+export function App() {
+    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const birthdayRef = React.useRef<React.ComponentRef<typeof FancyButton>>(null);
+
+    React.useLayoutEffect(() => {
+        if (birthdayRef.current !== null) {
+            birthdayRef.current.fancyClick();
+        } else {
+            // this looks redundant but it ensures the type actually has "null" in it instead of "never"
+            // $ExpectType null
+            birthdayRef.current;
+        }
+    });
+
+    return <>
+        <Person {...state} />
+        <FancyButton onClick={() => dispatch({ type: "getOlder" })}>
+            Birthday time!
+        </FancyButton>
+        <FancyButton onClick={() => dispatch({ type: "resetAge" })}>
+            Let's start over.
+        </FancyButton>
+    </>;
+}
+
+interface Context {
+    test: true;
+}
+const context = React.createContext<Context>({ test: true });
+
+function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
+    const value: Context = React.useContext(context);
+    const [, setState] = React.useState(() => 0);
+    // Bonus typescript@next version
+    // const [reducerState, dispatch] = React.useReducer(reducer, true as const, arg => arg && initialState);
+    // Compile error in typescript@3.0 but not in typescript@3.1.
+    // const [reducerState, dispatch] = React.useReducer(reducer, true as true, arg => arg && initialState);
+    const [reducerState, dispatch] = React.useReducer(reducer, true as true, (arg: true): AppState => arg && initialState);
+
+    const [, simpleDispatch] = React.useReducer(v => v + 1, 0);
+
+    // inline object, to (manually) check if autocomplete works
+    React.useReducer(reducer, { age: 42, name: 'The Answer' });
+
+    // Implicit any
+    // @ts-expect-error
+    const anyCallback = React.useCallback(value => {
+        // $ExpectType any
+        return value;
+    }, []);
+    // $ExpectType any
+    anyCallback({});
+    // $ExpectType (value: string) => number
+    const typedCallback = React.useCallback((value: string) => {
+        return Number(value);
+    }, []);
+    // $ExpectType number
+    typedCallback("1");
+    // Argument of type '{}' is not assignable to parameter of type 'string'.
+    // @ts-expect-error
+    typedCallback({});
+
+    function useContextuallyTypedCallback(fn: (event: Event) => string) {}
+    useContextuallyTypedCallback(React.useCallback(event => {
+        // $ExpectType Event
+        event;
+        return String(event);
+    }, []));
+
+    // test useRef and its convenience overloads
+    // $ExpectType MutableRefObject<number>
+    React.useRef(0);
+
+    // these are not very useful (can't assign anything else to .current)
+    // but it's the only safe way to resolve them
+    // $ExpectType MutableRefObject<null>
+    React.useRef(null);
+    // $ExpectType MutableRefObject<undefined>
+    React.useRef(undefined);
+
+    // |null convenience overload
+    // it should _not_ be mutable if the generic argument doesn't include null
+    // $ExpectType RefObject<number>
+    React.useRef<number>(null);
+    // but it should be mutable if it does (i.e. is not the convenience overload)
+    // $ExpectType MutableRefObject<number | null>
+    React.useRef<number | null>(null);
+
+    // |undefined convenience overload
+    // with no contextual type or generic argument it should default to undefined only (not {} or unknown!)
+    // $ExpectType MutableRefObject<undefined>
+    React.useRef();
+    // $ExpectType MutableRefObject<number | undefined>
+    React.useRef<number>();
+    // don't just accept a potential undefined if there is a generic argument
+    // @ts-expect-error
+    React.useRef<number>(undefined);
+    // make sure once again there's no |undefined if the initial value doesn't either
+    // $ExpectType MutableRefObject<number>
+    React.useRef<number>(1);
+    // and also that it is not getting erased if the parameter is wider
+    // $ExpectType MutableRefObject<number | undefined>
+    React.useRef<number | undefined>(1);
+
+    // should be contextually typed
+    const a: React.MutableRefObject<number | undefined> = React.useRef(undefined);
+    const b: React.MutableRefObject<number | undefined> = React.useRef();
+    const c: React.MutableRefObject<number | null> = React.useRef(null);
+    const d: React.RefObject<number> = React.useRef(null);
+
+    const id = React.useMemo(() => Math.random(), []);
+    React.useImperativeHandle(ref, () => ({ id }), [id]);
+    // was named like this in the first alpha, renamed before release
+    // @ts-expect-error
+    React.useImperativeMethods(ref, () => ({}), [id]);
+
+    // make sure again this is not going to the |null convenience overload
+    // $ExpectType MutableRefObject<boolean>
+    const didLayout = React.useRef(false);
+
+    React.useLayoutEffect(() => {
+        setState(1);
+        setState(prevState => prevState - 1);
+        didLayout.current = true;
+    }, []);
+    React.useEffect(() => {
+        dispatch({ type: 'getOlder' });
+        // @ts-expect-error
+        dispatch();
+
+        simpleDispatch();
+        setState(reducerState.age);
+    }, []);
+
+    // effects are only allowed to either be actually void or return actually void functions
+    React.useEffect(() => () => {});
+    // indistinguishable
+    React.useEffect(() => () => undefined);
+    // @ts-expect-error
+    React.useEffect(() => null);
+    // @ts-expect-error
+    React.useEffect(() => Math.random() ? null : undefined);
+    // @ts-expect-error
+    React.useEffect(() => () => null);
+    // @ts-expect-error
+    React.useEffect(() => () => Math.random() ? null : undefined);
+    // @ts-expect-error
+    React.useEffect(() => async () => {});
+    // @ts-expect-error
+    React.useEffect(async () => () => {});
+
+    React.useDebugValue(id, value => value.toFixed());
+    React.useDebugValue(id);
+
+    // allow passing an explicit undefined
+    React.useMemo(() => {}, undefined);
+    // but don't allow it to be missing
+    // @ts-expect-error
+    React.useMemo(() => {});
+
+    // useState convenience overload
+    // default to undefined only (not that useful, but type-safe -- no {} or unknown!)
+    // $ExpectType undefined
+    React.useState()[0];
+    // $ExpectType number | undefined
+    React.useState<number>()[0];
+    // default overload
+    // $ExpectType number
+    React.useState(0)[0];
+    // $ExpectType undefined
+    React.useState(undefined)[0];
+    // make sure the generic argument does reject actual potentially undefined inputs
+    // @ts-expect-error
+    React.useState<number>(undefined)[0];
+    // make sure useState does not widen
+    const [toggle, setToggle] = React.useState(false);
+    // $ExpectType boolean
+    toggle;
+    // make sure setState accepts a function
+    setToggle(r => !r);
+
+    // Undesired
+    // Should not type-check since `number` will be `number` at runtime but `() => number` in the type-checker
+    const [number, setNumber] = React.useState<() => number>(() => 0);
+    // Should be `number`
+    // $EpectType () => number
+    number;
+
+    const [numFunc, setNumFunc] =  React.useState<() => number>(() => () => 0);
+    // $ExpectType () => number
+    numFunc;
+    // Undesired
+    // Should not typecheck since that would update the state to `number` when the type-checker would still consider the state to be `() => number`
+    setNumFunc(() => 42);
+    // this is the correct way to set a function in state
+    setNumFunc(() => () => 42);
+
+    // when using a function without a generic, infer the return type
+    // $ExpectType number
+    React.useState(() => 0)[0];
+    // When storing a function it must be wrapped
+    // $ExpectType () => number
+    React.useState<() => number>(() => () => 0)[0];
+    // When storing a function, even without a generic, it must be wrapped
+    // $ExpectType () => number
+    React.useState(() => () => 0)[0];
+
+    // Undesired
+    // Classes should only be accepted as a return value of state initializer/updater functions not direct input.
+    // React would call the constructor causing a TypeError.
+    React.useState(class {});
+    // This is the correct way to store classes in state.
+    // $ExpectType typeof A
+    React.useState(() => class A {})[0];
+
+    const [_, setClass] = React.useState(() => class {});
+    // Undesired
+    // Classes should only be accepted as a return value of state initializer/updater functions not direct input.
+    // React would call the constructor causing a TypeError,
+    setClass(class {});
+    setClass(() => class {});
+
+    // useReducer convenience overload
+
+    return React.useCallback(() => didLayout.current, []);
+}
+
+const UsesEveryHook = React.forwardRef(
+    function UsesEveryHook(props: {}, ref?: React.Ref<{ id: number }>) {
+        // $ExpectType boolean
+        useEveryHook(ref)();
+
+        return null;
+    }
+);
+const everyHookRef = React.createRef<{ id: number }>();
+<UsesEveryHook ref={everyHookRef}/>;
+
+<UsesEveryHook ref={ref => {
+    // $ExpectType { id: number; } | null
+    ref;
+ }}/>;
+
+function useConcurrentHooks() {
+    const [toggle, setToggle] = React.useState(false);
+
+    const [done, startTransition] = React.useTransition();
+    // $ExpectType boolean
+    done;
+
+    // $ExpectType boolean
+    const deferredToggle = React.useDeferredValue(toggle);
+
+    const [func] = React.useState(() => () => 0);
+
+    // $ExpectType () => number
+    func;
+    // $ExpectType () => number
+    const deferredFunc = React.useDeferredValue(func);
+
+    class Constructor {}
+    // $ExpectType typeof Constructor
+    const deferredConstructor = React.useDeferredValue(Constructor);
+
+    // $ExpectType () => string
+    const deferredConstructible = React.useDeferredValue(Constructible);
+
+    React.useInsertionEffect(() => {});
+    React.useInsertionEffect(() => {}, []);
+    React.useInsertionEffect(() => {
+        return () => {};
+    }, [toggle]);
+
+    return () => {
+        startTransition(() => {
+            setToggle(toggle => !toggle);
+        });
+
+        // The function must be synchronous, even if it can start an asynchronous update
+        // it's no different from an useEffect callback in this respect
+        // @ts-expect-error
+        startTransition(async () => {});
+
+        // Unlike Effect callbacks, though, there is no possible destructor to return
+        // @ts-expect-error
+        startTransition(() => () => {});
+    };
+
+    function Constructible() {
+        return '';
+    }
+}
+
+function startTransitionTest() {
+    function transitionToPage(page: string) {}
+
+    React.startTransition(() => {
+        transitionToPage('/');
+    });
+
+    // @ts-expect-error
+    React.startTransition(async () => {});
+}
+
+function Dialog() {
+    const id = React.useId();
+    const nameId = `${id}-name`;
+    const descriptionId = `${id}-description`;
+
+    return (
+        <div role="dialog" aria-labelledby={nameId} aria-describedby={descriptionId}>
+            <h2 id={nameId}>Name</h2>
+            <p id={descriptionId}>Description</p>
+        </div>
+    );
+}
+
+// keep in sync with `use-sync-external-store-tests.ts`
+interface Store<State> {
+    getState(): State;
+    getServerState(): State;
+    subscribe(onStoreChange: () => void): () => void;
+}
+
+declare const numberStore: Store<number>;
+function useVersion(): number {
+    return useSyncExternalStore(numberStore.subscribe, numberStore.getState);
+}
+
+function useStoreWrong() {
+    useSyncExternalStore(
+        // no unsubscribe returned
+        // @ts-expect-error
+        () => {
+            return null;
+        },
+        () => 1,
+    );
+
+    // `string` is not assignable to `number`
+    // @ts-expect-error
+    const version: number = useSyncExternalStore(
+        () => () => {},
+        () => '1',
+    );
+}
+
+declare const objectStore: Store<{ version: { major: number; minor: number }; users: string[] }>;
+function useUsers(): string[] {
+    return useSyncExternalStore(
+        objectStore.subscribe,
+        () => objectStore.getState().users,
+        () => objectStore.getServerState().users,
+    );
+}

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -1,0 +1,829 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMServer from "react-dom/server";
+import * as PropTypes from "prop-types";
+import createFragment = require("react-addons-create-fragment");
+import * as LinkedStateMixin from "react-addons-linked-state-mixin";
+import * as PureRenderMixin from "react-addons-pure-render-mixin";
+import shallowCompare = require("react-addons-shallow-compare");
+import update = require("react-addons-update");
+import createReactClass = require("create-react-class");
+import * as DOM from "react-dom-factories";
+import 'trusted-types';
+
+// NOTE: forward declarations for tests
+declare function setInterval(...args: any[]): any;
+declare function clearInterval(...args: any[]): any;
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+interface Props {
+    hello: string;
+    world?: string | null | undefined;
+    foo: number;
+}
+
+interface State {
+    inputValue?: string | null | undefined;
+    seconds?: number | undefined;
+}
+
+interface Snapshot {
+    baz: string;
+}
+
+interface Context {
+    someValue?: string | null | undefined;
+}
+
+interface ChildContext {
+    someOtherValue: string;
+}
+
+interface MyComponent extends React.Component<Props, State> {
+    reset(): void;
+}
+
+// use any for ClassAttribute type sine we're using string refs
+const props: Props & React.ClassAttributes<any> = {
+    key: 42,
+    ref: "myComponent42",
+    hello: "world",
+    foo: 42
+};
+
+const scProps: SCProps = {
+    foo: 42
+};
+
+declare const container: Element;
+
+//
+// Top-Level API
+// --------------------------------------------------------------------------
+{
+    interface State {
+        inputValue: string;
+        seconds: number;
+    }
+    class SettingStateFromCtorComponent extends React.Component<Props, State, Snapshot> {
+        constructor(props: Props) {
+            super(props);
+            // @ts-expect-error
+            this.state = {
+                inputValue: 'hello'
+            };
+        }
+        render() { return null; }
+    }
+
+    class BadlyInitializedState extends React.Component<Props, State, Snapshot> {
+        // state = {
+        //     secondz: 0,
+        //     inputValuez: 'hello'
+        // };
+        render() { return null; }
+    }
+    class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
+        render() { return null; }
+        componentDidMount() {
+            console.log(this.state.inputValue);
+        }
+        mutateState() {
+            // @ts-expect-error
+            this.state = {
+                inputValue: 'hello'
+            };
+
+            // Even if state is not set, this is allowed by React
+            this.setState({ inputValue: 'hello' });
+            this.setState((prevState, props) => {
+                // @ts-expect-error
+                props = { foo: 'nope' };
+                // @ts-expect-error
+                props.foo = 'nope';
+
+                return { inputValue: prevState.inputValue + ' foo' };
+            });
+        }
+        mutateProps() {
+            // @ts-expect-error
+            this.props = {};
+            // @ts-expect-error
+            this.props = {
+                key: 42,
+                ref: "myComponent42",
+                hello: "world",
+                foo: 42
+            };
+        }
+    }
+}
+
+class ModernComponent extends React.Component<Props, State, Snapshot>
+    implements MyComponent, React.ChildContextProvider<ChildContext> {
+    static propTypes: React.ValidationMap<Props> = {
+        hello: PropTypes.string.isRequired,
+        world: PropTypes.string,
+        foo: PropTypes.number.isRequired
+    };
+
+    static contextTypes: React.ValidationMap<Context> = {
+        someValue: PropTypes.string
+    };
+
+    static childContextTypes: React.ValidationMap<ChildContext> = {
+        someOtherValue: PropTypes.string.isRequired
+    };
+
+    context: Context = {};
+
+    getChildContext() {
+        return {
+            someOtherValue: "foo"
+        };
+    }
+
+    state = {
+        inputValue: this.context.someValue,
+        seconds: this.props.foo
+    };
+
+    reset() {
+        this._myComponent.reset();
+        this.setState({
+            inputValue: this.context.someValue,
+            seconds: this.props.foo
+        });
+    }
+
+    private readonly _myComponent: MyComponent;
+    private _input: HTMLInputElement | null;
+
+    render() {
+        return DOM.div(null,
+            DOM.input({
+                ref: input => this._input = input,
+                value: this.state.inputValue ? this.state.inputValue : undefined
+            }),
+            DOM.input({
+                onChange: event => console.log(event.target)
+            }));
+    }
+
+    shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: any): boolean {
+        return shallowCompare(this, nextProps, nextState);
+    }
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<Props>) {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot: Snapshot) {
+        return;
+    }
+}
+
+class ModernComponentArrayRender extends React.Component<Props> {
+    render() {
+        return [DOM.h1({ key: "1" }, "1"),
+        DOM.h1({ key: "2" }, "2")];
+    }
+}
+
+class ModernComponentNoState extends React.Component<Props> { }
+class ModernComponentNoPropsAndState extends React.Component { }
+
+interface SCProps {
+    foo?: number | undefined;
+}
+
+function FunctionComponent(props: SCProps) {
+    return props.foo ? DOM.div(null, props.foo) : null;
+}
+
+// tslint:disable-next-line:no-namespace
+namespace FunctionComponent {
+    export const displayName = "FunctionComponent";
+    export const defaultProps = { foo: 42 };
+}
+
+const FunctionComponent2: React.FunctionComponent<SCProps> =
+    // props is contextually typed
+    props => DOM.div(null, props.foo);
+FunctionComponent2.displayName = "FunctionComponent2";
+FunctionComponent2.defaultProps = {
+    foo: 42
+};
+
+// allows null as props
+const FunctionComponent4: React.FunctionComponent = props => null;
+
+// undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+// leaving here to document limitation and inspect error message
+// @ts-expect-error
+const FunctionComponent5: React.FunctionComponent = () => false;
+
+// React.createFactory
+const factory: React.CFactory<Props, ModernComponent> =
+    React.createFactory(ModernComponent);
+const factoryElement: React.CElement<Props, ModernComponent> =
+    factory(props);
+
+const functionComponentFactory: React.FunctionComponentFactory<SCProps> =
+    React.createFactory(FunctionComponent);
+const functionComponentFactoryElement: React.FunctionComponentElement<SCProps> =
+    functionComponentFactory(props);
+
+const legacyStatelessComponentFactory: React.SFCFactory<SCProps> =
+    React.createFactory(FunctionComponent);
+
+const domFactory: React.DOMFactory<React.DOMAttributes<{}>, Element> =
+    React.createFactory("div");
+const domFactoryElement: React.DOMElement<React.DOMAttributes<{}>, Element> =
+    domFactory();
+
+// React.createElement
+const element: React.CElement<Props, ModernComponent> = React.createElement(ModernComponent, props);
+const elementNoState: React.CElement<Props, ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
+const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
+const functionComponentElement: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent, scProps);
+const functionComponentElementNullProps: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent4, null);
+const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
+const domElementNullProps = React.createElement("div", null);
+const htmlElement = React.createElement("input", { type: "text" });
+const inputElementNullProps: React.DOMElement<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> = React.createElement("input", null);
+const svgElement = React.createElement("svg", { accentHeight: 12 });
+const svgElementNullProps = React.createElement("svg", null);
+const fragmentElement: React.ReactElement<{}> = React.createElement(React.Fragment, {}, [React.createElement("div"), React.createElement("div")]);
+const fragmentElementNullProps: React.ReactElement<{}> = React.createElement(React.Fragment, null, [React.createElement("div"), React.createElement("div")]);
+
+const customProps: React.HTMLProps<HTMLElement> = props;
+const customDomElement = "my-element";
+const nonLiteralElement = React.createElement(customDomElement, customProps);
+const customDomElementNullProps = React.createElement(customDomElement, null);
+
+// https://github.com/Microsoft/TypeScript/issues/15019
+
+function foo3(child: React.ComponentClass<{ name: string }> | React.FunctionComponent<{ name: string }> | string) {
+    React.createElement(child, { name: "bar" });
+}
+
+// React.cloneElement
+const clonedElement: React.CElement<Props, ModernComponent> = React.cloneElement(element, { foo: 43 });
+
+React.cloneElement(element, {});
+React.cloneElement(element, {}, null);
+
+const clonedElement2: React.CElement<Props, ModernComponent> =
+    React.cloneElement(element, {
+        ref: c => c && c.reset()
+    });
+const clonedElement3: React.CElement<Props, ModernComponent> =
+    React.cloneElement(element, {
+        key: "8eac7",
+        foo: 55
+    });
+const clonedfunctionComponentElement: React.FunctionComponentElement<SCProps> =
+    React.cloneElement(functionComponentElement, { foo: 44 });
+// Clone base DOMElement
+const clonedDOMElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> =
+    React.cloneElement(domElement, {
+        className: "clonedDOMElement"
+    });
+// Clone ReactHTMLElement
+const clonedHtmlElement: React.ReactHTMLElement<HTMLInputElement> =
+    React.cloneElement(htmlElement, {
+        className: "clonedHTMLElement"
+    });
+// Clone ReactSVGElement
+const clonedSvgElement: React.ReactSVGElement =
+    React.cloneElement(svgElement, {
+        className: "clonedVGElement"
+    });
+
+// React.render
+const component: ModernComponent = ReactDOM.render(element, container);
+const componentNullContainer: ModernComponent = ReactDOM.render(element, null);
+
+const componentElementOrNull: ModernComponent = ReactDOM.render(element, container);
+const componentNoState: ModernComponentNoState = ReactDOM.render(elementNoState, container);
+const componentNoStateElementOrNull: ModernComponentNoState = ReactDOM.render(elementNoState, container);
+const domComponent: Element = ReactDOM.render(domElement, container);
+
+// Other Top-Level API
+const unmounted: boolean = ReactDOM.unmountComponentAtNode(container);
+const str: string = ReactDOMServer.renderToString(element);
+const markup: string = ReactDOMServer.renderToStaticMarkup(element);
+const notValid: boolean = React.isValidElement(props); // false
+const isValid = React.isValidElement(element); // true
+let domNode = ReactDOM.findDOMNode(component);
+domNode = ReactDOM.findDOMNode(domNode as Element);
+const fragmentType: React.ComponentType = React.Fragment;
+
+//
+// React Elements
+// --------------------------------------------------------------------------
+
+const type: React.ComponentClass<Props> = element.type;
+const elementProps: Props = element.props;
+const key = element.key;
+
+//
+// Component API
+// --------------------------------------------------------------------------
+
+// modern
+const componentState: State = component.state;
+component.setState({ inputValue: "!!!" });
+component.forceUpdate();
+
+const myComponent = component as MyComponent;
+myComponent.reset();
+
+//
+// Refs
+// --------------------------------------------------------------------------
+
+interface RCProps { }
+
+class RefComponent extends React.Component<RCProps> {
+    static create = React.createFactory(RefComponent);
+    refMethod() {
+    }
+}
+
+let componentRef: RefComponent | null = new RefComponent({});
+RefComponent.create({ ref: "componentRef" });
+// type of c should be inferred
+RefComponent.create({ ref: c => componentRef = c });
+componentRef.refMethod();
+
+let domNodeRef: Element | null;
+DOM.div({ ref: "domRef" });
+// type of node should be inferred
+DOM.div({ ref: node => domNodeRef = node });
+
+let inputNodeRef: HTMLInputElement | null;
+DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
+
+interface ForwardingRefComponentProps {
+    hello: string;
+    world?: string | null | undefined;
+    foo: number;
+}
+
+const ForwardingRefComponent = React.forwardRef((props: ForwardingRefComponentProps, ref: React.Ref<RefComponent>) => {
+    return React.createElement(RefComponent, { ref });
+});
+
+// Declaring forwardRef render function separately (not inline).
+const ForwardRefRenderFunction = (props: ForwardingRefComponentProps, ref: React.ForwardedRef<RefComponent>)  => {
+    return React.createElement(RefComponent, { ref });
+};
+React.forwardRef(ForwardRefRenderFunction);
+
+const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
+ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
+
+// render function tests
+// need the explicit type declaration for typescript < 3.1
+const ForwardRefRenderFunctionWithPropTypes: { (): null, propTypes?: {} | undefined } = () => null;
+// Warning: forwardRef render functions do not support propTypes or defaultProps
+// @ts-expect-error
+React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
+
+const ForwardRefRenderFunctionWithDefaultProps: { (): null, defaultProps?: {} | undefined } = () => null;
+// Warning: forwardRef render functions do not support propTypes or defaultProps
+// @ts-expect-error
+React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);
+
+function RefCarryingComponent() {
+    const ref = React.createRef<RefComponent>();
+    // Without the explicit type argument, TypeScript infers `{ref: React.RefObject<RefComponent>}`
+    // from the second argument because both of the inferences generated by the first argument
+    // (both to the `P` in the call signature and the `P` in `defaultProps`) have low priority.
+    // Then we get a type error because `ForwardingRefComponent.defaultProps` has the wrong type.
+    // Can/should this be fixed somehow?
+    return React.createElement<React.RefAttributes<RefComponent> & ForwardingRefComponentProps>(
+        ForwardingRefComponent,
+        {
+            ref,
+            hello: 'there',
+            foo: 0,
+        },
+    );
+}
+const ForwardingRefComponent2 = React.forwardRef<HTMLElement>((props, ref) => {
+    return React.createElement('div', {
+        ref(e: HTMLDivElement) {
+            if (typeof ref === 'function') {
+                ref(e);
+            } else if (ref) {
+                ref.current = e;
+            }
+        }
+    });
+});
+
+const MemoizedForwardingRefComponent = React.memo(ForwardingRefComponent);
+const LazyComponent = React.lazy(() => Promise.resolve({ default: RefComponent }));
+
+type ClassComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
+type FunctionComponentWithoutPropsAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType never
+type FunctionComponentWithPropsAsRef = React.ElementRef<typeof FunctionComponent>; // $ExpectType never
+type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
+type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
+type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
+type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent
+type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType RefComponent
+
+//
+// Attributes
+// --------------------------------------------------------------------------
+
+const children: any[] = ["Hello world", [null], DOM.span(null)];
+const divStyle: React.CSSProperties = { // CSSProperties
+    flex: "1 1 main-size",
+    backgroundImage: "url('hello.png')"
+};
+const htmlAttr: React.HTMLProps<HTMLElement> = {
+    key: 36,
+    ref: "htmlComponent",
+    children,
+    className: "test-attr",
+    style: divStyle,
+    slot: "HTMLComponent",
+    onClick: (event: React.MouseEvent<{}>) => {
+        event.preventDefault();
+        event.stopPropagation();
+    },
+    onClickCapture: (event: React.MouseEvent<{}>) => {
+        event.preventDefault();
+        event.stopPropagation();
+    },
+    onAnimationStart: event => {
+        const currentTarget: EventTarget & HTMLElement = event.currentTarget;
+    },
+    onBlur: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
+    onFocus: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
+    dangerouslySetInnerHTML: {
+        __html: "<strong>STRONG</strong>"
+    },
+    unselectable: 'on',
+    'aria-atomic': false,
+    'aria-checked': 'true',
+    'aria-colcount': 7,
+    'aria-label': 'test',
+    'aria-relevant': 'additions removals'
+};
+DOM.div(htmlAttr);
+DOM.span(htmlAttr);
+DOM.input(htmlAttr);
+
+DOM.svg({
+    viewBox: "0 0 48 48",
+    xmlns: "http://www.w3.org/2000/svg"
+},
+    DOM.rect({
+        className: 'foobar',
+        id: 'foo',
+        color: 'black',
+        x: 22,
+        y: 10,
+        width: 4,
+        height: 28,
+        strokeDasharray: '30%',
+        strokeDashoffset: '20%'
+    }),
+    DOM.rect({
+        x: 10,
+        y: 22,
+        width: 28,
+        height: 4,
+        strokeDasharray: 30,
+        strokeDashoffset: 20
+    }),
+    DOM.path({
+        d: "M0,0V3H3V0ZM1,1V2H2V1Z",
+        fill: "#999999",
+        fillRule: "evenodd"
+    })
+);
+
+declare const window: Window;
+const trustedTypes = window.trustedTypes!;
+const trustedHtml = trustedTypes.emptyHTML;
+
+const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
+    dangerouslySetInnerHTML: {
+        __html: trustedHtml
+    }
+};
+DOM.div(trustedTypesHTMLAttr);
+DOM.span(trustedTypesHTMLAttr);
+
+//
+// React.Children
+// --------------------------------------------------------------------------
+
+const mappedChildrenArray: number[] =
+    React.Children.map(children, (child: any) => 42);
+const childrenArray: Array<React.ReactElement<{ p: number }>> = children;
+const mappedChildrenArrayWithKnownChildren: number[] =
+    React.Children.map(childrenArray, (child) => child.props.p);
+React.Children.forEach(children, (child) => { });
+const nChildren: number = React.Children.count(children);
+let onlyChild: React.ReactElement = React.Children.only(DOM.div()); // ok
+onlyChild = React.Children.only([null, [[["Hallo"], true]], false]); // error
+const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined>> = React.Children.toArray(children);
+
+declare const numberChildren: number[];
+declare const nodeChildren: React.ReactNode;
+declare const elementChildren: JSX.Element[];
+declare const mixedChildren: Array<JSX.Element | string>;
+declare const singlePluralChildren: JSX.Element | JSX.Element[];
+declare const renderPropsChildren: () => JSX.Element;
+
+// $ExpectType null
+const mappedChildrenArray0 = React.Children.map(null, num => num);
+// $ExpectType undefined
+const mappedChildrenArray1 = React.Children.map(undefined, num => num);
+// $ExpectType number[]
+const mappedChildrenArray2 = React.Children.map(numberChildren, num => num);
+// $ExpectType Element[]
+const mappedChildrenArray3 = React.Children.map(elementChildren, element => element);
+// $ExpectType (string | Element)[]
+const mappedChildrenArray4 = React.Children.map(mixedChildren, elementOrString => elementOrString);
+// This test uses a conditional type because otherwise it gets flaky and can resolve to either Key or ReactText, both
+// of which are aliases for `string | number`.
+const mappedChildrenArray5 = React.Children.map(singlePluralChildren, element => element.key);
+// $ExpectType true
+type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] ? true : false;
+// $ExpectType string[]
+const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);
+// The return type may not be an array
+// @ts-expect-error
+const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
+
+//
+// createFragment addon
+// --------------------------------------------------------------------------
+createFragment({
+    a: DOM.div(),
+    b: ["a", false, React.createElement("span")]
+});
+
+//
+// LinkedStateMixin addon
+// --------------------------------------------------------------------------
+createReactClass({
+    mixins: [LinkedStateMixin],
+    getInitialState() {
+        return {
+            isChecked: false,
+            message: "hello!"
+        };
+    },
+    render() {
+        return DOM.div(null,
+            DOM.input({
+                type: "checkbox",
+                checkedLink: this.linkState("isChecked")
+            }),
+            DOM.input({
+                type: "text",
+                valueLink: this.linkState("message")
+            })
+        );
+    }
+});
+
+//
+// PureRenderMixin addon
+// --------------------------------------------------------------------------
+createReactClass({
+    mixins: [PureRenderMixin],
+    render() { return DOM.div(null); }
+});
+
+//
+// update addon
+// --------------------------------------------------------------------------
+{
+    // These are copied from https://facebook.github.io/react/docs/update.html
+    const initialArray = [1, 2, 3];
+    const newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
+
+    const collection = [1, 2, { a: [12, 17, 15] }];
+    const newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
+    // => [1, 2, {a: [12, 13, 14, 15]}]
+
+    const obj = { a: 5, b: 3 };
+    const newObj = update(obj, {
+        b: {
+            $apply: (x) => x * 2
+        }
+    });
+    // => {a: 5, b: 6}
+    const newObj2 = update(obj, { b: { $set: obj.b * 2 } });
+
+    const objShallow = { a: 5, b: 3 };
+    const newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}
+}
+
+//
+// Events
+// --------------------------------------------------------------------------
+function eventHandler<T extends React.BaseSyntheticEvent>(e: T) {}
+
+function handler(e: React.MouseEvent) {
+    eventHandler(e);
+}
+
+const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {};
+
+//
+// The SyntheticEvent.target.value should be accessible for onChange
+// --------------------------------------------------------------------------
+class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
+    state: { value: string };
+    constructor(props: {}) {
+        super(props);
+        this.state = { value: 'a' };
+    }
+    render() {
+        return DOM.textarea({
+            value: this.state.value,
+            onChange: e => {
+                const target: HTMLTextAreaElement = e.target;
+            }
+        });
+    }
+}
+
+DOM.input({
+    onChange: event => {
+        // `event.target` is guaranteed to be HTMLInputElement
+        const target: HTMLInputElement = event.target;
+    }
+});
+
+// A ChangeEvent is a valid FormEvent (maintain compatibility with existing
+// event handlers)
+
+type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
+type InputFormEvent = React.FormEvent<HTMLInputElement>;
+const changeEvent: InputChangeEvent = undefined as any;
+const formEvent: InputFormEvent = changeEvent;
+
+// defaultProps should be optional of props
+{
+    interface ComponentProps {
+        prop1: string;
+        prop2: string;
+        prop3?: string | undefined;
+    }
+    class ComponentWithDefaultProps extends React.Component<ComponentProps> {
+        static defaultProps = {
+            prop3: "default value",
+        };
+    }
+    const VariableWithAClass: React.ComponentClass<ComponentProps> = ComponentWithDefaultProps;
+}
+
+// complex React.DOMElement type
+declare var x: React.DOMElement<{
+    className: string;
+    style: {
+        height: string;
+        overflowY: "auto";
+        transition: string;
+    };
+}, Element>;
+
+// React 16 should be able to render its children directly
+class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        const { children } = this.props;
+        return children !== undefined ? children : null;
+    }
+}
+
+// ReactNode tests
+{
+    // Mix of empty return and some return results in `(undefined | JSX.Element)[]`
+    const mixedEmptyReturn: React.ReactNode = ['a', 'b', null].map(label => {
+        if (!label) {
+            return;
+        }
+        return label;
+    });
+    // But just an empty return results in `void`.
+    // @ts-expect-error
+    const emptyReturn: React.ReactNode = ['a', 'b'].map(label => {
+        return;
+    });
+    // Mix of no return and some return results in `(undefined | JSX.Element)[]`
+    const mixedNoReturn: React.ReactNode = ['a', 'b', null].map(label => {
+        if (label) {
+            return label;
+        }
+    });
+    // But no return results in `void`.
+    // @ts-expect-error
+    const noReturn: React.ReactNode = ['a', 'b'].map(label => {});
+}
+
+const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });
+React.createElement(Memoized1, { foo: 'string' });
+
+const Memoized2 = React.memo<{ bar: string }>(
+    function Bar(props: { bar: string }) { return null; },
+    (prevProps, nextProps) => prevProps.bar === nextProps.bar
+);
+React.createElement(Memoized2, { bar: 'string' });
+
+const specialSfc1: React.ExoticComponent<any> = Memoized1;
+const functionComponent: React.FunctionComponent<any> = Memoized2;
+
+const propsWithChildren: React.PropsWithChildren<Props> = {
+    hello: "world",
+    foo: 42,
+    children: React.createElement(functionComponent),
+};
+
+type UnionProps =
+    | ({ type: 'single'; value?: number } & React.RefAttributes<HTMLDivElement>)
+    | ({ type: 'multiple'; value?: number[] } & React.RefAttributes<HTMLDivElement>);
+
+// @ts-expect-error
+const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
+    type: 'single',
+    value: [2],
+};
+
+// JSXElemenConstructor vs Component assignability
+{
+    interface ExactProps {
+        value: 'A' | 'B';
+    }
+    interface NarrowerProps {
+        value: 'A';
+    }
+    interface WiderProps {
+        value: 'A' | 'B' | 'C';
+    }
+
+    // We don't actually care about the concrete type of `Wrapper` i.e.
+    // we don't care about the value created by `new Wrapper()`.
+    // We only care about the props we can pass to the component.
+    let Wrapper: React.JSXElementConstructor<ExactProps>;
+    // @ts-expect-error
+    Wrapper = class Narrower extends React.Component<NarrowerProps> {};
+    // @ts-expect-error
+    Wrapper = (props: NarrowerProps) => null;
+    Wrapper = class Exact extends React.Component<ExactProps> {};
+    Wrapper = (props: ExactProps) => null;
+    Wrapper = class Wider extends React.Component<WiderProps> {};
+    Wrapper = (props: WiderProps) => null;
+
+    React.createElement(Wrapper, { value: 'A' });
+    React.createElement(Wrapper, { value: 'B' });
+    // @ts-expect-error
+    React.createElement(Wrapper, { value: 'C' });
+}
+
+// ComponentPropsWithRef and JSXElementConstructor
+{
+    interface Props {
+        value: string;
+    }
+    type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
+    const props: Props = {
+        value: 'inferred',
+        // @ts-expect-error
+        notImplemented: 5
+    };
+    const inferredProps: InferredProps = {
+        value: 'inferred',
+        // @ts-expect-error
+        notImplemented: 5
+    };
+}

--- a/types/react/ts5.0/test/managedAttributes.tsx
+++ b/types/react/ts5.0/test/managedAttributes.tsx
@@ -1,0 +1,257 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+interface Props {
+    bool?: boolean;
+    fnc: () => any;
+    node?: React.ReactNode;
+    num?: number;
+    reqNode: NonNullable<React.ReactNode>;
+    str: string;
+}
+
+const propTypes = {
+    bool: PropTypes.bool,
+    fnc: PropTypes.func.isRequired,
+    node: PropTypes.node,
+    num: PropTypes.number,
+    str: PropTypes.string.isRequired,
+    extraStr: PropTypes.string.isRequired,
+    extraNum: PropTypes.number
+};
+
+const defaultProps = {
+    fnc: (() => 'abc') as () => any,
+    extraBool: false,
+    reqNode: 'text_node' as NonNullable<React.ReactNode>
+};
+
+class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
+
+const annotatedPropTypesAndDefaultPropsTests = [
+    // @ts-expect-error
+    <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
+    <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // @ts-expect-error
+    <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
+    <AnnotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={() => {}}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
+
+class UnannotatedPropTypesAndDefaultProps extends React.Component {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
+
+const unannotatedPropTypesAndDefaultPropsTests = [
+    // @ts-expect-error
+    <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
+    <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // @ts-expect-error
+    <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
+    <UnannotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={() => {}}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
+
+class AnnotatedPropTypes extends React.Component<Props> {
+    static propTypes = propTypes;
+}
+
+const annotatedPropTypesTests = [
+    // @ts-expect-error
+    <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
+    <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />,
+    // @ts-expect-error
+    <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
+    // @ts-expect-error
+    <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <AnnotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={() => {}}
+        node={<React.Fragment />}
+        num={0}
+        reqNode={<React.Fragment />}
+        str='abc'
+    />
+];
+
+class UnannotatedPropTypes extends React.Component {
+    static propTypes = propTypes;
+}
+
+const unannotatedPropTypesTests = [
+    // @ts-expect-error
+    <UnannotatedPropTypes />, // str, extraStr and fnc are required
+    <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' />,
+    // @ts-expect-error
+    <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
+    // @ts-expect-error
+    <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <UnannotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={() => {}}
+        node={<React.Fragment />}
+        num={0}
+        str='abc'
+    />
+];
+
+class AnnotatedDefaultProps extends React.Component<Props> {
+    static defaultProps = defaultProps;
+}
+
+const annotatedDefaultPropsTests = [
+    // @ts-expect-error
+    <AnnotatedDefaultProps />, // str is required
+    <AnnotatedDefaultProps str='abc' />,
+    <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
+    // @ts-expect-error
+    <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
+    <AnnotatedDefaultProps
+        bool={true}
+        extraBool={false}
+        fnc={() => {}}
+        node={null}
+        num={0}
+        reqNode={undefined}
+        str='abc'
+    />
+];
+
+class UnannotatedDefaultProps extends React.Component {
+    static defaultProps = defaultProps;
+}
+
+const unannotatedDefaultPropsTests = [
+    <UnannotatedDefaultProps />,
+    <UnannotatedDefaultProps
+        extraBool={true}
+        fnc={() => {}}
+        reqNode={<span />}
+    />
+];
+
+class ComponentWithNoDefaultProps extends React.Component<Props> {}
+
+function FunctionalComponent(props: Props) { return <>{props.reqNode}</>; }
+FunctionalComponent.defaultProps = defaultProps;
+
+const functionalComponentTests = [
+    // @ts-expect-error
+    <FunctionalComponent />,
+    <FunctionalComponent str='' />
+];
+
+const MemoFunctionalComponent = React.memo(FunctionalComponent);
+const MemoAnnotatedDefaultProps = React.memo(AnnotatedDefaultProps);
+const LazyMemoFunctionalComponent = React.lazy(async () => ({ default: MemoFunctionalComponent }));
+const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
+
+const memoTests = [
+    // @ts-expect-error
+    <MemoFunctionalComponent />,
+    <MemoFunctionalComponent str='abc' />,
+    // @ts-expect-error
+    <MemoAnnotatedDefaultProps />,
+    <AnnotatedDefaultProps str='abc' />,
+    <MemoAnnotatedDefaultProps str='abc' />,
+    <LazyMemoFunctionalComponent str='abc' />,
+    // @ts-expect-error
+    <LazyMemoAnnotatedDefaultProps />,
+    <LazyMemoAnnotatedDefaultProps str='abc' />
+];
+
+const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithNoDefaultProps>) => (
+    <ComponentWithNoDefaultProps ref={ref} {...props}/>
+));
+ForwardRef.defaultProps = defaultProps;
+
+const forwardRefTests = [
+    // @ts-expect-error
+    <ForwardRef />,
+    <ForwardRef
+        fnc={() => {}}
+        reqNode={<span />}
+        str=''
+    />,
+    // same bug as MemoFunctionalComponent and React.SFC-typed things
+    // @ts-expect-error
+    <ForwardRef str='abc' />
+];
+
+const weakComponentPropTypes = {
+    foo: PropTypes.string,
+    bar: PropTypes.bool.isRequired
+};
+interface WeakComponentProps1 {
+    foo: any;
+    bar: number;
+}
+interface WeakComponentProps2 {
+    foo: string;
+    bar: any;
+}
+interface WeakComponentProps3 {
+    foo: any;
+    bar: any;
+}
+
+// $ExpectType true
+type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+    foo?: string | null | undefined
+    bar: boolean
+} ? true : false;
+// $ExpectType true
+type weakComponentTest2 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+    foo?: string | null | undefined
+    bar: number
+} ? true : false;
+// $ExpectType true
+type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+    foo: string
+    bar: boolean
+} ? true : false;
+
+// @ts-expect-error
+const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
+const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
+
+interface IndexedComponentProps {
+    [K: string]: boolean;
+}
+interface WeakIndexedComponentProps {
+    [K: string]: any;
+}
+
+const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
+// @ts-expect-error
+const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
+const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
+const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };
+
+const optionalUnionPropTest: JSX.LibraryManagedAttributes<{ propTypes: {} }, { optional?: string } | { optional?: number }> = {};

--- a/types/react/ts5.0/test/next.tsx
+++ b/types/react/ts5.0/test/next.tsx
@@ -1,0 +1,83 @@
+/// <reference types="../next"/>
+
+const contextUsers = React.createContext(['HAL']);
+const promisedUsers = Promise.resolve(['Dave']);
+
+function useUse() {
+    // @ts-expect-error Missing value
+    React.use();
+
+    // $ExpectType string[]
+    const users = React.use(promisedUsers);
+    // @ts-expect-error incompatible type. Mainly to potentially inspect TypeScript error message
+    React.use({});
+
+    // $ExpectType string[]
+    const contextValue = React.use(contextUsers);
+}
+
+function serverContextTest() {
+    const ServerContext = React.createServerContext<string>('ServerContext', 'default');
+
+    function ServerContextUser() {
+        const context = React.useContext(ServerContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+    // @ts-expect-error Consumer pattern is not supported on server context
+    ServerContext.Consumer;
+
+    function ServerContextProivder() {
+        return (
+            <ServerContext.Provider value="provided">
+                <ServerContextUser />
+            </ServerContext.Provider>
+        );
+    }
+
+    const ClientContext = React.createContext<string>('default');
+    function ClientContextUser() {
+        const context = React.useContext(ClientContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+
+    // plain objects work
+    React.createServerContext('PlainObjectContext', { foo: 1 });
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext('DateContext', new Date());
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext('SetContext', new Set());
+}
+
+function cacheTest() {
+    const getLength = React.cache((a: string) => a.length);
+    const fooLength: number = getLength('foo');
+    getLength(
+        // @ts-expect-error -- number not assignable to string
+        133,
+    );
+
+    React.cache(
+        // @ts-expect-error implicit any
+        a => a,
+    );
+}
+
+function useCacheTest() {
+    const useCacheRefresh = React.unstable_useCacheRefresh;
+
+    const refresh = useCacheRefresh();
+
+    function handleRefresh() {
+        // @ts-expect-error -- experimental only
+        refresh(() => 'refresh', 'initial');
+        // @ts-expect-error -- experimental only
+        refresh(() => 'refresh');
+        refresh();
+
+        // @ts-expect-error -- experimental only
+        refresh(() => 'refresh', 0);
+
+        // @ts-expect-error -- experimental only
+        refresh(() => 'refresh');
+    }
+}

--- a/types/react/ts5.0/test/next.tsx
+++ b/types/react/ts5.0/test/next.tsx
@@ -42,6 +42,10 @@ function serverContextTest() {
 
     // plain objects work
     React.createServerContext('PlainObjectContext', { foo: 1 });
+    // readonly arrays work
+    React.createServerContext('ReadonlyArrayContext', ['foo', 'bar'] as const);
+    // nested readonly arrays work
+    React.createServerContext('ReadonlyArrayContext', ['foo', ['bar']] as const);
     // @ts-expect-error Incompatible with JSON stringify+parse
     React.createServerContext('DateContext', new Date());
     // @ts-expect-error Incompatible with JSON stringify+parse

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -1,0 +1,776 @@
+import PropTypes = require("prop-types");
+import React = require("react");
+
+interface SCProps {
+    foo?: number | undefined;
+}
+const FunctionComponent: React.FunctionComponent<SCProps> = ({ foo }: SCProps) => {
+    return <div>{foo}</div>;
+};
+FunctionComponent.displayName = "FunctionComponent3";
+FunctionComponent.defaultProps = {
+    foo: 42
+};
+<FunctionComponent />;
+<slot name="slot1"></slot>;
+// `FunctionComponent` has no `children`
+// @ts-expect-error
+<FunctionComponent>24</FunctionComponent>;
+
+const VoidFunctionComponent: React.VoidFunctionComponent<SCProps> = ({ foo }: SCProps) => {
+    return <div>{foo}</div>;
+};
+VoidFunctionComponent.displayName = "VoidFunctionComponent1";
+VoidFunctionComponent.defaultProps = {
+    foo: 42
+};
+<VoidFunctionComponent />;
+
+// @ts-expect-error
+const VoidFunctionComponent2: React.VoidFunctionComponent<SCProps> = ({ foo, children }) => {
+    return <div>{foo}{children}</div>;
+};
+VoidFunctionComponent2.displayName = "VoidFunctionComponent2";
+VoidFunctionComponent2.defaultProps = {
+    foo: 42
+};
+// @ts-expect-error
+<VoidFunctionComponent2>24</VoidFunctionComponent2>;
+
+const ComponentWithChildren1: React.FunctionComponent<React.PropsWithChildren> = ({children}) => {
+    return <div>{children}</div>;
+};
+<ComponentWithChildren1></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 foo={42}></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 foo="42"></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 bar={42}></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 bar="42"></ComponentWithChildren1>;
+
+interface ComponentWithChildren2Props {
+    foo?: number | undefined;
+}
+const ComponentWithChildren2: React.FunctionComponent<React.PropsWithChildren<ComponentWithChildren2Props>> = ({children}) => {
+    return <div>{children}</div>;
+};
+<ComponentWithChildren2></ComponentWithChildren2>;
+<ComponentWithChildren2 foo={42}></ComponentWithChildren2>;
+// @ts-expect-error
+<ComponentWithChildren2 foo="42"></ComponentWithChildren2>;
+// @ts-expect-error
+<ComponentWithChildren2 bar={42}></ComponentWithChildren2>;
+// @ts-expect-error
+<ComponentWithChildren2 bar="42"></ComponentWithChildren2>;
+
+interface ComponentWithChildren3Props {
+    foo?: number | undefined;
+    bar: number;
+}
+const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<ComponentWithChildren3Props>> = ({children}) => {
+    return <div>{children}</div>;
+};
+// @ts-expect-error
+<ComponentWithChildren3></ComponentWithChildren3>;
+// @ts-expect-error
+<ComponentWithChildren3 foo={42}></ComponentWithChildren3>;
+// @ts-expect-error
+<ComponentWithChildren3 foo="42"></ComponentWithChildren3>;
+<ComponentWithChildren3 bar={42}></ComponentWithChildren3>;
+// @ts-expect-error
+<ComponentWithChildren3 bar="42"></ComponentWithChildren3>;
+
+// svg sanity check
+<svg viewBox="0 0 1000 1000">
+    <g>
+        <text x="200" y="300" strokeWidth="5" stroke="black" alignmentBaseline="middle">
+            Hello, world!
+            <animateMotion
+                path="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z"
+                dur="5s"
+                repeatCount="indefinite"
+            />
+        </text>
+        <div slot="Some Div"> Hello again! </div>
+    </g>
+</svg>;
+
+// React-specific Attributes
+<div
+    defaultChecked
+    defaultValue="some value"
+    contentEditable
+    suppressContentEditableWarning
+    suppressHydrationWarning
+>
+    <b>foo</b>
+</div>;
+
+// WAI-ARIA 1.1 Attributes
+<div
+    aria-atomic={false}
+    aria-checked='true'
+    aria-colcount={7}
+    aria-label='test'
+>
+    <b>bar</b>
+</div>;
+
+// button type attribute
+<button type="submit">foo</button>;
+<button type="reset">foo</button>;
+<button type="button">foo</button>;
+// @ts-expect-error
+<button type="botton">foo</button>;
+// @ts-expect-error
+<button type={"botton" as string}>foo</button>;
+
+interface Props {
+    hello: string;
+}
+interface State {
+    foobar: string;
+}
+class ComponentWithPropsAndState extends React.Component<Props, State> {
+}
+<ComponentWithPropsAndState hello="TypeScript" />;
+
+class ComponentWithoutState extends React.Component<Props> {
+}
+<ComponentWithoutState hello="TypeScript" />;
+
+class ComponentWithoutPropsAndState extends React.Component {
+}
+<ComponentWithoutPropsAndState />;
+
+const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
+    return <div />;
+};
+<FunctionComponentWithoutProps />;
+
+// React.createContext
+const ContextWithRenderProps = React.createContext('defaultValue');
+
+// unstable APIs should not be part of the typings
+// @ts-expect-error
+const ContextUsingUnstableObservedBits = React.createContext(undefined, (previous, next) => 7);
+// @ts-expect-error
+<ContextWithRenderProps.Consumer unstable_observedBits={4}>
+    {(value: unknown) => null}
+</ContextWithRenderProps.Consumer>;
+
+// Fragments
+<div>
+    <React.Fragment>
+        <React.Fragment key="foo">
+            <span>Child 1</span>
+            <span>Child 2</span>
+        </React.Fragment>
+        <React.Fragment key="bar">
+            <span>Child 3</span>
+            <span>Child 4</span>
+        </React.Fragment>
+    </React.Fragment>
+</div>;
+
+// Strict Mode
+<div>
+    <React.StrictMode>
+        <div />
+    </React.StrictMode>
+</div>;
+
+// Below tests that setState() works properly for both regular and callback modes
+class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
+    handleSomething = () => {
+      // @ts-expect-error
+      this.setState({ foo: '' });
+      this.setState({ foo: true });
+      this.setState({ foo: true, bar: true });
+      this.setState({});
+      this.setState(null);
+      // @ts-expect-error
+      this.setState({ foo: true, foo2: true });
+      // @ts-expect-error
+      this.setState(() => ({ foo: '' }));
+      this.setState(() => ({ foo: true }));
+      this.setState(() => ({ foo: true, bar: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: true, foo2: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: '', foo2: true }));
+      this.setState(() => ({ })); // ok!
+      // @ts-expect-error
+      this.setState({ foo: true, bar: undefined});
+      this.setState(prevState => (prevState.bar ? { bar: false } : null));
+    }
+}
+
+// Below tests that extended types for state work
+export abstract class SetStateTestForExtendsState<P, S extends { baseProp: string }> extends React.Component<P, S> {
+    foo() {
+        this.setState({ baseProp: 'foobar' });
+    }
+}
+
+// Below tests that & generic still works
+// This is invalid because 'S' may specify a different type for `baseProp`.
+// export abstract class SetStateTestForAndedState<P, S> extends React.Component<P, S & { baseProp: string }> {
+//        foo() {
+//            this.setState({ baseProp: 'foobar' });
+//        }
+// }
+
+interface NewProps { foo: string; }
+interface NewState { bar: string; }
+
+class ComponentWithNewLifecycles extends React.Component<NewProps, NewState, { baz: string }> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<NewProps, NewState> = (nextProps) => {
+        return { bar: `${nextProps.foo}bar` };
+    }
+
+    state = {
+        bar: 'foo'
+    };
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>) {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<NewProps>, prevState: Readonly<NewState>, snapshot: { baz: string }) {
+        return;
+    }
+
+    render() {
+        return this.state.bar;
+    }
+}
+<ComponentWithNewLifecycles foo="bar" />;
+
+class PureComponentWithNewLifecycles extends React.PureComponent<NewProps, NewState, { baz: string }> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<NewProps, NewState> = (nextProps) => {
+        return { bar: `${nextProps.foo}bar` };
+    }
+
+    state = {
+        bar: 'foo'
+    };
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>) {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<NewProps>, prevState: Readonly<NewState>, snapshot: { baz: string }) {
+        return;
+    }
+
+    render() {
+        return this.state.bar;
+    }
+}
+<PureComponentWithNewLifecycles foo="bar" />;
+
+class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', string>> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<{}, Record<'a'|'b'|'c', string>> = () => {
+        return { a: 'a' };
+    }
+}
+const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
+
+const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
+// @ts-expect-error
+componentWithBadLifecycle.getSnapshotBeforeUpdate = () => {
+    return 'number';
+};
+// @ts-expect-error
+componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => {
+    return;
+};
+
+const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });
+<Memoized1 foo='string'/>;
+
+const Memoized2 = React.memo(
+    function Bar(props: { bar: string }) { return null; },
+    (prevProps, nextProps) => prevProps.bar === nextProps.bar
+);
+<Memoized2 bar='string'/>;
+
+const Memoized3 = React.memo(class Test extends React.Component<{ x?: string | undefined }> {});
+<Memoized3 ref={ref => { if (ref) { ref.props.x; } }}/>;
+
+const memoized4Ref = React.createRef<HTMLDivElement>();
+const Memoized4 = React.memo(React.forwardRef((props: {}, ref: React.Ref<HTMLDivElement>) => <div ref={ref}/>));
+<Memoized4 ref={memoized4Ref}/>;
+
+const Memoized5 = React.memo<{ test: boolean }>(
+    prop => <>{prop.test}</>,
+    (prevProps, nextProps) => nextProps.test === prevProps.test
+);
+
+<Memoized5 test/>;
+
+const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
+<Memoized6/>;
+// @ts-expect-error
+<Memoized6 foo/>;
+
+// NOTE: this test _requires_ TypeScript 3.1
+// It is passing, for what it's worth.
+// const Memoized7 = React.memo((() => {
+//     function HasDefaultProps(props: { test: boolean }) { return null; }
+//     HasDefaultProps.defaultProps = {
+//         test: true
+//     };
+//     return HasDefaultProps;
+// })());
+// // $ExpectType boolean
+// Memoized7.type.defaultProps.test;
+
+const LazyClassComponent = React.lazy(async () => ({ default: ComponentWithPropsAndState }));
+const LazyMemoized3 = React.lazy(async () => ({ default: Memoized3 }));
+const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
+
+<React.Suspense fallback={<Memoized1 foo='string' />}>
+    <LazyClassComponent hello='test'/>
+    <LazyClassComponent ref={ref => { if (ref) { ref.props.hello; } }} hello='test'/>
+    <LazyMemoized3 ref={ref => { if (ref) { ref.props.x; } }}/>
+    <LazyRefForwarding ref={memoized4Ref}/>
+</React.Suspense>;
+
+<React.Suspense fallback={null}/>;
+<React.Suspense/>;
+
+// unstable API should not be part of the typings
+// @ts-expect-error
+<React.Suspense fallback={null} unstable_avoidThisFallback />;
+
+class LegacyContext extends React.Component {
+    static contextTypes = { foo: PropTypes.node.isRequired };
+
+    render() {
+        // $ExpectType unknown
+        this.context;
+        return (this.context as any).foo;
+    }
+}
+
+class LegacyContextAnnotated extends React.Component {
+    static contextTypes = { foo: PropTypes.node.isRequired };
+    context: { foo: React.ReactNode } = { foo: {} as React.ReactNode };
+
+    render() {
+        // $ExpectType ReactNode
+        this.context.foo;
+        return this.context.foo;
+    }
+}
+
+class NewContext extends React.Component {
+    static contextType = ContextWithRenderProps;
+    context: React.ContextType<typeof ContextWithRenderProps> = "";
+
+    render() {
+        // $ExpectType string
+        this.context;
+        return this.context;
+    }
+}
+
+const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
+const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
+const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
+const divRef = React.createRef<HTMLDivElement>();
+/**
+ * This should be fine to give React to manage i.e. pass it to `<div ref />`.
+ * However, TypeScript has no notion of write-only properties: https://github.com/microsoft/TypeScript/issues/21759
+ */
+const badlyAuthoredRef: React.RefObject<HTMLDivElement | null | undefined> = { current: undefined };
+
+<ForwardRef ref={divFnRef}/>;
+<ForwardRef ref={divRef}/>;
+// @ts-expect-error
+<ForwardRef ref='string'/>;
+<ForwardRef2 ref={divFnRef}/>;
+<ForwardRef2 ref={divRef}/>;
+// @ts-expect-error
+<ForwardRef2 ref='string'/>;
+// @ts-expect-error Undesired behavior
+<ForwardRef2 ref={badlyAuthoredRef} />;
+
+const htmlElementFnRef = (instance: HTMLElement | null) => {};
+const htmlElementRef = React.createRef<HTMLElement>();
+<div ref={htmlElementFnRef} />;
+<div ref={htmlElementRef} />;
+// `current` is nullable
+const unsoundDivFnRef = (current: HTMLDivElement) => {};
+declare const unsoundDivObjectRef: { current: HTMLDivElement };
+// `current` is nullable but type-checks
+// this is consistent with ref objects
+// If this ever not type-checks, `<div ref={unsoundDivObjectRef}` should also fail type-checking
+<div ref={unsoundDivFnRef} />;
+<div ref={unsoundDivObjectRef} />;
+
+const newContextRef = React.createRef<NewContext>();
+<NewContext ref={newContextRef}/>;
+<NewContext ref='string'/>;
+
+const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewContext>) => <NewContext ref={ref}/>);
+<ForwardNewContext ref={newContextRef}/>;
+// @ts-expect-error
+<ForwardNewContext ref='string'/>;
+
+const ForwardRef3 = React.forwardRef(
+    (props: JSX.IntrinsicElements['div'] & Pick<JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
+        <div {...props} ref={ref}/>
+);
+
+<ForwardRef3 ref={divFnRef}/>;
+<ForwardRef3 ref={divRef}/>;
+
+const { Profiler } = React;
+
+// 'id' is missing
+// @ts-expect-error
+<Profiler />;
+// 'onRender' is missing
+// @ts-expect-error
+<Profiler id="test" />;
+// 'number' is not assignable to 'string'
+// @ts-expect-error
+<Profiler id={2} />;
+
+<Profiler
+  id="test"
+  onRender={(
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+    interactions
+  ) => {
+    const message = `${id} ${phase} took ${actualDuration.toFixed(2)}s actual, ${baseDuration.toFixed(2)}s base`;
+
+    const commitMessage = `commit started ${startTime.toFixed(2)} within ${commitTime}`;
+
+    const interactionsSummary = Array.from(interactions)
+      .map(interaction => {
+        return `${interaction.id}: '${interaction.name}' started at ${interaction.timestamp.toFixed(2)}`;
+      })
+      .join("\n");
+    const interactionMessage = `there were ${interactions.size} interactions:\n${interactionsSummary}`;
+  }}
+>
+  <div />
+</Profiler>;
+
+type ImgProps = React.ComponentProps<'img'>;
+const imgProps: ImgProps = {};
+// the order of the strings in the union seems to vary
+// with the typescript version, so test assignment instead
+imgProps.decoding = 'async';
+imgProps.decoding = 'auto';
+imgProps.decoding = 'sync';
+imgProps.loading = 'eager';
+imgProps.loading = 'lazy';
+// @ts-expect-error
+imgProps.loading = 'nonsense';
+// @ts-expect-error
+imgProps.decoding = 'nonsense';
+type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
+type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
+// $ExpectType false
+type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
+
+const HasClassName: React.ElementType<{ className?: string | undefined }> = 'a';
+// @ts-expect-error
+const HasFoo: React.ElementType<{ foo: boolean }> = 'a';
+const HasFoo2: React.ElementType<{ foo: boolean }> = (props: { foo: boolean }) => null;
+// @ts-expect-error
+const HasFoo3: React.ElementType<{ foo: boolean }> = (props: { foo: string }) => null;
+const HasHref: React.ElementType<{ href?: string | undefined }> = 'a';
+// @ts-expect-error
+const HasHref2: React.ElementType<{ href?: string | undefined }> = 'div';
+
+// @ts-expect-error
+const CustomElement: React.ElementType = 'my-undeclared-element';
+
+// custom elements now need to be declared as intrinsic elements
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            'my-declared-element': {};
+        }
+    }
+}
+
+const CustomElement2: React.ElementType = 'my-declared-element';
+
+interface TestPropTypesProps {
+    foo: string;
+}
+interface TestPropTypesProps1 {
+    foo?: string | undefined;
+}
+interface TestPropTypesProps2 {
+    foo: string | null;
+}
+interface TestPropTypesProps3 {
+    foo?: string | null | undefined;
+}
+const testPropTypes = {
+    foo: PropTypes.string
+};
+type DeclaredPropTypes<P> = Required<Exclude<React.FunctionComponent<P>['propTypes'], undefined>>;
+// $ExpectType false
+type propTypesTest = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps> ? true : false;
+// $ExpectType true
+type propTypesTest1 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps1> ? true : false;
+// $ExpectType true
+type propTypesTest2 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps2> ? true : false;
+// $ExpectType true
+type propTypesTest3 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps3> ? true : false;
+function CustomSelect(props: {
+    children: ReadonlyArray<
+      React.ReactElement<
+        React.ComponentPropsWithoutRef<typeof CustomSelectOption>
+      >
+    >;
+  }): JSX.Element {
+    return (
+      <div>
+        <ul>{props.children}</ul>
+        <select>
+          {React.Children.map(props.children, child => (
+            // key should be mappable from children.
+            <option key={child.key} value={child.props.value}>
+              {child.props.children}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+}
+function CustomSelectOption(props: {
+    value: string;
+    children: React.ReactNode;
+}): JSX.Element {
+    return <li data-value={props.value}>{props.children}</li>;
+}
+function Example() {
+    return (
+        <CustomSelect>
+        <CustomSelectOption value="one">One</CustomSelectOption>
+        <CustomSelectOption value="two">Two</CustomSelectOption>
+        </CustomSelect>
+    );
+}
+
+function reactNodeTests() {
+    function *createChildren() {
+        yield <div key="one">one</div>;
+        yield <div key="two">two</div>;
+    }
+
+    <div>{Object.freeze([<div key="one">one</div>, <div key="two">two</div>])}</div>;
+    <div>{new Set([<div key="one">one</div>, <div key="two">two</div>])}</div>;
+    // TODO: This warns at runtime so we should probably reject it as well
+    <div>
+        {
+            new Map([
+                ['one', <div key="one">one</div>],
+                ['two', <div key="two">two</div>],
+            ])
+        }
+    </div>;
+    <div>{createChildren()}</div>;
+}
+
+function elementTypeTests() {
+    const ReturnVoid = () => {};
+    class RenderVoid extends React.Component {
+        // @ts-expect-error
+        render() {}
+    }
+
+    const ReturnUndefined = () => undefined;
+    class RenderUndefined extends React.Component {
+        render() {
+          return undefined;
+        }
+    }
+
+    const ReturnNull = () => null;
+    class RenderNull extends React.Component {
+        render() {
+          return null;
+        }
+    }
+
+    const ReturnNumber = () => 0xeac1;
+    class RenderNumber extends React.Component {
+        render() {
+          return 0xeac1;
+        }
+    }
+
+    const ReturnString = () => 'Hello, Dave!';
+    class RenderString extends React.Component {
+        render() {
+          return 'Hello, Dave!';
+        }
+    }
+
+    const ReturnSymbol = () => Symbol.for('react');
+    class RenderSymbol extends React.Component {
+        // @ts-expect-error
+        render() {
+          return Symbol.for('react');
+        }
+    }
+
+    const ReturnArray = () => [<div key="one" />];
+    class RenderArray extends React.Component {
+        render() {
+          return [<div key="one" />];
+        }
+    }
+
+    const ReturnElement = () => <div />;
+    class RenderElement extends React.Component {
+        render() {
+          return <div />;
+        }
+    }
+
+    const ReturnReactNode = ({children}: {children?: React.ReactNode}) => children;
+    class RenderReactNode extends React.Component<{children?: React.ReactNode}> {
+        render() {
+          return this.props.children;
+        }
+    }
+
+    // Desired behavior.
+    // @ts-expect-error
+    <ReturnVoid />;
+    // @ts-expect-error
+    React.createElement(ReturnVoid);
+    // @ts-expect-error
+    <RenderVoid />;
+    // @ts-expect-error
+    React.createElement(RenderVoid);
+
+    // Undesired behavior. Returning `undefined` should be accepted in all forms.
+    // @ts-expect-error
+    <ReturnUndefined />;
+    // @ts-expect-error
+    React.createElement(ReturnUndefined);
+    <RenderUndefined />;
+    React.createElement(RenderUndefined);
+
+    // Desired behavior.
+    <ReturnNull />;
+    React.createElement(ReturnNull);
+    <RenderNull />;
+    React.createElement(RenderNull);
+
+    // Undesired behavior. Returning `number` should be accepted in all forms.
+    // @ts-expect-error
+    <ReturnNumber />;
+    // @ts-expect-error
+    React.createElement(ReturnNumber);
+    <RenderNumber />;
+    React.createElement(RenderNumber);
+
+    // Undesired behavior. Returning `string` should be accepted in all forms.
+    // @ts-expect-error
+    <ReturnString />;
+    // @ts-expect-error
+    React.createElement(ReturnString);
+    <RenderString />;
+    React.createElement(RenderString);
+
+    // Desired behavior.
+    // @ts-expect-error
+    <ReturnSymbol />;
+    // @ts-expect-error
+    React.createElement(ReturnSymbol);
+    // @ts-expect-error
+    <RenderSymbol />;
+    // @ts-expect-error
+    React.createElement(RenderSymbol);
+
+    // Undesired behavior. Returning `Array` should be accepted in all forms.
+    // @ts-expect-error
+    <ReturnArray />;
+    // @ts-expect-error
+    React.createElement(ReturnArray);
+    <RenderArray />;
+    React.createElement(RenderArray);
+
+    // Desired behavior.
+    <ReturnElement />;
+    React.createElement(ReturnElement);
+    <RenderElement />;
+    React.createElement(RenderElement);
+
+    // Undesired behavior. Returning `ReactNode` should be accepted in all forms.
+    // @ts-expect-error
+    <ReturnReactNode />;
+    // @ts-expect-error
+    React.createElement(ReturnReactNode);
+    <RenderReactNode />;
+    React.createElement(RenderReactNode);
+}
+
+function managingRefs() {
+    const genericRefBad = React.useRef<Element>();
+    // $ExpectType Element | undefined
+    genericRefBad.current;
+    const genericRef = React.useRef<Element>(null);
+    // $ExpectType Element | null
+    genericRef.current;
+
+    const inputRefBad = React.useRef<HTMLInputElement>();
+    // $ExpectType HTMLInputElement | undefined
+    inputRefBad.current;
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    // $ExpectType HTMLInputElement | null
+    inputRef.current;
+
+    // @ts-expect-error: Type 'undefined' is not assignable to type 'HTMLInputElement | null'
+    <input ref={genericRefBad} />;
+    <input ref={genericRef} />;
+    // @ts-expect-error: Type 'undefined' is not assignable to type 'HTMLInputElement | null'
+    <input ref={inputRefBad} />;
+    <input ref={inputRef} />;
+    // @ts-expect-error: Type 'undefined' is not assignable to type 'HTMLInputElement | null'
+    <div ref={inputRefBad} />;
+    // Undesired. Should not typecheck since
+    // `inputRef.current` will contain `HTMLDivElement | null` at runtime
+    // while it has `HTMLInputElement | null` at compiletime.
+    <div ref={inputRef} />;
+
+    const ElementComponent = React.forwardRef<Element>((_, ref) => {
+        if (typeof ref === 'object' && ref !== null) {
+            // $ExpectType Element | null
+            ref.current;
+        }
+        return <div ref={ref} />;
+    });
+    // @ts-expect-error Type 'undefined' is not assignable to type 'Element | null'
+    <ElementComponent ref={genericRefBad} />;
+    <ElementComponent ref={genericRef} />;
+    // @ts-expect-error Type 'undefined' is not assignable to type 'Element | null'
+    <ElementComponent ref={inputRefBad} />;
+    // Undesired, should not typecheck since
+    // `inputRef.current` will contain `Element | null` at runtime
+    // while it has `HTMLInputElement | null` at compiletime.
+    <ElementComponent ref={inputRef} />;
+}

--- a/types/react/ts5.0/tsconfig.json
+++ b/types/react/ts5.0/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "files": [
+        "index.d.ts",
+        "test/index.ts",
+        "test/tsx.tsx",
+        "test/cssProperties.tsx",
+        "test/elementAttributes.tsx",
+        "test/managedAttributes.tsx",
+        "test/hooks.tsx",
+        "test/experimental.tsx",
+        "test/next.tsx"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "exactOptionalPropertyTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "preserve"
+    }
+}

--- a/types/react/ts5.0/tslint.json
+++ b/types/react/ts5.0/tslint.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false,
+        "no-object-literal-type-assertion": false,
+        "strict-export-declare-modifiers": false,
+        "void-return": false
+    }
+}


### PR DESCRIPTION
If https://github.com/microsoft/TypeScript/pull/51328 ships we want to take advantage of it immediately. We could just add `JSX.ElementType` now but this would leave us in an awkward spot where you couldn't use `React.FC` to return all the valid things from render. So I'd rather make a clear cut where we consider TS 5.1. + React 18 types fixed. Supporting all other combinations would add a lot of work and this way we have another carrot for people to update TypeScript and React (especially because the biggest motivator is only in React 18 anyway: Server Components). 

We can leverage the fork for other things as well (e.g. adding `data-${string}` props to HTML attributes).