### PR TITLE
[react-datepicker] fix formatWeekDay types

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 4.10
+// Type definitions for react-datepicker 4.11
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 //                 Greg Smith <https://github.com/smrq>
@@ -13,6 +13,7 @@
 //                 Shiftr Tech SAS <https://github.com/ShiftrTechSAS>
 //                 Pirasis Leelatanon <https://github.com/1pete>
 //                 Alexander Shipulin <https://github.com/y>
+//                 Rafik Ogandzhanian <https://github.com/inomn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 
@@ -95,7 +96,7 @@ export interface ReactDatePickerProps<
     filterTime?(date: Date): boolean;
     fixedHeight?: boolean | undefined;
     forceShowMonthNavigation?: boolean | undefined;
-    formatWeekDay?(day: Date, locale: Locale): React.ReactNode;
+    formatWeekDay?(day: string): React.ReactNode;
     formatWeekNumber?(date: Date): string | number;
     highlightDates?: Array<HighlightDates | Date> | undefined;
     id?: string | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -2,18 +2,13 @@ import * as React from 'react';
 import DatePicker, {
     CalendarContainer,
     registerLocale,
-    setDefaultLocale,
-    getDefaultLocale,
     ReactDatePickerProps,
     ReactDatePickerCustomHeaderProps,
 } from 'react-datepicker';
 import enUS from 'date-fns/locale/en-US';
-import { format } from 'date-fns';
 import { Modifier } from 'react-popper';
 
 registerLocale('en-GB', { options: { weekStartsOn: 1 } });
-setDefaultLocale('en-GB');
-const defaultLocale = getDefaultLocale();
 
 const topLogger: Modifier<'topLogger'> = {
     name: 'topLogger',
@@ -25,8 +20,6 @@ const topLogger: Modifier<'topLogger'> = {
         }
     },
 };
-
-const DATE_FNS_FORMAT = 'EEEEE';
 
 <DatePicker
     adjustDateOnChange
@@ -68,7 +61,7 @@ const DATE_FNS_FORMAT = 'EEEEE';
     filterTime={date => true}
     fixedHeight
     forceShowMonthNavigation
-    formatWeekDay={(day, locale) => format(day, DATE_FNS_FORMAT, { locale })}
+    formatWeekDay={(day) => day[0]}
     formatWeekNumber={date => 0}
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Changing an existing definition:
The previous change for formatWeekDay should be reverted (see https://github.com/Hacker0x01/react-datepicker/issues/3918#issuecomment-1502104135)

Actual API for date-picker prop returns only locale-based string of the Weekday.

The flow:
- Internal function https://github.com/Hacker0x01/react-datepicker/blob/321084ab1ddf384b1114bfc62e18b363f2b18e1e/src/calendar.jsx#L419 
- returns `getFormattedWeekdayInLocale` https://github.com/Hacker0x01/react-datepicker/blob/f1391821e1726f22f2d9b287ab0bc1e932b0f486/src/date_utils.js#L383
- And finally there we call OUR callback function, with only One parameter - result of `date-fns` `format` function (called here: https://github.com/Hacker0x01/react-datepicker/blob/f1391821e1726f22f2d9b287ab0bc1e932b0f486/src/date_utils.js#L145 ) and return type of `format` is string. 
- Additionally check react-datepicker's own tests: https://github.com/Hacker0x01/react-datepicker/blob/fd6e1f6261edb06a035bee4b267c33553e4de9e7/test/calendar_test.js#L165 `day[0]` - a string