### PR TITLE
[react][experimental] Add Client Functions as Form Actions

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -105,4 +105,8 @@ declare module '.' {
 
     // tslint:disable-next-line ban-types
     export function experimental_useEffectEvent<T extends Function>(event: T): T;
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
+        functions: (formData: FormData) => void;
+    }
 }

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -149,6 +149,7 @@ interface SVGTSpanElement extends SVGElement { }
 interface SVGUseElement extends SVGElement { }
 interface SVGViewElement extends SVGElement { }
 
+interface FormData {}
 interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1930,11 +1930,21 @@ declare namespace React {
         is?: string | undefined;
     }
 
+    /**
+     * For internal usage only.
+     * Different release channels declare additional types of ReactNode this particular release channel accepts.
+     * App or library types should never augment this interface.
+     */
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {}
+
     interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
         // Standard HTML Attributes
         accept?: string | undefined;
         acceptCharset?: string | undefined;
-        action?: string | undefined;
+        action?:
+            | string
+            | undefined
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS];
         allowFullScreen?: boolean | undefined;
         allowTransparency?: boolean | undefined;
         alt?: string | undefined;
@@ -1963,7 +1973,10 @@ declare namespace React {
         download?: any;
         encType?: string | undefined;
         form?: string | undefined;
-        formAction?: string | undefined;
+        formAction?:
+            | string
+            | undefined
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS];
         formEncType?: string | undefined;
         formMethod?: string | undefined;
         formNoValidate?: boolean | undefined;
@@ -2091,7 +2104,10 @@ declare namespace React {
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
         disabled?: boolean | undefined;
         form?: string | undefined;
-        formAction?: string | undefined;
+        formAction?:
+            | string
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS]
+            | undefined;
         formEncType?: string | undefined;
         formMethod?: string | undefined;
         formNoValidate?: boolean | undefined;
@@ -2150,7 +2166,10 @@ declare namespace React {
 
     interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
         acceptCharset?: string | undefined;
-        action?: string | undefined;
+        action?:
+            | string
+            | undefined
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS];
         autoComplete?: string | undefined;
         encType?: string | undefined;
         method?: string | undefined;
@@ -2240,7 +2259,10 @@ declare namespace React {
         disabled?: boolean | undefined;
         enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
         form?: string | undefined;
-        formAction?: string | undefined;
+        formAction?:
+            | string
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS]
+            | undefined;
         formEncType?: string | undefined;
         formMethod?: string | undefined;
         formNoValidate?: boolean | undefined;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -109,3 +109,33 @@ const eventCallbacksTestCases = [
     <output onClick={e => e.currentTarget.value} />,
     <time onClick={e => e.currentTarget.dateTime} />,
 ];
+
+function formActionsTest() {
+    <form
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+        action={formData => {
+            // $ExpectType FormData
+            formData;
+        }}
+    >
+        <input type="text" name="title" defaultValue="Hello" />
+        <input
+            type="submit"
+            // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+            value="Save"
+        />
+        <button
+            // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+        >
+            Delete
+        </button>
+    </form>;
+}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -71,3 +71,30 @@ function useEvent() {
         }),
     );
 }
+
+function formActionsTest() {
+    <form
+        action={formData => {
+            // $ExpectType FormData
+            formData;
+        }}
+    >
+        <input type="text" name="title" defaultValue="Hello" />
+        <input
+            type="submit"
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+            value="Save"
+        />
+        <button
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+        >
+            Delete
+        </button>
+    </form>;
+}


### PR DESCRIPTION
Add types for https://github.com/facebook/react/pull/26674

We can't use the usual method of augmenting the the attributes interface because we widen the types of `action` and `formAction` (not add a property) so we have to use the other trick of getting the valid types from another (internal) interface that we augment instead. 

/cc @sebmarkbage

## for reviewers

CI failures are unrelated and already on master