### PR TITLE
[@types/vinyl-fs] Remove `rimraf` Dependency from `vinyl-fs/v0` Properly

### DIFF
--- a/types/vinyl-fs/v0/package.json
+++ b/types/vinyl-fs/v0/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "rimraf": "^5.0.0"
-    }
-}

--- a/types/vinyl-fs/v0/vinyl-fs-tests.ts
+++ b/types/vinyl-fs/v0/vinyl-fs-tests.ts
@@ -212,7 +212,8 @@ describe('source stream', () => {
 
 // const path = require('path');
 // const fs = require('graceful-fs');
-import { rimraf } from 'rimraf';
+// import rimraf = require('rimraf');
+const rimraf = (...args: any[]) => undefined as any;
 
 // const bufEqual = require('buffer-equal');
 // const through = require('through2');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #65257
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

Related to: #65257, #65300 and #65302

In my most recent PR, #65257, I introduced errors causing that the `rimraf` dependency did not get removed from `vinyl-fs/v0` but only from `vinyl-fs` and `vinyl-fs/v1`.

Changes introduced in this PR will remove the dependency from `vinyl-fs/v0` properly. This time without introducing an error. Promise.