### PR TITLE
Adds Cookiebot to the Window interface (cookiebot-sdk)

### DIFF
--- a/types/cookiebot-sdk/cookiebot-sdk-tests.ts
+++ b/types/cookiebot-sdk/cookiebot-sdk-tests.ts
@@ -3,6 +3,11 @@ const hasAcceptedPreferences: boolean = Cookiebot.consent.preferences; // $Expec
 const hasAcceptedMarketing: boolean = Cookiebot.consent.marketing; // $ExpectType boolean
 const hasAcceptedNecessary: boolean = Cookiebot.consent.necessary; // $ExpectType boolean
 
+const hasAcceptedStatisticsFromWindow: boolean = !!window.Cookiebot?.consent.statistics; // $ExpectType boolean
+const hasAcceptedPreferencesFromWindow: boolean = !!window.Cookiebot?.consent.preferences; // $ExpectType boolean
+const hasAcceptedMarketingFromWindow: boolean = !!window.Cookiebot?.consent.marketing; // $ExpectType boolean
+const hasAcceptedNecessaryFromWindow: boolean = !!window.Cookiebot?.consent.necessary; // $ExpectType boolean
+
 Cookiebot.show();
 Cookiebot.hide();
 Cookiebot.renew();
@@ -10,6 +15,14 @@ Cookiebot.getScript('', true, () => {});
 Cookiebot.runScripts();
 Cookiebot.withdraw();
 Cookiebot.submitCustomConsent(true, true, true);
+
+window.Cookiebot?.show();
+window.Cookiebot?.hide();
+window.Cookiebot?.renew();
+window.Cookiebot?.getScript('', true, () => {});
+window.Cookiebot?.runScripts();
+window.Cookiebot?.withdraw();
+window.Cookiebot?.submitCustomConsent(true, true, true);
 
 window.addEventListener('CookiebotOnAccept', (event) => {
   event; // $ExpectType Event

--- a/types/cookiebot-sdk/index.d.ts
+++ b/types/cookiebot-sdk/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package Cookiebot SDK 2.43
 // Project: https://www.cookiebot.com/en/developer/
 // Definitions by: Liam Martens <https://github.com/LiamMartens>
+//                 Patric Eberle <https://github.com/patric-eberle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare const Cookiebot: {

--- a/types/cookiebot-sdk/index.d.ts
+++ b/types/cookiebot-sdk/index.d.ts
@@ -30,6 +30,10 @@ declare const Cookiebot: {
     submitCustomConsent(optinPreferences: boolean, optinStatistics: boolean, optinMarketing: boolean): void;
 };
 
+interface Window {
+  Cookiebot?: typeof Cookiebot;
+}
+
 interface WindowEventMap {
     CookiebotOnConsentReady: Event;
     CookiebotOnLoad: Event;


### PR DESCRIPTION
This will allow to use `window.Cookiebot`, unlike the current implementation, which only allows to use `Cookiebot` in code, which is error prone, if the instance is not yet ready. `declare const Cookiebot` has been retained for backwards compatibility

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65389>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.