### PR TITLE
[ramda] Bump `types-ramda` package to latest

### DIFF
--- a/types/ramda/OTHER_FILES.txt
+++ b/types/ramda/OTHER_FILES.txt
@@ -132,6 +132,7 @@ es/mergeWith.d.ts
 es/mergeWithKey.d.ts
 es/minBy.d.ts
 es/modify.d.ts
+es/modifyPath.d.ts
 es/min.d.ts
 es/modulo.d.ts
 es/move.d.ts
@@ -387,6 +388,7 @@ src/mergeWith.d.ts
 src/mergeWithKey.d.ts
 src/minBy.d.ts
 src/modify.d.ts
+src/modifyPath.d.ts
 src/min.d.ts
 src/modulo.d.ts
 src/move.d.ts

--- a/types/ramda/es/modifyPath.d.ts
+++ b/types/ramda/es/modifyPath.d.ts
@@ -1,0 +1,2 @@
+import { modifyPath } from '../index';
+export default modifyPath;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,9 +1,8 @@
 // Type definitions for ramda 0.29
 // Project: https://ramdajs.com
-// Definitions by: Scott O'Malley <https://github.com/TheHandsomeCoder>
-//                 Harris Miller <https://github.com/harris-miller>
-//                 Kevin Wallace <https://github.com/kedashoe>
+// Definitions by: Harris Miller <https://github.com/harris-miller>
 //                 Nicholai Nissen <https://github.com/Nicholaiii>
+//                 Kevin Wallace <https://github.com/kedashoe>
 //                 Wang Zengdi <https://github.com/adispring>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 5.0

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -4,7 +4,6 @@
 //                 Erwin Poeze <https://github.com/donnut>
 //                 Matt DeKrey <https://github.com/mdekrey>
 //                 Stephen King <https://github.com/sbking>
-//                 Alejandro Fernandez Haro <https://github.com/afharo>
 //                 Vítor Castro <https://github.com/teves-castro>
 //                 Simon Højberg <https://github.com/hojberg>
 //                 Samson Keung <https://github.com/samsonkeung>

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,36 +1,10 @@
 // Type definitions for ramda 0.29
 // Project: https://ramdajs.com
 // Definitions by: Scott O'Malley <https://github.com/TheHandsomeCoder>
-//                 Erwin Poeze <https://github.com/donnut>
-//                 Matt DeKrey <https://github.com/mdekrey>
-//                 Stephen King <https://github.com/sbking>
-//                 Vítor Castro <https://github.com/teves-castro>
-//                 Simon Højberg <https://github.com/hojberg>
-//                 Samson Keung <https://github.com/samsonkeung>
-//                 Angelo Ocana <https://github.com/angeloocana>
-//                 Rayner Pupo <https://github.com/raynerd>
-//                 Nikita Moshensky <https://github.com/moshensky>
-//                 Ethan Resnick <https://github.com/ethanresnick>
-//                 Tomas Szabo <https://github.com/deftomat>
-//                 Maciek Blim <https://github.com/blimusiek>
-//                 Marcin Biernat <https://github.com/biern>
-//                 Rayhaneh Banyassady <https://github.com/rayhaneh>
-//                 Ryan McCuaig <https://github.com/rgm>
-//                 Drew Wyatt <https://github.com/drewwyatt>
-//                 John Ottenlips <https://github.com/jottenlips>
-//                 Nitesh Phadatare <https://github.com/minitesh>
-//                 Krantisinh Deshmukh <https://github.com/krantisinh>
-//                 Aram Kharazyan <https://github.com/nemo108>
-//                 Jituan Lin <https://github.com/jituanlin>
-//                 Philippe Mills <https://github.com/Philippe-mills>
-//                 Saul Mirone <https://github.com/Saul-Mirone>
-//                 Nicholai Nissen <https://github.com/Nicholaiii>
-//                 Jorge Santana <https://github.com/LORDBABUINO>
-//                 Mikael Couzic <https://github.com/couzic>
-//                 Nikita Balikhin <https://github.com/NEWESTERS>
-//                 Wang Zengdi <https://github.com/adispring>
-//                 Marcus Blättermann <https://github.com/essenmitsosse>
 //                 Harris Miller <https://github.com/harris-miller>
+//                 Kevin Wallace <https://github.com/kedashoe>
+//                 Nicholai Nissen <https://github.com/Nicholaiii>
+//                 Wang Zengdi <https://github.com/adispring>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 5.0
 

--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "types-ramda": "^0.29.1"
+        "types-ramda": "^0.29.2"
     }
 }

--- a/types/ramda/src/modifyPath.d.ts
+++ b/types/ramda/src/modifyPath.d.ts
@@ -1,0 +1,2 @@
+import { modifyPath } from '../index';
+export default modifyPath;

--- a/types/ramda/test/find-tests.ts
+++ b/types/ramda/test/find-tests.ts
@@ -2,8 +2,8 @@ import * as R from 'ramda';
 
 () => {
     const xs = [{ a: 1 }, { a: 2 }, { a: 3 }];
-    R.find(R.propEq('a', 2))(xs); // => {a: 2}
-    R.find(R.propEq('a', 4))(xs); // => undefined
+    R.find(R.propEq(2, 'a'))(xs); // => {a: 2}
+    R.find(R.propEq(4, 'a'))(xs); // => undefined
 };
 
 () => {

--- a/types/ramda/test/findIndex-tests.ts
+++ b/types/ramda/test/findIndex-tests.ts
@@ -2,8 +2,8 @@ import * as R from 'ramda';
 
 () => {
     const xs = [{ a: 1 }, { a: 2 }, { a: 3 }];
-    R.findIndex(R.propEq('a', 2))(xs); // => 1
-    R.findIndex(R.propEq('a', 4))(xs); // => -1
+    R.findIndex(R.propEq(2, 'a'))(xs); // => 1
+    R.findIndex(R.propEq(4, 'a'))(xs); // => -1
 
     R.findIndex((x: number) => x === 1, [1, 2, 3]);
 };

--- a/types/ramda/test/findLast-tests.ts
+++ b/types/ramda/test/findLast-tests.ts
@@ -5,8 +5,8 @@ import * as R from 'ramda';
         { a: 1, b: 0 },
         { a: 1, b: 1 },
     ];
-    R.findLast(R.propEq('a', 1))(xs); // => {a: 1, b: 1}
-    R.findLast(R.propEq('a', 4))(xs); // => undefined
+    R.findLast(R.propEq(1, 'a'))(xs); // => {a: 1, b: 1}
+    R.findLast(R.propEq(4, 'a'))(xs); // => undefined
 };
 
 () => {

--- a/types/ramda/test/findLastIndex-tests.ts
+++ b/types/ramda/test/findLastIndex-tests.ts
@@ -5,7 +5,7 @@ import * as R from 'ramda';
         { a: 1, b: 0 },
         { a: 1, b: 1 },
     ];
-    R.findLastIndex(R.propEq('a', 1))(xs); // => 1
-    R.findLastIndex(R.propEq('a', 4))(xs); // => -1
+    R.findLastIndex(R.propEq(1, 'a'))(xs); // => 1
+    R.findLastIndex(R.propEq(4, 'a'))(xs); // => -1
     R.findLastIndex((x: number) => x === 1, [1, 2, 3]);
 };

--- a/types/ramda/test/propEq-tests.ts
+++ b/types/ramda/test/propEq-tests.ts
@@ -7,11 +7,11 @@ import * as R from 'ramda';
         3: 'asdf',
     };
 
-    const func1: (obj: Record<'foo', 'bar'>) => boolean = R.propEq('foo', 'bar');
+    const func1: (obj: Record<'foo', 'bar'>) => boolean = R.propEq('bar', 'foo');
 
-    const func2: (obj: Record<'baz', number>) => boolean = R.propEq('baz', 5);
+    const func2: (obj: Record<'baz', number>) => boolean = R.propEq(5, 'baz');
 
-    const func3: (obj: Record<number, string>) => boolean = R.propEq(5, 'qwerty');
+    const func3: (obj: Record<number, string>) => boolean = R.propEq('qwerty', 5);
 
     const func4: {
         <V>(val: V, obj: Record<'foo', V>): boolean;
@@ -26,8 +26,8 @@ interface Obj {
 
 () => {
     const xs: Obj = { a: 1, b: 0 };
-    R.propEq('a', 1, xs); // => true
-    R.propEq('a', 4, xs); // => false
+    R.propEq(1, 'a', xs); // => true
+    R.propEq(4, 'a', xs); // => false
 };
 
 () => {
@@ -40,8 +40,8 @@ interface Obj {
     };
     const value = '';
 
-    R.propEq('foo', value)(obj);
+    R.propEq(value, 'foo')(obj);
 
     // @ts-expect-error
-    R.propEq('bar', value)(obj);
+    R.propEq(value, 'bar')(obj);
 };


### PR DESCRIPTION
This MR
* updates tests that use `propEq`, as ramda@0.29.0 swapped the argument order
* Adds new re-exports for new `modifyPath` function
* Bumps `types-ramda` to latest