### PR TITLE
[freedom] remove unused header from non-index.d.ts

### DIFF
--- a/types/freedom/freedom-core-env.d.ts
+++ b/types/freedom/freedom-core-env.d.ts
@@ -1,8 +1,1 @@
-// Type definitions for freedom v0.6.26
-// Project: https://github.com/freedomjs/freedom
-// Definitions by: Jonathan Pevarnek <https://github.com/jpevarnek/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare var freedom :freedom.FreedomInCoreEnv;

--- a/types/freedom/freedom-module-env.d.ts
+++ b/types/freedom/freedom-module-env.d.ts
@@ -1,8 +1,1 @@
-// Type definitions for freedom v0.6.26
-// Project: https://github.com/freedomjs/freedom
-// Definitions by: Jonathan Pevarnek <https://github.com/jpevarnek/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 declare var freedom :freedom.FreedomInModuleEnv;


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.