### PR TITLE
[@testing-library/jest-dom] Add `exports` to `package.json`

### DIFF
--- a/types/testing-library__jest-dom/package.json
+++ b/types/testing-library__jest-dom/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "exports": {
+        ".": {
+          "types": "./index.d.ts"
+        },
+        "./matchers": {
+          "types": "./matchers.d.ts"
+        }
+      }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. **Not sure how to test this with the dtslint tests.**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/testing-library/jest-dom/blob/main/matchers.js

## Explanation

`@testing-library/jest-dom` has a [`matchers`](https://github.com/testing-library/jest-dom/blob/main/matchers.js) entrypoint which you can use like this:

```ts
import matchers from '@testing-library/jest-dom/matchers';
import { expect } from 'vitest';

expect.extend(matchers);
```

However, the `@types` package did not have `exports` in `package.json`, so the first line of this code produced an error when using `"type": "module"` and `"moduleResolution": "nodenext"`. This PR fixes that.

