### PR TITLE
[json-logic-js] make is_logic a type guard

### DIFF
--- a/types/json-logic-js/index.d.ts
+++ b/types/json-logic-js/index.d.ts
@@ -297,7 +297,7 @@ export function rm_operation(name: string): void;
 
 // These functions are undocumented, but are exported by the real package
 // so they're typed here for completeness.
-export function is_logic(logic: any): boolean;
+export function is_logic(logic: any): logic is RulesLogic;
 export function truthy(value: any): boolean;
 export function get_operator(logic: Record<string, any>): string;
 export function get_values(logic: Record<string, any>): any;

--- a/types/json-logic-js/json-logic-js-tests.ts
+++ b/types/json-logic-js/json-logic-js-tests.ts
@@ -254,6 +254,13 @@ jsonLogic.uses_data({ logic: ['test', 'test'] });
 // $ExpectType boolean
 jsonLogic.rule_like('test', 'test');
 
+const test: unknown = { logic: ['test', 'test'] };
+
+if (jsonLogic.is_logic(test)) {
+    // $ExpectType RulesLogic<never>
+    test;
+}
+
 // Test the extensibility of the RulesLogic type
 
 type StartsWithAndEndsWith =


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jwadhams/json-logic-js/blob/2.0.2/logic.js#L175-L182
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

