### PR TITLE
[webrtc] remove unused header from non-index.d.ts

### DIFF
--- a/types/webrtc/MediaStream.d.ts
+++ b/types/webrtc/MediaStream.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for WebRTC
-// Project: http://dev.w3.org/2011/webrtc/
-// Definitions by: Ken Smith <https://github.com/smithkl42/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 // Taken from http://dev.w3.org/2011/webrtc/editor/getusermedia.html
 // version: W3C Editor's Draft 29 June 2015
 

--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for WebRTC 2016-09-13
-// Project: https://www.w3.org/TR/webrtc/
-// Definitions by: Danilo Bargen <https://github.com/dbrgn/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-//
 // W3 Spec: https://www.w3.org/TR/webrtc/
 //
 // Note: Commented out definitions clash with definitions in lib.es6.d.ts. I

--- a/types/webrtc/ts5.0/MediaStream.d.ts
+++ b/types/webrtc/ts5.0/MediaStream.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for WebRTC
-// Project: http://dev.w3.org/2011/webrtc/
-// Definitions by: Ken Smith <https://github.com/smithkl42/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 // Taken from http://dev.w3.org/2011/webrtc/editor/getusermedia.html
 // version: W3C Editor's Draft 29 June 2015
 

--- a/types/webrtc/ts5.0/RTCPeerConnection.d.ts
+++ b/types/webrtc/ts5.0/RTCPeerConnection.d.ts
@@ -1,10 +1,3 @@
-// Type definitions for WebRTC 2016-09-13
-// Project: https://www.w3.org/TR/webrtc/
-// Definitions by: Danilo Bargen <https://github.com/dbrgn/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-//
-// W3 Spec: https://www.w3.org/TR/webrtc/
-//
 // Note: Commented out definitions clash with definitions in lib.es6.d.ts. I
 // still kept them in here though, as sometimes they're more specific than the
 // ES6 library ones.

--- a/types/webrtc/ts5.0/index.d.ts
+++ b/types/webrtc/ts5.0/index.d.ts
@@ -1,8 +1,2 @@
-// Type definitions for webrtc
-// Project: https://webrtc.org/
-// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.9
-
 /// <reference path="RTCPeerConnection.d.ts" />
 /// <reference path="MediaStream.d.ts" />


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.