### PR TITLE
[arbiter] remove unused header from non-index.d.ts

### DIFF
--- a/types/arbiter/arbiter-tests.ts
+++ b/types/arbiter/arbiter-tests.ts
@@ -1,13 +1,3 @@
-// Type definitions for Arbiter.js 1.0
-// Project: http://arbiterjs.com/
-// Definitions by: Arash Shakery <https://github.com/arash16>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// May 22 2013
-
-
-
-
-
 // Publish a simple message
 Arbiter.publish('component/msg');
 


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header to `package.json` in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.