### PR TITLE
[react] Add support for `useOptimistic` without reducer

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -124,8 +124,11 @@ declare module '.' {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
+    function experimental_useOptimistic<State>(
+        passthrough: State,
+    ): [State, (action: State | ((pendingState: State) => State)) => void];
     function experimental_useOptimistic<State, Action>(
         passthrough: State,
-        reducer?: (state: State, action: Action) => State,
+        reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
 }

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -149,4 +149,13 @@ function Optimistic() {
         );
         addToOptimisticCartTyped2(String(item));
     };
+
+    const [state, setStateDefaultAction] = useOptimistic(1);
+    const handleClick = () => {
+        setStateDefaultAction(2);
+        setStateDefaultAction(() => 3);
+        setStateDefaultAction(n => n + 1);
+        // @ts-expect-error string is not assignable to number
+        setStateDefaultAction('4');
+    };
 }

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -124,8 +124,11 @@ declare module '.' {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
+    function experimental_useOptimistic<State>(
+        passthrough: State,
+    ): [State, (action: State | ((pendingState: State) => State)) => void];
     function experimental_useOptimistic<State, Action>(
         passthrough: State,
-        reducer?: (state: State, action: Action) => State,
+        reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
 }

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -149,4 +149,13 @@ function Optimistic() {
         );
         addToOptimisticCartTyped2(String(item));
     };
+
+    const [state, setStateDefaultAction] = useOptimistic(1);
+    const handleClick = () => {
+        setStateDefaultAction(2);
+        setStateDefaultAction(() => 3);
+        setStateDefaultAction(n => n + 1);
+        // @ts-expect-error string is not assignable to number
+        setStateDefaultAction('4');
+    };
 }


### PR DESCRIPTION
In `useOptimistic` the updater function works like the updater returned from `useState` if no reducer is passed to `useOptimistic`: https://github.com/facebook/react/blob/aef7ce5547c9489dc48e31f69b002cd17206e0cb/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js#L656-L722