### PR TITLE
[react] Fix invalid readonly array value in `ServerContextJSONArray`

### DIFF
--- a/types/react/next.d.ts
+++ b/types/react/next.d.ts
@@ -55,7 +55,7 @@ declare module '.' {
 
     export function use<T>(usable: Usable<T>): T;
 
-    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONArray> {}
+    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONValue> {}
     export type ServerContextJSONValue =
         | string
         | boolean

--- a/types/react/test/next.tsx
+++ b/types/react/test/next.tsx
@@ -42,6 +42,8 @@ function serverContextTest() {
 
     // plain objects work
     React.createServerContext('PlainObjectContext', { foo: 1 });
+    // readonly arrays work
+    React.createServerContext('ReadonlyArrayContext', [1, 2, 3] as const);
     // @ts-expect-error Incompatible with JSON stringify+parse
     React.createServerContext('DateContext', new Date());
     // @ts-expect-error Incompatible with JSON stringify+parse

--- a/types/react/test/next.tsx
+++ b/types/react/test/next.tsx
@@ -43,7 +43,9 @@ function serverContextTest() {
     // plain objects work
     React.createServerContext('PlainObjectContext', { foo: 1 });
     // readonly arrays work
-    React.createServerContext('ReadonlyArrayContext', [1, 2, 3] as const);
+    React.createServerContext('ReadonlyArrayContext', ['foo', 'bar'] as const);
+    // nested readonly arrays work
+    React.createServerContext('ReadonlyArrayContext', ['foo', ['bar']] as const);
     // @ts-expect-error Incompatible with JSON stringify+parse
     React.createServerContext('DateContext', new Date());
     // @ts-expect-error Incompatible with JSON stringify+parse


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Accidental mistake in initial PR