### PR TITLE
p5 - add static methods back to Vector class

### DIFF
--- a/types/p5/src/math/p5.Vector.d.ts
+++ b/types/p5/src/math/p5.Vector.d.ts
@@ -314,7 +314,7 @@ declare module '../../index' {
          *   @return A new p5.Vector object
          */
         static random3D(): Vector;
-  
+
         /**
          *   Returns a string representation of a vector v by
          *   calling String(v) or v.toString(). This method is

--- a/types/p5/src/math/p5.Vector.d.ts
+++ b/types/p5/src/math/p5.Vector.d.ts
@@ -37,6 +37,285 @@ declare module '../../index' {
         constructor(x?: number, y?: number, z?: number);
 
         /**
+         *   Adds x, y, and z components to a vector, adds one
+         *   vector to another, or adds two independent vectors
+         *   together. The version of the method that adds two
+         *   vectors together is a static method and returns a
+         *   p5.Vector, the others act directly on the vector.
+         *   Additionally, you may provide arguments to this
+         *   method as an array. See the examples for more
+         *   context.
+         *   @param v1 A p5.Vector to add
+         *   @param v2 A p5.Vector to add
+         *   @param [target] The vector to receive the result
+         *   @return The resulting p5.Vector
+         */
+        static add(v1: Vector, v2: Vector, target?: Vector): Vector;
+
+        /**
+         *   Gives the remainder of a vector when it is divided
+         *   by another vector. See examples for more context.
+         *   @param v1 The dividend p5.Vector
+         *   @param v2 The divisor p5.Vector
+         *   @return The resulting p5.Vector
+         */
+        static rem(v1: Vector, v2: Vector): Vector;
+
+        /**
+         *   Subtracts x, y, and z components from a vector,
+         *   subtracts one vector from another, or subtracts
+         *   two independent vectors. The version of the method
+         *   that subtracts two vectors is a static method and
+         *   returns a p5.Vector, the others act directly on
+         *   the vector. Additionally, you may provide
+         *   arguments to this method as an array. See the
+         *   examples for more context.
+         *   @param v1 A p5.Vector to subtract from
+         *   @param v2 A p5.Vector to subtract
+         *   @param [target] The vector to receive the result
+         *   @return The resulting p5.Vector
+         */
+        static sub(v1: Vector, v2: Vector, target?: Vector): Vector;
+
+        /**
+         *   Multiplies the vector by a scalar, multiplies the
+         *   x, y, and z components from a vector, or
+         *   multiplies the x, y, and z components of two
+         *   independent vectors. When multiplying a vector by
+         *   a scalar, the x, y, and z components of the vector
+         *   are all multiplied by the scalar. When multiplying
+         *   a vector by a vector, the x, y, z components of
+         *   both vectors are multiplied by each other (for
+         *   example, with two vectors a and b: a.x * b.x, a.y
+         *   * b.y, a.z * b.z). The static version of this
+         *   method creates a new p5.Vector while the
+         *   non-static version acts on the vector directly.
+         *   Additionally, you may provide arguments to this
+         *   function as an array. See the examples for more
+         *   context.
+         *   @param v The vector to multiply with the
+         *   components of the original vector
+         *   @param n The number to multiply with the vector
+         *   @param [target] the vector to receive the result
+         */
+        static mult(v: Vector, n: number, target?: Vector): Vector;
+
+        /**
+         *   Multiplies the vector by a scalar, multiplies the
+         *   x, y, and z components from a vector, or
+         *   multiplies the x, y, and z components of two
+         *   independent vectors. When multiplying a vector by
+         *   a scalar, the x, y, and z components of the vector
+         *   are all multiplied by the scalar. When multiplying
+         *   a vector by a vector, the x, y, z components of
+         *   both vectors are multiplied by each other (for
+         *   example, with two vectors a and b: a.x * b.x, a.y
+         *   * b.y, a.z * b.z). The static version of this
+         *   method creates a new p5.Vector while the
+         *   non-static version acts on the vector directly.
+         *   Additionally, you may provide arguments to this
+         *   function as an array. See the examples for more
+         *   context.
+         *   @param [target] the vector to receive the result
+         */
+        static mult(v0: Vector, v1: Vector, target?: Vector): Vector;
+
+        /**
+         *   Multiplies the vector by a scalar, multiplies the
+         *   x, y, and z components from a vector, or
+         *   multiplies the x, y, and z components of two
+         *   independent vectors. When multiplying a vector by
+         *   a scalar, the x, y, and z components of the vector
+         *   are all multiplied by the scalar. When multiplying
+         *   a vector by a vector, the x, y, z components of
+         *   both vectors are multiplied by each other (for
+         *   example, with two vectors a and b: a.x * b.x, a.y
+         *   * b.y, a.z * b.z). The static version of this
+         *   method creates a new p5.Vector while the
+         *   non-static version acts on the vector directly.
+         *   Additionally, you may provide arguments to this
+         *   function as an array. See the examples for more
+         *   context.
+         *   @param arr The array to multiply with the
+         *   components of the vector
+         *   @param [target] the vector to receive the result
+         */
+        static mult(v0: Vector, arr: number[], target?: Vector): Vector;
+
+        /**
+         *   Divides the vector by a scalar, divides a vector
+         *   by the x, y, and z arguments, or divides the x, y,
+         *   and z components of two vectors against each
+         *   other. When dividing a vector by a scalar, the x,
+         *   y, and z components of the vector are all divided
+         *   by the scalar. When dividing a vector by a vector,
+         *   the x, y, z components of the source vector are
+         *   treated as the dividend, and the x, y, z
+         *   components of the argument is treated as the
+         *   divisor. (For example, with two vectors a and b:
+         *   a.x / b.x, a.y / b.y, a.z / b.z.) The static
+         *   version of this method creates a new p5.Vector
+         *   while the non-static version acts on the vector
+         *   directly. Additionally, you may provide arguments
+         *   to this method as an array. See the examples for
+         *   more context.
+         *   @param v The vector to divide the components of
+         *   the original vector by
+         *   @param n The number to divide the vector by
+         *   @param [target] The vector to receive the result
+         */
+        static div(v: Vector, n: number, target?: Vector): Vector;
+
+        /**
+         *   Divides the vector by a scalar, divides a vector
+         *   by the x, y, and z arguments, or divides the x, y,
+         *   and z components of two vectors against each
+         *   other. When dividing a vector by a scalar, the x,
+         *   y, and z components of the vector are all divided
+         *   by the scalar. When dividing a vector by a vector,
+         *   the x, y, z components of the source vector are
+         *   treated as the dividend, and the x, y, z
+         *   components of the argument is treated as the
+         *   divisor. (For example, with two vectors a and b:
+         *   a.x / b.x, a.y / b.y, a.z / b.z.) The static
+         *   version of this method creates a new p5.Vector
+         *   while the non-static version acts on the vector
+         *   directly. Additionally, you may provide arguments
+         *   to this method as an array. See the examples for
+         *   more context.
+         *   @param [target] The vector to receive the result
+         */
+        static div(v0: Vector, v1: Vector, target?: Vector): Vector;
+
+        /**
+         *   Divides the vector by a scalar, divides a vector
+         *   by the x, y, and z arguments, or divides the x, y,
+         *   and z components of two vectors against each
+         *   other. When dividing a vector by a scalar, the x,
+         *   y, and z components of the vector are all divided
+         *   by the scalar. When dividing a vector by a vector,
+         *   the x, y, z components of the source vector are
+         *   treated as the dividend, and the x, y, z
+         *   components of the argument is treated as the
+         *   divisor. (For example, with two vectors a and b:
+         *   a.x / b.x, a.y / b.y, a.z / b.z.) The static
+         *   version of this method creates a new p5.Vector
+         *   while the non-static version acts on the vector
+         *   directly. Additionally, you may provide arguments
+         *   to this method as an array. See the examples for
+         *   more context.
+         *   @param arr The array to divide the components of
+         *   the vector by
+         *   @param [target] The vector to receive the result
+         */
+        static div(v0: Vector, arr: number[], target?: Vector): Vector;
+
+        /**
+         *   Calculates the magnitude (length) of the vector
+         *   and returns the result as a float. (This is simply
+         *   the equation sqrt(x*x + y*y + z*z).)
+         *   @param vecT The vector to return the magnitude of
+         *   @return The magnitude of vecT
+         */
+        static mag(vecT: Vector): number;
+
+        /**
+         *   Calculates the dot product of two vectors. The
+         *   version of the method that computes the dot
+         *   product of two independent vectors is a static
+         *   method. See the examples for more context.
+         *   @param v1 The first p5.Vector
+         *   @param v2 The second p5.Vector
+         *   @return The dot product
+         */
+        static dot(v1: Vector, v2: Vector): number;
+
+        /**
+         *   Calculates and returns a vector composed of the
+         *   cross product between two vectors. Both the static
+         *   and non-static methods return a new p5.Vector. See
+         *   the examples for more context.
+         *   @param v1 The first p5.Vector
+         *   @param v2 The second p5.Vector
+         *   @return The cross product
+         */
+        static cross(v1: Vector, v2: Vector): number;
+
+        /**
+         *   Calculates the Euclidean distance between two
+         *   points (considering a point as a vector object).
+         *   If you are looking to calculate distance between 2
+         *   points see dist()
+         *   @param v1 The first p5.Vector
+         *   @param v2 The second p5.Vector
+         *   @return The distance
+         */
+        static dist(v1: Vector, v2: Vector): number;
+
+        /**
+         *   Normalize the vector to length 1 (make it a unit
+         *   vector).
+         *   @param v The vector to normalize
+         *   @param [target] The vector to receive the result
+         *   @return The vector v, normalized to a length of 1
+         */
+        static normalize(v: Vector, target?: Vector): Vector;
+
+        /**
+         *   Rotate the vector by an angle (only 2D vectors);
+         *   magnitude remains the same.
+         *   @param angle The angle of rotation
+         *   @param [target] The vector to receive the result
+         */
+        static rotate(v: Vector, angle: number, target?: Vector): Vector;
+
+        /**
+         *   Linear interpolate the vector to another vector.
+         *   @param amt The amount of interpolation; some value
+         *   between 0.0 (old vector) and 1.0 (new vector). 0.9
+         *   is very near the new vector. 0.5 is halfway in
+         *   between.
+         *   @param [target] The vector to receive the result
+         *   @return The lerped value
+         */
+        static lerp(v1: Vector, v2: Vector, amt: number, target?: Vector): Vector;
+
+        /**
+         *   Make a new 2D vector from an angle.
+         *   @param angle The desired angle, in radians
+         *   (unaffected by angleMode)
+         *   @param [length] The length of the new vector
+         *   (defaults to 1)
+         *   @return The new p5.Vector object
+         */
+        static fromAngle(angle: number, length?: number): Vector;
+
+        /**
+         *   Make a new 3D vector from a pair of ISO spherical
+         *   angles.
+         *   @param theta The polar angle, in radians (zero is
+         *   up)
+         *   @param phi The azimuthal angle, in radians (zero
+         *   is out of the screen)
+         *   @param [length] The length of the new vector
+         *   (defaults to 1)
+         *   @return A new p5.Vector object
+         */
+        static fromAngles(theta: number, phi: number, length?: number): Vector;
+
+        /**
+         *   Make a new 2D unit vector from a random angle.
+         *   @return A new p5.Vector object
+         */
+        static random2D(): Vector;
+
+        /**
+         *   Make a new random 3D unit vector.
+         *   @return A new p5.Vector object
+         */
+        static random3D(): Vector;
+  
+        /**
          *   Returns a string representation of a vector v by
          *   calling String(v) or v.toString(). This method is
          *   useful for logging vectors in the console.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://p5js.org/reference/#/p5.Vector
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is a fix, all static methods were removed from p5 types recently although not changed in the code. Mentioned in [this issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/64988)