### PR TITLE
[murmurhash-js] remove unused header from non-index.d.ts

### DIFF
--- a/types/murmurhash-js/murmurhash2_gc.d.ts
+++ b/types/murmurhash-js/murmurhash2_gc.d.ts
@@ -1,7 +1,2 @@
-// Type definitions for murmurhash-js v1.0.0
-// Project: https://github.com/mikolalysenko/murmurhash-js
-// Definitions by: Chi Vinh Le <https://github.com/cvle>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare const murmur: (str: string, seed?: number) => number;
 export = murmur;

--- a/types/murmurhash-js/murmurhash3_gc.d.ts
+++ b/types/murmurhash-js/murmurhash3_gc.d.ts
@@ -1,7 +1,2 @@
-// Type definitions for murmurhash-js v1.0.0
-// Project: https://github.com/mikolalysenko/murmurhash-js
-// Definitions by: Chi Vinh Le <https://github.com/cvle>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare const murmur: (str: string, seed?: number) => number;
 export = murmur;


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.