### PR TITLE
[rr-notifications] Test intended usage

### DIFF
--- a/types/rr-notifications/rr-notifications-tests.tsx
+++ b/types/rr-notifications/rr-notifications-tests.tsx
@@ -4,10 +4,8 @@ import { useNotification, NotificationsProvider } from 'rr-notifications';
 useNotification().showNotification({ text: 'hi!' });
 useNotification().removeNotification('2020-04-06T21:31:29.000Z')();
 
-const node = NotificationsProvider({
-    renderNotification({ removeNotification, payload }) {
+<NotificationsProvider
+    renderNotification={({ removeNotification, payload }) => {
         return React.createElement('span', { onClick: removeNotification }, `<pre>${JSON.stringify(payload)}</pre>`);
-    },
-});
-
-node; // $ExpectType ReactElement<any, any> | null
+    }}
+/>;

--- a/types/rr-notifications/tsconfig.json
+++ b/types/rr-notifications/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "strict": true,
         "baseUrl": "../",
+        "jsx": "react",
         "typeRoots": [
             "../"
         ],
@@ -15,6 +16,6 @@
     },
     "files": [
         "index.d.ts",
-        "rr-notifications-tests.ts"
+        "rr-notifications-tests.tsx"
     ]
 }


### PR DESCRIPTION
The `FunctionComponent` type is not intended to be called (because the runtime implementation might have hooks). Therefore its return value is also not meant as a public API.

If you want to type a function that returns a `React.ReactElement | null` you should type it as such. 

Though I'm fairly certain `NotificationsProvider` is meant to be used in JSX so we now test it as such.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135