### PR TITLE
[@types/tabulator-tables] fix debugInvalidComponentFuncs syntax

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -40,7 +40,7 @@ export interface OptionsDebug {
     debugEventsInternal?: boolean;
 
     /** Disable component function warnings */
-    debugInvalidComponentFunc?: boolean;
+    debugInvalidComponentFuncs?: boolean;
 
     /** Disable deprecation warnings */
     debugDeprecation?: boolean;

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1088,7 +1088,7 @@ table = new Tabulator('#test', {
 
 // 5.3
 options = {
-    debugInvalidComponentFunc: false,
+    debugInvalidComponentFuncs: false,
     debugDeprecation: false,
 };
 


### PR DESCRIPTION
`debugInvalidComponentFuncs` require an `s` at the end of its name


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `debugInvalidComponentFuncs` in [Tabulator documentation](https://tabulator.info/docs/5.4/debug#warning-components), and in [Tabulator source code](https://github.com/olifolkerd/tabulator/blob/master/src/js/core/defaults/options.js#L6)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.