### PR TITLE
[slickgrid] remove unused header from non-index.d.ts

### DIFF
--- a/types/slickgrid/slick.autotooltips.d.ts
+++ b/types/slickgrid/slick.autotooltips.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for SlickGrid AutoToolTips Plugin 2.1.0
-// Project: https://github.com/mleibman/SlickGrid
-// Definitions by: Ryo Iwamoto <https://github.com/ryiwamoto>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace Slick {
     export interface SlickGridAutoTooltipsOption extends PluginOptions {
         /**

--- a/types/slickgrid/slick.checkboxselectcolumn.d.ts
+++ b/types/slickgrid/slick.checkboxselectcolumn.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for SlickGrid CheckboxSelectColumn Plugin 2.1.0
-// Project: https://github.com/mleibman/SlickGrid
-// Definitions by: berwyn <https://github.com/berwyn>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Slick {
     export interface SlickGridCheckBoxSelectColumnOptions extends PluginOptions {
         /**

--- a/types/slickgrid/slick.columnpicker.d.ts
+++ b/types/slickgrid/slick.columnpicker.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for SlickGrid ColumnPicker Control 2.1.0
-// Project: https://github.com/mleibman/SlickGrid
-// Definitions by: berwyn <https://github.com/berwyn>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Slick {
     export namespace Controls {
         export interface SlickColumnPickerOptions {

--- a/types/slickgrid/slick.headerbuttons.d.ts
+++ b/types/slickgrid/slick.headerbuttons.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for SlickGrid HeaderButtons Plugin 2.1.0
-// Project: https://github.com/mleibman/SlickGrid
-// Definitions by: Derek Cicerone <https://github.com/derekcicerone/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace Slick {
 
     export interface Column<T extends SlickData> {

--- a/types/slickgrid/slick.rowselectionmodel.d.ts
+++ b/types/slickgrid/slick.rowselectionmodel.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for SlickGrid RowSelectionModel Plugin 2.1.0
-// Project: https://github.com/mleibman/SlickGrid
-// Definitions by: Derek Cicerone <https://github.com/derekcicerone/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare namespace Slick {
     class RowSelectionModel<T extends SlickData, E> extends SelectionModel<T, E> {
         constructor(options?:{selectActiveRow:boolean;});


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.