### PR TITLE
use export default Mark to fix issues with compilation

### DIFF
--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -152,7 +152,7 @@ declare class Mark {
     unmark(options?: Mark.MarkOptions): void;
 }
 
-export = Mark;
+export default Mark;
 
 /* augment JQuery */
 declare global {


### PR DESCRIPTION
using export = Mark breaks compilation of this in my experience

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

I don't think this applies with anything, this is a completely broken type def