### PR TITLE
Update node-osc types to include missing callback arg

### DIFF
--- a/types/node-osc/index.d.ts
+++ b/types/node-osc/index.d.ts
@@ -15,12 +15,12 @@ export interface Argument {
 
 export type ArgumentType = boolean | number | string | Argument;
 
-export interface RequestInfo { 
-  address: string; 
-  family: string; 
-  port: number; 
-  size: number 
-};
+export interface RequestInfo {
+    address: string;
+    family: string;
+    port: number;
+    size: number;
+}
 
 /**
  * A message that can be sent over OSC
@@ -35,10 +35,10 @@ export class Message {
 export type MessageLike =
     | [string, ...ArgumentType[]]
     | {
-          address: string;
+        address: string;
 
-          args: ArgumentType[];
-      };
+        args: ArgumentType[];
+    };
 
 /**
  * An OSC Bundle message

--- a/types/node-osc/index.d.ts
+++ b/types/node-osc/index.d.ts
@@ -15,6 +15,13 @@ export interface Argument {
 
 export type ArgumentType = boolean | number | string | Argument;
 
+export interface RequestInfo { 
+  address: string; 
+  family: string; 
+  port: number; 
+  size: number 
+};
+
 /**
  * A message that can be sent over OSC
  */
@@ -79,7 +86,7 @@ export type ServerBundleListener = (bundle: Bundle) => void;
 
 export type ServerErrorListner = (error: Error) => void;
 
-export type ServerMessageListener = (message: [string, ...ArgumentType[]]) => void;
+export type ServerMessageListener = (message: [string, ...ArgumentType[]], rinfo: RequestInfo) => void;
 
 /**
  * A server to handle OSC messages

--- a/types/node-osc/node-osc-tests.ts
+++ b/types/node-osc/node-osc-tests.ts
@@ -92,8 +92,8 @@ oscServer.on("error", err => {
     // console.error("Error on OSC server", err);
 });
 
-oscServer.on("message", msg => {
-    // console.log(`Message: ${msg}`);
+oscServer.on("message", (msg, rinfo) => {
+    // console.log(`Message: ${msg} , request info`, rinfo);
 });
 
 oscServer.on("/test", msg => {


### PR DESCRIPTION
ServerMessageListener should define `rinfo`, not just `message`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [MylesBorins/node-osc/blob/main/lib/Server.mjs#L22](https://github.com/MylesBorins/node-osc/blob/main/lib/Server.mjs#L22)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
