### PR TITLE
Fix postcss dependents for postcss@8.4.22

### DIFF
--- a/types/postcss-js/index.d.ts
+++ b/types/postcss-js/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { AcceptedPlugin, ProcessOptions, Root, LazyResult } from 'postcss';
-import NoWorkResult from 'postcss/lib/no-work-result';
+import NoWorkResult = require('postcss/lib/no-work-result');
 
 /** CSS-in-JS object */
 export type CssInJs = Record<string, any>;

--- a/types/postcss-js/index.d.ts
+++ b/types/postcss-js/index.d.ts
@@ -42,7 +42,7 @@ export function async(plugins: AcceptedPlugin[]): (input: CssInJs) => Promise<Cs
 // This lets the postcss-js parser be used
 // as long as the object passed to `process` is a CSS-in-JS object
 declare module 'postcss/lib/processor' {
-    export default interface Processor {
+    class Processor_ {
         process(
             obj: CssInJs,
             opts: Omit<ProcessOptions, 'parser'> & { parser: typeof parse },

--- a/types/postcss-js/postcss-js-tests.ts
+++ b/types/postcss-js/postcss-js-tests.ts
@@ -12,7 +12,7 @@ const style = {
 postcss()
     .process(style, { parser: postcssJs.parse })
     .then(result => {
-        result; // $ExpectType Result
+        result; // $ExpectType Result_
     });
 
 // Try to parse random object with postcss-js parser (errors)

--- a/types/rtlcss/index.d.ts
+++ b/types/rtlcss/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { PluginCreator, Postcss, Root } from 'postcss';
-import Processor from 'postcss/lib/processor';
+import Processor = require('postcss/lib/processor');
 
 declare namespace rtlcss {
     interface MapOptions {

--- a/types/rtlcss/rtlcss-tests.ts
+++ b/types/rtlcss/rtlcss-tests.ts
@@ -6,12 +6,12 @@ const css = 'body { direction:ltr; }';
 rtlcss.process(css);
 rtlcss.process(css, {}, [], {
     pre: (root, postcss) => {
-        root; // $ExpectType Root
-        postcss; // $ExpectType Postcss
+        root; // $ExpectType Root_
+        postcss; // $ExpectType typeof postcss
     },
     post: (root, postcss) => {
-        root; // $ExpectType Root
-        postcss; // $ExpectType Postcss
+        root; // $ExpectType Root_
+        postcss; // $ExpectType typeof postcss
     },
 });
 
@@ -43,8 +43,8 @@ const config = {
     plugins: [],
 };
 
-// $ExpectType Processor
+// $ExpectType Processor_
 rtlcss.configure(config);
 
-// $ExpectType Processor | Plugin
+// $ExpectType Processor_ | Plugin
 rtlcss(options);

--- a/types/rtlcss/rtlcss-tests.ts
+++ b/types/rtlcss/rtlcss-tests.ts
@@ -43,7 +43,7 @@ const config = {
     plugins: [],
 };
 
-// $ExpectType Processor_
+// $ExpectType Processor
 rtlcss.configure(config);
 
 // $ExpectType Processor_ | Plugin


### PR DESCRIPTION
1. rtlcss needs to update its import and some of its expected type names.
2. postcss-js needs to update how it merges with Processor.