### PR TITLE
[af-utils__react-virtual-headless] Test intended usage

### DIFF
--- a/types/af-utils__react-virtual-headless/af-utils__react-virtual-headless-tests.tsx
+++ b/types/af-utils__react-virtual-headless/af-utils__react-virtual-headless-tests.tsx
@@ -89,14 +89,19 @@ useOnce(() => null);
 // @ts-expect-error
 useOnce(() => {});
 
-// $ExpectType ReactElement<any, any> | null
-Subscription({ model: useVirtual(), children: <>Abc</> });
+<Subscription model={useVirtual()}>Abc</Subscription>;
 
-// $ExpectType ReactElement<any, any> | null
-Subscription({ model: useVirtual(), events: [EVT_FROM], children: <>Abc</> });
+<Subscription model={useVirtual()} events={[EVT_FROM]}>
+    Abc
+</Subscription>;
 
-// @ts-expect-error
-Subscription({ model: useVirtual(), events: EVT_FROM, children: <>Abc</> });
+<Subscription
+    model={useVirtual()}
+    // @ts-expect-error
+    events={EVT_FROM}
+>
+    Abc
+</Subscription>;
 
 // @ts-expect-error
 Subscription({ model: useVirtual(), children: { abc: 1 } });


### PR DESCRIPTION
The `FunctionComponent` type is not intended to be called (because the runtime implementation might have hooks). Therefore its return value is also not meant as a public API.

If you want to type a function that returns a `React.ReactElement | null` you should type it as such. 

Though I'm fairly certain `Subscription` is meant to be used in JSX so we now test it as such.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135