### PR TITLE
@types/dat.gui: Update generic type constraint to work with TypeScript ^4.9.0

### DIFF
--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -72,10 +72,10 @@ export class GUI {
         max?: number,
         step?: number,
     ): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, status: boolean): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: string[]): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: number[]): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: Object): GUIController;
+    add<T extends object>(target: T, propName: keyof T, status: boolean): GUIController;
+    add<T extends object>(target: T, propName: keyof T, items: string[]): GUIController;
+    add<T extends object>(target: T, propName: keyof T, items: number[]): GUIController;
+    add<T extends object>(target: T, propName: keyof T, items: Object): GUIController;
 
     addColor(target: Object, propName: string): GUIController;
 
@@ -113,7 +113,7 @@ export class GUI {
     useLocalStorage: boolean;
 }
 
-export class GUIController<T extends Record<string, unknown> = Record<string, unknown>> {
+export class GUIController<T extends object = object> {
     domElement: HTMLElement;
     object: Object;
     property: string;

--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -65,7 +65,7 @@ export class GUI {
     __folders: { [folderName: string]: GUI };
     domElement: HTMLElement;
 
-    add<T extends Record<string, unknown>>(
+    add<T extends object>(
         target: T,
         propName: keyof T,
         min?: number,


### PR DESCRIPTION
Use `object` type for generic constraints instead of `Record<string,unknown>`.

See [TypeScript Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#unlisted-property-narrowing-with-the-in-operator) (end of section)

The problem:
With the new version, the `Record<string,unknown>` type constraints an object to have a string index signature.
This disallows to pass in a class instance with getters and setters to be controlled by the gui elements.
switching to the `object` type will fix this problem and should not introduce any other