### PR TITLE
Fix typo in envhandlebars references

### DIFF
--- a/types/envhandlebars/index.d.ts
+++ b/types/envhandlebars/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cgmartin/envhandlebars#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="Node" />
+/// <reference types="node" />
 import H = require('handlebars');
 
 /**


### PR DESCRIPTION
Hit this in the monorepo script; uppercase _technically_ works but isn't canonical.