### PR TITLE
[newman] Add missing timings property to NewmanRun

### DIFF
--- a/types/newman/index.d.ts
+++ b/types/newman/index.d.ts
@@ -188,6 +188,7 @@ export interface NewmanRun {
         testScripts: NewmanRunStat;
         prerequestScripts: NewmanRunStat;
     };
+    timings: NewmanRunTimings;
     failures: NewmanRunFailure[];
     executions: NewmanRunExecution[];
 }
@@ -196,6 +197,37 @@ export interface NewmanRunStat {
     failed?: number | undefined;
     pending?: number | undefined;
 }
+
+/** Stores all generic timing information */
+export interface NewmanRunTimings {
+    /** The average response time of the run */
+    responseAverage: number;
+    /** The miminum response time of the run */
+    responseMin: number;
+    /** The maximum response time of the run */
+    responseMax: number;
+    /** Standard deviation of response time of the run */
+    responseSd: number;
+    /** The average DNS lookup time of the run */
+    dnsAverage: number;
+    /** The minimum DNS lookup time of the run */
+    dnsMin: number;
+    /** The maximum DNS lookup time of the run */
+    dnsMax: number;
+    /** Standard deviation of DNS lookup time of the run */
+    dnsSd: number;
+    /** The average first byte time of the run */
+    firstByteAverage: number;
+    /** The minimum first byte time of the run */
+    firstByteMin: number;
+    /** The maximum first byte time of the run */
+    firstByteMax: number;
+    /** Standard deviation of first byte time of the run */
+    firstByteSd: number;
+    started?: number;
+    completed?: number;
+}
+
 export interface NewmanRunExecution {
     item: NewmanRunExecutionItem;
     assertions: NewmanRunExecutionAssertion[];

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -9,6 +9,7 @@ import {
     NewmanRunExecutionItem,
     NewmanRunFailure,
     NewmanRunSummary,
+    NewmanRunTimings,
 } from 'newman';
 import { Collection, CollectionDefinition, VariableScope, VariableScopeDefinition } from 'postman-collection';
 import * as http from 'http';
@@ -39,6 +40,7 @@ run(
     },
     (err, summary: NewmanRunSummary) => {
         summary.run; // $ExpectType NewmanRun
+        summary.run.timings; // $ExpectType NewmanRunTimings
         summary.run.executions; // $ExpectType NewmanRunExecution[]
         summary.run.failures; // $ExpectType NewmanRunFailure[]
         summary.run.failures[0].source; // $ExpectType NewmanRunExecutionItem | undefined


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Required timings parameters initialized [here](https://github.com/postmanlabs/newman/blob/7382a2a4c238379fce4b4c893023e12abfa49771/lib/run/summary.js#L68-L152), optional timings parameters set [here](https://github.com/postmanlabs/newman/blob/7382a2a4c238379fce4b4c893023e12abfa49771/lib/run/summary.js#L270-L273).