### PR TITLE
[node] Update types to v18.16

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -319,16 +319,6 @@ declare module 'async_hooks' {
          */
         triggerAsyncId(): number;
     }
-    interface AsyncLocalStorageOptions<T> {
-        /**
-         * Optional callback invoked before a store is propagated to a new async resource.
-         * Returning `true` allows propagation, returning `false` avoids it. Default is to propagate always.
-         * @param type The type of async event.
-         * @param store The current store.
-         * @since v18.13.0
-         */
-        onPropagate?: ((type: string, store: T) => boolean) | undefined;
-    }
     /**
      * This class creates stores that stay coherent through asynchronous operations.
      *
@@ -378,8 +368,23 @@ declare module 'async_hooks' {
      * @since v13.10.0, v12.17.0
      */
     class AsyncLocalStorage<T> {
-        constructor(options?: AsyncLocalStorageOptions<T>);
-
+        /**
+         * Binds the given function to the current execution context.
+         * @since v18.16.0
+         * @param fn The function to bind to the current execution context.
+         * @returns A new function that calls `fn` within the captured execution context.
+         */
+        static bind<Func extends (...args: any[]) => any>(fn: Func): Func & {
+            asyncResource: AsyncResource;
+        };
+        /**
+         * Captures the current execution context and returns a function that accepts a function as an argument.
+         * Whenever the returned function is called, it calls the function passed to it within the captured context.
+         * @since v18.16.0
+         */
+        static snapshot(): (<R, TArgs extends any[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R) & {
+            asyncResource: AsyncResource;
+        };
         /**
          * Disables the instance of `AsyncLocalStorage`. All subsequent calls
          * to `asyncLocalStorage.getStore()` will return `undefined` until`asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()` is called again.

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -428,6 +428,14 @@ declare module 'buffer' {
              */
             concat(list: ReadonlyArray<Uint8Array>, totalLength?: number): Buffer;
             /**
+             * Copies the underlying memory of `view` into a new `Buffer`.
+             * @since v18.16.0
+             * @param view The `TypedArray` to copy.
+             * @param offset The starting offset within `view`.
+             * @param length The number of elements from `view` to copy.
+             */
+            copyBytesFrom(view: NodeJS.TypedArray, offset?: number, length?: number): Buffer;
+            /**
              * Compares `buf1` to `buf2`, typically for the purpose of sorting arrays of`Buffer` instances. This is equivalent to calling `buf1.compare(buf2)`.
              *
              * ```js

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -610,10 +610,14 @@ declare module 'events' {
                 emit(eventName: string | symbol, ...args: any[]): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
+                 *
+                 * If `listener` is provided, it will return how many times the listener
+                 * is found in the list of the listeners of the event.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
                  */
-                listenerCount(eventName: string | symbol): number;
+                listenerCount(eventName: string | symbol, listener?: Function): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 18.15
+// Type definitions for non-npm package Node.js 18.16
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test/async_hooks.ts
+++ b/types/node/test/async_hooks.ts
@@ -70,11 +70,7 @@ import {
 }
 
 {
-    const ctx = new AsyncLocalStorage<string>({
-        onPropagate(type, store) {
-            return store === 'test';
-        }
-    });
+    const ctx = new AsyncLocalStorage<string>();
     ctx.disable();
     const exitResult: number = ctx.exit((a: number) => {
         return 42;
@@ -84,4 +80,17 @@ import {
         return 42;
     }, 1);
     ctx.enterWith('test');
+}
+
+{
+    const fn = AsyncLocalStorage.bind(() => 123);
+    fn(); // $ExpectType number
+}
+
+{
+    const asyncLocalStorage = new AsyncLocalStorage<number>();
+    const runInAsyncScope = asyncLocalStorage.run(123, () => AsyncLocalStorage.snapshot());
+    const result = asyncLocalStorage.run(321, () => {  // $ExpectType number | undefined
+        return runInAsyncScope(() => asyncLocalStorage.getStore());
+    });
 }

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -474,3 +474,9 @@ buff.writeDoubleBE(123.123, 0);
 {
     buff.compare(buff); // $ExpectType 0 | 1 | -1
 }
+
+{
+    const u16 = new Uint16Array([0xffff]);
+    Buffer.copyBytesFrom(u16); // $ExpectType Buffer
+    Buffer.copyBytesFrom(u16, 1, 5); // $ExpectType Buffer
+}

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -30,6 +30,9 @@ declare const any: any;
 
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
+
+    const handler: Function = () => {};
+    result = emitter.listenerCount(event, handler);
 }
 
 {

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -299,6 +299,7 @@ access('file/that/does/not/exist', (err) => {
 {
     const controller: AbortController = util.transferableAbortController();
     const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
+    util.aborted(signal, {}).then(() => {});
 }
 
 {

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -17,6 +17,7 @@ import { EventLoopUtilization } from 'node:perf_hooks';
                     argv: ['asd'],
                     workerData: script,
                     transferList: [port1],
+                    name: 'my worker'
                 });
                 worker.on('message', resolve);
                 worker.on('error', reject);

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -768,12 +768,9 @@ declare module 'tls' {
          */
         crl?: string | Buffer | Array<string | Buffer> | undefined;
         /**
-         * Diffie Hellman parameters, required for Perfect Forward Secrecy. Use
-         * openssl dhparam to create the parameters. The key length must be
-         * greater than or equal to 1024 bits or else an error will be thrown.
-         * Although 1024 bits is permissible, use 2048 bits or larger for
-         * stronger security. If omitted or invalid, the parameters are
-         * silently discarded and DHE ciphers will not be available.
+         * `'auto'` or custom Diffie-Hellman parameters, required for non-ECDHE perfect forward secrecy.
+         * If omitted or invalid, the parameters are silently discarded and DHE ciphers will not be available.
+         * ECDHE-based perfect forward secrecy will still be available.
          */
         dhparam?: string | Buffer | undefined;
         /**

--- a/types/node/ts4.8/async_hooks.d.ts
+++ b/types/node/ts4.8/async_hooks.d.ts
@@ -319,16 +319,6 @@ declare module 'async_hooks' {
          */
         triggerAsyncId(): number;
     }
-    interface AsyncLocalStorageOptions<T> {
-        /**
-         * Optional callback invoked before a store is propagated to a new async resource.
-         * Returning `true` allows propagation, returning `false` avoids it. Default is to propagate always.
-         * @param type The type of async event.
-         * @param store The current store.
-         * @since v18.13.0
-         */
-        onPropagate?: ((type: string, store: T) => boolean) | undefined;
-    }
     /**
      * This class creates stores that stay coherent through asynchronous operations.
      *
@@ -378,8 +368,23 @@ declare module 'async_hooks' {
      * @since v13.10.0, v12.17.0
      */
     class AsyncLocalStorage<T> {
-        constructor(options?: AsyncLocalStorageOptions<T>);
-
+        /**
+         * Binds the given function to the current execution context.
+         * @since v18.16.0
+         * @param fn The function to bind to the current execution context.
+         * @returns A new function that calls `fn` within the captured execution context.
+         */
+        static bind<Func extends (...args: any[]) => any>(fn: Func): Func & {
+            asyncResource: AsyncResource;
+        };
+        /**
+         * Captures the current execution context and returns a function that accepts a function as an argument.
+         * Whenever the returned function is called, it calls the function passed to it within the captured context.
+         * @since v18.16.0
+         */
+        static snapshot(): (<R, TArgs extends any[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R) & {
+            asyncResource: AsyncResource;
+        };
         /**
          * Disables the instance of `AsyncLocalStorage`. All subsequent calls
          * to `asyncLocalStorage.getStore()` will return `undefined` until`asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()` is called again.

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -200,8 +200,7 @@ declare module 'buffer' {
     import { Blob as NodeBlob } from 'buffer';
     // This conditional type will be the existing global Blob in a browser, or
     // the copy below in a Node environment.
-    type __Blob = typeof globalThis extends { onmessage: any; Blob: any } ? {} : NodeBlob;
-
+    type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
         // Buffer class
         type BufferEncoding =
@@ -428,6 +427,14 @@ declare module 'buffer' {
              * @param totalLength Total length of the `Buffer` instances in `list` when concatenated.
              */
             concat(list: ReadonlyArray<Uint8Array>, totalLength?: number): Buffer;
+            /**
+             * Copies the underlying memory of `view` into a new `Buffer`.
+             * @since v18.16.0
+             * @param view The `TypedArray` to copy.
+             * @param offset The starting offset within `view`.
+             * @param length The number of elements from `view` to copy.
+             */
+            copyBytesFrom(view: NodeJS.TypedArray, offset?: number, length?: number): Buffer;
             /**
              * Compares `buf1` to `buf2`, typically for the purpose of sorting arrays of`Buffer` instances. This is equivalent to calling `buf1.compare(buf2)`.
              *

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -610,10 +610,14 @@ declare module 'events' {
                 emit(eventName: string | symbol, ...args: any[]): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
+                 *
+                 * If `listener` is provided, it will return how many times the listener
+                 * is found in the list of the listeners of the event.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
                  */
-                listenerCount(eventName: string | symbol): number;
+                listenerCount(eventName: string | symbol, listener?: Function): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has

--- a/types/node/ts4.8/test/async_hooks.ts
+++ b/types/node/ts4.8/test/async_hooks.ts
@@ -70,11 +70,7 @@ import {
 }
 
 {
-    const ctx = new AsyncLocalStorage<string>({
-        onPropagate(type, store) {
-            return store === 'test';
-        }
-    });
+    const ctx = new AsyncLocalStorage<string>();
     ctx.disable();
     const exitResult: number = ctx.exit((a: number) => {
         return 42;
@@ -84,4 +80,17 @@ import {
         return 42;
     }, 1);
     ctx.enterWith('test');
+}
+
+{
+    const fn = AsyncLocalStorage.bind(() => 123);
+    fn(); // $ExpectType number
+}
+
+{
+    const asyncLocalStorage = new AsyncLocalStorage<number>();
+    const runInAsyncScope = asyncLocalStorage.run(123, () => AsyncLocalStorage.snapshot());
+    const result = asyncLocalStorage.run(321, () => {  // $ExpectType number | undefined
+        return runInAsyncScope(() => asyncLocalStorage.getStore());
+    });
 }

--- a/types/node/ts4.8/test/buffer.ts
+++ b/types/node/ts4.8/test/buffer.ts
@@ -474,3 +474,9 @@ buff.writeDoubleBE(123.123, 0);
 {
     buff.compare(buff); // $ExpectType 0 | 1 | -1
 }
+
+{
+    const u16 = new Uint16Array([0xffff]);
+    Buffer.copyBytesFrom(u16); // $ExpectType Buffer
+    Buffer.copyBytesFrom(u16, 1, 5); // $ExpectType Buffer
+}

--- a/types/node/ts4.8/test/events.ts
+++ b/types/node/ts4.8/test/events.ts
@@ -30,6 +30,9 @@ declare const any: any;
 
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
+
+    const handler: Function = () => {};
+    result = emitter.listenerCount(event, handler);
 }
 
 {

--- a/types/node/ts4.8/test/util.ts
+++ b/types/node/ts4.8/test/util.ts
@@ -299,6 +299,7 @@ access('file/that/does/not/exist', (err) => {
 {
     const controller: AbortController = util.transferableAbortController();
     const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
+    util.aborted(signal, {}).then(() => {});
 }
 
 {

--- a/types/node/ts4.8/test/worker_threads.ts
+++ b/types/node/ts4.8/test/worker_threads.ts
@@ -17,6 +17,7 @@ import { EventLoopUtilization } from 'node:perf_hooks';
                     argv: ['asd'],
                     workerData: script,
                     transferList: [port1],
+                    name: 'my worker'
                 });
                 worker.on('message', resolve);
                 worker.on('error', reject);

--- a/types/node/ts4.8/tls.d.ts
+++ b/types/node/ts4.8/tls.d.ts
@@ -768,12 +768,9 @@ declare module 'tls' {
          */
         crl?: string | Buffer | Array<string | Buffer> | undefined;
         /**
-         * Diffie Hellman parameters, required for Perfect Forward Secrecy. Use
-         * openssl dhparam to create the parameters. The key length must be
-         * greater than or equal to 1024 bits or else an error will be thrown.
-         * Although 1024 bits is permissible, use 2048 bits or larger for
-         * stronger security. If omitted or invalid, the parameters are
-         * silently discarded and DHE ciphers will not be available.
+         * `'auto'` or custom Diffie-Hellman parameters, required for non-ECDHE perfect forward secrecy.
+         * If omitted or invalid, the parameters are silently discarded and DHE ciphers will not be available.
+         * ECDHE-based perfect forward secrecy will still be available.
          */
         dhparam?: string | Buffer | undefined;
         /**

--- a/types/node/ts4.8/url.d.ts
+++ b/types/node/ts4.8/url.d.ts
@@ -834,6 +834,11 @@ declare module 'url' {
          */
         set(name: string, value: string): void;
         /**
+         * The total number of parameter entries.
+         * @since v18.16.0
+         */
+        readonly size: number;
+        /**
          * Sort all existing name-value pairs in-place by their names. Sorting is done
          * with a [stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability), so relative order between name-value pairs
          * with the same name is preserved.

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -226,6 +226,12 @@ declare module 'util' {
      */
     export function transferableAbortSignal(signal: AbortSignal): AbortSignal;
     /**
+     * Listens to abort event on the provided `signal` and returns a promise that is fulfilled when the `signal` is aborted.
+     * If the passed `resource` is garbage collected before the `signal` is aborted, the returned promise shall remain pending indefinitely.
+     * @param resource  Any non-null entity, reference to which is held weakly.
+     */
+    export function aborted(signal: AbortSignal, resource: any): Promise<void>;
+    /**
      * The `util.inspect()` method returns a string representation of `object` that is
      * intended for debugging. The output of `util.inspect` may change at any time
      * and should not be depended upon programmatically. Additional `options` may be

--- a/types/node/ts4.8/worker_threads.d.ts
+++ b/types/node/ts4.8/worker_threads.d.ts
@@ -262,6 +262,12 @@ declare module 'worker_threads' {
          * @default true
          */
         trackUnmanagedFds?: boolean | undefined;
+        /**
+         * An optional `name` to be appended to the worker title
+         * for debuggin/identification purposes, making the final title as
+         * `[worker ${id}] ${name}`.
+         */
+        name?: string | undefined;
     }
     interface ResourceLimits {
         /**

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -834,6 +834,11 @@ declare module 'url' {
          */
         set(name: string, value: string): void;
         /**
+         * The total number of parameter entries.
+         * @since v18.16.0
+         */
+        readonly size: number;
+        /**
          * Sort all existing name-value pairs in-place by their names. Sorting is done
          * with a [stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability), so relative order between name-value pairs
          * with the same name is preserved.

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -226,6 +226,12 @@ declare module 'util' {
      */
     export function transferableAbortSignal(signal: AbortSignal): AbortSignal;
     /**
+     * Listens to abort event on the provided `signal` and returns a promise that is fulfilled when the `signal` is aborted.
+     * If the passed `resource` is garbage collected before the `signal` is aborted, the returned promise shall remain pending indefinitely.
+     * @param resource  Any non-null entity, reference to which is held weakly.
+     */
+    export function aborted(signal: AbortSignal, resource: any): Promise<void>;
+    /**
      * The `util.inspect()` method returns a string representation of `object` that is
      * intended for debugging. The output of `util.inspect` may change at any time
      * and should not be depended upon programmatically. Additional `options` may be

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -262,6 +262,12 @@ declare module 'worker_threads' {
          * @default true
          */
         trackUnmanagedFds?: boolean | undefined;
+        /**
+         * An optional `name` to be appended to the worker title
+         * for debuggin/identification purposes, making the final title as
+         * `[worker ${id}] ${name}`.
+         */
+        name?: string | undefined;
     }
     interface ResourceLimits {
         /**


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v18.16.0

- async_hooks: add AsyncLocalStorage.bind() and .snapshot()
- async_hooks: remove experimental onPropagate option
- buffer: add Buffer.copyBytesFrom(...)
- events: add listener argument to listenerCount
- tls: support automatic DHE
- util: add aborted() utility function
- url: implement URLSearchParams size getter
- worker: add support for worker name in inspector and trace_events

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
