### PR TITLE
[bmapgl] remove unused header from non-index.d.ts

### DIFF
--- a/types/bmapgl/bmapgl.base.d.ts
+++ b/types/bmapgl/bmapgl.base.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.bmapgllib.d.ts
+++ b/types/bmapgl/bmapgl.bmapgllib.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.control.d.ts
+++ b/types/bmapgl/bmapgl.control.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.core.d.ts
+++ b/types/bmapgl/bmapgl.core.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.maplayer.d.ts
+++ b/types/bmapgl/bmapgl.maplayer.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.maptype.d.ts
+++ b/types/bmapgl/bmapgl.maptype.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.mapvgl.d.ts
+++ b/types/bmapgl/bmapgl.mapvgl.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.overlay.d.ts
+++ b/types/bmapgl/bmapgl.overlay.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.panorama.d.ts
+++ b/types/bmapgl/bmapgl.panorama.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.rightmenu.d.ts
+++ b/types/bmapgl/bmapgl.rightmenu.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.service.d.ts
+++ b/types/bmapgl/bmapgl.service.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 

--- a/types/bmapgl/bmapgl.tools.d.ts
+++ b/types/bmapgl/bmapgl.tools.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for BaiduMap JsAPI GL v1.0
-// Project: http://lbsyun.baidu.com/index.php?title=jspopularGL
-// Definitions by: Junior2ran <https://github.com/Junior2ran>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /* *****************************************************************************
 Copyright [Junior2ran] [hdr01@126.com]
 


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.