### PR TITLE
[kolite] remove unused header from non-index.d.ts

### DIFF
--- a/types/kolite/knockout.activity.d.ts
+++ b/types/kolite/knockout.activity.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for KoLite 1.1
-// Project: https://github.com/CodeSeven/kolite
-// Definitions by: Boris Yankov <https://github.com/borisyankov>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
 /// <reference types="jquery" />
 /// <reference types="knockout" />
 

--- a/types/kolite/knockout.command.d.ts
+++ b/types/kolite/knockout.command.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for KoLite 1.1
-// Project: https://github.com/CodeSeven/kolite
-// Definitions by: Boris Yankov <https://github.com/borisyankov>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
 /// <reference types="jquery" />
 /// <reference types="knockout" />
 

--- a/types/kolite/knockout.dirtyFlag.d.ts
+++ b/types/kolite/knockout.dirtyFlag.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for KoLite 1.1
-// Project: https://github.com/CodeSeven/kolite
-// Definitions by: Boris Yankov <https://github.com/borisyankov>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
 /// <reference types="jquery" />
 /// <reference types="knockout" />
 


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.