### PR TITLE
[jest] Change array matchers to allow readonly arrays

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -691,7 +691,7 @@ declare namespace jest {
          * Optionally, you can provide a type for the elements via a generic.
          */
         // eslint-disable-next-line no-unnecessary-generics
-        arrayContaining<E = any>(arr: E[]): any;
+        arrayContaining<E = any>(arr: readonly E[]): any;
         /**
          * `expect.not.objectContaining(object)` matches any received object
          * that does not recursively match the expected properties. That is, the
@@ -769,7 +769,7 @@ declare namespace jest {
          * Optionally, you can provide a type for the elements via a generic.
          */
         // eslint-disable-next-line no-unnecessary-generics
-        arrayContaining<E = any>(arr: E[]): any;
+        arrayContaining<E = any>(arr: readonly E[]): any;
         /**
          * Verifies that a certain number of assertions are called during a test.
          * This is often useful when testing asynchronous code, in order to
@@ -1059,7 +1059,7 @@ declare namespace jest {
          * expect(houseForSale).toHaveProperty('kitchen.area', 20);
          */
         // eslint-disable-next-line no-unnecessary-generics
-        toHaveProperty<E = any>(propertyPath: string | any[], value?: E): R;
+        toHaveProperty<E = any>(propertyPath: string | readonly any[], value?: E): R;
         /**
          * Use to test that the mock function successfully returned (i.e., did not throw an error) at least one time
          */
@@ -1590,7 +1590,7 @@ declare namespace jasmine {
     function clock(): Clock;
     function any(aclass: any): Any;
     function anything(): Any;
-    function arrayContaining(sample: any[]): ArrayContaining;
+    function arrayContaining(sample: readonly any[]): ArrayContaining;
     function objectContaining(sample: any): ObjectContaining;
     function createSpy(name?: string, originalFn?: (...args: any[]) => any): Spy;
     function createSpyObj(baseName: string, methodNames: any[]): any;
@@ -1618,7 +1618,7 @@ declare namespace jasmine {
     }
 
     interface ArrayContaining {
-        new (sample: any[]): any;
+        new (sample: readonly any[]): any;
         asymmetricMatch(other: any): boolean;
         jasmineToString(): string;
     }

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1432,6 +1432,9 @@ describe('', () => {
         expect({}).toBe(expect.arrayContaining(['a', 'b']));
         expect(['abc']).toBe(expect.arrayContaining(['a', 'b']));
 
+        expect({}).toBe(expect.arrayContaining(['a', 'b'] as const));
+        expect(['abc']).toBe(expect.arrayContaining(['a', 'b'] as const));
+
         expect.objectContaining({});
         expect.stringMatching('foo');
         expect.stringMatching(/foo/);
@@ -1599,6 +1602,9 @@ expect(7).toBe(jasmine.any(Number));
 
 expect({}).toBe(jasmine.arrayContaining(['a', 'b']));
 expect(['abc']).toBe(jasmine.arrayContaining(['a', 'b']));
+
+expect({}).toBe(jasmine.arrayContaining(['a', 'b'] as const));
+expect(['abc']).toBe(jasmine.arrayContaining(['a', 'b'] as const));
 
 jasmine.arrayContaining([]);
 new (jasmine.arrayContaining([]))([]);

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1458,6 +1458,7 @@ describe('', () => {
         expect('How are you?').toEqual(expect.not.stringMatching(/Hello world!/));
         expect({ bar: 'baz' }).toEqual(expect.not.objectContaining({ foo: 'bar' }));
         expect(['Alice', 'Bob', 'Eve']).toEqual(expect.not.arrayContaining(['Samantha']));
+        expect(['Alice', 'Bob', 'Eve']).toEqual(expect.not.arrayContaining(['Samantha'] as const));
 
         /* Miscellaneous */
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1290,6 +1290,8 @@ describe('', () => {
         expect({}).toHaveProperty(['property'], {});
         expect({}).toHaveProperty(['property', 'deep']);
         expect({}).toHaveProperty(['property', 'deep'], {});
+        expect({}).toHaveProperty(['property', 'deep'] as const);
+        expect({}).toHaveProperty(['property', 'deep'] as const, {});
 
         expect(jest.fn()).toHaveReturned();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

> This is more of a quality of life change.
