### PR TITLE
[@wordpress/editor] fix type function uploadMedia()

### DIFF
--- a/types/wordpress__editor/utils/index.d.ts
+++ b/types/wordpress__editor/utils/index.d.ts
@@ -1,4 +1,11 @@
-export { uploadMedia as mediaUpload } from '@wordpress/media-utils';
+import type { UploadMediaOptions } from '@wordpress/media-utils';
+
+export type MediaUploadOptions = Omit<UploadMediaOptions, 'maxUploadFileSize' | 'onError' | 'wpAllowedMimeTypes'> &
+    Partial<Pick<UploadMediaOptions, 'maxUploadFileSize'>> & {
+        onError?(message: string): void;
+    };
+
+export function mediaUpload(options: MediaUploadOptions): void;
 
 /**
  * Performs some basic cleanup of a string for use as a post slug

--- a/types/wordpress__editor/wordpress__editor-tests.tsx
+++ b/types/wordpress__editor/wordpress__editor-tests.tsx
@@ -2,6 +2,8 @@ import { dispatch, select } from '@wordpress/data';
 import * as e from '@wordpress/editor';
 
 declare const BLOCK_INSTANCE: import('@wordpress/blocks').BlockInstance;
+declare const FILELIST: FileList;
+declare const FILE_ARRAY: File[];
 
 // $ExpectType EditorStoreDescriptor
 e.store;
@@ -404,3 +406,32 @@ select('core/editor').getPostEdits().foo;
 
 // $ExpectType boolean
 select('core/editor').inSomeHistory(state => state.foo === true);
+
+//
+// Utils
+// ============================================================================
+
+// $ExpectType void
+e.mediaUpload({
+    filesList: FILELIST,
+    onFileChange(files) {
+        console.log(files[0].alt, files[0].media_type);
+    },
+});
+
+// $ExpectType void
+e.mediaUpload({
+    additionalData: {
+        foo: 'foo',
+        bar: ['bar', 'baz'],
+    },
+    allowedTypes: ['image/jpeg'],
+    filesList: FILE_ARRAY,
+    maxUploadFileSize: 5000,
+    onError(message) {
+        console.log(message);
+    },
+    onFileChange(files) {
+        console.log(files[0].alt, files[0].media_type);
+    },
+});


### PR DESCRIPTION
The `uploadMedia` function in the "@wordpress/editor" package is a wrapper for the `mediaUpload` function in the "@wordpress/media-utils" package, but some of its arguments and return value are different.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
