### PR TITLE
[postcss-flexbugs-fixes] Updates types for postcss-flexbugs-fixes 5.0

### DIFF
--- a/types/postcss-flexbugs-fixes/index.d.ts
+++ b/types/postcss-flexbugs-fixes/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for postcss-flexbugs-fixes 4.2
+// Type definitions for postcss-flexbugs-fixes 5.0
 // Project: https://github.com/luisrudge/postcss-flexbugs-fixes#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin } from 'postcss';
+import { PluginCreator } from 'postcss';
 
 declare namespace postcssFlexbugsFixes {
-    type PostcssFlexbugsFixesPlugin = Plugin<Options>;
+    type PostcssFlexbugsFixesPlugin = PluginCreator<Options>;
 
     interface Options {
         /**

--- a/types/postcss-flexbugs-fixes/package.json
+++ b/types/postcss-flexbugs-fixes/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^7.0.27"
+        "postcss": "^8.1.4"
     }
 }

--- a/types/postcss-flexbugs-fixes/postcss-flexbugs-fixes-tests.ts
+++ b/types/postcss-flexbugs-fixes/postcss-flexbugs-fixes-tests.ts
@@ -1,9 +1,10 @@
 import postcss = require('postcss');
 import plugin = require('postcss-flexbugs-fixes');
 
-// $ExpectType Processor
 postcss([plugin]);
 
 const options: plugin.Options = { bug4: false, bug6: false, bug81a: false };
-// $ExpectType Processor
 postcss([plugin(options)]);
+
+// @ts-expect-error
+postcss([plugin({ bug42: false })]);

--- a/types/postcss-flexbugs-fixes/tsconfig.json
+++ b/types/postcss-flexbugs-fixes/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "es2018.promise"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: version 5 of the plugin is about migrating to postcss 8 instead of postcss 7
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
