### PR TITLE
Fix typo in siren-parser references

### DIFF
--- a/types/siren-parser/chai.d.ts
+++ b/types/siren-parser/chai.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="Chai" />
+/// <reference types="chai" />
 
 declare namespace Chai {
     interface Assertion {


### PR DESCRIPTION
Hit this in the monorepo script; uppercase _technically_ works but isn't canonical.