### PR TITLE
[google-apps-script] remove unused header from non-index.d.ts

### DIFF
--- a/types/google-apps-script/addons/google-apps-script.addon-event-objects.d.ts
+++ b/types/google-apps-script/addons/google-apps-script.addon-event-objects.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script Event Objects 2021-04-15
-// Project: https://developers.google.com/apps-script/
-// Definitions by: Oleg Valter <https://github.com/Oaphi>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
     /**
      * @summary Apps Script Addon Event Objects

--- a/types/google-apps-script/apis/adsense_v1_4.d.ts
+++ b/types/google-apps-script/apis/adsense_v1_4.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Adsense {
     namespace Collection {

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Analytics {
     namespace Collection {

--- a/types/google-apps-script/apis/analyticsreporting_v4.d.ts
+++ b/types/google-apps-script/apis/analyticsreporting_v4.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AnalyticsReporting {
     namespace Collection {

--- a/types/google-apps-script/apis/appsactivity_v1.d.ts
+++ b/types/google-apps-script/apis/appsactivity_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Appsactivity {
     namespace Collection {

--- a/types/google-apps-script/apis/bigquery_v2.d.ts
+++ b/types/google-apps-script/apis/bigquery_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace BigQuery {
     namespace Collection {

--- a/types/google-apps-script/apis/calendar_v3.d.ts
+++ b/types/google-apps-script/apis/calendar_v3.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Calendar {
     namespace Collection {

--- a/types/google-apps-script/apis/classroom_v1.d.ts
+++ b/types/google-apps-script/apis/classroom_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2020-02-03
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
     namespace Classroom {
         namespace Collection {

--- a/types/google-apps-script/apis/content_v2.d.ts
+++ b/types/google-apps-script/apis/content_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Content {
     namespace Collection {

--- a/types/google-apps-script/apis/dfareporting_v3_3.d.ts
+++ b/types/google-apps-script/apis/dfareporting_v3_3.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Dfareporting {
     namespace Collection {

--- a/types/google-apps-script/apis/directory_v1.d.ts
+++ b/types/google-apps-script/apis/directory_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminDirectory {
     namespace Collection {

--- a/types/google-apps-script/apis/docs_v1.d.ts
+++ b/types/google-apps-script/apis/docs_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Docs {
     namespace Collection {

--- a/types/google-apps-script/apis/drive_v2.d.ts
+++ b/types/google-apps-script/apis/drive_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Drive {
     namespace Collection {

--- a/types/google-apps-script/apis/driveactivity_v2.d.ts
+++ b/types/google-apps-script/apis/driveactivity_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace DriveActivity {
     namespace Collection {

--- a/types/google-apps-script/apis/gmail_v1.d.ts
+++ b/types/google-apps-script/apis/gmail_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Gmail {
     namespace Collection {

--- a/types/google-apps-script/apis/groupsmigration_v1.d.ts
+++ b/types/google-apps-script/apis/groupsmigration_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminGroupsMigration {
     namespace Collection {

--- a/types/google-apps-script/apis/groupssettings_v1.d.ts
+++ b/types/google-apps-script/apis/groupssettings_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminGroupsSettings {
     namespace Collection {

--- a/types/google-apps-script/apis/licensing_v1.d.ts
+++ b/types/google-apps-script/apis/licensing_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminLicenseManager {
     namespace Collection {

--- a/types/google-apps-script/apis/mirror_v1.d.ts
+++ b/types/google-apps-script/apis/mirror_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Mirror {
     namespace Collection {

--- a/types/google-apps-script/apis/peopleapi_v1.d.ts
+++ b/types/google-apps-script/apis/peopleapi_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace People {
     namespace Collection {

--- a/types/google-apps-script/apis/reports_v1.d.ts
+++ b/types/google-apps-script/apis/reports_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminReports {
     namespace Collection {

--- a/types/google-apps-script/apis/reseller_v1.d.ts
+++ b/types/google-apps-script/apis/reseller_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace AdminReseller {
     namespace Collection {

--- a/types/google-apps-script/apis/sheets_v4.d.ts
+++ b/types/google-apps-script/apis/sheets_v4.d.ts
@@ -1,4 +1,3 @@
-
 declare namespace GoogleAppsScript {
   namespace Sheets {
     namespace Collection {

--- a/types/google-apps-script/apis/sheets_v4.d.ts
+++ b/types/google-apps-script/apis/sheets_v4.d.ts
@@ -1,7 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace GoogleAppsScript {
   namespace Sheets {

--- a/types/google-apps-script/apis/slides_v1.d.ts
+++ b/types/google-apps-script/apis/slides_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Slides {
     namespace Collection {

--- a/types/google-apps-script/apis/tagmanager_v2.d.ts
+++ b/types/google-apps-script/apis/tagmanager_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace TagManager {
     namespace Collection {

--- a/types/google-apps-script/apis/tasks_v1.d.ts
+++ b/types/google-apps-script/apis/tasks_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace Tasks {
     namespace Collection {

--- a/types/google-apps-script/apis/youtube_v3.d.ts
+++ b/types/google-apps-script/apis/youtube_v3.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace YouTube {
     namespace Collection {

--- a/types/google-apps-script/apis/youtubeanalytics_v2.d.ts
+++ b/types/google-apps-script/apis/youtubeanalytics_v2.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace YouTubeAnalytics {
     namespace Collection {

--- a/types/google-apps-script/apis/youtubepartner_v1.d.ts
+++ b/types/google-apps-script/apis/youtubepartner_v1.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2019-03-25
-// Project: https://developers.google.com/apps-script/
-// Generator: https://github.com/grant/google-apps-script-dts
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   namespace YoutubePartner {
     namespace Collection {

--- a/types/google-apps-script/google-apps-script-events.d.ts
+++ b/types/google-apps-script/google-apps-script-events.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Google Apps Script 2019-04-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 oshliaer <https://github.com/oshliaer>
-//                 RCRJ <https://github.com/RCRJ>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.script.d.ts" />
 /// <reference path="google-apps-script.spreadsheet.d.ts" />
 /// <reference path="google-apps-script.slides.d.ts" />

--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 interface Console {

--- a/types/google-apps-script/google-apps-script.cache.d.ts
+++ b/types/google-apps-script/google-apps-script.cache.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.calendar.d.ts
+++ b/types/google-apps-script/google-apps-script.calendar.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for Google Apps Script 2021-01-24
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-//                 Safal Pillai <https://github.com/malienist>
-//                 Oleg Valter <https://github.com/Oaphi>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.conference-data.d.ts" />
 /// <reference path="google-apps-script.gmail.d.ts" />

--- a/types/google-apps-script/google-apps-script.charts.d.ts
+++ b/types/google-apps-script/google-apps-script.charts.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.conference-data.d.ts
+++ b/types/google-apps-script/google-apps-script.conference-data.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Google Apps Script 2020-04-19
-// Project: https://developers.google.com/apps-script/
-// Definitions by: motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.contacts.d.ts
+++ b/types/google-apps-script/google-apps-script.contacts.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.content.d.ts
+++ b/types/google-apps-script/google-apps-script.content.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.data-studio.d.ts
+++ b/types/google-apps-script/google-apps-script.data-studio.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.document.d.ts
+++ b/types/google-apps-script/google-apps-script.document.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.drive.d.ts
+++ b/types/google-apps-script/google-apps-script.drive.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-//                 mahaker <https://github.com/mahaker/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.forms.d.ts
+++ b/types/google-apps-script/google-apps-script.forms.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.gmail.d.ts
+++ b/types/google-apps-script/google-apps-script.gmail.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.groups.d.ts
+++ b/types/google-apps-script/google-apps-script.groups.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.html.d.ts
+++ b/types/google-apps-script/google-apps-script.html.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.jdbc.d.ts
+++ b/types/google-apps-script/google-apps-script.jdbc.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.language.d.ts
+++ b/types/google-apps-script/google-apps-script.language.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.lock.d.ts
+++ b/types/google-apps-script/google-apps-script.lock.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.mail.d.ts
+++ b/types/google-apps-script/google-apps-script.mail.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.maps.d.ts
+++ b/types/google-apps-script/google-apps-script.maps.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.optimization.d.ts
+++ b/types/google-apps-script/google-apps-script.optimization.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.properties.d.ts
+++ b/types/google-apps-script/google-apps-script.properties.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/google-apps-script.script.d.ts
+++ b/types/google-apps-script/google-apps-script.script.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 /// <reference path="google-apps-script.document.d.ts" />

--- a/types/google-apps-script/google-apps-script.sites.d.ts
+++ b/types/google-apps-script/google-apps-script.sites.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.slides.d.ts
+++ b/types/google-apps-script/google-apps-script.slides.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 /// <reference path="google-apps-script.spreadsheet.d.ts" />

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-//                 Alexander Kuzmenko <https://github.com/eightalex>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 /// <reference path="google-apps-script.charts.d.ts" />

--- a/types/google-apps-script/google-apps-script.types.d.ts
+++ b/types/google-apps-script/google-apps-script.types.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2015-11-12
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace GoogleAppsScript {
   type BigNumber = any;
   type Byte = number;

--- a/types/google-apps-script/google-apps-script.url-fetch.d.ts
+++ b/types/google-apps-script/google-apps-script.url-fetch.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-//                 takoyaki9n <https://github.com/takoyaki9n>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.utilities.d.ts
+++ b/types/google-apps-script/google-apps-script.utilities.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 /// <reference path="google-apps-script.base.d.ts" />
 

--- a/types/google-apps-script/google-apps-script.xml-service.d.ts
+++ b/types/google-apps-script/google-apps-script.xml-service.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Google Apps Script 2020-01-02
-// Project: https://developers.google.com/apps-script/
-// Definitions by: PopGoesTheWza <https://github.com/PopGoesTheWza>
-//                 motemen <https://github.com/motemen/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="google-apps-script.types.d.ts" />
 
 declare namespace GoogleAppsScript {


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.

I'll note that it looks like some of these were created by https://github.com/grant/google-apps-script-dts, however, it doesn't look like this script has been updated or used in a while. Any generated files shouldn't have this header.