### PR TITLE
[iscroll] remove unused header from non-index.d.ts

### DIFF
--- a/types/iscroll/iscroll-lite.d.ts
+++ b/types/iscroll/iscroll-lite.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for iScroll Lite 5
-// Project: http://cubiq.org/iscroll-5-ready-for-beta-test
-// Definitions by: Christiaan Rakowski <https://github.com/csrakowski/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 interface IScrollOptions {
     //hScroll?: boolean;
     //vScroll?: boolean;

--- a/types/iscroll/v4/iscroll-lite.d.ts
+++ b/types/iscroll/v4/iscroll-lite.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for iScroll Lite 4.1
-// Project: http://cubiq.org/iscroll-4
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christiaan Rakowski <https://github.com/csrakowski/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 interface iScrollEvent {
     (e: Event): void;
 }


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header to `package.json` in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.