### PR TITLE
Include 'editor' in react-email-editor types

### DIFF
--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -200,6 +200,10 @@ export default class Component extends ReactComponent<EmailEditorProps> {
     registerCallback(type: 'image', callback: FileUploadCallback): void;
     registerCallback(type: 'displayCondition', callback: DisplayConditionCallback): void;
     addEventListener(type: string, callback: EventCallback): void;
+    editor: {
+        loadBlank(type: object): void;
+        loadDesign(design: Design): void;
+    };
     loadBlank(type: object): void;
     loadDesign(design: Design): void;
     saveDesign(callback: SaveDesignCallback): void;


### PR DESCRIPTION
Method `emailEditorRef.current.loadBlank` does not work unless it is declared as `emailEditorRef.current.editor.loadBlank`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

