### PR TITLE
polygon-lookup: PolygonLookup#lookup returns Feature<Polygon>, not Polygon

### DIFF
--- a/types/polygon-lookup/index.d.ts
+++ b/types/polygon-lookup/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Florian Keller <https://github.com/ffflorian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { FeatureCollection, Polygon } from 'geojson';
+import { Feature, FeatureCollection, Polygon } from 'geojson';
 import RBush from 'rbush';
 
 declare namespace PolygonLookup {
@@ -31,12 +31,12 @@ declare class PolygonLookup {
      * @param y The y-coordinate of the point.
      * @param limit Number of results to return (`-1` to return all the results).
      * @return  If one or more bounding box intersections are
-     * found and limit is `undefined`, return the first polygon that intersects
+     * found and limit is `undefined`, return the first feature that intersects
      * (`x`, `y`); otherwise, `undefined`. If a limit is passed in, return
      * intersecting polygons as a GeoJSON `FeatureCollection`.
      */
-    search(x: number, y: number): Polygon | undefined;
-    search(x: number, y: number, limit: number): FeatureCollection | undefined;
+    search(x: number, y: number): Feature<Polygon> | undefined;
+    search(x: number, y: number, limit: number): FeatureCollection<Polygon> | undefined;
 
     /**
      * Build a spatial index for a set of polygons, and store both the polygons and

--- a/types/polygon-lookup/polygon-lookup-tests.ts
+++ b/types/polygon-lookup/polygon-lookup-tests.ts
@@ -1,7 +1,7 @@
 import PolygonLookup = require('polygon-lookup');
 import { FeatureCollection } from 'geojson';
 
-const featureCollection: FeatureCollection = {
+const inputFeatureCollection: FeatureCollection = {
     type: 'FeatureCollection',
     features: [
         {
@@ -22,6 +22,10 @@ const featureCollection: FeatureCollection = {
     ],
 };
 
-const lookup = new PolygonLookup(featureCollection);
-lookup.search(1, 2);
-lookup.search(1, 2, 1);
+const lookup = new PolygonLookup(inputFeatureCollection);
+
+// $ExpectType Feature<Polygon, GeoJsonProperties> | undefined
+const foundFeature = lookup.search(1, 2);
+
+// $ExpectType FeatureCollection<Polygon, GeoJsonProperties> | undefined
+const foundFeatureCollection = lookup.search(1, 2, 1);


### PR DESCRIPTION


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/polygon-lookup
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I made two separate changes:
```
    search(x: number, y: number): Feature<Polygon> | undefined;
```
It now returns a Feature instead of a Polygon, this matches what the javascript returns. Confusingly, the original js code refers to Feature<Polygon>s as Polygons.

```
    search(x: number, y: number, limit: number): FeatureCollection<Polygon> | undefined;
```
Specifying that the return type is FeatureCollection<Polygon> instead of just FeatureCollection. The readme documents that all features are converted to Polygons.