### PR TITLE
[react-dom] Add `this: void` to PipeableStream functions

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -39,7 +39,9 @@ export interface RenderToPipeableStreamOptions {
 }
 
 export interface PipeableStream {
+    // tslint:disable-next-line:void-return
     abort(this: void): void;
+    // tslint:disable-next-line:void-return
     pipe<Writable extends NodeJS.WritableStream>(this: void, destination: Writable): Writable;
 }
 

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -39,8 +39,8 @@ export interface RenderToPipeableStreamOptions {
 }
 
 export interface PipeableStream {
-    abort(): void;
-    pipe<Writable extends NodeJS.WritableStream>(destination: Writable): Writable;
+    abort(this: void): void;
+    pipe<Writable extends NodeJS.WritableStream>(this: void, destination: Writable): Writable;
 }
 
 /**

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -368,7 +368,7 @@ function hydrateRoot() {
 }
 
 /**
- * source:
+ * source: https://react.dev/reference/react-dom/server/renderToPipeableStream
  */
 function pipeableStreamDocumentedExample() {
     function App() {
@@ -382,16 +382,18 @@ function pipeableStreamDocumentedExample() {
     }
 
     let didError = false;
-    const res: Response = {} as any;
-    const stream = ReactDOMServer.renderToPipeableStream(<App />, {
+    const response: Response = {} as any;
+    const { pipe } = ReactDOMServer.renderToPipeableStream(<App />, {
+        bootstrapScripts: ['/main.js'],
         onShellReady() {
-            res.statusCode = didError ? 500 : 200;
-            res.setHeader('Content-type', 'text/html');
-            stream.pipe(res);
+            response.statusCode = didError ? 500 : 200;
+            response.setHeader('content-type', 'text/html');
+            pipe(response);
         },
         onShellError(error) {
-            res.statusCode = 500;
-            res.send('<!doctype html><p>Loading...</p><script src="clientrender.js"></script>');
+            response.statusCode = 500;
+            response.setHeader('content-type', 'text/html');
+            response.send('<h1>Something went wrong</h1>');
         },
         onAllReady() {},
         onError(err) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests)

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/server/renderToPipeableStream and https://typescript-eslint.io/rules/unbound-method

The [React documentation](https://react.dev/reference/react-dom/server/renderToPipeableStream) specifically uses the pattern of destructuring the `PipeableStream` object returned from `renderToPipeableStream()`:

```js
import { renderToPipeableStream } from 'react-dom/server';

const { pipe } = renderToPipeableStream(<App />, {
  bootstrapScripts: ['/main.js'],
  onShellReady() {
    response.setHeader('content-type', 'text/html');
    pipe(response);
  }
});
```

However, this causes an error with the typescript-eslint rule [unbound-method](https://typescript-eslint.io/rules/unbound-method). This rule is a [recommended](https://typescript-eslint.io/rules/#supported-rules) rule and is included with the config extension `plugin:@typescript-eslint/recommended-type-checked`.

```
error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead  @typescript-eslint/unbound-method
```

This pull request updates the test to more closely match the documentation and add `void: this` as the first parameter to the interface functions, `pipe()` and `abort()`.

The test fails on `dts-lint` rule `void-return`, I opened a bug in that repo: https://github.com/microsoft/DefinitelyTyped-tools/issues/671

`this: void` is not used anywhere else within the DefinitelyTyped repository, except as a [documentation type in selenium-webdriver](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/80908e3bef3bb789d841104d5719f56e155a70ff/types/selenium-webdriver/index.d.ts#L1564).