### PR TITLE
Add DEFAULT_CIPHERS option for node 18, tls module

### DIFF
--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -1093,6 +1093,13 @@ declare module 'tls' {
      */
     let DEFAULT_MIN_VERSION: SecureVersion;
     /**
+     * The default value of the ciphers option of tls.createSecureContext().
+     * It can be assigned any of the supported OpenSSL ciphers. 
+     * Defaults to the content of crypto.constants.defaultCoreCipherList, unless 
+     * changed using CLI options using --tls-default-ciphers.
+     */
+    let DEFAULT_CIPHERS: string;
+    /**
      * An immutable array of strings representing the root certificates (in PEM
      * format) used for verifying peer certificates. This is the default value
      * of the ca option to tls.createSecureContext().


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [Node TLS](https://nodejs.org/docs/latest-v18.x/api/tls.html)

