### PR TITLE
[@types/node] Add promiseHooks type definitions to node:v8

### DIFF
--- a/types/node/test/v8.ts
+++ b/types/node/test/v8.ts
@@ -22,3 +22,15 @@ v8.stopCoverage();
         console.log(profiler.stop());
     }, 1000);
 }
+
+const disable = v8.promiseHooks.createHook({
+    init: (promise, parent) => {},
+    before: promise => {},
+    after: promise => {},
+    settled: promise => {},
+});
+
+const stopInit = v8.promiseHooks.onInit((promise, parent) => {});
+const stopBefore = v8.promiseHooks.onBefore(promise => {});
+const stopAfter = v8.promiseHooks.onAfter(promise => {});
+const stopSettled = v8.promiseHooks.onSettled(promise => {});

--- a/types/node/ts4.8/test/v8.ts
+++ b/types/node/ts4.8/test/v8.ts
@@ -22,3 +22,15 @@ v8.stopCoverage();
         console.log(profiler.stop());
     }, 1000);
 }
+
+const disable = v8.promiseHooks.createHook({
+    init: (promise, parent) => {},
+    before: promise => {},
+    after: promise => {},
+    settled: promise => {},
+});
+
+const stopInit = v8.promiseHooks.onInit((promise, parent) => {});
+const stopBefore = v8.promiseHooks.onBefore(promise => {});
+const stopAfter = v8.promiseHooks.onAfter(promise => {});
+const stopSettled = v8.promiseHooks.onSettled(promise => {});

--- a/types/node/ts4.8/v8.d.ts
+++ b/types/node/ts4.8/v8.d.ts
@@ -441,6 +441,100 @@ declare module 'v8' {
         spaceAvailableSize: number;
         physicalSpaceSize: number;
     }
+    /**
+     * Called when a promise is constructed. This does not mean that corresponding before/after events will occur, only that the possibility exists. This will
+     * happen if a promise is created without ever getting a continuation.
+     * @since v17.1.0, v16.14.0
+     * @param promise The promise being created.
+     * @param parent The promise continued from, if applicable.
+     */
+    interface Init {
+        (promise: Promise<unknown>, parent: Promise<unknown>): void;
+    }
+    /**
+     * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
+     *
+     * The before callback will be called 0 to N times. The before callback will typically be called 0 times if no continuation was ever made for the promise.
+     * The before callback may be called many times in the case where many continuations have been made from the same promise.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Before {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
+     * @since v17.1.0, v16.14.0
+     */
+    interface After {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
+     * {@link Promise.reject()}.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Settled {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
+     * around an await, and when the promise resolves or rejects.
+     *
+     * Because promises are asynchronous resources whose lifecycle is tracked via the promise hooks mechanism, the `init()`, `before()`, `after()`, and
+     * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
+     * @since v17.1.0, v16.14.0
+     */
+    interface HookCallbacks {
+        init?: Init;
+        before?: Before;
+        after?: After;
+        settled?: Settled;
+    }
+    interface PromiseHooks {
+        /**
+         * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param init The {@link Init | `init` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onInit: (init: Init) => Function;
+        /**
+         * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onSettled: (settled: Settled) => Function;
+        /**
+         * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onBefore: (before: Before) => Function;
+        /**
+         * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onAfter: (after: After) => Function;
+        /**
+         * Registers functions to be called for different lifetime events of each promise.
+         * The callbacks `init()`/`before()`/`after()`/`settled()` are called for the respective events during a promise's lifetime.
+         * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
+         * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param callbacks The {@link HookCallbacks | Hook Callbacks} to register
+         * @return Used for disabling hooks
+         */
+        createHook: (callbacks: HookCallbacks) => Function;
+    }
+    /**
+     * The `promiseHooks` interface can be used to track promise lifecycle events.
+     * @since v17.1.0, v16.14.0
+     */
+    const promiseHooks: PromiseHooks;
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/test/v8.ts
+++ b/types/node/v16/test/v8.ts
@@ -14,3 +14,15 @@ const fileName = v8.writeHeapSnapshot('file');
 
 v8.takeCoverage();
 v8.stopCoverage();
+
+const disable = v8.promiseHooks.createHook({
+    init: (promise, parent) => {},
+    before: promise => {},
+    after: promise => {},
+    settled: promise => {},
+});
+
+const stopInit = v8.promiseHooks.onInit((promise, parent) => {});
+const stopBefore = v8.promiseHooks.onBefore(promise => {});
+const stopAfter = v8.promiseHooks.onAfter(promise => {});
+const stopSettled = v8.promiseHooks.onSettled(promise => {});

--- a/types/node/v16/ts4.8/test/v8.ts
+++ b/types/node/v16/ts4.8/test/v8.ts
@@ -14,3 +14,15 @@ const fileName = v8.writeHeapSnapshot('file');
 
 v8.takeCoverage();
 v8.stopCoverage();
+
+const disable = v8.promiseHooks.createHook({
+    init: (promise, parent) => {},
+    before: promise => {},
+    after: promise => {},
+    settled: promise => {},
+});
+
+const stopInit = v8.promiseHooks.onInit((promise, parent) => {});
+const stopBefore = v8.promiseHooks.onBefore(promise => {});
+const stopAfter = v8.promiseHooks.onAfter(promise => {});
+const stopSettled = v8.promiseHooks.onSettled(promise => {});

--- a/types/node/v16/ts4.8/v8.d.ts
+++ b/types/node/v16/ts4.8/v8.d.ts
@@ -372,6 +372,13 @@ declare module 'v8' {
      * @since v15.1.0, v12.22.0
      */
     function stopCoverage(): void;
+    /**
+     * Called when a promise is constructed. This does not mean that corresponding before/after events will occur, only that the possibility exists. This will
+     * happen if a promise is created without ever getting a continuation.
+     * @since v17.1.0, v16.14.0
+     * @param promise The promise being created.
+     * @param parent The promise continued from, if applicable.
+     */
     interface Init {
         (promise: Promise<unknown>, parent: Promise<unknown>): void;
     }

--- a/types/node/v16/ts4.8/v8.d.ts
+++ b/types/node/v16/ts4.8/v8.d.ts
@@ -372,6 +372,93 @@ declare module 'v8' {
      * @since v15.1.0, v12.22.0
      */
     function stopCoverage(): void;
+    interface Init {
+        (promise: Promise<unknown>, parent: Promise<unknown>): void;
+    }
+    /**
+     * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
+     *
+     * The before callback will be called 0 to N times. The before callback will typically be called 0 times if no continuation was ever made for the promise.
+     * The before callback may be called many times in the case where many continuations have been made from the same promise.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Before {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
+     * @since v17.1.0, v16.14.0
+     */
+    interface After {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
+     * {@link Promise.reject()}.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Settled {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
+     * around an await, and when the promise resolves or rejects.
+     *
+     * Because promises are asynchronous resources whose lifecycle is tracked via the promise hooks mechanism, the `init()`, `before()`, `after()`, and
+     * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
+     * @since v17.1.0, v16.14.0
+     */
+    interface HooksCallbacks {
+        init?: Init;
+        before?: Before;
+        after?: After;
+        settled?: Settled;
+    }
+    interface PromiseHooks {
+        /**
+         * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param init The {@link Init | `init` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onInit: (init: Init) => Function;
+        /**
+         * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onSettled: (settled: Settled) => Function;
+        /**
+         * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onBefore: (before: Before) => Function;
+        /**
+         * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onAfter: (after: After) => Function;
+        /**
+         * Registers functions to be called for different lifetime events of each promise.
+         * The callbacks `init()`/`before()`/`after()`/`settled()` are called for the respective events during a promise's lifetime.
+         * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
+         * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+         * @return Used for disabling hooks
+         */
+        createHook: (callbacks: HooksCallbacks) => Function;
+    }
+    /**
+     * The `promiseHooks` interface can be used to track promise lifecycle events.
+     * @since v17.1.0, v16.14.0
+     */
+    const promiseHooks: PromiseHooks;
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/ts4.8/v8.d.ts
+++ b/types/node/v16/ts4.8/v8.d.ts
@@ -408,7 +408,7 @@ declare module 'v8' {
      * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
      * @since v17.1.0, v16.14.0
      */
-    interface HooksCallbacks {
+    interface HookCallbacks {
         init?: Init;
         before?: Before;
         after?: After;
@@ -449,10 +449,10 @@ declare module 'v8' {
          * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
          * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
-         * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+         * @param callbacks The {@link HookCallbacks | Hook Callbacks} to register
          * @return Used for disabling hooks
          */
-        createHook: (callbacks: HooksCallbacks) => Function;
+        createHook: (callbacks: HookCallbacks) => Function;
     }
     /**
      * The `promiseHooks` interface can be used to track promise lifecycle events.

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -372,6 +372,95 @@ declare module 'v8' {
      * @since v15.1.0, v12.22.0
      */
     function stopCoverage(): void;
+    /**
+     * Called when a promise is constructed. This does not mean that corresponding before/after events will occur, only that the possibility exists. This will
+     * happen if a promise is created without ever getting a continuation.
+     * @since v17.1.0, v16.14.0
+     * @param promise The promise being created.
+     * @param parent The promise continued from, if applicable.
+     */
+    interface Init {
+      <TPromise, TParent>(promise: Promise<TPromise>, parent: Promise<TParent>): void
+    }
+    /**
+     * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
+     *
+     * The before callback will be called 0 to N times. The before callback will typically be called 0 times if no continuation was ever made for the promise.
+     * The before callback may be called many times in the case where many continuations have been made from the same promise.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Before {
+      <T>(promise: Promise<T>): void
+    }
+    /**
+     * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
+     * @since v17.1.0, v16.14.0
+     */
+    interface After {
+      <T>(promise: Promise<T>): void
+    }
+    /**
+     * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
+     * {@link Promise.reject()}.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Settled {
+      <T>(promise: Promise<T>): void
+    }
+    /**
+     * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
+     * around an await, and when the promise resolves or rejects.
+     *
+     * Because promises are asynchronous resources whose lifecycle is tracked via the promise hooks mechanism, the `init()`, `before()`, `after()`, and
+     * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Callbacks {
+      init: Init
+      before: Before
+      after: After
+      settled: Settled
+    }
+    interface PromiseHooks {
+      /**
+       * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+       * @since v17.1.0, v16.14.0
+       * @param init The {@link Init | `init` callback}  callback to call when a promise is created.
+       */
+      onInit: (init: Init) => Function
+      /**
+       * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+       * @since v17.1.0, v16.14.0
+       * @param settled The {@link Settled | `settled` callback} callback to call when a promise is created.
+       */
+      onSettled: (settled: Settled) => Function
+      /**
+       * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+       * @since v17.1.0, v16.14.0
+       * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+       */
+      onBefore: (before: Before) => Function
+      /**
+       * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+       * @since v17.1.0, v16.14.0
+       * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+       */
+      onAfter: (after: After) => Function
+      /**
+       * Registers functions to be called for different lifetime events of each promise.
+       * The callbacks init()/before()/after()/settled() are called for the respective events during a promise's lifetime.
+       * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
+       * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
+       * @since v17.1.0, v16.14.0
+       * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+       */
+      createHook: (callbacks: Callbacks) => Function
+    }
+    /**
+     * The `promiseHooks` interface can be used to track promise lifecycle events.
+     * @since v17.1.0, v16.14.0
+     */
+    export const promiseHooks: PromiseHooks    export const promiseHooks: PromiseHooks
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -452,7 +452,7 @@ declare module 'v8' {
         onAfter: (after: After) => Function;
         /**
          * Registers functions to be called for different lifetime events of each promise.
-         * The callbacks init()/before()/after()/settled() are called for the respective events during a promise's lifetime.
+         * The callbacks `init()`/`before()`/`after()`/`settled()` are called for the respective events during a promise's lifetime.
          * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
          * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -380,7 +380,7 @@ declare module 'v8' {
      * @param parent The promise continued from, if applicable.
      */
     interface Init {
-        <TPromise, TParent>(promise: Promise<TPromise>, parent: Promise<TParent>): void;
+        (promise: Promise<unknown>, parent: Promise<unknown>): void;
     }
     /**
      * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
@@ -390,14 +390,14 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Before {
-        <T>(promise: Promise<T>): void;
+        (promise: Promise<unknown>): void;
     }
     /**
      * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
      * @since v17.1.0, v16.14.0
      */
     interface After {
-        <T>(promise: Promise<T>): void;
+        (promise: Promise<unknown>): void;
     }
     /**
      * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
@@ -405,7 +405,7 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Settled {
-        <T>(promise: Promise<T>): void;
+        (promise: Promise<unknown>): void;
     }
     /**
      * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
@@ -460,7 +460,7 @@ declare module 'v8' {
      * The `promiseHooks` interface can be used to track promise lifecycle events.
      * @since v17.1.0, v16.14.0
      */
-    export const promiseHooks: PromiseHooks;
+    const promiseHooks: PromiseHooks;
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -380,7 +380,7 @@ declare module 'v8' {
      * @param parent The promise continued from, if applicable.
      */
     interface Init {
-      <TPromise, TParent>(promise: Promise<TPromise>, parent: Promise<TParent>): void
+        <TPromise, TParent>(promise: Promise<TPromise>, parent: Promise<TParent>): void;
     }
     /**
      * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
@@ -390,14 +390,14 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Before {
-      <T>(promise: Promise<T>): void
+        <T>(promise: Promise<T>): void;
     }
     /**
      * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
      * @since v17.1.0, v16.14.0
      */
     interface After {
-      <T>(promise: Promise<T>): void
+        <T>(promise: Promise<T>): void;
     }
     /**
      * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
@@ -405,7 +405,7 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Settled {
-      <T>(promise: Promise<T>): void
+        <T>(promise: Promise<T>): void;
     }
     /**
      * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
@@ -416,51 +416,51 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Callbacks {
-      init: Init
-      before: Before
-      after: After
-      settled: Settled
+        init: Init;
+        before: Before;
+        after: After;
+        settled: Settled;
     }
     interface PromiseHooks {
-      /**
-       * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
-       * @since v17.1.0, v16.14.0
-       * @param init The {@link Init | `init` callback} to call when a promise is created.
-       */
-      onInit: (init: Init) => Function
-      /**
-       * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
-       * @since v17.1.0, v16.14.0
-       * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
-       */
-      onSettled: (settled: Settled) => Function
-      /**
-       * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
-       * @since v17.1.0, v16.14.0
-       * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
-       */
-      onBefore: (before: Before) => Function
-      /**
-       * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
-       * @since v17.1.0, v16.14.0
-       * @param after The {@link After | `after` callback} to call after a promise continuation executes.
-       */
-      onAfter: (after: After) => Function
-      /**
-       * Registers functions to be called for different lifetime events of each promise.
-       * The callbacks init()/before()/after()/settled() are called for the respective events during a promise's lifetime.
-       * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
-       * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
-       * @since v17.1.0, v16.14.0
-       * @param callbacks The {@link Callbacks | Hook Callbacks} to register
-       */
-      createHook: (callbacks: Callbacks) => Function
+        /**
+         * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param init The {@link Init | `init` callback} to call when a promise is created.
+         */
+        onInit: (init: Init) => Function;
+        /**
+         * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
+         */
+        onSettled: (settled: Settled) => Function;
+        /**
+         * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+         */
+        onBefore: (before: Before) => Function;
+        /**
+         * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+         */
+        onAfter: (after: After) => Function;
+        /**
+         * Registers functions to be called for different lifetime events of each promise.
+         * The callbacks init()/before()/after()/settled() are called for the respective events during a promise's lifetime.
+         * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
+         * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+         */
+        createHook: (callbacks: Callbacks) => Function;
     }
     /**
      * The `promiseHooks` interface can be used to track promise lifecycle events.
      * @since v17.1.0, v16.14.0
      */
-    export const promiseHooks: PromiseHooks
+    export const promiseHooks: PromiseHooks;
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -415,7 +415,7 @@ declare module 'v8' {
      * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
      * @since v17.1.0, v16.14.0
      */
-    interface Callbacks {
+    interface HookCallbacks {
         init?: Init;
         before?: Before;
         after?: After;
@@ -456,10 +456,10 @@ declare module 'v8' {
          * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
          * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
-         * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+         * @param callbacks The {@link HookCallbacks | Hook Callbacks} to register
          * @return Used for disabling hooks
          */
-        createHook: (callbacks: Callbacks) => Function;
+        createHook: (callbacks: HookCallbacks) => Function;
     }
     /**
      * The `promiseHooks` interface can be used to track promise lifecycle events.

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -460,7 +460,7 @@ declare module 'v8' {
      * The `promiseHooks` interface can be used to track promise lifecycle events.
      * @since v17.1.0, v16.14.0
      */
-    export const promiseHooks: PromiseHooks    export const promiseHooks: PromiseHooks
+    export const promiseHooks: PromiseHooks
 }
 declare module 'node:v8' {
     export * from 'v8';

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -425,13 +425,13 @@ declare module 'v8' {
       /**
        * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
        * @since v17.1.0, v16.14.0
-       * @param init The {@link Init | `init` callback}  callback to call when a promise is created.
+       * @param init The {@link Init | `init` callback} to call when a promise is created.
        */
       onInit: (init: Init) => Function
       /**
        * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
        * @since v17.1.0, v16.14.0
-       * @param settled The {@link Settled | `settled` callback} callback to call when a promise is created.
+       * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
        */
       onSettled: (settled: Settled) => Function
       /**

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -416,34 +416,38 @@ declare module 'v8' {
      * @since v17.1.0, v16.14.0
      */
     interface Callbacks {
-        init: Init;
-        before: Before;
-        after: After;
-        settled: Settled;
+        init?: Init;
+        before?: Before;
+        after?: After;
+        settled?: Settled;
     }
     interface PromiseHooks {
         /**
          * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
          * @param init The {@link Init | `init` callback} to call when a promise is created.
+         * @return Call to stop the hook.
          */
         onInit: (init: Init) => Function;
         /**
          * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
          * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
+         * @return Call to stop the hook.
          */
         onSettled: (settled: Settled) => Function;
         /**
          * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
          * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+         * @return Call to stop the hook.
          */
         onBefore: (before: Before) => Function;
         /**
          * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
          * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+         * @return Call to stop the hook.
          */
         onAfter: (after: After) => Function;
         /**
@@ -453,6 +457,7 @@ declare module 'v8' {
          * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
          * @since v17.1.0, v16.14.0
          * @param callbacks The {@link Callbacks | Hook Callbacks} to register
+         * @return Used for disabling hooks
          */
         createHook: (callbacks: Callbacks) => Function;
     }

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -441,6 +441,100 @@ declare module 'v8' {
         spaceAvailableSize: number;
         physicalSpaceSize: number;
     }
+    /**
+     * Called when a promise is constructed. This does not mean that corresponding before/after events will occur, only that the possibility exists. This will
+     * happen if a promise is created without ever getting a continuation.
+     * @since v17.1.0, v16.14.0
+     * @param promise The promise being created.
+     * @param parent The promise continued from, if applicable.
+     */
+    interface Init {
+        (promise: Promise<unknown>, parent: Promise<unknown>): void;
+    }
+    /**
+     * Called before a promise continuation executes. This can be in the form of `then()`, `catch()`, or `finally()` handlers or an await resuming.
+     *
+     * The before callback will be called 0 to N times. The before callback will typically be called 0 times if no continuation was ever made for the promise.
+     * The before callback may be called many times in the case where many continuations have been made from the same promise.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Before {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called immediately after a promise continuation executes. This may be after a `then()`, `catch()`, or `finally()` handler or before an await after another await.
+     * @since v17.1.0, v16.14.0
+     */
+    interface After {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Called when the promise receives a resolution or rejection value. This may occur synchronously in the case of {@link Promise.resolve()} or
+     * {@link Promise.reject()}.
+     * @since v17.1.0, v16.14.0
+     */
+    interface Settled {
+        (promise: Promise<unknown>): void;
+    }
+    /**
+     * Key events in the lifetime of a promise have been categorized into four areas: creation of a promise, before/after a continuation handler is called or
+     * around an await, and when the promise resolves or rejects.
+     *
+     * Because promises are asynchronous resources whose lifecycle is tracked via the promise hooks mechanism, the `init()`, `before()`, `after()`, and
+     * `settled()` callbacks must not be async functions as they create more promises which would produce an infinite loop.
+     * @since v17.1.0, v16.14.0
+     */
+    interface HookCallbacks {
+        init?: Init;
+        before?: Before;
+        after?: After;
+        settled?: Settled;
+    }
+    interface PromiseHooks {
+        /**
+         * The `init` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param init The {@link Init | `init` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onInit: (init: Init) => Function;
+        /**
+         * The `settled` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param settled The {@link Settled | `settled` callback} to call when a promise is created.
+         * @return Call to stop the hook.
+         */
+        onSettled: (settled: Settled) => Function;
+        /**
+         * The `before` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param before The {@link Before | `before` callback} to call before a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onBefore: (before: Before) => Function;
+        /**
+         * The `after` hook must be a plain function. Providing an async function will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param after The {@link After | `after` callback} to call after a promise continuation executes.
+         * @return Call to stop the hook.
+         */
+        onAfter: (after: After) => Function;
+        /**
+         * Registers functions to be called for different lifetime events of each promise.
+         * The callbacks `init()`/`before()`/`after()`/`settled()` are called for the respective events during a promise's lifetime.
+         * All callbacks are optional. For example, if only promise creation needs to be tracked, then only the init callback needs to be passed.
+         * The hook callbacks must be plain functions. Providing async functions will throw as it would produce an infinite microtask loop.
+         * @since v17.1.0, v16.14.0
+         * @param callbacks The {@link HookCallbacks | Hook Callbacks} to register
+         * @return Used for disabling hooks
+         */
+        createHook: (callbacks: HookCallbacks) => Function;
+    }
+    /**
+     * The `promiseHooks` interface can be used to track promise lifecycle events.
+     * @since v17.1.0, v16.14.0
+     */
+    const promiseHooks: PromiseHooks;
 }
 declare module 'node:v8' {
     export * from 'v8';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v16.x/api/v8.html#promise-hooks
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Things to consider:
- `Function` might not be the best return type for the on* hooks. The node docs just say that they return a Function, and imply they have no parameters.
- Interfaces names could be prefixed with `PromiseHook` or something similar.