### PR TITLE
remove unused header from non-index.d.ts (loose ends)

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Chrome Cast application development
-// Project: https://developers.google.com/cast/
-// Definitions by: Thomas Stig Jacobsen <https://github.com/eXeDK>
-//                 Stefan Ullinger <https://github.com/stefanullinger>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 ////////////////////
 // Cast
 // @see https://code.google.com/p/chromium/codesearch#chromium/src/ui/file_manager/externs/chrome_cast.js

--- a/types/commangular/commangular-mock.d.ts
+++ b/types/commangular/commangular-mock.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Commangular Mock 0.9.0
-// Project: http://commangular.org
-// Definitions by: Hiraash Thawfeek <https://github.com/hiraash>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare module commangular {
 
     ///////////////////////////////////////////////////////////////////////////

--- a/types/cordova-ionic/keyboard.d.ts
+++ b/types/cordova-ionic/keyboard.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Cordova Keyboard plugin
-// Project: https://github.com/driftyco/ionic-plugins-keyboard
-// Definitions by: Hendrik Maus <https://github.com/hendrikmaus>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Ionic {
   interface Keyboard {
 

--- a/types/datejs/sugarpak.d.ts
+++ b/types/datejs/sugarpak.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for DateJS - SugarPak Extensions
-// Project: http://www.datejs.com/
-// Definitions by: David Khristepher Santos <https://github.com/rupertavery>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /** SugarPak.js - Domain Specific Language -  Syntactical Sugar */
 declare namespace sugarpak {
 

--- a/types/disposable-email-domains/wildcard.d.ts
+++ b/types/disposable-email-domains/wildcard.d.ts
@@ -1,7 +1,2 @@
-// Type definitions for disposable-email-domains v1.0
-// Project: https://github.com/ivolo/disposable-email-domains
-// Definitions by: Alexander Håkansson <https://github.com/hsson>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare const wildcards: string[];
 export = wildcards;

--- a/types/doccookies/doccookies-tests.ts
+++ b/types/doccookies/doccookies-tests.ts
@@ -1,10 +1,3 @@
-// Type definitions for docCookies
-// Project: https://developer.mozilla.org/en-US/docs/Web/API/document.cookie
-// Definitions by: Jon Egerton <https://github.com/jonegerton>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
-
 docCookies.setItem("test0", "Hello world!");
 docCookies.setItem("test1", "Unicode test: \u00E0\u00E8\u00EC\u00F2\u00F9", Infinity);
 docCookies.setItem("test2", "Hello world!", new Date(2020, 5, 12));

--- a/types/echarts/options/tooltip.d.ts
+++ b/types/echarts/options/tooltip.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for ECharts v4.7.0
 declare namespace echarts {
     namespace EChartOption {
         interface BaseTooltip {

--- a/types/gapi.analytics/gapi.analytics-tests.ts
+++ b/types/gapi.analytics/gapi.analytics-tests.ts
@@ -1,5 +1,3 @@
-// Type definitions for Google Analytics API
-
 function test_namespace() {
     var analytics : boolean = gapi.client.analytics instanceof Object;
 

--- a/types/hapi__nes/lib/client.d.ts
+++ b/types/hapi__nes/lib/client.d.ts
@@ -1,11 +1,3 @@
-// Type definitions for @hapi/nes 11.0
-// Project: https://github.com/hapijs/nes
-// Definitions by: Ivo Stratev <https://github.com/NoHomey>
-//                 Rodrigo Saboya <https://github.com/saboya>
-//                 Silas Rech <https://github.com/lenovouser>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
-
 declare class Client {
     constructor(url: string, options?: Client.ClientOptions);
     onError: (err: any) => void;

--- a/types/hooker/hooker-tests.ts
+++ b/types/hooker/hooker-tests.ts
@@ -1,11 +1,5 @@
-
-
 import hooker = require('hooker');
 
-// Type definitions for JavaScript Hooker v0.2.3
-// Project: https://github.com/cowboy/javascript-hooker
-// Definitions by: Michael Zabka <https://github.com/misak113/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 function tests() {
     var objectToHook: any = {
         hello: 'world'

--- a/types/ix.js/l2o.d.ts
+++ b/types/ix.js/l2o.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for IxJS 1.0.6 / l2o.js
-// Project: https://github.com/Reactive-Extensions/IxJS
-// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Ix {
     export interface Disposable {
         dispose(): void;

--- a/types/jqgrid/jqgrid-tests.ts
+++ b/types/jqgrid/jqgrid-tests.ts
@@ -1,7 +1,3 @@
-// Type definitions for jQuery jqgrid Plugin 1.3
-// Definitions by: Lokesh Peta <https://github.com/lokeshpeta/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 var mydata: any[] = [];
 
 $('#jqGrid')

--- a/types/js-money/lib/currency.d.ts
+++ b/types/js-money/lib/currency.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for js-money 0.6
-// Project: https://github.com/davidkalosi/js-money#readme
-// Definitions by: Kanat Kubash <https://github.com/kanatkubash>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Currencies {
     interface Currency {
         symbol: string;

--- a/types/jsfl/xJSFL.d.ts
+++ b/types/jsfl/xJSFL.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for xJSFL
-// Project: http://www.xjsfl.com/
-// Definitions by: soywiz <https://github.com/soywiz/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 ///<reference path="index.d.ts" />
 
 interface _xjsfl {

--- a/types/microsoft-ajax/microsoft-ajax-tests.ts
+++ b/types/microsoft-ajax/microsoft-ajax-tests.ts
@@ -1,9 +1,3 @@
-// Type definitions for Microsoft ASP.NET Ajax client side library
-// Project: http://msdn.microsoft.com/en-us/library/ee341002(v=vs.100).aspx
-// Definitions by: Patrick Magee <https://github.com/pjmagee/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 function GlobalNamespace_Tests() {
 
     var arrayVar = new Array("Saturn", "Mars", "Jupiter");

--- a/types/minilog/minilog-tests.ts
+++ b/types/minilog/minilog-tests.ts
@@ -1,9 +1,3 @@
-// Type definitions for minilog v2
-// Project: https://github.com/mixu/minilog
-// Definitions by: Guido <http://guido.io>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 //Following are example snippets from mixu.net/minilog
 import Minilog = require("minilog");
 var log = Minilog('app');

--- a/types/nanp/nanp-tests.ts
+++ b/types/nanp/nanp-tests.ts
@@ -1,7 +1,3 @@
-// Type definitions for nanp v0.3.0
-// Project: https://github.com/weisjohn/nanp
-// Definitions by: Karn Saheb <https://github.com/karn/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Tests taken from project readme.
 
 

--- a/types/nes/client.d.ts
+++ b/types/nes/client.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for nes 7.0.0
-// Project: https://github.com/hapijs/nes
-// Definitions by: Ivo Stratev <https://github.com/NoHomey>
-//                 Rodrigo Saboya <https://github.com/saboya>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare class Client {
     constructor(url: string, options?: Client.ClientOptions);
     onError: (err: any) => void;

--- a/types/node-mysql-wrapper/my-meteor.d.ts
+++ b/types/node-mysql-wrapper/my-meteor.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for meteorjs for node-mysql-wrapper which helps in development
-// Project: https://github.com/nodets/node-mysql-wrapper
-// Definitions by: Makis Maropoulos <https://github.com/kataras>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Mongo {
     var Collection: CollectionStatic;
     interface CollectionStatic {

--- a/types/purl/purl-jquery.d.ts
+++ b/types/purl/purl-jquery.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Purl 2.3.1
-// Project: https://github.com/allmarkedup/purl
-// Definitions by: Daniel Ferreira Monteiro Alves <https://github.com/danfma>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference types="jquery" />
 
 

--- a/types/rangy/rangy-classapplier.d.ts
+++ b/types/rangy/rangy-classapplier.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Rangy Class Applier module
-// Project: https://github.com/timdown/rangy
-// Definitions by: Maxime Kjaer <https://github.com/MaximeKjaer>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="index.d.ts"/>
 
 interface RangyStatic {

--- a/types/riotjs/riotjs-render.d.ts
+++ b/types/riotjs/riotjs-render.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for riot.js
-// Project: https://github.com/moot/riotjs
-// Definitions by: vvakame <https://github.com/vvakame>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference types="jquery" />
 
 interface JQueryStatic {

--- a/types/rx-angular/rx-angular-tests.ts
+++ b/types/rx-angular/rx-angular-tests.ts
@@ -1,8 +1,3 @@
-// Type definitions for angularjs extensions to rxjs
-// Project: http://reactivex.io/
-// Definitions by: Mick Delaney <https://github.com/mickdelaney/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 var app = angular.module('testModule');
 
 interface AppScope extends rx.angular.IRxScope {

--- a/types/rx-node/rx-node-tests.ts
+++ b/types/rx-node/rx-node-tests.ts
@@ -1,8 +1,3 @@
-// Type definitions for RxJS bindings for Node
-// Project: https://github.com/Reactive-Extensions/rx-node
-// Definitions by: Andre Luiz dos Santos <https://github.com/andre-luiz-dos-santos/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 {
     var source = Rx.Observable.return(42);
     var emitter = RxNode.toEventEmitter(source, 'data');

--- a/types/sandboxed-module/sandboxed-module-tests.ts
+++ b/types/sandboxed-module/sandboxed-module-tests.ts
@@ -1,9 +1,3 @@
-// Type definitions for sandboxed-module v2.0.3
-// Project: https://github.com/felixge/node-sandboxed-module
-// Definitions by: Sven Reglitzki <https://github.com/svi3c/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 import SandboxedModule = require("sandboxed-module");
 
 var sandboxedModule:SandboxedModule = SandboxedModule.load("foo");

--- a/types/steam/steam-tests.ts
+++ b/types/steam/steam-tests.ts
@@ -1,8 +1,3 @@
-// Type definitions for steam
-// Project: https://github.com/seishun/node-steam
-// Definitions by: Andrey Kurdyumov <https://github.com/kant2002>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 import Steam = require("steam");
 
 var bot = new Steam.SteamClient();

--- a/types/umbraco/umbraco-resources.d.ts
+++ b/types/umbraco/umbraco-resources.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Umbraco v7.2.8
-// Project: https://github.com/umbraco
-// Definitions by: DeCareSystemsIreland <https://github.com/DeCareSystemsIreland>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference types="angular" />
 
 declare namespace umbraco.resources{

--- a/types/umbraco/umbraco-services.d.ts
+++ b/types/umbraco/umbraco-services.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for Umbraco v7.2.8
-// Project: https://github.com/umbraco
-// Definitions by: DeCareSystemsIreland <https://github.com/DeCareSystemsIreland>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 /// <reference types="angular" />
 
 declare namespace umbraco.services {

--- a/types/xrm/v7/parature.d.ts
+++ b/types/xrm/v7/parature.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for Microsoft Parature extentions to Xrm.Page - available for CRM Online Only
-// Project: http://msdn.microsoft.com/en-us/library/gg328255.aspx
-// Definitions by: David Berry <https://github.com/6ix4our/>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace Xrm.Page
 {
     /**

--- a/types/yui/yui-test.d.ts
+++ b/types/yui/yui-test.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for yui 3.14.0
-// Project: https://github.com/yui/yui3/blob/release-3.14.0/src/test/js
-// Definitions by: Gia Bảo @ Sân Đình <https://github.com/giabao>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace YUITest {
     interface YUITestStatic {
         Assert: IAssert


### PR DESCRIPTION
This header has no effect outside of `index.d.ts`; we're planning on moving the contents of the `index.d.ts` header to `package.json` in a migration to monorepos (as well as no longer requiring `index.d.ts` at all), so leaving this here will really only cause confusion.

This is all of the other misc ones I didn't cover individually in other large PRs.