### PR TITLE
[cldrjs] remove unused header from non-index.d.ts

### DIFF
--- a/types/cldrjs/cldr/event.d.ts
+++ b/types/cldrjs/cldr/event.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Cldr.js 0.4.4
-// Project: https://github.com/rxaviers/cldrjs
-// Definitions by: Raman But-Husaim <https://github.com/RamanBut-Husaim>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 // The definition file for event module.
 
 declare module "cldr/event" {

--- a/types/cldrjs/cldr/supplemental.d.ts
+++ b/types/cldrjs/cldr/supplemental.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Cldr.js 0.4.4
-// Project: https://github.com/rxaviers/cldrjs
-// Definitions by: Raman But-Husaim <https://github.com/RamanBut-Husaim>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 // The definition file for supplemental module.
 
 import * as cldr from "cldrjs";


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.