### PR TITLE
[matter-js] Correct Constraint.bodyA .bodyB nullability

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1851,7 +1851,7 @@ declare namespace Matter {
          * @type body
          * @default null
          */
-        bodyA: Body;
+        bodyA: Body | null;
 
         /**
          * The second possible `Body` that this constraint is attached to.
@@ -1860,7 +1860,7 @@ declare namespace Matter {
          * @type body
          * @default null
          */
-        bodyB: Body;
+        bodyB: Body | null;
 
         /**
          * An integer `Number` uniquely identifying number generated in `Composite.create` by `Common.nextId`.

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -111,6 +111,11 @@ var constraint1 = Constraint.create({
 
 World.addConstraint(engine.world, constraint1);
 
+// $ExpectType Body | null
+var bodyA = constraint1.bodyA;
+// $ExpectType Body | null
+var bodyB = constraint1.bodyB;
+
 // Query
 // $ExpectType Collision[]
 var collisions = Query.ray([box1, box2, circle1], { x: 1, y: 2 }, { x: 3, y: 4 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Source code which provides context for the suggested changes:

- [Constraint.js](https://github.com/liabru/matter-js/blob/039212a56e5a0d353a078b270accf9b347c3e421/src/constraint/Constraint.js#LL410-L424) lines 410 to 424 for 0.18.0, showing these properties are by default `null`
- also see context around the changes themselves (shows the same doc strings)

Discussion of the issue: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63739
