### PR TITLE
[react-simple-oauth2-login] Change `children` type to `ReactNode`

### DIFF
--- a/types/react-simple-oauth2-login/index.d.ts
+++ b/types/react-simple-oauth2-login/index.d.ts
@@ -14,14 +14,14 @@ export interface OAuth2LoginProps {
     onSuccess: (data: Record<string, any>) => void;
     onFailure: (err: Error) => void;
     buttonText?: string;
-    children?: React.ReactChildren;
+    children?: React.ReactNode;
     popupWidth?: number;
     popupHeight?: number;
     className?: string;
     render?: (props: {
         className: string,
         buttonText: string,
-        children: React.ReactChildren,
+        children: React.ReactNode,
         onClick: () => void
     }) => void;
     isCrossOrigin?: boolean;

--- a/types/react-simple-oauth2-login/react-simple-oauth2-login-tests.tsx
+++ b/types/react-simple-oauth2-login/react-simple-oauth2-login-tests.tsx
@@ -18,3 +18,20 @@ export function Test() {
         />
     );
 }
+
+export function TestChildren() {
+    return (
+        <OAuth2Login
+            clientId="1234567890"
+            authorizationUrl="https://example.com/oauth/authorize"
+            redirectUri="https://example.com/oauth/callback"
+            responseType="code"
+            onSuccess={() => {}}
+            onFailure={() => {}}
+        >
+            <div className="child-test"></div>
+            <div className="child-test"></div>
+            <div className="child-test"></div>
+        </OAuth2Login>
+    );
+}


### PR DESCRIPTION
Related discussion: #65251

Fixes the type of the `children` prop.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  `PropTypes` define `children` as `node`: <https://github.com/bhubr/react-simple-oauth2-login/blob/f3c989c6a21c85759d566e6f2eabb8164aecdde1/src/OAuth2Login.jsx#L144>
  &nbsp;
  Also, children are passed along to the children of another element without modification, which should support `ReactNode`:
  <https://github.com/bhubr/react-simple-oauth2-login/blob/f3c989c6a21c85759d566e6f2eabb8164aecdde1/src/OAuth2Login.jsx#L116>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
