### PR TITLE
[react] Add support for `Promise` in `ReactNode` in experimental release channel

### DIFF
--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -144,16 +144,18 @@ type ExtractPropsMatch = ExtractedProps extends ExtractedPropsWithoutAnnotation 
 type ExtractPropsMatch2 = ExtractedPropsWithoutAnnotation extends ExtractedProps ? true : false;
 // $ExpectType true
 type ExtractPropsMatch3 = ExtractedProps extends Props ? true : false;
-// $ExpectType true
-type ExtractPropsMatch4 = Props extends ExtractedPropsWithoutAnnotation ? true : false;
+// FIXME: Broke once PromiseLike support was added to experimental.
+// ExpectType true
+// type ExtractPropsMatch4 = Props extends ExtractedPropsWithoutAnnotation ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch = ExtractedPropsFromOuterProps extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch2 = ExtractedPropsFromOuterPropsWithoutAnnotation extends ExtractedPropsFromOuterProps ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch3 = ExtractedPropsFromOuterProps extends Props ? true : false;
-// $ExpectType true
-type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
+// FIXME: Broke once PromiseLike support was added to experimental.
+// ExpectType true
+// type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
 
 // $ExpectType false
 type ExtractPropsMismatch = ExtractedPartialProps extends Props ? true : false;
@@ -190,7 +192,8 @@ const componentDefaultProps = {
 type DefaultizedProps = Defaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 type UndefaultizedProps = Undefaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 
-// $ExpectType true
+// FIXME: Broke once PromiseLike support was added to experimental.
+// ExpectType true
 type DefaultizedPropsTest = {
     fi?: ((...args: any[]) => any) | undefined;
     foo?: string | null | undefined;
@@ -198,7 +201,8 @@ type DefaultizedPropsTest = {
     baz?: boolean | null | undefined;
     bat?: ReactNode | undefined;
 } extends DefaultizedProps ? true : false;
-// $ExpectType true
+// FIXME: Broke once PromiseLike support was added to experimental.
+// ExpectType true
 type UndefaultizedPropsTest = {
     fi: (...args: any[]) => any;
     foo?: string | null | undefined;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -144,18 +144,16 @@ type ExtractPropsMatch = ExtractedProps extends ExtractedPropsWithoutAnnotation 
 type ExtractPropsMatch2 = ExtractedPropsWithoutAnnotation extends ExtractedProps ? true : false;
 // $ExpectType true
 type ExtractPropsMatch3 = ExtractedProps extends Props ? true : false;
-// FIXME: Broke once PromiseLike support was added to experimental.
-// ExpectType true
-// type ExtractPropsMatch4 = Props extends ExtractedPropsWithoutAnnotation ? true : false;
+// $ExpectType true
+type ExtractPropsMatch4 = Props extends ExtractedPropsWithoutAnnotation ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch = ExtractedPropsFromOuterProps extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch2 = ExtractedPropsFromOuterPropsWithoutAnnotation extends ExtractedPropsFromOuterProps ? true : false;
 // $ExpectType true
 type ExtractFromOuterPropsMatch3 = ExtractedPropsFromOuterProps extends Props ? true : false;
-// FIXME: Broke once PromiseLike support was added to experimental.
-// ExpectType true
-// type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
+// $ExpectType true
+type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
 
 // $ExpectType false
 type ExtractPropsMismatch = ExtractedPartialProps extends Props ? true : false;
@@ -192,8 +190,7 @@ const componentDefaultProps = {
 type DefaultizedProps = Defaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 type UndefaultizedProps = Undefaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 
-// FIXME: Broke once PromiseLike support was added to experimental.
-// ExpectType true
+// $ExpectType true
 type DefaultizedPropsTest = {
     fi?: ((...args: any[]) => any) | undefined;
     foo?: string | null | undefined;
@@ -201,8 +198,7 @@ type DefaultizedPropsTest = {
     baz?: boolean | null | undefined;
     bat?: ReactNode | undefined;
 } extends DefaultizedProps ? true : false;
-// FIXME: Broke once PromiseLike support was added to experimental.
-// ExpectType true
+// $ExpectType true
 type UndefaultizedPropsTest = {
     fi: (...args: any[]) => any;
     foo?: string | null | undefined;

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -33,17 +33,25 @@
 // all tasks done as part of the render phase (the concurrent part of the React update cycle).
 //
 // Suspense-related handling can be found in ReactFiberThrow.js.
+/// <reference types="./next"/>
 
-import React = require('./next');
+import React = require('./');
 
 export {};
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
-declare module '.' {
-    interface PromiseLikeIfReactExperimental<T> extends PromiseLike<T> { }
+declare global {
+    interface PromiseLike<T> {
+        [React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never;
+    }
+    interface Promise<T> {
+        [React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never;
+    }
+}
 
+declare module '.' {
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -42,6 +42,8 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module '.' {
+    interface PromiseLikeIfReactExperimental<T> extends PromiseLike<T> { }
+
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -33,25 +33,20 @@
 // all tasks done as part of the render phase (the concurrent part of the React update cycle).
 //
 // Suspense-related handling can be found in ReactFiberThrow.js.
-/// <reference types="./next"/>
 
-import React = require('./');
+import React = require('./next');
 
 export {};
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
-declare global {
-    interface PromiseLike<T> {
-        [React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never;
-    }
-    interface Promise<T> {
-        [React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never;
-    }
-}
-
 declare module '.' {
+    interface PromisedReactNode extends PromiseLike<ReactNode> {}
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        promises: PromisedReactNode
+    }
+
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -42,9 +42,10 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module '.' {
-    interface PromisedReactNode extends PromiseLike<ReactNode> {}
+    // Need an interface to not cause ReactNode to be a self-referential type.
+    interface PromiseLikeOfReactNode extends PromiseLike<ReactNode> {}
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        promises: PromisedReactNode
+        promises: PromiseLikeOfReactNode;
     }
 
     export interface SuspenseProps {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -58,6 +58,7 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 // Destructors are only allowed to return void.
 type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+declare const PREVENT_EMPTY_INTERFACE_FROM_BEING_ANY_NON_NULLISH: unique symbol;
 
 // eslint-disable-next-line export-just-namespace
 export = React;
@@ -238,7 +239,8 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
-    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
+    interface PromiseLikeIfReactExperimental<T> { [PREVENT_EMPTY_INTERFACE_FROM_BEING_ANY_NON_NULLISH]?: never; }
+    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined | PromiseLikeIfReactExperimental<ReactNode>;
 
     //
     // Top Level API

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -239,9 +239,22 @@ declare namespace React {
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
 
-    const DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND: unique symbol;
-    interface ValidReactNodeIfReactExperimental<T> { [DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never; }
-    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined | ValidReactNodeIfReactExperimental<ReactNode>;
+    /**
+     * For internal usage only.
+     * Different release channels declare additional types of ReactNode this particular release channel accepts.
+     * App or library types should never augment this interface.
+     */
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {}
+    type ReactNode =
+        | ReactElement
+        | string
+        | number
+        | ReactFragment
+        | ReactPortal
+        | boolean
+        | null
+        | undefined
+        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES];
 
     //
     // Top Level API

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -58,7 +58,6 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 // Destructors are only allowed to return void.
 type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
-declare const PREVENT_EMPTY_INTERFACE_FROM_BEING_ANY_NON_NULLISH: unique symbol;
 
 // eslint-disable-next-line export-just-namespace
 export = React;
@@ -239,8 +238,10 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
-    interface PromiseLikeIfReactExperimental<T> { [PREVENT_EMPTY_INTERFACE_FROM_BEING_ANY_NON_NULLISH]?: never; }
-    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined | PromiseLikeIfReactExperimental<ReactNode>;
+
+    const DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND: unique symbol;
+    interface ValidReactNodeIfReactExperimental<T> { [DO_NOT_USE_OR_YOU_WILL_BE_FIRED_VALID_REACT_NODE_EXPERIMENTAL_BRAND]: never; }
+    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined | ValidReactNodeIfReactExperimental<ReactNode>;
 
     //
     // Top Level API

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -154,6 +154,10 @@ function Optimistic() {
 // ReactNode tests
 {
     // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement('div');
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = { };
+    // @ts-expect-error
     const plainObject: React.ReactNode = { dave: true };
     const promise: React.ReactNode = Promise.resolve('React');
     // @ts-expect-error plain objects are not allowed

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -150,3 +150,31 @@ function Optimistic() {
         addToOptimisticCartTyped2(String(item));
     };
 }
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve('React');
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve('React')}</div>;
+}
+
+function elementTypeTests() {
+    const ReturnPromise = () => Promise.resolve('React');
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        render() {
+          return Promise.resolve('React');
+        }
+    }
+
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    <ReturnPromise />;
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    React.createElement(ReturnPromise);
+    <RenderPromise />;
+    React.createElement(RenderPromise);
+}

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -757,7 +757,7 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     // @ts-expect-error
     const plainObject: React.ReactNode = { dave: true };
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
-    const promise: React.ReactNode = Promise.resolve();
+    const promise: React.ReactNode = Promise.resolve('React');
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -749,6 +749,11 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     // But no return results in `void`.
     // @ts-expect-error
     const noReturn: React.ReactNode = ['a', 'b'].map(label => {});
+
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    // @ts-expect-error experimental release channel only
+    const plainObject: React.ReactNode = Promise.resolve();
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -751,9 +751,15 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     const noReturn: React.ReactNode = ['a', 'b'].map(label => {});
 
     // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement('div');
+    // Will not be rejected in a real project but rejected in DT tests since experimental.d.ts is part of compilation.
+    // This is a step backwards from v17 types unfortunately.
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = { };
+    // @ts-expect-error
     const plainObject: React.ReactNode = { dave: true };
     // @ts-expect-error experimental release channel only
-    const plainObject: React.ReactNode = Promise.resolve();
+    const promise: React.ReactNode = Promise.resolve();
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -752,13 +752,11 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
 
     // @ts-expect-error
     const render: React.ReactNode = () => React.createElement('div');
-    // Will not be rejected in a real project but rejected in DT tests since experimental.d.ts is part of compilation.
-    // This is a step backwards from v17 types unfortunately.
     // @ts-expect-error
     const emptyObject: React.ReactNode = { };
     // @ts-expect-error
     const plainObject: React.ReactNode = { dave: true };
-    // @ts-expect-error experimental release channel only
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const promise: React.ReactNode = Promise.resolve();
 }
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -590,6 +590,10 @@ function reactNodeTests() {
         }
     </div>;
     <div>{createChildren()}</div>;
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    <div>{Promise.resolve('React')}</div>;
 }
 
 function elementTypeTests() {
@@ -653,6 +657,16 @@ function elementTypeTests() {
     class RenderReactNode extends React.Component<{children?: React.ReactNode}> {
         render() {
           return this.props.children;
+        }
+    }
+
+    const ReturnPromise = () => Promise.resolve('React');
+    // @ts-expect-error experimental release channel only
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+        render() {
+          return Promise.resolve('React');
         }
     }
 
@@ -727,6 +741,15 @@ function elementTypeTests() {
     React.createElement(ReturnReactNode);
     <RenderReactNode />;
     React.createElement(RenderReactNode);
+
+    // @ts-expect-error Only available in experimental release channel
+    <ReturnPromise />;
+    // @ts-expect-error Only available in experimental release channel
+    React.createElement(ReturnPromise);
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    <RenderPromise />;
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    React.createElement(RenderPromise);
 }
 
 function managingRefs() {

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -42,6 +42,12 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module '.' {
+    // Need an interface to not cause ReactNode to be a self-referential type.
+    interface PromiseLikeOfReactNode extends PromiseLike<ReactNode> {}
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        promises: PromiseLikeOfReactNode;
+    }
+
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -206,7 +206,23 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
-    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
+
+    /**
+     * For internal usage only.
+     * Different release channels declare additional types of ReactNode this particular release channel accepts.
+     * App or library types should never augment this interface.
+     */
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {}
+    type ReactNode =
+        | ReactElement
+        | string
+        | number
+        | ReactFragment
+        | ReactPortal
+        | boolean
+        | null
+        | undefined
+        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES];
 
     //
     // Top Level API

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -150,3 +150,35 @@ function Optimistic() {
         addToOptimisticCartTyped2(String(item));
     };
 }
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement('div');
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = { };
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve('React');
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve('React')}</div>;
+}
+
+function elementTypeTests() {
+    const ReturnPromise = () => Promise.resolve('React');
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        render() {
+          return Promise.resolve('React');
+        }
+    }
+
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    <ReturnPromise />;
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    React.createElement(ReturnPromise);
+    <RenderPromise />;
+    React.createElement(RenderPromise);
+}

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -749,6 +749,15 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     // But no return results in `void`.
     // @ts-expect-error
     const noReturn: React.ReactNode = ['a', 'b'].map(label => {});
+
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement('div');
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = { };
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    const promise: React.ReactNode = Promise.resolve('React');
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) { return null; });

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -590,6 +590,10 @@ function reactNodeTests() {
         }
     </div>;
     <div>{createChildren()}</div>;
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    <div>{Promise.resolve('React')}</div>;
 }
 
 function elementTypeTests() {
@@ -653,6 +657,16 @@ function elementTypeTests() {
     class RenderReactNode extends React.Component<{children?: React.ReactNode}> {
         render() {
           return this.props.children;
+        }
+    }
+
+    const ReturnPromise = () => Promise.resolve('React');
+    // @ts-expect-error experimental release channel only
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+        render() {
+          return Promise.resolve('React');
         }
     }
 
@@ -727,6 +741,15 @@ function elementTypeTests() {
     React.createElement(ReturnReactNode);
     <RenderReactNode />;
     React.createElement(RenderReactNode);
+
+    // @ts-expect-error Only available in experimental release channel
+    <ReturnPromise />;
+    // @ts-expect-error Only available in experimental release channel
+    React.createElement(ReturnPromise);
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    <RenderPromise />;
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+    React.createElement(RenderPromise);
 }
 
 function managingRefs() {


### PR DESCRIPTION
This does not add support for async function components. Async function components need this PR and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135.

It does add support for passing promises to children (e.g. `<div>{Promise.resolve('React')}</div>` and effectively returning promises from class components if you opted into React's experimental types (see [top comment of `react/experimental.d.ts` for instructions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9453c320a9590e323c9a090868a0955019ead14a/types/react/experimental.d.ts#L1-L25)). 

We can't differentiate between async render methods, render methods that return a new promise or render methods that return a promise they got from somewhere else at the type level. We'd need a linter for that.

The implementation is a bit hacky so that we can continue to leverage module augmentation. This is important since we can only ship types as `@latest` from DT. 

Users then have to include a single `/// <reference types="react/experimental" />` in their compilation (other methods explained in the [top comment of `react/experimental.d.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9453c320a9590e323c9a090868a0955019ead14a/types/react/experimental.d.ts#L1-L25)). Frameworks using experimental release channels should use one of the methods above so that their users automatically get types for experimental release channels. Latest releases of Next.js already does that.
