### PR TITLE
[business-rules-engine] remove unused header from non-index.d.ts

### DIFF
--- a/types/business-rules-engine/Utils.d.ts
+++ b/types/business-rules-engine/Utils.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for business-rules-engine - v1.0.20
-// Project: https://github.com/rsamec/form
-// Definitions by: Roman Samec <https://github.com/rsamec>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Utils {
     class StringFce {
         static format(s: string, args: any): string;

--- a/types/business-rules-engine/node-validators.d.ts
+++ b/types/business-rules-engine/node-validators.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for business-rules-engine - v1.0.20
-// Project: https://github.com/rsamec/form
-// Definitions by: Roman Samec <https://github.com/rsamec>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 import Validation = require("business-rules-engine");
 export as namespace Validators;
 


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.