### PR TITLE
[react] Allow returning ReactNode from function components

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -82,7 +82,7 @@ declare namespace React {
                * @deprecated https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-stateless-function-components
                */
               deprecatedLegacyContext?: any,
-          ) => ReactElement<any, any> | null)
+          ) => ReactNode)
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
@@ -113,7 +113,7 @@ declare namespace React {
         C extends
             | ForwardRefExoticComponent<any>
             | { new (props: any): Component<any> }
-            | ((props: any, context?: any) => ReactElement | null)
+            | ((props: any, context?: any) => ReactNode)
             | keyof JSX.IntrinsicElements
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
@@ -380,7 +380,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement|null);
+        (props: P): ReactNode;
         readonly $$typeof: symbol;
     }
 
@@ -550,7 +550,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): ReactNode;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -566,7 +566,7 @@ declare namespace React {
      * @deprecated - Equivalent with `React.FunctionComponent`.
      */
     interface VoidFunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): ReactNode;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -576,7 +576,7 @@ declare namespace React {
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: P, ref: ForwardedRef<T>): ReactElement | null;
+        (props: P, ref: ForwardedRef<T>): ReactNode;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -3188,6 +3188,7 @@ declare global {
      * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
      */
     namespace JSX {
+        type ElementType = React.ElementType;
         interface Element extends React.ReactElement<any, any> { }
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3126,6 +3126,7 @@ declare namespace React {
     }
 
     namespace JSX {
+        type ElementType = GlobalJSXElementType;
         interface Element extends GlobalJSXElement {}
         interface ElementClass extends GlobalJSXElementClass {}
         interface ElementAttributesProperty extends GlobalJSXElementAttributesProperty {}
@@ -3406,6 +3407,7 @@ declare global {
 // React.JSX needs to point to global.JSX to keep global module augmentations intact.
 // But we can't access global.JSX so we need to create these aliases instead.
 // Once the global JSX namespace will be removed we replace React.JSX with the contents of global.JSX
+type GlobalJSXElementType = JSX.ElementType;
 interface GlobalJSXElement extends JSX.Element {}
 interface GlobalJSXElementClass extends JSX.ElementClass {}
 interface GlobalJSXElementAttributesProperty extends JSX.ElementAttributesProperty {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3125,6 +3125,7 @@ declare namespace React {
         componentStack: string;
     }
 
+    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         type ElementType = GlobalJSXElementType;
         interface Element extends GlobalJSXElement {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3188,7 +3188,18 @@ declare global {
      * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
      */
     namespace JSX {
-        type ElementType = React.ElementType;
+        // We don't just alias React.ElementType because React.ElementType
+        // historically does more than we need it to.
+        // E.g. it also contains .propTypes and so TS also verifies the declared
+        // props type does match the declared .propTypes.
+        // But if libraries declared their .propTypes but not props type,
+        // or they mismatch, you won't be able to use the class component
+        // as a JSX.ElementType.
+        // We could fix this everywhere but we're ultimately not interested in
+        // .propTypes assignability so we might as well drop it entirely here to
+        //  reduce the work of the type-checker.
+        // TODO: Check impact of making React.ElementType<P = any> = React.JSXElementConstructor<P>
+        type ElementType = string | React.JSXElementConstructor<any>;
         interface Element extends React.ReactElement<any, any> { }
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,6 +1,7 @@
 import * as React from './';
 
 export namespace JSX {
+    type ElementType = React.JSX.ElementType;
     interface Element extends React.JSX.Element {}
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,6 +1,7 @@
 import * as React from './';
 
 export namespace JSX {
+    type ElementType = React.JSX.ElementType;
     interface Element extends React.JSX.Element {}
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -176,7 +176,6 @@ function Optimistic() {
 
 function elementTypeTests() {
     const ReturnPromise = () => Promise.resolve('React');
-    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
     const FCPromise: React.FC = ReturnPromise;
     class RenderPromise extends React.Component {
         render() {
@@ -184,9 +183,7 @@ function elementTypeTests() {
         }
     }
 
-    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
     <ReturnPromise />;
-    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
     React.createElement(ReturnPromise);
     <RenderPromise />;
     React.createElement(RenderPromise);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -218,14 +218,6 @@ FunctionComponent2.defaultProps = {
     foo: 42
 };
 
-// allows null as props
-const FunctionComponent4: React.FunctionComponent = props => null;
-
-// undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
-// leaving here to document limitation and inspect error message
-// @ts-expect-error
-const FunctionComponent5: React.FunctionComponent = () => false;
-
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
     React.createFactory(ModernComponent);
@@ -250,7 +242,7 @@ const element: React.CElement<Props, ModernComponent> = React.createElement(Mode
 const elementNoState: React.CElement<Props, ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
 const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
 const functionComponentElement: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent, scProps);
-const functionComponentElementNullProps: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent4, null);
+const functionComponentElementNullProps: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent2, null);
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
 const domElementNullProps = React.createElement("div", null);
 const htmlElement = React.createElement("input", { type: "text" });

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -612,12 +612,15 @@ function reactNodeTests() {
 
 function elementTypeTests() {
     const ReturnVoid = () => {};
+    // @ts-expect-error
+    const FCVoid: React.FC = ReturnVoid;
     class RenderVoid extends React.Component {
         // @ts-expect-error
         render() {}
     }
 
     const ReturnUndefined = () => undefined;
+    const FCUndefined: React.FC = ReturnUndefined;
     class RenderUndefined extends React.Component {
         render() {
           return undefined;
@@ -625,6 +628,7 @@ function elementTypeTests() {
     }
 
     const ReturnNull = () => null;
+    const FCNull: React.FC = ReturnNull;
     class RenderNull extends React.Component {
         render() {
           return null;
@@ -632,6 +636,7 @@ function elementTypeTests() {
     }
 
     const ReturnNumber = () => 0xeac1;
+    const FCNumber: React.FC = ReturnNumber;
     class RenderNumber extends React.Component {
         render() {
           return 0xeac1;
@@ -639,6 +644,7 @@ function elementTypeTests() {
     }
 
     const ReturnString = () => 'Hello, Dave!';
+    const FCString: React.FC = ReturnString;
     class RenderString extends React.Component {
         render() {
           return 'Hello, Dave!';
@@ -646,6 +652,8 @@ function elementTypeTests() {
     }
 
     const ReturnSymbol = () => Symbol.for('react');
+    // @ts-expect-error
+    const FCSymbol: React.FC = ReturnSymbol;
     class RenderSymbol extends React.Component {
         // @ts-expect-error
         render() {
@@ -654,6 +662,7 @@ function elementTypeTests() {
     }
 
     const ReturnArray = () => [<div key="one" />];
+    const FCVArray: React.FC = ReturnArray;
     class RenderArray extends React.Component {
         render() {
           return [<div key="one" />];
@@ -661,6 +670,7 @@ function elementTypeTests() {
     }
 
     const ReturnElement = () => <div />;
+    const FCElement: React.FC = ReturnElement;
     class RenderElement extends React.Component {
         render() {
           return <div />;
@@ -668,6 +678,7 @@ function elementTypeTests() {
     }
 
     const ReturnReactNode = ({children}: {children?: React.ReactNode}) => children;
+    const FCReactNode: React.FC = ReturnReactNode;
     class RenderReactNode extends React.Component<{children?: React.ReactNode}> {
         render() {
           return this.props.children;
@@ -675,7 +686,7 @@ function elementTypeTests() {
     }
 
     const ReturnPromise = () => Promise.resolve('React');
-    // @ts-expect-error experimental release channel only
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const FCPromise: React.FC = ReturnPromise;
     class RenderPromise extends React.Component {
         // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
@@ -703,10 +714,8 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderVoid);
 
-    // Undesired behavior. Returning `undefined` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnUndefined />;
-    // @ts-expect-error
     React.createElement(ReturnUndefined);
     <RenderUndefined />;
     React.createElement(RenderUndefined);
@@ -717,18 +726,14 @@ function elementTypeTests() {
     <RenderNull />;
     React.createElement(RenderNull);
 
-    // Undesired behavior. Returning `number` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnNumber />;
-    // @ts-expect-error
     React.createElement(ReturnNumber);
     <RenderNumber />;
     React.createElement(RenderNumber);
 
-    // Undesired behavior. Returning `string` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnString />;
-    // @ts-expect-error
     React.createElement(ReturnString);
     <RenderString />;
     React.createElement(RenderString);
@@ -743,10 +748,7 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderSymbol);
 
-    // Undesired behavior. Returning `Array` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnArray />;
-    // @ts-expect-error
     React.createElement(ReturnArray);
     <RenderArray />;
     React.createElement(RenderArray);
@@ -757,17 +759,15 @@ function elementTypeTests() {
     <RenderElement />;
     React.createElement(RenderElement);
 
-    // Undesired behavior. Returning `ReactNode` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnReactNode />;
-    // @ts-expect-error
     React.createElement(ReturnReactNode);
     <RenderReactNode />;
     React.createElement(RenderReactNode);
 
-    // @ts-expect-error Only available in experimental release channel
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     <ReturnPromise />;
-    // @ts-expect-error Only available in experimental release channel
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(ReturnPromise);
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     <RenderPromise />;


### PR DESCRIPTION
Note: This change only applies to TypeScript 5.1 and later

Adds a new `ElementType` under the JSX namespace that is used by TypeScript 5.1 to determine if  an element type is valid. This will allow function components, forwardRef components etc to return `ReactNode` (strings, arrays, numbers, boolean, undefined) from render. This won't change anything for class components since they already worked as intended. 

For example:

```tsx
async function Component() {
  return null;
}

// Would error but doesn't anymore with this change
<Component />;

async function Layout({ children }) {
  return children;
}

// Would error but doesn't anymore with this change
<Layout />;
```

Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18912
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20249
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20356
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20942
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26890
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33006
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33908
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41808
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25349
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23422


## for reviewers

This PR will not land before 5.1.2 is published ([scheduled for 30th May](https://github.com/microsoft/TypeScript/issues/53031)). It's up for review early (probably once RC is out) to ship it as soon as possible to avoid the "why hasn't this been fixed yet" crowd.

<details>
<summary>`20a2f4db4f` N=1 --extendedDiagnostics diff</summary>

```diff
 Files:                        43577
 Lines of Library:             37989
-Lines of Definitions:        346337
+Lines of Definitions:        346349
-Lines of TypeScript:        1907773
+Lines of TypeScript:        1907763
 Lines of JavaScript:              0
 Lines of JSON:               563522
 Lines of Other:                   0
-Identifiers:                2741434
+Identifiers:                2741435
-Symbols:                    6350962
+Symbols:                    6339383
-Types:                      2447541
+Types:                      2436031
-Instantiations:            28166165
+Instantiations:            28140173
-Memory used:               6588764K
+Memory used:               6574798K
-Assignability cache size:   1116038
+Assignability cache size:   1122063
-Identity cache size:         110625
+Identity cache size:         110731
-Subtype cache size:           56507
+Subtype cache size:           56510
-Strict subtype cache size:   108885
+Strict subtype cache size:   108283
```
</details>