### PR TITLE
Trusted Types: Make injection sink functions accept TrustedHTML

### DIFF
--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -31,6 +31,24 @@ declare global {
     // Attach the relevant Trusted Types properties to the Window object.
     // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
     interface Window extends lib.TrustedTypesWindow {}
+
+    // Injection sinks that take TrustedHTML
+    interface DOMParser {
+        parseFromString(string: string | TrustedHTML, type: DOMParserSupportedType): Document;
+    }
+
+    interface Element {
+        insertAdjacentHTML(position: string, string: string | TrustedHTML): void;
+    }
+
+    interface Document {
+        write(text: string | TrustedHTML): void;
+        writeln(text: string | TrustedHTML): void;
+    }
+
+    interface Range {
+        createContextualFragment(fragment: string | TrustedHTML): DocumentFragment;
+    }
 }
 
 // These are the available exports when using the polyfill as npm package (e.g. in nodejs)

--- a/types/trusted-types/test/browser.ts
+++ b/types/trusted-types/test/browser.ts
@@ -120,3 +120,23 @@ window.TrustedScriptURL;
 
 // @ts-expect-error
 trustedTypes;
+
+// Verify that DOM injection sinks can take TrustedHTML
+
+const policyHTML = policy.createHTML('<p></p>');
+
+// DOMParser injection sink
+const parser = new DOMParser();
+parser.parseFromString(policyHTML, 'text/html');
+
+// Eleemnt injection sink
+const el = new Element();
+el.insertAdjacentHTML('afterbegin', policyHTML);
+
+// Document injection sinks
+const doc = new Document();
+doc.write(policyHTML);
+doc.writeln(policyHTML);
+
+// Range injection sink
+const range = doc.createRange().createContextualFragment(policyHTML);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/w3c/trusted-types/blob/main/explainer.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Should it be updated in this PR?)

---
Makes some injection sinks support receiving TrustedHTML. I wanted to do some attributes, such as `innerHTML` too, but I couldn't figure it out. I decided not to do importScripts, because setting up the WebWorker scope in the tests seem a bit too tricky for quick Friday afternoon.
