### PR TITLE
[angular] remove unused header from non-index.d.ts

### DIFF
--- a/types/angular/angular-component-router.d.ts
+++ b/types/angular/angular-component-router.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Angular JS 1.5 component router
-// Project: http://angularjs.org
-// Definitions by: David Reher <https://github.com/davidreher>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace angular {
     /**
      * `Instruction` is a tree of {@link ComponentInstruction}s with all the information needed


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.