### PR TITLE
Added argument to 'change values' in 'semantic-ui-dropdown'

### DIFF
--- a/types/semantic-ui-dropdown/global.d.ts
+++ b/types/semantic-ui-dropdown/global.d.ts
@@ -13,6 +13,10 @@ declare namespace SemanticUI {
          */
         (behavior: 'setup menu'): JQuery;
         /**
+         * Changes dropdown to use new values. values structure: [ {value, text, name} ].
+         */
+        (behavior: 'change values'): JQuery;
+        /**
          * Refreshes all cached selectors and data
          */
         (behavior: 'refresh'): JQuery;

--- a/types/semantic-ui-dropdown/global.d.ts
+++ b/types/semantic-ui-dropdown/global.d.ts
@@ -13,10 +13,6 @@ declare namespace SemanticUI {
          */
         (behavior: 'setup menu'): JQuery;
         /**
-         * Changes dropdown to use new values. values structure: [ {value, text, name} ].
-         */
-        (behavior: 'change values'): JQuery;
-        /**
          * Refreshes all cached selectors and data
          */
         (behavior: 'refresh'): JQuery;
@@ -60,6 +56,10 @@ declare namespace SemanticUI {
          * Saves current text and value as new defaults (for use with restore)
          */
         (behavior: 'save defaults'): JQuery;
+		/**
+         * Changes dropdown to use new values. values structure: [ {value, text, name} ].
+         */
+        (behavior: 'change values', values: any[]): JQuery;
         /**
          * Sets value as selected
          */

--- a/types/semantic-ui-dropdown/global.d.ts
+++ b/types/semantic-ui-dropdown/global.d.ts
@@ -56,10 +56,10 @@ declare namespace SemanticUI {
          * Saves current text and value as new defaults (for use with restore)
          */
         (behavior: 'save defaults'): JQuery;
-		/**
+        /**
          * Changes dropdown to use new values. values structure: [ {value, text, name} ].
          */
-        (behavior: 'change values', values: { value?: any, text?: string, name?: string }[]): JQuery;
+        (behavior: 'change values', values: Array<{ value?: any, text?: string, name?: string }>): JQuery;
         /**
          * Sets value as selected
          */

--- a/types/semantic-ui-dropdown/global.d.ts
+++ b/types/semantic-ui-dropdown/global.d.ts
@@ -59,7 +59,7 @@ declare namespace SemanticUI {
 		/**
          * Changes dropdown to use new values. values structure: [ {value, text, name} ].
          */
-        (behavior: 'change values', values: any[]): JQuery;
+        (behavior: 'change values', values: { value?: any, text?: string, name?: string }[]): JQuery;
         /**
          * Sets value as selected
          */

--- a/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
+++ b/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
@@ -11,6 +11,7 @@ function test_dropdown_static() {
 function test_dropdown() {
     const selector = '.ui.dropdown';
     $(selector).dropdown('setup menu'); // $ExpectType JQuery<HTMLElement>
+    $(selector).dropdown('change values'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('refresh'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('toggle'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('show'); // $ExpectType JQuery<HTMLElement>

--- a/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
+++ b/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
@@ -11,7 +11,6 @@ function test_dropdown_static() {
 function test_dropdown() {
     const selector = '.ui.dropdown';
     $(selector).dropdown('setup menu'); // $ExpectType JQuery<HTMLElement>
-    $(selector).dropdown('change values'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('refresh'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('toggle'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('show'); // $ExpectType JQuery<HTMLElement>
@@ -23,6 +22,7 @@ function test_dropdown() {
     $(selector).dropdown('restore placeholder text'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('restore default value'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('save defaults'); // $ExpectType JQuery<HTMLElement>
+    $(selector).dropdown('change values', ['456']); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('set selected', 123); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('remove selected', false); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('set selected', ['456']); // $ExpectType JQuery<HTMLElement>

--- a/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
+++ b/types/semantic-ui-dropdown/semantic-ui-dropdown-tests.ts
@@ -22,7 +22,7 @@ function test_dropdown() {
     $(selector).dropdown('restore placeholder text'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('restore default value'); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('save defaults'); // $ExpectType JQuery<HTMLElement>
-    $(selector).dropdown('change values', ['456']); // $ExpectType JQuery<HTMLElement>
+    $(selector).dropdown('change values', [{value: '123', text: 'testing', name: 'test'}]); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('set selected', 123); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('remove selected', false); // $ExpectType JQuery<HTMLElement>
     $(selector).dropdown('set selected', ['456']); // $ExpectType JQuery<HTMLElement>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://semantic-ui.com/modules/dropdown.html#/usage)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I added the change values a little while back. I thought the update wasn't out yet, but just realized it is out but did not really work cause I forgot to set the values argument of it. So this fixes that issue.