### PR TITLE
[react-datepicker] Add missed showIcon prop to react-datepicker

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -181,6 +181,7 @@ export interface ReactDatePickerProps<
     showWeekNumbers?: boolean | undefined;
     showYearDropdown?: boolean | undefined;
     showYearPicker?: boolean | undefined;
+    showIcon?: boolean | undefined;
     startDate?: Date | null | undefined;
     startOpen?: boolean | undefined;
     strictParsing?: boolean | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -62,7 +62,7 @@ const DATE_FNS_FORMAT = 'EEEEE';
     dropdownMode="scroll"
     endDate={new Date()}
     excludeDates={[new Date()]}
-    excludeDateIntervals={[{start: new Date(), end: new Date()}]}
+    excludeDateIntervals={[{ start: new Date(), end: new Date() }]}
     excludeTimes={[new Date()]}
     filterDate={date => true}
     filterTime={date => true}
@@ -73,7 +73,7 @@ const DATE_FNS_FORMAT = 'EEEEE';
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""
     includeDates={[new Date()]}
-    includeDateIntervals={[{start: new Date(), end: new Date()}]}
+    includeDateIntervals={[{ start: new Date(), end: new Date() }]}
     includeTimes={[new Date()]}
     injectTimes={[new Date()]}
     inline
@@ -189,6 +189,7 @@ const DATE_FNS_FORMAT = 'EEEEE';
     timeInputLabel=""
     timeIntervals={1}
     title=""
+    showIcon
     todayButton={<div />}
     useShortMonthInDropdown
     useWeekdaysShort


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L184

