### PR TITLE
[@types/babel__traverse]: Revert infer type predicates in find/findPath

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -439,12 +439,3 @@ const outerIdentifierPathTrue = newPath.getOuterBindingIdentifierPaths(true);
 outerIdentifierPathTrue; // $ExpectType Record<string, NodePath<Identifier>[]>
 const outerIdentifierPathBoolean = newPath.getOuterBindingIdentifierPaths(booleanVar);
 outerIdentifierPathBoolean; // $ExpectType Record<string, NodePath<Identifier> | NodePath<Identifier>[]>
-
-function isIdentifierPath(path: NodePath<t.Node>): path is NodePath<t.Identifier> {
-    return t.isIdentifier(path.node);
-}
-declare const childPath: NodePath<t.Node>;
-childPath.findParent(() => true); // $ExpectType NodePath<Node> | null
-childPath.findParent(isIdentifierPath); // $ExpectType NodePath<Identifier> | null
-childPath.find(() => true); // $ExpectType NodePath<Node> | null
-childPath.find(isIdentifierPath); // $ExpectType NodePath<Identifier> | null

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -294,7 +294,6 @@ export class NodePath<T = Node> {
      * to return a truthy value, or `null` if the `callback` never returns a
      * truthy value.
      */
-    findParent<T extends t.Node>(callback: (path: NodePath) => path is NodePath<T>): NodePath<T> | null;
     findParent(callback: (path: NodePath) => boolean): NodePath | null;
 
     /**
@@ -302,7 +301,6 @@ export class NodePath<T = Node> {
      * `NodePath` that causes the provided `callback` to return a truthy value,
      * or `null` if the `callback` never returns a truthy value.
      */
-    find<T extends t.Node>(callback: (path: NodePath) => path is NodePath<T>): NodePath<T> | null;
     find(callback: (path: NodePath) => boolean): NodePath | null;
 
     /** Get the parent function of the current path. */


### PR DESCRIPTION
This reverts commit a7da713fe6ebbb37d3d7128b46bf849436bac75b (#65262)

It seems to only work with `useStrictNullChecks` which caused the build to break for many people who didn't use this setting, and tests didn't catch it.
Imo it's more important to restore the previous (working) user experience than force everyone to change their build setup.

Im a bit hesitant to "try" fixing the types again (to work without strict) for a critical package, maybe later or in combination with other PRs it could be implemented.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65262#issuecomment-1522493401
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
