### PR TITLE
[@types/vinyl-fs] Remove Unnecessary Dependencies

### DIFF
--- a/types/vinyl-fs/index.d.ts
+++ b/types/vinyl-fs/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 remisery <https://github.com/remisery>
 //                 TeamworkGuy2 <https://github.com/TeamworkGuy2>
+//                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/vinyl-fs/package.json
+++ b/types/vinyl-fs/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "dependencies": {
-      "@types/rimraf": "^2.0.3"
-  }
-}

--- a/types/vinyl-fs/v1/vinyl-fs-tests.ts
+++ b/types/vinyl-fs/v1/vinyl-fs-tests.ts
@@ -212,7 +212,8 @@ describe('source stream', () => {
 
 // const path = require('path');
 // const fs = require('graceful-fs');
-import rimraf = require('rimraf');
+// import rimraf = require('rimraf');
+const rimraf = (...args: any[]) => undefined as any;
 
 // const bufEqual = require('buffer-equal');
 // const through = require('through2');

--- a/types/vinyl-fs/vinyl-fs-tests.ts
+++ b/types/vinyl-fs/vinyl-fs-tests.ts
@@ -212,7 +212,8 @@ describe('source stream', () => {
 
 // const path = require('path');
 // const fs = require('graceful-fs');
-import rimraf = require('rimraf');
+// import rimraf = require('rimraf');
+const rimraf = (...args: any[]) => undefined as any;
 
 // const bufEqual = require('buffer-equal');
 // const through = require('through2');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change (no changes to type declarations were made).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: trust me bro
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Currently, `@types/vinyl-fs` has `@types/rimraf@2` listed as its dependency despite the fact that it is not used in the type declarations.

This causes any TypeScript project that has the most recent version of `glob` in its dependency tree to break.

Changes made in this PR remove the unnecessary `@types/rimraf` dependency from the `@types/vinyl-fs` package and thus fix this issue.

### Workaround
The current workaround is to add the following snippet to your `package.json` file:

```json
  "overrides": {
    "@types/vinyl-fs": {
      "@types/rimraf": "^4.0.5"
    }
  }
```