### PR TITLE
[@json2csv] Add types for `@json2csv` packages

### DIFF
--- a/types/json2csv__formatters/index.d.ts
+++ b/types/json2csv__formatters/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for @json2csv/formatters 6.1
+// Project: https://github.com/juanjoDiaz/json2csv
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export * from './src';
+export { default as default } from './src';

--- a/types/json2csv__formatters/json2csv__formatters-tests.ts
+++ b/types/json2csv__formatters/json2csv__formatters-tests.ts
@@ -1,0 +1,56 @@
+import * as formatters from '@json2csv/formatters';
+
+formatters.default(123); // $ExpectType string
+
+// @ts-expect-error Not a number being passed
+formatters.number()('foo');
+formatters.number()(123); // $ExpectType string
+formatters.number({})(123); // $ExpectType string
+// $ExpectType string
+formatters.number({
+    separator: ',',
+    decimals: 2,
+})(123);
+
+formatters.object()({ foo: 'bar' }); // $ExpectType string
+formatters.object()([1, 2, 3]); // $ExpectType string
+formatters.object({})({ foo: 'bar' }); // $ExpectType string
+// $ExpectType string
+formatters.object({
+    stringFormatter: value => value,
+})({ foo: 'bar' });
+
+// @ts-expect-error Not a string being passed
+formatters.string()(123);
+formatters.string()('foo'); // $ExpectType string
+formatters.string({})('foo'); // $ExpectType string
+// $ExpectType string
+formatters.string({
+    quote: '"',
+    escapedQuote: '\\"',
+})('foo');
+
+// @ts-expect-error Not a string being passed
+formatters.stringExcel(123);
+formatters.stringExcel('foo'); // $ExpectType string
+
+// @ts-expect-error Not a string being passed
+formatters.stringQuoteOnlyIfNecessary()(123);
+formatters.stringQuoteOnlyIfNecessary()('foo'); // $ExpectType string
+formatters.stringQuoteOnlyIfNecessary({})('foo'); // $ExpectType string
+// $ExpectType string
+formatters.stringQuoteOnlyIfNecessary({
+    quote: '"',
+    escapedQuote: '\\"',
+    separator: '|',
+    eol: '\r\n',
+})('foo');
+
+// @ts-expect-error Not a symbol being passed
+formatters.symbol()(123);
+formatters.symbol()(Symbol.iterator); // $ExpectType string
+formatters.symbol({})(Symbol.iterator); // $ExpectType string
+// $ExpectType string
+formatters.symbol({
+    stringFormatter: value => value,
+})(Symbol.iterator);

--- a/types/json2csv__formatters/src/default.d.ts
+++ b/types/json2csv__formatters/src/default.d.ts
@@ -1,0 +1,1 @@
+export default function defaultFormatter(value: any): string;

--- a/types/json2csv__formatters/src/index.d.ts
+++ b/types/json2csv__formatters/src/index.d.ts
@@ -1,0 +1,7 @@
+export { default as default } from './default';
+export { default as number } from './number';
+export { default as object } from './object';
+export { default as string } from './string';
+export { default as stringExcel } from './stringExcel';
+export { default as stringQuoteOnlyIfNecessary } from './stringQuoteOnlyIfNecessary';
+export { default as symbol } from './symbol';

--- a/types/json2csv__formatters/src/number.d.ts
+++ b/types/json2csv__formatters/src/number.d.ts
@@ -1,0 +1,8 @@
+export interface Options {
+    /** Separator to replace `.` */
+    separator?: string | undefined;
+    /** Amount of decimals to keep */
+    decimals?: number | undefined;
+}
+
+export default function numberFormatter(opts?: Options): (value: number) => string;

--- a/types/json2csv__formatters/src/object.d.ts
+++ b/types/json2csv__formatters/src/object.d.ts
@@ -1,0 +1,9 @@
+export interface Options {
+    /**
+     * The string formatter to use.
+     * Defaults to the builtin string formatter
+     */
+    stringFormatter?: ((value: any) => string) | undefined;
+}
+
+export default function objectFormatter(opts?: Options): (value: any) => string;

--- a/types/json2csv__formatters/src/string.d.ts
+++ b/types/json2csv__formatters/src/string.d.ts
@@ -1,0 +1,6 @@
+export interface Options {
+    quote?: string | undefined;
+    escapedQuote?: string | undefined;
+}
+
+export default function stringFormatter(opts?: Options): (value: string) => string;

--- a/types/json2csv__formatters/src/stringExcel.d.ts
+++ b/types/json2csv__formatters/src/stringExcel.d.ts
@@ -1,0 +1,1 @@
+export default function stringExcel(value: string): string;

--- a/types/json2csv__formatters/src/stringQuoteOnlyIfNecessary.d.ts
+++ b/types/json2csv__formatters/src/stringQuoteOnlyIfNecessary.d.ts
@@ -1,0 +1,8 @@
+export interface Options {
+    quote?: string | undefined;
+    escapedQuote?: string | undefined;
+    separator?: string | undefined;
+    eol?: string | undefined;
+}
+
+export default function stringQuoteOnlyIfNecessaryFormatter(opts?: Options): (value: string) => string;

--- a/types/json2csv__formatters/src/symbol.d.ts
+++ b/types/json2csv__formatters/src/symbol.d.ts
@@ -1,0 +1,5 @@
+export interface Options {
+    stringFormatter?: ((value: string) => string) | undefined;
+}
+
+export default function symbolFormatter(opts?: Options): (value: symbol) => string;

--- a/types/json2csv__formatters/tsconfig.json
+++ b/types/json2csv__formatters/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json2csv__formatters-tests.ts"]
+}

--- a/types/json2csv__formatters/tsconfig.json
+++ b/types/json2csv__formatters/tsconfig.json
@@ -9,6 +9,7 @@
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],
+        "paths": { "@json2csv/*": ["json2csv__*"] },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/json2csv__formatters/tslint.json
+++ b/types/json2csv__formatters/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/json2csv__node/index.d.ts
+++ b/types/json2csv__node/index.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for @json2csv/node 6.1
+// Project: http://juanjodiaz.github.io/json2csv
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export * from './src';

--- a/types/json2csv__node/json2csv__node-tests.ts
+++ b/types/json2csv__node/json2csv__node-tests.ts
@@ -1,0 +1,49 @@
+import { AsyncParser, AsyncOptions, StreamOptions, Transform, TransformOptions } from '@json2csv/node';
+import { flatten, unwind } from '@json2csv/transforms';
+import defaultFormatter from '@json2csv/formatters';
+
+const streamOptions: StreamOptions = {
+    fields: [
+        'foo',
+        () => 'foo',
+        { value: 'foo' },
+        {
+            label: 'Foo',
+            value: 'foo',
+            default: 'bar',
+        },
+    ],
+    transforms: [flatten(), unwind()],
+    formatters: { object: defaultFormatter },
+    defaultValue: 'bar',
+    delimiter: '\t',
+    eol: '\r\n',
+    header: true,
+    includeEmptyRows: true,
+    withBOM: true,
+    ndjson: true,
+};
+
+const transformOptions: TransformOptions = { allowHalfOpen: true };
+
+new AsyncParser();
+new AsyncParser({}, {});
+new AsyncParser(streamOptions, transformOptions);
+
+const parser = new AsyncParser();
+parser.parse('foo'); // $ExpectType JSON2CSVNodeTransform
+
+const asyncOptions: AsyncOptions = {
+    stringBufferSize: 123,
+    numberBufferSize: 123,
+    separator: '\t',
+    objectMode: true,
+};
+
+new Transform();
+new Transform({}, {}, {});
+new Transform(streamOptions, transformOptions, asyncOptions);
+
+const transform = new Transform();
+transform.promise(); // $ExpectType Promise<string>
+transform.endUnderlyingLayer();

--- a/types/json2csv__node/src/AsyncParser.d.ts
+++ b/types/json2csv__node/src/AsyncParser.d.ts
@@ -1,0 +1,13 @@
+import { Stream, TransformOptions } from 'node:stream';
+import JSON2CSVNodeTransform from './Transform';
+import { StreamOptions } from '@json2csv/plainjs';
+
+export { StreamOptions, TransformOptions };
+
+export default class JSON2CSVNodeAsyncParser {
+    constructor(opts?: StreamOptions, transformOpts?: TransformOptions);
+    parse(data: string | Stream | object): JSON2CSVNodeTransform;
+
+    opts?: StreamOptions | undefined;
+    transformOpts?: TransformOptions | undefined;
+}

--- a/types/json2csv__node/src/Transform.d.ts
+++ b/types/json2csv__node/src/Transform.d.ts
@@ -1,0 +1,37 @@
+/// <reference types="node" />
+import { Transform, TransformOptions } from 'node:stream';
+import { StreamParser, StreamOptions, AsyncOptions } from '@json2csv/plainjs';
+
+declare class _Transform extends Transform implements StreamParser {
+    getHeader: StreamParser['getHeader'];
+    preprocessOpts: StreamParser['preprocessOpts'];
+    preprocessFieldsInfo: StreamParser['preprocessFieldsInfo'];
+    preprocessRow: StreamParser['preprocessRow'];
+    processRow: StreamParser['processRow'];
+    processCell: StreamParser['processCell'];
+    processValue: StreamParser['processValue'];
+    configureCallbacks: StreamParser['configureCallbacks'];
+    initTokenizer: StreamParser['initTokenizer'];
+    getObjectModeTokenzier: StreamParser['getObjectModeTokenzier'];
+    getNdJsonTokenizer: StreamParser['getNdJsonTokenizer'];
+    getBinaryModeTokenizer: StreamParser['getBinaryModeTokenizer'];
+    pushHeaderIfNotWritten: StreamParser['pushHeaderIfNotWritten'];
+    pushHeader: StreamParser['pushHeader'];
+    pushLine: StreamParser['pushLine'];
+    onHeader: StreamParser['onHeader'];
+    onLine: StreamParser['onLine'];
+    onData: StreamParser['onData'];
+    onError: StreamParser['onError'];
+    onEnd: StreamParser['onEnd'];
+}
+
+export default class JSON2CSVNodeTransform extends _Transform {
+    constructor(opts?: StreamOptions, transformOpts?: TransformOptions, asyncOptions?: AsyncOptions);
+
+    promise(): Promise<string>;
+    endUnderlyingLayer(): void;
+
+    opts: Required<StreamOptions>;
+}
+
+export {};

--- a/types/json2csv__node/src/Transform.d.ts
+++ b/types/json2csv__node/src/Transform.d.ts
@@ -2,7 +2,13 @@
 import { Transform, TransformOptions } from 'node:stream';
 import { StreamParser, StreamOptions, AsyncOptions } from '@json2csv/plainjs';
 
+/**
+ * @todo Update this body to match StreamParser whenever it changes.
+ * Doing this is the closest I think we can get with TypeScript to mimicking
+ * {@link <https://github.com/juanjoDiaz/json2csv/blob/2d827e99d849e3afbbfcde4fa25f9789aab25c83/packages/node/src/Transform.js#L9>}
+ */
 declare class _Transform extends Transform implements StreamParser {
+    opts: StreamParser['opts'];
     getHeader: StreamParser['getHeader'];
     preprocessOpts: StreamParser['preprocessOpts'];
     preprocessFieldsInfo: StreamParser['preprocessFieldsInfo'];

--- a/types/json2csv__node/src/index.d.ts
+++ b/types/json2csv__node/src/index.d.ts
@@ -1,0 +1,3 @@
+export { AsyncOptions } from '@json2csv/plainjs';
+export { default as AsyncParser, StreamOptions, TransformOptions } from './AsyncParser';
+export { default as Transform } from './Transform';

--- a/types/json2csv__node/tsconfig.json
+++ b/types/json2csv__node/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "lib": ["dom", "es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "paths": { "@json2csv/*": ["json2csv__*"] },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json2csv__node-tests.ts"]
+}

--- a/types/json2csv__node/tslint.json
+++ b/types/json2csv__node/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/json2csv__plainjs/index.d.ts
+++ b/types/json2csv__plainjs/index.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for @json2csv/plainjs 6.1
+// Project: https://github.com/juanjoDiaz/json2csv
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export * from './src';

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -86,5 +86,5 @@ streamParser.write('foo');
 streamParser.end();
 
 utils.getProp({}, 'foo', 'bar'); // $ExpectType any
-utils.flattenReducer([1, 2, 3], [4, 5, 6]); // $ExpectType number
+utils.flattenReducer([1, 2, 3], [4, 5, 6]); // $ExpectType number[]
 utils.fastJoin(['foo', 'bar'], ','); // $ExpectType string

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -1,6 +1,5 @@
-import { Parser, StreamParser, Field } from '@json2csv/plainjs';
-import BaseParser, { Options as ParserOptions } from '@json2csv/plainjs/src/BaseParser';
-import { Options as StreamParserOptions, AsyncOptions } from '@json2csv/plainjs/src/StreamParser';
+import { Parser, StreamParser, Field, ParserOptions, StreamOptions, AsyncOptions } from '@json2csv/plainjs';
+import BaseParser from '@json2csv/plainjs/src/BaseParser';
 import { default as defaultFormatter } from '@json2csv/formatters';
 import { flatten, unwind } from '@json2csv/transforms';
 
@@ -51,7 +50,7 @@ function baseTests(parser: BaseParser) {
 baseTests(parser);
 parser.parse('foo'); // $ExpectType string
 
-const streamOptions: StreamParserOptions = { ...options, ndjson: true };
+const streamOptions: StreamOptions = { ...options, ndjson: true };
 const asyncOptions: AsyncOptions = {
     stringBufferSize: 123,
     numberBufferSize: 123,

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -1,0 +1,86 @@
+import { Parser, StreamParser, Field } from '@json2csv/plainjs';
+import BaseParser, { Options as ParserOptions } from '@json2csv/plainjs/src/BaseParser';
+import { Options as StreamParserOptions, AsyncOptions } from '@json2csv/plainjs/src/StreamParser';
+import { default as defaultFormatter } from '@json2csv/formatters';
+import { flatten, unwind } from '@json2csv/transforms';
+
+import Tokenizer from '@streamparser/json/tokenizer';
+
+const options: ParserOptions = {
+    fields: [
+        'foo',
+        () => 'foo',
+        { value: 'foo' },
+        {
+            label: 'Foo',
+            value: 'foo',
+            default: 'bar',
+        },
+    ],
+    transforms: [flatten(), unwind()],
+    formatters: { object: defaultFormatter },
+    defaultValue: 'bar',
+    delimiter: '\t',
+    eol: '\r\n',
+    header: true,
+    includeEmptyRows: true,
+    withBOM: true,
+};
+
+new Parser();
+new Parser({});
+new Parser(options);
+
+const parser = new Parser();
+
+function baseTests(parser: BaseParser) {
+    parser.getHeader(); // $ExpectType string
+    // @ts-expect-error `globalDefaultValue` missing
+    parser.preprocessFieldsInfo([]);
+    parser.preprocessFieldsInfo([] as Field[], 'foo'); // $ExpectType FieldObject[]
+    parser.preprocessOpts(); // $ExpectType Required<Options>
+    parser.preprocessOpts({}); // $ExpectType Required<Options>
+    parser.preprocessOpts(options); // $ExpectType Required<Options>
+    parser.preprocessRow([]); // $ExpectType any[]
+    parser.processCell([], { value: 'foo' }); // $ExpectType string
+    parser.processRow(); // $ExpectType string | undefined
+    parser.processRow([]); // $ExpectType string | undefined
+    parser.processValue(123); // $ExpectType string
+}
+
+baseTests(parser);
+parser.parse('foo'); // $ExpectType string
+
+const streamOptions: StreamParserOptions = { ...options, ndjson: true };
+const asyncOptions: AsyncOptions = {
+    stringBufferSize: 123,
+    numberBufferSize: 123,
+    separator: '\t',
+    objectMode: true,
+};
+
+new StreamParser();
+new StreamParser({}, {});
+new StreamParser(streamOptions, asyncOptions);
+const streamParser = new StreamParser();
+
+baseTests(streamParser);
+streamParser.initTokenizer();
+streamParser.initTokenizer({}, {});
+streamParser.initTokenizer(streamOptions, asyncOptions);
+streamParser.configureCallbacks(new Tokenizer(), new Tokenizer());
+streamParser.getBinaryModeTokenizer(); // $ExpectType Tokenizer
+streamParser.getBinaryModeTokenizer(asyncOptions); // $ExpectType Tokenizer
+streamParser.getNdJsonTokenizer(); // $ExpectType Tokenizer
+streamParser.getNdJsonTokenizer(asyncOptions); // $ExpectType Tokenizer
+streamParser.getObjectModeTokenzier();
+streamParser.onData('foo');
+streamParser.onEnd();
+streamParser.onError();
+streamParser.onHeader('foo');
+streamParser.onLine([]);
+streamParser.pushHeader();
+streamParser.pushHeaderIfNotWritten();
+streamParser.pushLine('foo');
+streamParser.write('foo');
+streamParser.end();

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -4,7 +4,7 @@ import * as utils from '@json2csv/plainjs/src/utils';
 import { default as defaultFormatter } from '@json2csv/formatters';
 import { flatten, unwind } from '@json2csv/transforms';
 
-import { Tokenizer, TokenParser } from '@streamparser/json';
+import { Tokenizer, TokenParser } from '@streamparser/json/index';
 
 const options: ParserOptions = {
     fields: [
@@ -34,7 +34,7 @@ new Parser(options);
 const parser = new Parser();
 
 function baseTests(parser: BaseParser) {
-    parser.opts; // $ExpectType ParserOptions
+    parser.opts; // $ExpectType Required<Options>
     parser.getHeader(); // $ExpectType string
     // @ts-expect-error `globalDefaultValue` missing
     parser.preprocessFieldsInfo([]);
@@ -65,7 +65,7 @@ new StreamParser({}, {});
 new StreamParser(streamOptions, asyncOptions);
 const streamParser = new StreamParser();
 
-streamParser.tokenizer; // $ExpectType TBD
+streamParser.tokenizer; // $ExpectType Tokenizer | { write(data: any): void; end(): void; } | undefined
 streamParser.tokenParser; // $ExpectType TokenParser | undefined
 
 baseTests(streamParser);

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -1,5 +1,6 @@
 import { Parser, StreamParser, Field, ParserOptions, StreamOptions, AsyncOptions } from '@json2csv/plainjs';
 import BaseParser from '@json2csv/plainjs/src/BaseParser';
+import * as utils from '@json2csv/plainjs/src/utils';
 import { default as defaultFormatter } from '@json2csv/formatters';
 import { flatten, unwind } from '@json2csv/transforms';
 
@@ -83,3 +84,7 @@ streamParser.pushHeaderIfNotWritten();
 streamParser.pushLine('foo');
 streamParser.write('foo');
 streamParser.end();
+
+utils.getProp({}, 'foo', 'bar'); // $ExpectType any
+utils.flattenReducer([1, 2, 3], [4, 5, 6]); // $ExpectType number
+utils.fastJoin(['foo', 'bar'], ','); // $ExpectType string

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -85,6 +85,18 @@ streamParser.pushLine('foo');
 streamParser.write('foo');
 streamParser.end();
 
+streamParser.onData = data => {
+    data; // $ExpectType any
+};
+streamParser.onEnd = () => {};
+streamParser.onError = () => {};
+streamParser.onHeader = header => {
+    header; // $ExpectType string
+};
+streamParser.onLine = line => {
+    line; // $ExpectType any[]
+};
+
 utils.getProp({}, 'foo', 'bar'); // $ExpectType any
 utils.flattenReducer([1, 2, 3], [4, 5, 6]); // $ExpectType number[]
 utils.fastJoin(['foo', 'bar'], ','); // $ExpectType string

--- a/types/json2csv__plainjs/json2csv__plainjs-tests.ts
+++ b/types/json2csv__plainjs/json2csv__plainjs-tests.ts
@@ -4,7 +4,7 @@ import * as utils from '@json2csv/plainjs/src/utils';
 import { default as defaultFormatter } from '@json2csv/formatters';
 import { flatten, unwind } from '@json2csv/transforms';
 
-import Tokenizer from '@streamparser/json/tokenizer';
+import { Tokenizer, TokenParser } from '@streamparser/json';
 
 const options: ParserOptions = {
     fields: [
@@ -34,6 +34,7 @@ new Parser(options);
 const parser = new Parser();
 
 function baseTests(parser: BaseParser) {
+    parser.opts; // $ExpectType ParserOptions
     parser.getHeader(); // $ExpectType string
     // @ts-expect-error `globalDefaultValue` missing
     parser.preprocessFieldsInfo([]);
@@ -64,11 +65,14 @@ new StreamParser({}, {});
 new StreamParser(streamOptions, asyncOptions);
 const streamParser = new StreamParser();
 
+streamParser.tokenizer; // $ExpectType TBD
+streamParser.tokenParser; // $ExpectType TokenParser | undefined
+
 baseTests(streamParser);
 streamParser.initTokenizer();
 streamParser.initTokenizer({}, {});
 streamParser.initTokenizer(streamOptions, asyncOptions);
-streamParser.configureCallbacks(new Tokenizer(), new Tokenizer());
+streamParser.configureCallbacks(new Tokenizer(), new TokenParser());
 streamParser.getBinaryModeTokenizer(); // $ExpectType Tokenizer
 streamParser.getBinaryModeTokenizer(asyncOptions); // $ExpectType Tokenizer
 streamParser.getNdJsonTokenizer(); // $ExpectType Tokenizer

--- a/types/json2csv__plainjs/package.json
+++ b/types/json2csv__plainjs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@streamparser/json": "^0.0.12"
+    }
+}

--- a/types/json2csv__plainjs/src/BaseParser.d.ts
+++ b/types/json2csv__plainjs/src/BaseParser.d.ts
@@ -15,6 +15,8 @@ export interface Options {
 export default class JSON2CSVBase {
     constructor(opts?: Options);
 
+    opts: Required<Options>;
+
     getHeader(): string;
 
     preprocessOpts(opts?: Options): Required<Options>;

--- a/types/json2csv__plainjs/src/BaseParser.d.ts
+++ b/types/json2csv__plainjs/src/BaseParser.d.ts
@@ -1,0 +1,27 @@
+import { Field, FieldObject, Formatters } from '.';
+
+export interface Options {
+    fields?: Field[] | undefined;
+    transforms?: Array<(dataRow: any) => any> | undefined;
+    formatters?: Formatters | undefined;
+    defaultValue?: string | undefined;
+    delimiter?: string | undefined;
+    eol?: string | undefined;
+    header?: boolean | undefined;
+    includeEmptyRows?: boolean | undefined;
+    withBOM?: boolean | undefined;
+}
+
+export default class JSON2CSVBase {
+    constructor(opts?: Options);
+
+    getHeader(): string;
+
+    preprocessOpts(opts?: Options): Required<Options>;
+    preprocessFieldsInfo(fields: Field[], globalDefaultValue: string): FieldObject[];
+    preprocessRow(row: any[]): any[];
+
+    processRow(row?: any[]): string | undefined;
+    processCell(row: any[], fieldInfo: FieldObject): string;
+    processValue(value: any): string;
+}

--- a/types/json2csv__plainjs/src/Parser.d.ts
+++ b/types/json2csv__plainjs/src/Parser.d.ts
@@ -1,0 +1,7 @@
+import JSON2CSVBase from './BaseParser';
+
+export default class JSON2CSVParser extends JSON2CSVBase {
+    parse(data: any): string;
+    preprocessData(data: any): any[];
+    processData(data: any[]): string;
+}

--- a/types/json2csv__plainjs/src/StreamParser.d.ts
+++ b/types/json2csv__plainjs/src/StreamParser.d.ts
@@ -1,0 +1,38 @@
+import Tokenizer, { TokenizerOptions } from '@streamparser/json/tokenizer';
+import JSON2CSVBase, { Options as BaseOptions } from './BaseParser';
+
+export interface Options extends BaseOptions {
+    ndjson?: boolean | undefined;
+}
+
+export interface AsyncOptions extends TokenizerOptions {
+    objectMode?: boolean | undefined;
+}
+
+export default class JSON2CSVStreamParser extends JSON2CSVBase {
+    constructor(opts?: BaseOptions, asyncOpts?: AsyncOptions);
+
+    configureCallbacks(tokenizer: Tokenizer, tokenParser: Tokenizer): void;
+
+    initTokenizer(opts?: BaseOptions, asyncOpts?: AsyncOptions): void;
+
+    getObjectModeTokenzier(): {
+        write(data: any): void;
+        end(): void;
+    };
+    getNdJsonTokenizer(asyncOpts?: AsyncOptions): Tokenizer;
+    getBinaryModeTokenizer(asyncOpts?: AsyncOptions): Tokenizer;
+
+    write(data: any): void;
+    end(): void;
+
+    pushHeaderIfNotWritten(): void;
+    pushHeader(): void;
+    pushLine(data: any): void;
+
+    onHeader(header: string): void;
+    onLine(line: any[]): void;
+    onData(data: any): void;
+    onError(): void;
+    onEnd(): void;
+}

--- a/types/json2csv__plainjs/src/StreamParser.d.ts
+++ b/types/json2csv__plainjs/src/StreamParser.d.ts
@@ -1,4 +1,4 @@
-import { Tokenizer, TokenizerOptions, TokenParser } from '@streamparser/json';
+import { Tokenizer, TokenizerOptions, TokenParser } from '@streamparser/json/index';
 import JSON2CSVBase, { Options as BaseOptions } from './BaseParser';
 
 export interface Options extends BaseOptions {

--- a/types/json2csv__plainjs/src/StreamParser.d.ts
+++ b/types/json2csv__plainjs/src/StreamParser.d.ts
@@ -1,4 +1,4 @@
-import Tokenizer, { TokenizerOptions } from '@streamparser/json/tokenizer';
+import { Tokenizer, TokenizerOptions, TokenParser } from '@streamparser/json';
 import JSON2CSVBase, { Options as BaseOptions } from './BaseParser';
 
 export interface Options extends BaseOptions {
@@ -12,7 +12,11 @@ export interface AsyncOptions extends TokenizerOptions {
 export default class JSON2CSVStreamParser extends JSON2CSVBase {
     constructor(opts?: BaseOptions, asyncOpts?: AsyncOptions);
 
-    configureCallbacks(tokenizer: Tokenizer, tokenParser: Tokenizer): void;
+    tokenizer?: Tokenizer | ReturnType<this['getObjectModeTokenzier']> | undefined;
+    tokenParser?: TokenParser | undefined;
+    protected _hasWritten?: boolean | undefined;
+
+    configureCallbacks(tokenizer: Tokenizer, tokenParser: TokenParser): void;
 
     initTokenizer(opts?: BaseOptions, asyncOpts?: AsyncOptions): void;
 

--- a/types/json2csv__plainjs/src/index.d.ts
+++ b/types/json2csv__plainjs/src/index.d.ts
@@ -1,0 +1,25 @@
+export interface Formatters {
+    header?: ((value: string) => string) | undefined;
+    undefined?: ((value: undefined) => string) | undefined;
+    boolean?: ((value: boolean) => boolean) | undefined;
+    number?: ((value: number) => number) | undefined;
+    bigint?: ((value: number) => number) | undefined;
+    string?: ((value: string) => string) | undefined;
+    symbol?: ((value: symbol) => string) | undefined;
+    function?: (value: (...args: any[]) => any) => string | undefined;
+    object?: ((value: any) => string) | undefined;
+}
+
+export interface FieldObject {
+    /** The label. Defaults to the value path if not provided */
+    label?: string | undefined;
+    /** The target path */
+    value: string | ((row: any[]) => string);
+    /** Default if value is not found */
+    default?: string | undefined;
+}
+
+export type Field = string | ((row: any[]) => string) | FieldObject;
+
+export { default as Parser } from './Parser';
+export { default as StreamParser } from './StreamParser';

--- a/types/json2csv__plainjs/src/index.d.ts
+++ b/types/json2csv__plainjs/src/index.d.ts
@@ -21,5 +21,6 @@ export interface FieldObject {
 
 export type Field = string | ((row: any[]) => string) | FieldObject;
 
+export { Options as ParserOptions } from './BaseParser';
 export { default as Parser } from './Parser';
-export { default as StreamParser } from './StreamParser';
+export { default as StreamParser, Options as StreamOptions, AsyncOptions } from './StreamParser';

--- a/types/json2csv__plainjs/src/utils.d.ts
+++ b/types/json2csv__plainjs/src/utils.d.ts
@@ -1,0 +1,3 @@
+export function getProp(obj: any, path: string, defaultValue: any): any;
+export function flattenReducer<T>(acc: T[], arr: T[]): T[];
+export function fastJoin(arr: any[], separator: string): string;

--- a/types/json2csv__plainjs/tsconfig.json
+++ b/types/json2csv__plainjs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "lib": ["dom", "es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "paths": { "@json2csv/*": ["json2csv__*"] },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json2csv__plainjs-tests.ts"]
+}

--- a/types/json2csv__plainjs/tsconfig.json
+++ b/types/json2csv__plainjs/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
-        "lib": ["dom", "es6"],
+        "lib": ["dom", "es6", "ES2016.Array.Include"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/json2csv__plainjs/tslint.json
+++ b/types/json2csv__plainjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/json2csv__transforms/index.d.ts
+++ b/types/json2csv__transforms/index.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for @json2csv/transforms 6.1
+// Project: https://github.com/juanjoDiaz/json2csv
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export * from './src';

--- a/types/json2csv__transforms/json2csv__transforms-tests.ts
+++ b/types/json2csv__transforms/json2csv__transforms-tests.ts
@@ -1,0 +1,28 @@
+import { flatten, unwind } from 'json2csv__transforms';
+import * as utils from 'json2csv__transforms/src/utils';
+
+flatten()({ foo: 'bar' }); // $ExpectType any
+flatten({})({ foo: 'bar' }); // $ExpectType any
+// $ExpectType any
+flatten({
+    objects: true,
+    arrays: true,
+    separator: '-',
+})({ foo: 'bar' });
+
+unwind()({ foo: 'bar' }); // $ExpectType any
+unwind({})({ foo: 'bar' }); // $ExpectType any
+// $ExpectType any
+unwind({
+    paths: 'foo',
+    blankOut: true,
+})({ foo: 'bar' });
+// $ExpectType any
+unwind({
+    paths: ['foo'],
+    blankOut: true,
+})({ foo: 'bar' });
+
+utils.setProp({}, 'foo', 'bar'); // $ExpectType any
+utils.unsetProp({ foo: 'bar' }, 'foo'); // $ExpectType any
+utils.flattenReducer([1], [2]); // $ExpectType number[]

--- a/types/json2csv__transforms/src/flatten.d.ts
+++ b/types/json2csv__transforms/src/flatten.d.ts
@@ -1,0 +1,22 @@
+export interface Options {
+    /**
+     * Whether to flatten objects
+     * @default true
+     */
+    objects?: boolean | undefined;
+    /**
+     * Whether to flatten arrays
+     * @default false
+     */
+    arrays?: boolean | undefined;
+    /**
+     * The separator to use
+     * @default '.'
+     */
+    separator?: string | undefined;
+}
+
+/**
+ * Flattens a data row recursively
+ */
+export default function flatten(opts?: Options): (dataRow: any) => any;

--- a/types/json2csv__transforms/src/index.d.ts
+++ b/types/json2csv__transforms/src/index.d.ts
@@ -1,0 +1,2 @@
+export { default as flatten } from './flatten';
+export { default as unwind } from './unwind';

--- a/types/json2csv__transforms/src/unwind.d.ts
+++ b/types/json2csv__transforms/src/unwind.d.ts
@@ -1,0 +1,13 @@
+export interface Options {
+    /**
+     * Paths used to deconstruct the array
+     */
+    paths?: string | string[] | undefined;
+    blankOut?: boolean | undefined;
+}
+
+/**
+ * Performs an unwind recursively in the specified sequence
+ * @param opts
+ */
+export default function unwind(opts?: Options): (dataRow: any) => any;

--- a/types/json2csv__transforms/src/utils.d.ts
+++ b/types/json2csv__transforms/src/utils.d.ts
@@ -1,0 +1,3 @@
+export function setProp(obj: any, path: string | string[], value: any): any;
+export function unsetProp(obj: any, path: string | string[]): any;
+export function flattenReducer<T>(acc: T[], arr: T[]): T[];

--- a/types/json2csv__transforms/tsconfig.json
+++ b/types/json2csv__transforms/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json2csv__transforms-tests.ts"]
+}

--- a/types/json2csv__transforms/tsconfig.json
+++ b/types/json2csv__transforms/tsconfig.json
@@ -9,6 +9,7 @@
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],
+        "paths": { "@json2csv/*": ["json2csv__*"] },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/json2csv__transforms/tslint.json
+++ b/types/json2csv__transforms/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/json2csv__whatwg/index.d.ts
+++ b/types/json2csv__whatwg/index.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for @json2csv/whatwg 6.1
+// Project: http://juanjodiaz.github.io/json2csv
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export * from './src';

--- a/types/json2csv__whatwg/json2csv__whatwg-tests.ts
+++ b/types/json2csv__whatwg/json2csv__whatwg-tests.ts
@@ -38,6 +38,12 @@ new AsyncParser(streamOptions, asyncOptions, { highWaterMark: 123 }, { highWater
 declare const readableStream: ReadableStream;
 
 const parser = new AsyncParser();
+
+parser.opts; // $ExpectType Options | undefined
+parser.asyncOpts; // $ExpectType AsyncOptions
+parser.readableStrategy; // $ExpectType QueuingStrategy<any> | undefined
+parser.writableStrategy; // $ExpectType QueuingStrategy<any> | undefined
+
 parser.parse('foo');
 parser.parse(readableStream);
 parser.parse([]);

--- a/types/json2csv__whatwg/json2csv__whatwg-tests.ts
+++ b/types/json2csv__whatwg/json2csv__whatwg-tests.ts
@@ -1,0 +1,48 @@
+import { AsyncParser, AsyncOptions, TransformStream, StreamOptions } from '@json2csv/whatwg';
+import { flatten, unwind } from '@json2csv/transforms';
+import defaultFormatter from '@json2csv/formatters';
+
+const streamOptions: StreamOptions = {
+    fields: [
+        'foo',
+        () => 'foo',
+        { value: 'foo' },
+        {
+            label: 'Foo',
+            value: 'foo',
+            default: 'bar',
+        },
+    ],
+    transforms: [flatten(), unwind()],
+    formatters: { object: defaultFormatter },
+    defaultValue: 'bar',
+    delimiter: '\t',
+    eol: '\r\n',
+    header: true,
+    includeEmptyRows: true,
+    withBOM: true,
+    ndjson: true,
+};
+
+const asyncOptions: AsyncOptions = {
+    stringBufferSize: 123,
+    numberBufferSize: 123,
+    separator: '\t',
+    objectMode: true,
+};
+
+new AsyncParser();
+new AsyncParser({}, {}, {}, {});
+new AsyncParser(streamOptions, asyncOptions, { highWaterMark: 123 }, { highWaterMark: 456 });
+
+declare const readableStream: ReadableStream;
+
+const parser = new AsyncParser();
+parser.parse('foo');
+parser.parse(readableStream);
+parser.parse([]);
+parser.parse({});
+
+new TransformStream();
+new TransformStream({});
+new TransformStream(streamOptions, asyncOptions, { highWaterMark: 123 }, { highWaterMark: 456 });

--- a/types/json2csv__whatwg/src/AsyncParser.d.ts
+++ b/types/json2csv__whatwg/src/AsyncParser.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="node" />
+import { AsyncOptions, StreamOptions } from '@json2csv/plainjs';
+import JSON2CSVWHATWGTransformStream from './TransformStream';
+import { Stream } from 'node:stream';
+
+export { AsyncOptions, StreamOptions };
+
+export default class JSON2CSVNodeAsyncParser<I = any, O = any> {
+    constructor(
+        opts?: StreamOptions,
+        asyncOpts?: AsyncOptions,
+        writableStrategy?: QueuingStrategy<I>,
+        readableStrategy?: QueuingStrategy<O>,
+    );
+
+    parse(data: string | Stream | object): ReadableStream<JSON2CSVWHATWGTransformStream>;
+}

--- a/types/json2csv__whatwg/src/AsyncParser.d.ts
+++ b/types/json2csv__whatwg/src/AsyncParser.d.ts
@@ -13,5 +13,11 @@ export default class JSON2CSVNodeAsyncParser<I = any, O = any> {
         readableStrategy?: QueuingStrategy<O>,
     );
 
+    opts?: StreamOptions | undefined;
+    // asyncOpts isn't optional since it's set to `{}` when nothing is passed
+    asyncOpts: AsyncOptions;
+    writableStrategy?: QueuingStrategy<I> | undefined;
+    readableStrategy?: QueuingStrategy<O> | undefined;
+
     parse(data: string | Stream | object): ReadableStream<JSON2CSVWHATWGTransformStream>;
 }

--- a/types/json2csv__whatwg/src/TransformStream.d.ts
+++ b/types/json2csv__whatwg/src/TransformStream.d.ts
@@ -1,0 +1,10 @@
+import { AsyncOptions, StreamOptions } from '@json2csv/plainjs';
+
+export default class JSON2CSVWHATWGTransformStream<I = any, O = any> extends TransformStream {
+    constructor(
+        opts?: StreamOptions,
+        asyncOpts?: AsyncOptions,
+        writableStrategy?: QueuingStrategy<I>,
+        readableStrategy?: QueuingStrategy<O>,
+    );
+}

--- a/types/json2csv__whatwg/src/index.d.ts
+++ b/types/json2csv__whatwg/src/index.d.ts
@@ -1,0 +1,2 @@
+export { default as AsyncParser, AsyncOptions, StreamOptions } from './AsyncParser';
+export { default as TransformStream } from './TransformStream';

--- a/types/json2csv__whatwg/tsconfig.json
+++ b/types/json2csv__whatwg/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "lib": ["dom", "es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "paths": { "@json2csv/*": ["json2csv__*"] },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json2csv__whatwg-tests.ts"]
+}

--- a/types/json2csv__whatwg/tslint.json
+++ b/types/json2csv__whatwg/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #65214

Adds types for the new `@json2csv` packages:
- `@json2csv/plainjs`
- `@json2csv/node`
- `@json2csv/whatwg`
- `@json2csv/formatters`
- `@json2csv/transforms`

The source for these packages can be found in this repository: <https://github.com/juanjoDiaz/json2csv/tree/main/packages/>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
