### PR TITLE
Disable tslint whitespace rule for FBT

### DIFF
--- a/types/fbt/fbt-tests.tsx
+++ b/types/fbt/fbt-tests.tsx
@@ -329,6 +329,7 @@ const JSXSimpleExampleWithParams = (
         Hello
     </fbt>
 );
+/* tslint:disable:whitespace */
 const JSXParamExample = (
     <fbt desc="JSX Param example">
         Hello, <fbt:param name="name">{person.getName()}</fbt:param>


### PR DESCRIPTION
Looks like tslint doesn't understand `foo:bar` names for JSX tags.

Edit: very likely the equivalent eslint rule does, so maybe switching to it would be a good idea to do soon.