### PR TITLE
[should-sinon] Make should.js extensions available globally

### DIFF
--- a/types/should-sinon/index.d.ts
+++ b/types/should-sinon/index.d.ts
@@ -4,14 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as s from 'sinon';
-import should = require('should');
+import * as s from 'should';
 
-declare module 'sinon' {
-    interface SinonSpyCallApi {
-        should: ShouldSinonAssertion;
-    }
-    interface ShouldSinonAssertion extends should.Assertion {
+declare module 'should' {
+    interface Assertion {
         /**
          * Assert stub was called with given object as this always. So if you call stub several times
          * all should be with the same object
@@ -88,4 +84,13 @@ declare module 'sinon' {
          */
         threw(ex: string | Error): void;
     }
+}
+
+// keep backwards compat with earlier DefinitelyTyped release which made these
+// types available
+declare module 'sinon' {
+    interface SinonSpyCallApi {
+        should: ShouldSinonAssertion;
+    }
+    type ShouldSinonAssertion = should.Assertion;
 }

--- a/types/should-sinon/should-sinon-tests.ts
+++ b/types/should-sinon/should-sinon-tests.ts
@@ -1,3 +1,6 @@
+import sinon = require('sinon');
+import should = require('should');
+
 const callback = sinon.spy();
 const obj = { };
 
@@ -22,3 +25,14 @@ callback.firstCall.should.be.calledThrice();
 callback.firstCall.should.be.calledTwice();
 callback.firstCall.should.be.calledWith(1, 2, 3);
 callback.firstCall.should.be.neverCalledWith(1, 2, 3);
+
+should(callback).should.be.alwaysCalledOn(obj);
+should(callback).should.be.alwaysCalledWith(1, 2, 3);
+should(callback).should.have.callCount(0);
+should(callback).should.be.called();
+should(callback).should.be.calledOn(obj);
+should(callback).should.be.calledOnce();
+should(callback).should.be.calledThrice();
+should(callback).should.be.calledTwice();
+should(callback).should.be.calledWith(1, 2, 3);
+should(callback).should.be.neverCalledWith(1, 2, 3);


### PR DESCRIPTION
sinon-should always extends the base should.js interface. E.g. String#should.called() works, even though it is not a stub (but will always fail).

This allows the use of should(stub).called* which is also a supported way of using should.js.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/shouldjs/sinon/blob/3d1841d244316a02671b54a33660127def0dd8b6/should-sinon.js#L10-L12
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
