### PR TITLE
three.js: Support rgba/hsla prefixes in `ColorModelString`

### DIFF
--- a/types/three/src/utils.d.ts
+++ b/types/three/src/utils.d.ts
@@ -1,6 +1,6 @@
 import { Color, ColorKeyword } from './math/Color';
 
-export type ColorModelString = `${'rgb' | 'hsl'}(${string})`;
+export type ColorModelString = `${'rgb' | 'rgba' | 'hsl' | 'hsla'}(${string})`;
 export type HexColorString = `#${string}`;
 
 export type ColorRepresentation = Color | ColorKeyword | ColorModelString | HexColorString | number;

--- a/types/three/test/utils.ts
+++ b/types/three/test/utils.ts
@@ -1,0 +1,9 @@
+import * as THREE from 'three';
+
+new THREE.Color('rgb(255, 0, 0)');
+new THREE.Color('rgba(255, 0, 0, 1)');
+new THREE.Color('hsl(0, 100%, 50%)');
+new THREE.Color('hsla(0, 100%, 50%, 1)');
+new THREE.Color('#ff0000');
+new THREE.Color('aliceblue');
+new THREE.Color(0xff0000);

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -94,6 +94,7 @@
         "test/textures/textures-source.ts",
         "test/utils/utils-webgl-portal.ts",
         "test/utils/utils-webgl-marchingcubes.ts",
+        "test/utils.ts",
         "test/webxr/webxr-ar-lighting.ts",
         "test/webxr/webxr-vr-handinput-cubes.ts"
     ]


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source code](https://github.com/mrdoob/three.js/blob/25859b6bdf64a13301dffdad6369b0c675584aa4/src/math/Color.js#L177), [Note about rgba and hsla in docs](https://threejs.org/docs/#api/en/math/Color.setStyle)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
