### PR TITLE
[react][experimental] Add support for async transition functions from `useTransition`

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -38,6 +38,9 @@ import React = require('./next');
 
 export {};
 
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
 declare module '.' {
     export interface SuspenseProps {
         /**
@@ -108,5 +111,16 @@ declare module '.' {
 
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
         functions: (formData: FormData) => void;
+    }
+
+    export interface TransitionStartFunction {
+        /**
+         * Marks all state updates inside the async function as transitions
+         *
+         * @see {https://react.dev/reference/react/useTransition#starttransition}
+         *
+         * @param callback
+         */
+        (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 }

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -72,6 +72,15 @@ function useEvent() {
     );
 }
 
+function useAsyncAction() {
+    const [isPending, startTransition] = React.useTransition();
+
+    function handleClick() {
+        // $ExpectType void
+        startTransition(async () => {});
+    }
+}
+
 function formActionsTest() {
     <form
         action={formData => {

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -340,7 +340,7 @@ function useConcurrentHooks() {
 
         // The function must be synchronous, even if it can start an asynchronous update
         // it's no different from an useEffect callback in this respect
-        // @ts-expect-error
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         startTransition(async () => {});
 
         // Unlike Effect callbacks, though, there is no possible destructor to return


### PR DESCRIPTION
Types for https://github.com/facebook/react/pull/26621

## for reviewers

CI failures are unrelated and already on master