### PR TITLE
Adding 'distance' return field to the 'polylabel' package

### DIFF
--- a/types/polylabel/index.d.ts
+++ b/types/polylabel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for polylabel 1.0
+// Type definitions for polylabel 1.2
 // Project: https://github.com/mapbox/polylabel
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/polylabel/index.d.ts
+++ b/types/polylabel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for polylabel 1.2
+// Type definitions for polylabel 1.1
 // Project: https://github.com/mapbox/polylabel
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/polylabel/index.d.ts
+++ b/types/polylabel/index.d.ts
@@ -12,6 +12,6 @@
  * @example
  * var p = polylabel(polygon, 1.0);
  */
-declare function polylabel(polygon: number[][][], precision?: number, debug?: boolean): number[];
+declare function polylabel(polygon: number[][][], precision?: number, debug?: boolean): number[] & {distance: number};
 declare namespace polylabel {}
 export default polylabel;

--- a/types/polylabel/polylabel-tests.ts
+++ b/types/polylabel/polylabel-tests.ts
@@ -5,3 +5,16 @@ polylabel(polygon);
 polylabel(polygon, 1.0);
 polylabel(polygon, 1.0, true);
 polylabel(polygon, 1.0, false);
+
+// $ExpectType number
+polylabel(polygon)[0];
+// $ExpectType number
+polylabel(polygon)[1];
+// $ExpectType number
+polylabel(polygon).distance;
+
+const [x, y] = polylabel(polygon);
+// $ExpectType number
+x;
+// $ExpectType number
+y;


### PR DESCRIPTION
This was added to library in June 2020 -- see https://github.com/mapbox/polylabel/pull/61

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/polylabel/pull/61
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.