### PR TITLE
[debug] add type for inspectOpts

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -55,5 +55,5 @@ debug2.log = function(this: debug1.Debugger, ...args) {
 };
 
 if (debug2.inspectOpts) {
-    debug2.inspectOpts.depth = 10;
+    debug2.inspectOpts.depth = 12;
 }

--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -53,3 +53,7 @@ debug2.log = function(this: debug1.Debugger, ...args) {
         diff,
     });
 };
+
+if (debug2.inspectOpts) {
+    debug2.inspectOpts.depth = 10;
+}

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -30,6 +30,13 @@ declare namespace debug {
         skips: RegExp[];
 
         formatters: Formatters;
+
+        inspectOpts?: {
+            hideDate?: boolean | number | null;
+            colors?: boolean | number | null;
+            depth?: boolean | number | null;
+            showHidden?: boolean | number | null;
+        };
     }
 
     type IDebug = Debug;


### PR DESCRIPTION
This adds the type for debug.inspectOpts, which are options passed to util.inspect()

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Code](https://github.com/debug-js/debug/blob/d1616622e4d404863c5a98443f755b4006e971dc/src/node.js#L124-L149)
  - [Docs](https://github.com/debug-js/debug#environment-variables)  "_Note: The environment variables beginning with `DEBUG_` end up being converted into an Options object that gets used with `%o/%O` formatters. See the Node.js documentation for [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options) for the complete list._"
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.