### PR TITLE
Allow MDX wrapper to be an intrinsic element

### DIFF
--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -5,10 +5,10 @@ type FunctionComponent<Props> = (props: Props) => JSX.Element | null;
 // tslint:disable-next-line: strict-export-declare-modifiers
 type ClassComponent<Props> = new (props: Props) => JSX.ElementClass;
 // tslint:disable-next-line: strict-export-declare-modifiers
-type Component<Props> = FunctionComponent<Props> | ClassComponent<Props>;
+type Component<Props> = FunctionComponent<Props> | ClassComponent<Props> | keyof JSX.IntrinsicElements;
 // tslint:disable-next-line: strict-export-declare-modifiers
 interface NestedMDXComponents {
-    [key: string]: NestedMDXComponents | Component<any> | keyof JSX.IntrinsicElements;
+    [key: string]: NestedMDXComponents | Component<any>;
 }
 
 // Public MDX helper types
@@ -19,7 +19,7 @@ interface NestedMDXComponents {
  * The key is the name of the element to override. The value is the component to render instead.
  */
 export type MDXComponents = NestedMDXComponents & {
-    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
+    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]>;
 } & {
     /**
      * If a wrapper component is defined, the MDX content will be wrapped inside of it.


### PR DESCRIPTION
For example, the following is valid:

```tsx
import Page from './page.mdx'

<Page components={{ wrapper: 'main' }} />
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.