### PR TITLE
[@types/babel__traverse]: infer type predicates in find/findPath

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -439,3 +439,12 @@ const outerIdentifierPathTrue = newPath.getOuterBindingIdentifierPaths(true);
 outerIdentifierPathTrue; // $ExpectType Record<string, NodePath<Identifier>[]>
 const outerIdentifierPathBoolean = newPath.getOuterBindingIdentifierPaths(booleanVar);
 outerIdentifierPathBoolean; // $ExpectType Record<string, NodePath<Identifier> | NodePath<Identifier>[]>
+
+function isIdentifierPath(path: NodePath<t.Node>): path is NodePath<t.Identifier> {
+    return t.isIdentifier(path.node);
+}
+declare const childPath: NodePath<t.Node>;
+childPath.findParent(() => true); // $ExpectType NodePath<Node> | null
+childPath.findParent(isIdentifierPath); // $ExpectType NodePath<Identifier> | null
+childPath.find(() => true); // $ExpectType NodePath<Node> | null
+childPath.find(isIdentifierPath); // $ExpectType NodePath<Identifier> | null

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -294,6 +294,7 @@ export class NodePath<T = Node> {
      * to return a truthy value, or `null` if the `callback` never returns a
      * truthy value.
      */
+    findParent<T extends t.Node>(callback: (path: NodePath) => path is NodePath<T>): NodePath<T> | null;
     findParent(callback: (path: NodePath) => boolean): NodePath | null;
 
     /**
@@ -301,6 +302,7 @@ export class NodePath<T = Node> {
      * `NodePath` that causes the provided `callback` to return a truthy value,
      * or `null` if the `callback` never returns a truthy value.
      */
+    find<T extends t.Node>(callback: (path: NodePath) => path is NodePath<T>): NodePath<T> | null;
     find(callback: (path: NodePath) => boolean): NodePath | null;
 
     /** Get the parent function of the current path. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/microsoft/TypeScript/blob/8749fb5c0a4a0e3407eb099322c85b850cc642aa/src/lib/es2015.core.d.ts#L11-L12
  - https://github.com/search?q=%2Fpath%5C.findParent%5C%28.%2B%3F%5C%29+as%2F+lang%3Atypescript&ref=opensearch&type=code
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The NodePath find/findParent functions can now infer type predicates similar to `Array.prototype.find` (opt-in / backwards compatible).
This results in a more accurate return type and can remove the need of potentially unsafe type assertions or duplicate checks.