### PR TITLE
[mongoose-aggregate-paginate-v2] Do not extend Document as this is not supported anymore in Mongoose v7

### DIFF
--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -66,7 +66,7 @@ declare module 'mongoose' {
         [customLabel: string]: T[] | number | boolean | null | undefined;
     }
 
-    interface AggregatePaginateModel<D extends Document> extends Model<D> {
+    interface AggregatePaginateModel<D> extends Model<D> {
         aggregatePaginate<T>(
             query?: Aggregate<T[]>,
             options?: PaginateOptions,

--- a/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
+++ b/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
@@ -10,13 +10,12 @@ import {
     AggregatePaginateModel,
     PaginateOptions,
     AggregatePaginateResult,
-    Document,
 } from 'mongoose';
 import mongooseAggregatePaginate = require('mongoose-aggregate-paginate-v2');
 import { Router, Request, Response } from 'express';
 
 //#region Test Models
-interface User extends Document {
+interface User {
     email: string;
     username: string;
     password: string;
@@ -28,7 +27,7 @@ interface HobbyStats {
     count: number;
 }
 
-const UserSchema: Schema = new Schema({
+const UserSchema: Schema = new Schema<User>({
     email: String,
     username: String,
     password: String,
@@ -37,9 +36,7 @@ const UserSchema: Schema = new Schema({
 
 UserSchema.plugin(mongooseAggregatePaginate);
 
-interface UserModel<T extends Document> extends AggregatePaginateModel<T> {}
-
-const UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<User>;
+const UserModel = model<User, AggregatePaginateModel<User>>('User', UserSchema);
 //#endregion
 
 //#region Test Paginate


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: removed Document extension support (https://mongoosejs.com/docs/migrating_to_7.html#removed-leandocument-and-support-for-extends-document), documentation how to add static methods (https://mongoosejs.com/docs/typescript/statics-and-methods.html#statics)

The current type definition still should work with Mongoose 6
