### PR TITLE
updated organization.get() promise type

### DIFF
--- a/types/onfleet__node-onfleet/Resources/Organization.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Organization.d.ts
@@ -1,5 +1,5 @@
 declare class Organization {
-    get(): Promise<Organization.OnfleetOrganization[]>;
+    get(): Promise<Organization.OnfleetOrganization>;
     get(id: string): Promise<Organization.OnfleetOrganization | Organization.Delegatee>;
     insertTask(id: string, obj: { tasks: string[] }): Promise<any>;
 }


### PR DESCRIPTION
While working with the Onfleet node wrapper I noticed a type error with the Organization.get() endpoint and it is that this endpoint returns an OnfleetOrganization object instead of an array.  

Please refer to the official Onfleet API docs: [https://docs.onfleet.com/reference/get-details](https://docs.onfleet.com/reference/get-details)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
