### PR TITLE
[imapflow] ImapFlow.status optional query args, FetchQueryObject.threadId boolean and a typo

### DIFF
--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -301,7 +301,7 @@ export interface StatusObject {
     uid?: number;
     uidValidity?: bigint;
     unseen?: number;
-    highestModSeq?: bigint;
+    highestModseq?: bigint;
 }
 
 export interface IdInfoObject {

--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -222,7 +222,7 @@ export interface FetchQueryObject {
     internalDate?: boolean;
     size?: boolean;
     source?: boolean | object;
-    threadId?: string;
+    threadId?: boolean;
     labels?: boolean;
     headers?: boolean | string[];
     bodyParts?: string[];

--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -117,12 +117,12 @@ export class ImapFlow extends EventEmitter {
     status(
         path: string,
         query: {
-            messages: boolean;
-            recent: boolean;
-            uidNext: boolean;
-            uidValidity: boolean;
-            unseen: boolean;
-            highestModseq: boolean;
+            messages?: boolean;
+            recent?: boolean;
+            uidNext?: boolean;
+            uidValidity?: boolean;
+            unseen?: boolean;
+            highestModseq?: boolean;
         },
     ): Promise<StatusObject>;
 


### PR DESCRIPTION
Hi! I noticed some small errors while working on my project, these should be straightforward:

- ImapFlow.status() query argument's properties should be made optional, the status() method internally checks if they are falsy, so it's pointless to list them all.
- FetchQueryObject.threadId should be a boolean value, the docs are a bit confusing because they list the type as String but then say "if true". Again, the fetch() method internally checks its truthiness.
- There is a typo on StatusObject.highestModSeq: it should be highestModseq as suggested in the docs.

I tested these 3 changes extensively on my own code. Thank you!



### DefinitelyTyped Template
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ImapFlow.status](https://imapflow.com/module-imapflow-ImapFlow.html#status) [FetchQueryObject](https://imapflow.com/global.html#FetchQueryObject) [StatusObject](https://imapflow.com/global.html#StatusObject)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
