### PR TITLE
[types/validator] Add new supported UUID versions 1 and 2

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -1148,9 +1148,9 @@ declare namespace validator {
      */
     function isUppercase(str: string): boolean;
 
-    type UUIDVersion = 3 | 4 | 5 | '3' | '4' | '5' | 'all';
+    type UUIDVersion = '1' | '2' | '3' | '4' | '5' | 'all' | 1 | 2 | 3 | 4 | 5;
     /**
-     * Check if the string is a UUID (version 3, 4 or 5).
+     * Check if the string is a UUID (version 1, 2, 3, 4 or 5).
      *
      * @param [version="all"] - UUID version
      */


### PR DESCRIPTION
New UUID versions 1 and 2 are now supported since 13.0.7 (https://github.com/validatorjs/validator.js/pull/1848)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link](https://github.com/validatorjs/validator.js/pull/1848)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not new version)
