### PR TITLE
Add new tabulator-tables editor selectContents param for number, input and TextArea Editor

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1799,11 +1799,15 @@ export interface NumberParams extends SharedEditorParams {
     max?: number | undefined;
     step?: number | undefined;
     verticalNavigation?: 'editor' | 'table' | undefined;
+    /** When the editor is loaded select its text content */
+    selectContents?: boolean | undefined;
 }
 
 export interface InputParams extends SharedEditorParams {
     /** Changes input type to 'search' and shows an 'X' clear button to clear the cell value easily. */
     search?: boolean | undefined;
+    /** When the editor is loaded select its text content */
+    selectContents?: boolean | undefined;
 }
 
 export interface TextAreaParams extends SharedEditorParams {
@@ -1811,6 +1815,8 @@ export interface TextAreaParams extends SharedEditorParams {
 
     /** Allow submission of the value of the editor when the shift and enter keys are pressed together. */
     shiftEnterSubmit?: boolean;
+    /** When the editor is loaded select its text content */
+    selectContents?: boolean | undefined;
 }
 
 export interface CheckboxParams extends SharedEditorParams {

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -20,6 +20,9 @@ import {
     JSONRecord,
     Options,
     ListEditorParams,
+    NumberParams,
+    InputParams,
+    TextAreaParams
 } from 'tabulator-tables';
 
 // tslint:disable:no-object-literal-type-assertion
@@ -1283,4 +1286,73 @@ table = new Tabulator('#testDataLoader', {
         },
     ],
     dataLoaderLoading: document.createElement('div') as HTMLElement,
+});
+
+// Testing editor params for Input, TextArea and Number
+
+const numberEditorParams: NumberParams = {
+    elementAttributes: {
+        maxlength: "10",
+    },
+    min: 0,
+    max: 100,
+    mask: '999',
+    maskAutoFill: false,
+    maskLetterChar: 'A',
+    maskNumberChar: '9',
+    maskWildcardChar: '*',
+    step: 1,
+    verticalNavigation: 'table',
+    selectContents: true,
+};
+
+const inputEditorParams: InputParams = {
+    elementAttributes: {
+        maxlength: "10"
+    },
+    mask: "AAA-999",
+    maskAutoFill: false,
+    maskLetterChar: 'A',
+    maskNumberChar: '9',
+    maskWildcardChar: '*',
+    search: true,
+    selectContents: true,
+};
+
+const textAreaEditorParams: TextAreaParams = {
+    elementAttributes: {
+        maxlength: "10"
+    },
+    mask: "AAA-999",
+    maskAutoFill: false,
+    maskLetterChar: 'A',
+    maskNumberChar: '9',
+    maskWildcardChar: '*',
+    verticalNavigation: 'editor',
+    shiftEnterSubmit: false,
+    selectContents: false,
+};
+
+table = new Tabulator('#test', {
+    data: [],
+    columns: [
+        {
+            field: 'number_field',
+            title: 'Number',
+            editor: 'number',
+            editorParams: numberEditorParams
+        },
+        {
+            field: 'input_field',
+            title: 'Input',
+            editor: 'input',
+            editorParams: inputEditorParams
+        },
+        {
+            field: 'textarea_field',
+            title: 'TextArea',
+            editor: 'textarea',
+            editorParams: textAreaEditorParams
+        }
+    ]
 });


### PR DESCRIPTION
Add new tabulator-tables editor selectContents param for number, input and TextArea Editor

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tabulator.info/docs/5.4/edit#editor-input
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
