### PR TITLE
[react-is] Publish types for 18.x

### DIFF
--- a/types/react-is/v17/index.d.ts
+++ b/types/react-is/v17/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-is 18.2
+// Type definitions for react-is 17.0
 // Project: https://reactjs.org/
 // Definitions by: Avi Vahl <https://github.com/AviVahl>
 //                 Christian Chown <https://github.com/christianchown>

--- a/types/react-is/v17/test/react-is-tests.tsx
+++ b/types/react-is/v17/test/react-is-tests.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactIs from 'react-is';
+
+// Below is taken from README of react-is
+// Determining if a Component is Valid
+
+interface CompProps {
+    forwardedRef: React.Ref<any>;
+    children?: React.ReactNode | undefined;
+}
+
+class ClassComponent extends React.Component<CompProps> {
+  render() {
+    return React.createElement('div');
+  }
+}
+
+const FunctionComponent = () => React.createElement('div');
+
+const ForwardRefComponent = React.forwardRef((props, ref) =>
+  React.createElement(ClassComponent, { forwardedRef: ref, ...props })
+);
+
+const LazyComponent = React.lazy(() =>
+  Promise.resolve({ default: ForwardRefComponent })
+);
+
+const MemoComponent = React.memo(FunctionComponent);
+
+const Context = React.createContext(false);
+
+ReactIs.isValidElementType('div'); // true
+ReactIs.isValidElementType(ClassComponent); // true
+ReactIs.isValidElementType(FunctionComponent); // true
+ReactIs.isValidElementType(ForwardRefComponent); // true
+ReactIs.isValidElementType(Context.Provider); // true
+ReactIs.isValidElementType(Context.Consumer); // true
+ReactIs.isValidElementType(React.createFactory('div')); // true
+ReactIs.isValidElementType(LazyComponent);
+ReactIs.isValidElementType(MemoComponent);
+
+// Determining an Element's Type
+
+// AsyncMode - unstable_AsyncMode is not implemented in @types/react yet
+// ReactIs.isAsyncMode(<React.unstable_AsyncMode />); // true
+// ReactIs.typeOf(<React.unstable_AsyncMode />) === ReactIs.AsyncMode; // true
+
+// Context
+const ThemeContext = React.createContext('blue');
+
+ReactIs.isContextConsumer(<ThemeContext.Consumer children={FunctionComponent} />); // true
+ReactIs.isContextProvider(<ThemeContext.Provider children={<FunctionComponent />} value='black' />); // true
+ReactIs.typeOf(<ThemeContext.Consumer children={FunctionComponent} />) === ReactIs.ContextConsumer; // true
+ReactIs.typeOf(<ThemeContext.Provider children={<FunctionComponent />} value='black' />) === ReactIs.ContextProvider; // true
+
+// Element
+ReactIs.isElement(<div />); // true
+ReactIs.typeOf(<div />) === ReactIs.Element; // true
+
+// Fragment
+ReactIs.isFragment(<></>); // true
+ReactIs.typeOf(<></>) === ReactIs.Fragment; // true
+
+// Portal
+const div = document.createElement('div');
+const portal = ReactDOM.createPortal(<div />, div);
+
+ReactIs.isPortal(portal); // true
+ReactIs.typeOf(portal) === ReactIs.Portal; // true
+
+// StrictMode
+ReactIs.isStrictMode(<React.StrictMode />); // true
+ReactIs.typeOf(<React.StrictMode />) === ReactIs.StrictMode; // true
+
+// Verify typeOf accepts any type of value (taken from tests of react-is)
+ReactIs.typeOf('abc') === undefined;
+ReactIs.typeOf(true) === undefined;
+ReactIs.typeOf(123) === undefined;
+ReactIs.typeOf({}) === undefined;
+ReactIs.typeOf(null) === undefined;
+ReactIs.typeOf(undefined) === undefined;
+
+// ForwardRef
+ReactIs.isForwardRef(<ForwardRefComponent />); // true
+ReactIs.typeOf(<ForwardRefComponent />) === ReactIs.ForwardRef; // true
+
+// Lazy
+ReactIs.isLazy(LazyComponent); // true
+ReactIs.typeOf(LazyComponent) === ReactIs.Lazy; // true
+
+// Memo
+ReactIs.isMemo(MemoComponent); // true
+ReactIs.typeOf(MemoComponent) === ReactIs.Memo; // true
+
+// Suspense
+ReactIs.isForwardRef(<React.Suspense fallback={<FunctionComponent />} />); // true
+ReactIs.typeOf(<React.Suspense fallback={<FunctionComponent />} />) === ReactIs.Suspense; // true

--- a/types/react-is/v17/tsconfig.json
+++ b/types/react-is/v17/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "react": ["react/v17"],
+            "react-dom": ["react-dom/v17"],
+            "react-is": ["react-is/v17"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true,
+        "jsx": "preserve"
+    },
+    "files": [
+        "index.d.ts",
+        "test/react-is-tests.tsx"
+    ]
+}

--- a/types/react-is/v17/tslint.json
+++ b/types/react-is/v17/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Not changes in 18. Just looks weird that `@types/react-is@17` is latest. 