### PR TITLE
Added useInnerBlocksProps to the API of @wordpress/block-editor

### DIFF
--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -15,7 +15,7 @@ export { default as BlockVerticalAlignmentToolbar } from './block-vertical-align
 export { default as ButtonBlockAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ContrastChecker } from './contrast-checker';
-export { default as InnerBlocks } from './inner-blocks';
+export { default as InnerBlocks, useInnerBlocksProps } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export { default as MediaPlaceholder } from './media-placeholder';

--- a/types/wordpress__block-editor/components/inner-blocks.d.ts
+++ b/types/wordpress__block-editor/components/inner-blocks.d.ts
@@ -3,6 +3,8 @@ import { ComponentType } from 'react';
 
 import { EditorTemplateLock } from '../';
 
+import { Merged, Reserved } from './use-block-props';
+
 declare namespace InnerBlocks {
     interface Props {
         allowedBlocks?: string[] | undefined;
@@ -52,5 +54,18 @@ declare const InnerBlocks: {
      */
     DefaultBlockAppender: ComponentType<{ children?: never | undefined }>;
 };
+
+export interface UseInnerBlocksProps {
+    <Props extends Record<string, unknown>>(
+        props?: Props & {
+            [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
+        } & { ref?: Ref<unknown> },
+        options?: InnerBlocks.Props
+    ): Omit<Props, 'ref'> & Merged & Reserved;
+
+    save: (props?: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export const useInnerBlocksProps: UseInnerBlocksProps;
 
 export default InnerBlocks;

--- a/types/wordpress__block-editor/components/inner-blocks.d.ts
+++ b/types/wordpress__block-editor/components/inner-blocks.d.ts
@@ -1,5 +1,5 @@
 import { TemplateArray } from '@wordpress/blocks';
-import { ComponentType } from 'react';
+import { ComponentType, Ref } from 'react';
 
 import { EditorTemplateLock } from '../';
 
@@ -57,9 +57,7 @@ declare const InnerBlocks: {
 
 export interface UseInnerBlocksProps {
     <Props extends Record<string, unknown>>(
-        props?: Props & {
-            [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
-        } & { ref?: Ref<unknown> },
+        props?: Props & { ref?: Ref<unknown> },
         options?: InnerBlocks.Props
     ): Omit<Props, 'ref'> & Merged & Reserved;
 

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -559,6 +559,29 @@ be.useBlockProps.save();
 // $ExpectType Record<string, unknown>
 be.useBlockProps.save({ foo: "bar" });
 
+{
+  const innerBlockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useInnerBlockProps();
+  innerBlockProps;
+}
+
+{
+  const innerBlockProps = be.useInnerBlockProps({ foo: "bar" });
+  // $ExpectType string
+  innerBlockProps.foo;
+}
+
+{
+  const innerBlockProps = be.useInnerBlockProps({ ref: useRef("test") });
+
+  innerBlockProps.ref((current: unknown) => {});
+}
+
+// $ExpectType Record<string, unknown>
+be.useInnerBlockProps.save();
+
+// $ExpectType Record<string, unknown>
+be.useInnerBlockProps.save({ foo: "bar" });
+
 // $ExpectType string
 be.getTypographyClassesAndStyles({}, false).className;
 be.getTypographyClassesAndStyles({}, {}).className;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -560,27 +560,27 @@ be.useBlockProps.save();
 be.useBlockProps.save({ foo: "bar" });
 
 {
-  const innerBlockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useInnerBlockProps();
-  innerBlockProps;
+  const innerBlocksProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useInnerBlocksProps();
+  innerBlocksProps;
 }
 
 {
-  const innerBlockProps = be.useInnerBlockProps({ foo: "bar" });
+  const innerBlocksProps = be.useInnerBlocksProps({ foo: "bar" });
   // $ExpectType string
-  innerBlockProps.foo;
+  innerBlocksProps.foo;
 }
 
 {
-  const innerBlockProps = be.useInnerBlockProps({ ref: useRef("test") });
+  const innerBlocksProps = be.useInnerBlocksProps({ ref: useRef("test") });
 
-  innerBlockProps.ref((current: unknown) => {});
+  innerBlocksProps.ref((current: unknown) => {});
 }
 
 // $ExpectType Record<string, unknown>
-be.useInnerBlockProps.save();
+be.useInnerBlocksProps.save();
 
 // $ExpectType Record<string, unknown>
-be.useInnerBlockProps.save({ foo: "bar" });
+be.useInnerBlocksProps.save({ foo: "bar" });
 
 // $ExpectType string
 be.getTypographyClassesAndStyles({}, false).className;


### PR DESCRIPTION
WordPress added useInnerBlocksProps in version 5.9. Its signature is, for the purposes of usability, a looser version of the useBlockProps signature with an additional argument for an InnerBlocks.Props instance. This is because the most common first argument to the function is the return value of useBlockProps, which cannot be fed back into itself.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://make.wordpress.org/core/2021/12/28/take-more-control-over-inner-block-areas-as-a-block-developer/](https://make.wordpress.org/core/2021/12/28/take-more-control-over-inner-block-areas-as-a-block-developer/)
