### PR TITLE
fix(Wavesurfer): allow `CanvasGradient` type

### DIFF
--- a/types/wavesurfer.js/types/params.d.ts
+++ b/types/wavesurfer.js/types/params.d.ts
@@ -79,7 +79,7 @@ export interface WaveSurferParams {
     /** An array of plugin definitions to register during instantiation. */
     plugins?: PluginDefinition[] | undefined;
     /** The fill color of the part of the waveform behind the cursor (default: '#555'). */
-    progressColor?: string | undefined;
+    progressColor?: string | CanvasGradient | undefined;
     /** Set to false to keep the media element in the DOM when the player is destroyed (default: true). */
     removeMediaElementOnDestroy?: boolean | undefined;
     /** Can be used to inject a custom renderer (default: MultiCanvas). */


### PR DESCRIPTION
String type will obviously break tracking gradient if forcing `CanvasGradient` to string. Should allow for both options, similar to the `waveColor` type in the same file.

https://github.com/wavesurfer-js/wavesurfer.js/pull/2345
https://github.com/wavesurfer-js/wavesurfer.js/blob/master/src/drawer.canvasentry.js#L161
