### PR TITLE
[dojo] remove unused header from non-index.d.ts

### DIFF
--- a/types/dojo/doh.d.ts
+++ b/types/dojo/doh.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace doh {
     namespace plugins {
         namespace alwaysAudio {

--- a/types/dojo/dojox.NodeList.d.ts
+++ b/types/dojo/dojox.NodeList.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace NodeList {

--- a/types/dojo/dojox.analytics.d.ts
+++ b/types/dojo/dojox.analytics.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.app.d.ts
+++ b/types/dojo/dojox.app.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
         namespace app {
         /**

--- a/types/dojo/dojox.atom.d.ts
+++ b/types/dojo/dojox.atom.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace atom {

--- a/types/dojo/dojox.av.d.ts
+++ b/types/dojo/dojox.av.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace av {

--- a/types/dojo/dojox.calc.d.ts
+++ b/types/dojo/dojox.calc.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
  declare namespace dojox {
 
     namespace calc {

--- a/types/dojo/dojox.calendar.d.ts
+++ b/types/dojo/dojox.calendar.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
 declare namespace dojox {
 
     namespace calendar {

--- a/types/dojo/dojox.charting.d.ts
+++ b/types/dojo/dojox.charting.d.ts
@@ -1,12 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-//                 Don Waldo <https://github.com/dgwaldo>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
 declare namespace dojox {
 
         namespace charting {

--- a/types/dojo/dojox.collections.d.ts
+++ b/types/dojo/dojox.collections.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.color.d.ts
+++ b/types/dojo/dojox.color.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.css3.d.ts
+++ b/types/dojo/dojox.css3.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
 

--- a/types/dojo/dojox.data.d.ts
+++ b/types/dojo/dojox.data.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
 

--- a/types/dojo/dojox.date.d.ts
+++ b/types/dojo/dojox.date.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace date {

--- a/types/dojo/dojox.dgauges.d.ts
+++ b/types/dojo/dojox.dgauges.d.ts
@@ -1,12 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
-
 declare namespace dojox {
 
     namespace dgauges {

--- a/types/dojo/dojox.dnd.d.ts
+++ b/types/dojo/dojox.dnd.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace dnd {

--- a/types/dojo/dojox.drawing.d.ts
+++ b/types/dojo/dojox.drawing.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.dtl.d.ts
+++ b/types/dojo/dojox.dtl.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.editor.d.ts
+++ b/types/dojo/dojox.editor.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace editor {

--- a/types/dojo/dojox.embed.d.ts
+++ b/types/dojo/dojox.embed.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
     namespace embed {
         /**

--- a/types/dojo/dojox.encoding.d.ts
+++ b/types/dojo/dojox.encoding.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace encoding {

--- a/types/dojo/dojox.flash.d.ts
+++ b/types/dojo/dojox.flash.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.form.d.ts
+++ b/types/dojo/dojox.form.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace form {

--- a/types/dojo/dojox.fx.d.ts
+++ b/types/dojo/dojox.fx.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.gantt.d.ts
+++ b/types/dojo/dojox.gantt.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace gantt {

--- a/types/dojo/dojox.gauges.d.ts
+++ b/types/dojo/dojox.gauges.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
 declare namespace dojox {
 
     namespace gauges {

--- a/types/dojo/dojox.geo.d.ts
+++ b/types/dojo/dojox.geo.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
 declare namespace dojox {
 
     namespace geo {

--- a/types/dojo/dojox.gesture.d.ts
+++ b/types/dojo/dojox.gesture.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace gesture {

--- a/types/dojo/dojox.gfx.d.ts
+++ b/types/dojo/dojox.gfx.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.gfx3d.d.ts
+++ b/types/dojo/dojox.gfx3d.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.grid.d.ts
+++ b/types/dojo/dojox.grid.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace grid {

--- a/types/dojo/dojox.help.d.ts
+++ b/types/dojo/dojox.help.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace help {

--- a/types/dojo/dojox.highlight.d.ts
+++ b/types/dojo/dojox.highlight.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.html.d.ts
+++ b/types/dojo/dojox.html.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.image.d.ts
+++ b/types/dojo/dojox.image.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojox/image.html

--- a/types/dojo/dojox.io.d.ts
+++ b/types/dojo/dojox.io.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace io {

--- a/types/dojo/dojox.jq.d.ts
+++ b/types/dojo/dojox.jq.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.json.d.ts
+++ b/types/dojo/dojox.json.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace json {

--- a/types/dojo/dojox.jsonPath.d.ts
+++ b/types/dojo/dojox.jsonPath.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.lang.d.ts
+++ b/types/dojo/dojox.lang.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace lang {

--- a/types/dojo/dojox.layout.d.ts
+++ b/types/dojo/dojox.layout.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     namespace layout {

--- a/types/dojo/dojox.main.d.ts
+++ b/types/dojo/dojox.main.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.math.d.ts
+++ b/types/dojo/dojox.math.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.mdnd.d.ts
+++ b/types/dojo/dojox.mdnd.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace mdnd {

--- a/types/dojo/dojox.mobile.d.ts
+++ b/types/dojo/dojox.mobile.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.mvc.d.ts
+++ b/types/dojo/dojox.mvc.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojox/mvc.html

--- a/types/dojo/dojox.rails.d.ts
+++ b/types/dojo/dojox.rails.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.robot.d.ts
+++ b/types/dojo/dojox.robot.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace robot {

--- a/types/dojo/dojox.rpc.d.ts
+++ b/types/dojo/dojox.rpc.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace rpc {

--- a/types/dojo/dojox.secure.d.ts
+++ b/types/dojo/dojox.secure.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace secure {

--- a/types/dojo/dojox.sketch.d.ts
+++ b/types/dojo/dojox.sketch.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojox/sketch.html

--- a/types/dojo/dojox.socket.d.ts
+++ b/types/dojo/dojox.socket.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojox/socket.html

--- a/types/dojo/dojox.sql.d.ts
+++ b/types/dojo/dojox.sql.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.storage.d.ts
+++ b/types/dojo/dojox.storage.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
         /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojox/storage.html

--- a/types/dojo/dojox.string.d.ts
+++ b/types/dojo/dojox.string.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace string_ {

--- a/types/dojo/dojox.testing.d.ts
+++ b/types/dojo/dojox.testing.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     namespace testing {

--- a/types/dojo/dojox.timing.d.ts
+++ b/types/dojo/dojox.timing.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.treemap.d.ts
+++ b/types/dojo/dojox.treemap.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     namespace treemap {

--- a/types/dojo/dojox.uuid.d.ts
+++ b/types/dojo/dojox.uuid.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.validate.d.ts
+++ b/types/dojo/dojox.validate.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace dojox {
 
     /**

--- a/types/dojo/dojox.widget.d.ts
+++ b/types/dojo/dojox.widget.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace dojox {
 
     namespace widget {

--- a/types/dojo/dojox.xml.d.ts
+++ b/types/dojo/dojox.xml.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Dojo v1.9
-// Project: http://dojotoolkit.org
-// Definitions by: Michael Van Sickle <https://github.com/vansimke>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 declare namespace dojox {
 
     namespace xml {


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.