### PR TITLE
[enzyme] Only test with supported React versions

### DIFF
--- a/types/enzyme/tsconfig.json
+++ b/types/enzyme/tsconfig.json
@@ -5,6 +5,14 @@
             "es6",
             "dom"
         ],
+        "paths": {
+            "react": [
+                "react/v16"
+            ],
+            "react/*": [
+                "react/v16/*"
+            ]
+        },
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Enzyme doesn't even support React 17 so it should only test against 16 highest.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135