### PR TITLE
[node] Update typings to v20.1

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1,7 +1,7 @@
 /**
  * The `node:assert` module provides a set of assertion functions for verifying
  * invariants.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/assert.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/assert.js)
  */
 declare module 'assert' {
     /**
@@ -35,9 +35,10 @@ declare module 'assert' {
             });
         }
         /**
-         * This feature is currently experimental and behavior might still change.
+         * This feature is deprecated and will be removed in a future version.
+         * Please consider using alternatives such as the `mock` helper function.
          * @since v14.2.0, v12.19.0
-         * @experimental
+         * @deprecated Deprecated
          */
         class CallTracker {
             /**

--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -12,7 +12,7 @@
  * import async_hooks from 'node:async_hooks';
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/async_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/async_hooks.js)
  */
 declare module 'async_hooks' {
     /**

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -41,7 +41,7 @@
  * // Creates a Buffer containing the Latin-1 bytes [0x74, 0xe9, 0x73, 0x74].
  * const buf7 = Buffer.from('tést', 'latin1');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/buffer.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/buffer.js)
  */
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
@@ -446,7 +446,7 @@ declare module 'buffer' {
              *
              * ```js
              * const u16 = new Uint16Array([0, 0xffff]);
-             * const buf = Buffer.copyBytesFrom(u16, 0, 1);
+             * const buf = Buffer.copyBytesFrom(u16, 1, 1);
              * u16[1] = 0;
              * console.log(buf.length); // 2
              * console.log(buf[0]); // 255
@@ -488,7 +488,7 @@ declare module 'buffer' {
              * // Prints: <Buffer 00 00 00 00 00>
              * ```
              *
-             * If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown.
+             * If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown.
              *
              * If `fill` is specified, the allocated `Buffer` will be initialized by calling `buf.fill(fill)`.
              *
@@ -525,7 +525,7 @@ declare module 'buffer' {
              */
             alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
             /**
-             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown.
+             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown.
              *
              * The underlying memory for `Buffer` instances created in this way is _not_
              * _initialized_. The contents of the newly created `Buffer` are unknown and _may contain sensitive data_. Use `Buffer.alloc()` instead to initialize`Buffer` instances with zeroes.
@@ -562,8 +562,8 @@ declare module 'buffer' {
              */
             allocUnsafe(size: number): Buffer;
             /**
-             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown. A zero-length `Buffer` is created
-             * if `size` is 0.
+             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown. A zero-length `Buffer` is created if
+             * `size` is 0.
              *
              * The underlying memory for `Buffer` instances created in this way is _not_
              * _initialized_. The contents of the newly created `Buffer` are unknown and _may contain sensitive data_. Use `buf.fill(0)` to initialize

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -63,7 +63,7 @@
  * For certain use cases, such as automating shell scripts, the `synchronous counterparts` may be more convenient. In many cases, however,
  * the synchronous methods can have significant impact on performance due to
  * stalling the event loop while spawned processes complete.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/child_process.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/child_process.js)
  */
 declare module 'child_process' {
     import { ObjectEncodingOptions } from 'node:fs';

--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -50,7 +50,7 @@
  * ```
  *
  * On Windows, it is not yet possible to set up a named pipe server in a worker.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/cluster.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/cluster.js)
  */
 declare module 'cluster' {
     import * as child from 'node:child_process';

--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -53,7 +53,7 @@
  * myConsole.warn(`Danger ${name}! Danger!`);
  * // Prints: Danger Will Robinson! Danger!, to err
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/console.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/console.js)
  */
 declare module 'console' {
     import console = require('node:console');

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -14,7 +14,7 @@
  * // Prints:
  * //   c0fa1bc00531bd78ef38c628449c5102aeabd49b5dc3a2a516ea6ea959d6658e
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/crypto.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/crypto.js)
  */
 declare module 'crypto' {
     import * as stream from 'node:stream';

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -23,7 +23,7 @@
  * server.bind(41234);
  * // Prints: server listening 0.0.0.0:41234
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/dgram.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/dgram.js)
  */
 declare module 'dgram' {
     import { AddressInfo } from 'node:net';

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @since v15.1.0, v14.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/diagnostics_channel.js)
  */
 declare module 'diagnostics_channel' {
     /**

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -42,7 +42,7 @@
  * ```
  *
  * See the `Implementation considerations section` for more information.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/dns.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/dns.js)
  */
 declare module 'dns' {
     import * as dnsPromises from 'node:dns/promises';
@@ -484,6 +484,14 @@ declare module 'dns' {
      * @since v0.1.16
      */
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
+    /**
+     * Get the default value for `verbatim` in {@link lookup} and `dnsPromises.lookup()`. The value could be:
+     *
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
+     * @since v20.1.0
+     */
+    export function getDefaultResultOrder(): 'ipv4first' | 'verbatim';
     /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted

--- a/types/node/domain.d.ts
+++ b/types/node/domain.d.ts
@@ -12,7 +12,7 @@
  * will be notified, rather than losing the context of the error in the`process.on('uncaughtException')` handler, or causing the program to
  * exit immediately with an error code.
  * @deprecated Since v1.4.2 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/domain.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/domain.js)
  */
 declare module 'domain' {
     import EventEmitter = require('node:events');
@@ -56,7 +56,7 @@ declare module 'domain' {
         exit(): void;
         /**
          * Run the supplied function in the context of the domain, implicitly
-         * binding all event emitters, timers, and lowlevel requests that are
+         * binding all event emitters, timers, and low-level requests that are
          * created in that context. Optionally, arguments can be passed to
          * the function.
          *

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -32,7 +32,7 @@
  * });
  * myEmitter.emit('event');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/events.js)
  */
 declare module 'events' {
     // NOTE: This class is in the docs but is **not actually exported** by Node.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -16,7 +16,7 @@
  *
  * All file system operations have synchronous, callback, and promise-based
  * forms, and are accessible using both CommonJS syntax and ES6 Modules (ESM).
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/fs.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/fs.js)
  */
 declare module 'fs' {
     import * as stream from 'node:stream';
@@ -847,6 +847,9 @@ declare module 'fs' {
      * Asynchronous [`stat(2)`](http://man7.org/linux/man-pages/man2/stat.2.html). The callback gets two arguments `(err, stats)` where`stats` is an `fs.Stats` object.
      *
      * In case of an error, the `err.code` will be one of `Common System Errors`.
+     *
+     * {@link stat} follows symbolic links. Use {@link lstat} to look at the
+     * links themselves.
      *
      * Using `fs.stat()` to check for the existence of a file before calling`fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended.
      * Instead, user code should open/read/write the file directly and handle the
@@ -1881,6 +1884,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | undefined
@@ -1898,6 +1902,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer',
         callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
@@ -1912,6 +1917,7 @@ declare module 'fs' {
         options:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | undefined
@@ -1932,6 +1938,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void
     ): void;
@@ -1947,6 +1954,7 @@ declare module 'fs' {
                 | {
                       encoding: BufferEncoding | null;
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
                 | BufferEncoding
                 | null
@@ -1963,6 +1971,7 @@ declare module 'fs' {
                 | {
                       encoding: 'buffer';
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
         ): Promise<Buffer[]>;
         /**
@@ -1975,6 +1984,7 @@ declare module 'fs' {
             options?:
                 | (ObjectEncodingOptions & {
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   })
                 | BufferEncoding
                 | null
@@ -1988,6 +1998,7 @@ declare module 'fs' {
             path: PathLike,
             options: ObjectEncodingOptions & {
                 withFileTypes: true;
+                recursive?: boolean | undefined;
             }
         ): Promise<Dirent[]>;
     }
@@ -2010,6 +2021,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | null
@@ -2025,6 +2037,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Buffer[];
@@ -2038,6 +2051,7 @@ declare module 'fs' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -2051,6 +2065,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Dirent[];
     /**
@@ -3850,6 +3865,9 @@ declare module 'fs' {
      */
     export function readvSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
     export interface OpenDirOptions {
+        /**
+         * @default 'utf8'
+         */
         encoding?: BufferEncoding | undefined;
         /**
          * Number of directory entries that are buffered
@@ -3858,6 +3876,10 @@ declare module 'fs' {
          * @default 32
          */
         bufferSize?: number | undefined;
+        /**
+         * @default false
+         */
+        recursive?: boolean;
     }
     /**
      * Synchronously open a directory. See [`opendir(3)`](http://man7.org/linux/man-pages/man3/opendir.3.html).
@@ -3920,6 +3942,10 @@ declare module 'fs' {
          * @default true
          */
         force?: boolean;
+        /**
+         * Modifiers for copy operation. See `mode` flag of {@link copyFileSync()}
+         */
+        mode?: number;
         /**
          * When `true` timestamps from `src` will
          * be preserved.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -642,6 +642,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -657,6 +658,7 @@ declare module 'fs/promises' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Promise<Buffer[]>;
@@ -670,6 +672,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -683,6 +686,7 @@ declare module 'fs/promises' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Promise<Dirent[]>;
     /**

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -37,7 +37,7 @@
  *   'Host', 'example.com',
  *   'accepT', '*' ]
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/http.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/http.js)
  */
 declare module 'http' {
     import * as stream from 'node:stream';
@@ -184,6 +184,13 @@ declare module 'http' {
          * @default 30000
          */
         connectionsCheckingInterval?: number | undefined;
+        /**
+         * Optionally overrides all `socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
+         * This affects `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
+         * Default: @see stream.getDefaultHighWaterMark().
+         * @since v20.1.0
+         */
+        highWaterMark?: number | undefined;
         /**
          * Use an insecure HTTP parser that accepts invalid HTTP headers when `true`.
          * Using the insecure parser should be avoided.

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -6,7 +6,7 @@
  * const http2 = require('node:http2');
  * ```
  * @since v8.4.0
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/http2.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/http2.js)
  */
 declare module 'http2' {
     import EventEmitter = require('node:events');

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -1,7 +1,7 @@
 /**
  * HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a
  * separate module.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/https.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/https.js)
  */
 declare module 'https' {
     import { Duplex } from 'node:stream';

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.0
+// Type definitions for non-npm package Node.js 20.1
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -22,7 +22,7 @@
  * ```js
  * import * as inspector from 'node:inspector';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/inspector.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/inspector.js)
  */
 declare module 'inspector' {
     import EventEmitter = require('node:events');

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -10,7 +10,7 @@
  * ```js
  * const net = require('node:net');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/net.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/net.js)
  */
 declare module 'net' {
     import * as stream from 'node:stream';

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * const os = require('node:os');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/os.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/os.js)
  */
 declare module 'os' {
     interface CpuInfo {

--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -13,7 +13,7 @@ declare module 'path/win32' {
  * ```js
  * const path = require('node:path');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/path.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/path.js)
  */
 declare module 'path' {
     namespace path {

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -27,7 +27,7 @@
  *   performance.measure('A to B', 'A', 'B');
  * });
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/perf_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/perf_hooks.js)
  */
 declare module 'perf_hooks' {
     import { AsyncResource } from 'node:async_hooks';

--- a/types/node/punycode.d.ts
+++ b/types/node/punycode.d.ts
@@ -24,7 +24,7 @@
  * made available to developers as a convenience. Fixes or other modifications to
  * the module must be directed to the [Punycode.js](https://github.com/bestiejs/punycode.js) project.
  * @deprecated Since v7.0.0 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/punycode.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/punycode.js)
  */
 declare module 'punycode' {
     /**

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -9,7 +9,7 @@
  * `querystring` is more performant than `URLSearchParams` but is not a
  * standardized API. Use `URLSearchParams` when performance is not critical or
  * when compatibility with browser code is desirable.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/querystring.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/querystring.js)
  */
 declare module 'querystring' {
     interface StringifyOptions {

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -30,7 +30,7 @@
  *
  * Once this code is invoked, the Node.js application will not terminate until the`readline.Interface` is closed because the interface waits for data to be
  * received on the `input` stream.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/readline.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/readline.js)
  */
 declare module 'readline' {
     import { Abortable, EventEmitter } from 'node:events';

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const repl = require('node:repl');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/repl.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/repl.js)
  */
 declare module 'repl' {
     import { Interface, Completer, AsyncCompleter } from 'node:readline';

--- a/types/node/scripts/generate-docs/ast-processing.ts
+++ b/types/node/scripts/generate-docs/ast-processing.ts
@@ -486,7 +486,9 @@ export class NodeProcessingContext {
         this.context.indent = getIndent(node);
         if (isFunctionDeclaration(node)) {
             processRes = this.processFunctionDeclaration(node);
-        } else if (isNamedModuleDeclaration(node) && !node.name.text.startsWith('node:')) { // apparently everything is a module
+        } else if (isNamedModuleDeclaration(node)
+            && !(node.name.text.startsWith('node:') && node.name.text !== 'node:test') // apparently everything is a module
+        ) {
             processRes = this.handleModuleDeclaration();
         } else if (isClassDeclaration(node)) {
             processRes = this.handleClassDeclaration(node);

--- a/types/node/scripts/generate-docs/docs.ts
+++ b/types/node/scripts/generate-docs/docs.ts
@@ -43,7 +43,7 @@ function transformer(printer: Printer, typeChecker: TypeChecker, rootDocs: DocRo
             const moduleName = node.name.text;
 
             // skip non prefixed modules
-            if (moduleName.startsWith('node:')) {
+            if (moduleName.startsWith('node:') && moduleName !== 'node:test') {
                 return node;
             }
 

--- a/types/node/scripts/generate-docs/node-doc-processing.ts
+++ b/types/node/scripts/generate-docs/node-doc-processing.ts
@@ -183,6 +183,7 @@ function fixupModuleStructure(node: DocRoot): void {
     // yet another rename
     renameModule('performance_measurement_apis', 'perf_hooks');
     renameModule('http/2', 'http2');
+    renameModule('test_runner', 'node:test');
     renameModule('tls_(ssl)', 'tls');
     renameModule('webassembly_system_interface_(wasi)', 'wasi');
     unnestModule(['fs', 'promises_api'], 'fs/promises');

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -14,7 +14,7 @@
  *
  * The `node:stream` module is useful for creating new types of stream instances.
  * It is usually not necessary to use the `node:stream` module to consume streams.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/stream.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/stream.js)
  */
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
@@ -1131,6 +1131,20 @@ declare module 'stream' {
          * @param stream a stream to attach a signal to
          */
         function addAbortSignal<T extends Stream>(signal: AbortSignal, stream: T): T;
+        /**
+         * Returns the default highWaterMark used by streams.
+         * Defaults to `16384` (16 KiB), or `16` for `objectMode`.
+         * @since v19.9.0
+         * @param objectMode
+         */
+        function getDefaultHighWaterMark(objectMode: boolean): number;
+        /**
+         * Sets the default highWaterMark used by streams.
+         * @since v19.9.0
+         * @param objectMode
+         * @param value highWaterMark value
+         */
+        function setDefaultHighWaterMark(objectMode: boolean, value: number): void;
         interface FinishedOptions extends Abortable {
             error?: boolean | undefined;
             readable?: boolean | undefined;

--- a/types/node/string_decoder.d.ts
+++ b/types/node/string_decoder.d.ts
@@ -36,7 +36,7 @@
  * decoder.write(Buffer.from([0x82]));
  * console.log(decoder.end(Buffer.from([0xAC])));
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/string_decoder.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/string_decoder.js)
  */
 declare module 'string_decoder' {
     class StringDecoder {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1,27 +1,112 @@
 /**
- * The `node:test` module provides a standalone testing module.
- * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/test.js)
+ * The `node:test` module facilitates the creation of JavaScript tests.
+ * To access it:
+ *
+ * ```js
+ * import test from 'node:test';
+ * ```
+ *
+ * This module is only available under the `node:` scheme. The following will not
+ * work:
+ *
+ * ```js
+ * import test from 'test';
+ * ```
+ *
+ * Tests created via the `test` module consist of a single function that is
+ * processed in one of three ways:
+ *
+ * 1. A synchronous function that is considered failing if it throws an exception,
+ * and is considered passing otherwise.
+ * 2. A function that returns a `Promise` that is considered failing if the`Promise` rejects, and is considered passing if the `Promise` resolves.
+ * 3. A function that receives a callback function. If the callback receives any
+ * truthy value as its first argument, the test is considered failing. If a
+ * falsy value is passed as the first argument to the callback, the test is
+ * considered passing. If the test function receives a callback function and
+ * also returns a `Promise`, the test will fail.
+ *
+ * The following example illustrates how tests are written using the`test` module.
+ *
+ * ```js
+ * test('synchronous passing test', (t) => {
+ *   // This test passes because it does not throw an exception.
+ *   assert.strictEqual(1, 1);
+ * });
+ *
+ * test('synchronous failing test', (t) => {
+ *   // This test fails because it throws an exception.
+ *   assert.strictEqual(1, 2);
+ * });
+ *
+ * test('asynchronous passing test', async (t) => {
+ *   // This test passes because the Promise returned by the async
+ *   // function is not rejected.
+ *   assert.strictEqual(1, 1);
+ * });
+ *
+ * test('asynchronous failing test', async (t) => {
+ *   // This test fails because the Promise returned by the async
+ *   // function is rejected.
+ *   assert.strictEqual(1, 2);
+ * });
+ *
+ * test('failing test using Promises', (t) => {
+ *   // Promises can be used directly as well.
+ *   return new Promise((resolve, reject) => {
+ *     setImmediate(() => {
+ *       reject(new Error('this will cause the test to fail'));
+ *     });
+ *   });
+ * });
+ *
+ * test('callback passing test', (t, done) => {
+ *   // done() is the callback function. When the setImmediate() runs, it invokes
+ *   // done() with no arguments.
+ *   setImmediate(done);
+ * });
+ *
+ * test('callback failing test', (t, done) => {
+ *   // When the setImmediate() runs, done() is invoked with an Error object and
+ *   // the test fails.
+ *   setImmediate(() => {
+ *     done(new Error('callback failure'));
+ *   });
+ * });
+ * ```
+ *
+ * If any tests fail, the process exit code is set to `1`.
+ * @since v18.0.0, v16.17.0
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/test.js)
  */
 declare module 'node:test' {
+    import { Readable } from 'node:stream';
     /**
-     * Programmatically start the test runner.
-     * @since v18.9.0
-     * @param options Configuration options for running tests.
-     * @returns A {@link TestsStream} that emits events about the test execution.
+     * ```js
+     * import { tap } from 'node:test/reporters';
+     * import process from 'node:process';
+     *
+     * run({ files: [path.resolve('./tests/test.js')] })
+     *   .compose(tap)
+     *   .pipe(process.stdout);
+     * ```
+     * @since v18.9.0, v16.19.0
+     * @param options Configuration options for running tests. The following properties are supported:
      */
     function run(options?: RunOptions): TestsStream;
     /**
-     * The `test()` function is the value imported from the test module. Each invocation of this
-     * function results in reporting the test to the {@link TestsStream}.
+     * The `test()` function is the value imported from the `test` module. Each
+     * invocation of this function results in reporting the test to the `TestsStream`.
      *
-     * The {@link TestContext} object passed to the fn argument can be used to perform actions
-     * related to the current test. Examples include skipping the test, adding additional
-     * diagnostic information, or creating subtests.
+     * The `TestContext` object passed to the `fn` argument can be used to perform
+     * actions related to the current test. Examples include skipping the test, adding
+     * additional diagnostic information, or creating subtests.
      *
-     * `test()` returns a {@link Promise} that resolves once the test completes. The return value
-     * can usually be discarded for top level tests. However, the return value from subtests should
-     * be used to prevent the parent test from finishing first and cancelling the subtest as shown
-     * in the following example.
+     * `test()` returns a `Promise` that resolves once the test completes.
+     * if `test()` is called within a `describe()` block, it resolve immediately.
+     * The return value can usually be discarded for top level tests.
+     * However, the return value from subtests should be used to prevent the parent
+     * test from finishing first and cancelling the subtest
+     * as shown in the following example.
      *
      * ```js
      * test('top level test', async (t) => {
@@ -35,49 +120,56 @@ declare module 'node:test' {
      *   });
      * });
      * ```
-     * @since v18.0.0
-     * @param name The name of the test, which is displayed when reporting test results.
-     *    Default: The `name` property of fn, or `'<anonymous>'` if `fn` does not have a name.
-     * @param options Configuration options for the test
-     * @param fn The function under test. The first argument to this function is a
-     *    {@link TestContext} object. If the test uses callbacks, the callback function is
-     *    passed as the second argument. Default: A no-op function.
-     * @returns A {@link Promise} resolved with `undefined` once the test completes.
+     *
+     * The `timeout` option can be used to fail the test if it takes longer than`timeout` milliseconds to complete. However, it is not a reliable mechanism for
+     * canceling tests because a running test might block the application thread and
+     * thus prevent the scheduled cancellation.
+     * @since v18.0.0, v16.17.0
+     * @param [name='The name'] The name of the test, which is displayed when reporting test results.
+     * @param options Configuration options for the test. The following properties are supported:
+     * @param [fn='A no-op function'] The function under test. The first argument to this function is a {@link TestContext} object. If the test uses callbacks, the callback function is passed as the
+     * second argument.
+     * @return Resolved with `undefined` once the test completes, or immediately if the test runs within {@link describe}.
      */
     function test(name?: string, fn?: TestFn): Promise<void>;
     function test(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(fn?: TestFn): Promise<void>;
     /**
-     * @since v18.6.0
-     * @param name The name of the suite, which is displayed when reporting suite results.
-     *    Default: The `name` property of fn, or `'<anonymous>'` if `fn` does not have a name.
-     * @param options Configuration options for the suite
-     * @param fn The function under suite. Default: A no-op function.
+     * The `describe()` function imported from the `node:test` module. Each
+     * invocation of this function results in the creation of a Subtest.
+     * After invocation of top level `describe` functions,
+     * all top level tests and suites will execute.
+     * @param [name='The name'] The name of the suite, which is displayed when reporting test results.
+     * @param options Configuration options for the suite. supports the same options as `test([name][, options][, fn])`.
+     * @param [fn='A no-op function'] The function under suite declaring all subtests and subsuites. The first argument to this function is a {@link SuiteContext} object.
+     * @return `undefined`.
      */
     function describe(name?: string, options?: TestOptions, fn?: SuiteFn): void;
     function describe(name?: string, fn?: SuiteFn): void;
     function describe(options?: TestOptions, fn?: SuiteFn): void;
     function describe(fn?: SuiteFn): void;
     namespace describe {
-        // Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
+        /**
+         * Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
+         */
         function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
         function skip(name?: string, fn?: SuiteFn): void;
         function skip(options?: TestOptions, fn?: SuiteFn): void;
         function skip(fn?: SuiteFn): void;
-        // Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
+         */
         function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
         function todo(name?: string, fn?: SuiteFn): void;
         function todo(options?: TestOptions, fn?: SuiteFn): void;
         function todo(fn?: SuiteFn): void;
     }
     /**
-     * @since v18.6.0
-     * @param name The name of the test, which is displayed when reporting test results.
-     *    Default: The `name` property of fn, or `'<anonymous>'` if `fn` does not have a name.
-     * @param options Configuration options for the test
-     * @param fn The function under test. If the test uses callbacks, the callback function is
-     *    passed as the second argument. Default: A no-op function.
+     * Shorthand for `test()`.
+     *
+     * The `it()` function is imported from the `node:test` module.
+     * @since v18.6.0, v16.17.0
      */
     function it(name?: string, options?: TestOptions, fn?: ItFn): void;
     function it(name?: string, fn?: ItFn): void;
@@ -142,14 +234,19 @@ declare module 'node:test' {
          * incremented from the primary's `process.debugPort`.
          */
         inspectPort?: number | (() => number) | undefined;
+        /**
+         * That can be used to only run tests whose name matches the provided pattern.
+         * Test name patterns are interpreted as JavaScript regular expressions.
+         * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
+         */
+        testNamePatterns?: string | RegExp | string[] | RegExp[];
     }
     /**
-     * A successful call of the `run()` method will return a new `TestsStream` object,
-     * streaming a series of events representing the execution of the tests.
-     * `TestsStream` will emit events in the order of the tests' definitions.
-     * @since v18.9.0
+     * A successful call to `run()` method will return a new `TestsStream` object, streaming a series of events representing the execution of the tests.`TestsStream` will emit events, in the
+     * order of the tests definition
+     * @since v18.9.0, v16.19.0
      */
-    interface TestsStream extends NodeJS.ReadableStream {
+    class TestsStream extends Readable implements NodeJS.ReadableStream {
         addListener(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         addListener(event: 'test:fail', listener: (data: TestFail) => void): this;
         addListener(event: 'test:pass', listener: (data: TestPass) => void): this;
@@ -284,11 +381,20 @@ declare module 'node:test' {
         nesting: number;
     }
     /**
-     * An instance of `TestContext` is passed to each test function in order to interact with the
-     * test runner. However, the `TestContext` constructor is not exposed as part of the API.
-     * @since v18.0.0
+     * An instance of `TestContext` is passed to each test function in order to
+     * interact with the test runner. However, the `TestContext` constructor is not
+     * exposed as part of the API.
+     * @since v18.0.0, v16.17.0
      */
-    interface TestContext {
+    class TestContext {
+        /**
+         * This function is used to create a hook running before subtest of the current test.
+         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
+         *    the second argument. Default: A no-op function.
+         * @param options Configuration options for the hook.
+         * @since v20.1.0
+         */
+        before: typeof before;
         /**
          * This function is used to create a hook running before each subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -314,44 +420,81 @@ declare module 'node:test' {
          */
         afterEach: typeof afterEach;
         /**
-         * This function is used to write diagnostics to the output. Any diagnostic information is
-         * included at the end of the test's results. This function does not return a value.
+         * This function is used to write diagnostics to the output. Any diagnostic
+         * information is included at the end of the test's results. This function does
+         * not return a value.
+         *
+         * ```js
+         * test('top level test', (t) => {
+         *   t.diagnostic('A diagnostic message');
+         * });
+         * ```
+         * @since v18.0.0, v16.17.0
          * @param message Message to be reported.
-         * @since v18.0.0
          */
         diagnostic(message: string): void;
         /**
          * The name of the test.
-         * @since v18.8.0
+         * @since v18.8.0, v16.18.0
          */
         readonly name: string;
         /**
-         * If `shouldRunOnlyTests` is truthy, the test context will only run tests that have the `only`
-         * option set. Otherwise, all tests are run. If Node.js was not started with the `--test-only`
-         * command-line option, this function is a no-op.
+         * If `shouldRunOnlyTests` is truthy, the test context will only run tests that
+         * have the `only` option set. Otherwise, all tests are run. If Node.js was not
+         * started with the `--test-only` command-line option, this function is a
+         * no-op.
+         *
+         * ```js
+         * test('top level test', (t) => {
+         *   // The test context can be set to run subtests with the 'only' option.
+         *   t.runOnly(true);
+         *   return Promise.all([
+         *     t.test('this subtest is now skipped'),
+         *     t.test('this subtest is run', { only: true }),
+         *   ]);
+         * });
+         * ```
+         * @since v18.0.0, v16.17.0
          * @param shouldRunOnlyTests Whether or not to run `only` tests.
-         * @since v18.0.0
          */
         runOnly(shouldRunOnlyTests: boolean): void;
         /**
-         * Can be used to abort test subtasks when the test has been aborted.
-         * @since v18.7.0
+         * ```js
+         * test('top level test', async (t) => {
+         *   await fetch('some/uri', { signal: t.signal });
+         * });
+         * ```
+         * @since v18.7.0, v16.17.0
          */
         readonly signal: AbortSignal;
         /**
-         * This function causes the test's output to indicate the test as skipped. If `message` is
-         * provided, it is included in the output. Calling `skip()` does not terminate execution of
-         * the test function. This function does not return a value.
+         * This function causes the test's output to indicate the test as skipped. If`message` is provided, it is included in the output. Calling `skip()` does
+         * not terminate execution of the test function. This function does not return a
+         * value.
+         *
+         * ```js
+         * test('top level test', (t) => {
+         *   // Make sure to return here as well if the test contains additional logic.
+         *   t.skip('this is skipped');
+         * });
+         * ```
+         * @since v18.0.0, v16.17.0
          * @param message Optional skip message.
-         * @since v18.0.0
          */
         skip(message?: string): void;
         /**
-         * This function adds a `TODO` directive to the test's output. If `message` is provided, it is
-         * included in the output. Calling `todo()` does not terminate execution of the test
-         * function. This function does not return a value.
+         * This function adds a `TODO` directive to the test's output. If `message` is
+         * provided, it is included in the output. Calling `todo()` does not terminate
+         * execution of the test function. This function does not return a value.
+         *
+         * ```js
+         * test('top level test', (t) => {
+         *   // This test is marked as `TODO`
+         *   t.todo('this is a todo');
+         * });
+         * ```
+         * @since v18.0.0, v16.17.0
          * @param message Optional `TODO` message.
-         * @since v18.0.0
          */
         todo(message?: string): void;
         /**
@@ -415,34 +558,68 @@ declare module 'node:test' {
     }
     /**
      * This function is used to create a hook running before running a suite.
-     * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-     *    the second argument. Default: A no-op function.
-     * @param options Configuration options for the hook.
-     * @since v18.8.0
+     *
+     * ```js
+     * describe('tests', async () => {
+     *   before(() => console.log('about to run some test'));
+     *   it('is a subtest', () => {
+     *     assert.ok('some relevant assertion here');
+     *   });
+     * });
+     * ```
+     * @since v18.8.0, v16.18.0
+     * @param [fn='A no-op function'] The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+     * @param options Configuration options for the hook. The following properties are supported:
      */
     function before(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function is used to create a hook running after running a suite.
-     * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-     *    the second argument. Default: A no-op function.
-     * @param options Configuration options for the hook.
-     * @since v18.8.0
+     * This function is used to create a hook running after  running a suite.
+     *
+     * ```js
+     * describe('tests', async () => {
+     *   after(() => console.log('finished running tests'));
+     *   it('is a subtest', () => {
+     *     assert.ok('some relevant assertion here');
+     *   });
+     * });
+     * ```
+     * @since v18.8.0, v16.18.0
+     * @param [fn='A no-op function'] The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+     * @param options Configuration options for the hook. The following properties are supported:
      */
     function after(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function is used to create a hook running before each subtest of the current suite.
-     * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-     *    the second argument. Default: A no-op function.
-     * @param options Configuration options for the hook.
-     * @since v18.8.0
+     * This function is used to create a hook running
+     * before each subtest of the current suite.
+     *
+     * ```js
+     * describe('tests', async () => {
+     *   beforeEach(() => console.log('about to run a test'));
+     *   it('is a subtest', () => {
+     *     assert.ok('some relevant assertion here');
+     *   });
+     * });
+     * ```
+     * @since v18.8.0, v16.18.0
+     * @param [fn='A no-op function'] The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+     * @param options Configuration options for the hook. The following properties are supported:
      */
     function beforeEach(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function is used to create a hook running after each subtest of the current test.
-     * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-     *    the second argument. Default: A no-op function.
-     * @param options Configuration options for the hook.
-     * @since v18.8.0
+     * This function is used to create a hook running
+     * after each subtest of the current test.
+     *
+     * ```js
+     * describe('tests', async () => {
+     *   afterEach(() => console.log('finished running a test'));
+     *   it('is a subtest', () => {
+     *     assert.ok('some relevant assertion here');
+     *   });
+     * });
+     * ```
+     * @since v18.8.0, v16.18.0
+     * @param [fn='A no-op function'] The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+     * @param options Configuration options for the hook. The following properties are supported:
      */
     function afterEach(fn?: HookFn, options?: HookOptions): void;
     /**
@@ -495,22 +672,87 @@ declare module 'node:test' {
     type FunctionPropertyNames<T> = {
         [K in keyof T]: T[K] extends Function ? K : never;
     }[keyof T];
-    interface MockTracker {
+    /**
+     * The `MockTracker` class is used to manage mocking functionality. The test runner
+     * module provides a top level `mock` export which is a `MockTracker` instance.
+     * Each test also provides its own `MockTracker` instance via the test context's`mock` property.
+     * @since v19.1.0, v18.13.0
+     */
+    class MockTracker {
         /**
          * This function is used to create a mock function.
-         * @param original An optional function to create a mock on.
-         * @param implementation An optional function used as the mock implementation for `original`.
-         *  This is useful for creating mocks that exhibit one behavior for a specified number of calls and then restore the behavior of `original`.
-         * @param options Optional configuration options for the mock function.
+         *
+         * The following example creates a mock function that increments a counter by one
+         * on each invocation. The `times` option is used to modify the mock behavior such
+         * that the first two invocations add two to the counter instead of one.
+         *
+         * ```js
+         * test('mocks a counting function', (t) => {
+         *   let cnt = 0;
+         *
+         *   function addOne() {
+         *     cnt++;
+         *     return cnt;
+         *   }
+         *
+         *   function addTwo() {
+         *     cnt += 2;
+         *     return cnt;
+         *   }
+         *
+         *   const fn = t.mock.fn(addOne, addTwo, { times: 2 });
+         *
+         *   assert.strictEqual(fn(), 2);
+         *   assert.strictEqual(fn(), 4);
+         *   assert.strictEqual(fn(), 5);
+         *   assert.strictEqual(fn(), 6);
+         * });
+         * ```
+         * @since v19.1.0, v18.13.0
+         * @param [original='A no-op function'] An optional function to create a mock on.
+         * @param implementation An optional function used as the mock implementation for `original`. This is useful for creating mocks that exhibit one behavior for a specified number of calls and
+         * then restore the behavior of `original`.
+         * @param options Optional configuration options for the mock function. The following properties are supported:
+         * @return The mocked function. The mocked function contains a special `mock` property, which is an instance of {@link MockFunctionContext}, and can be used for inspecting and changing the
+         * behavior of the mocked function.
          */
         fn<F extends Function = NoOpFunction>(original?: F, options?: MockFunctionOptions): Mock<F>;
         fn<F extends Function = NoOpFunction, Implementation extends Function = F>(original?: F, implementation?: Implementation, options?: MockFunctionOptions): Mock<F | Implementation>;
         /**
-         * This function is used to create a mock on an existing object method.
+         * This function is used to create a mock on an existing object method. The
+         * following example demonstrates how a mock is created on an existing object
+         * method.
+         *
+         * ```js
+         * test('spies on an object method', (t) => {
+         *   const number = {
+         *     value: 5,
+         *     subtract(a) {
+         *       return this.value - a;
+         *     },
+         *   };
+         *
+         *   t.mock.method(number, 'subtract');
+         *   assert.strictEqual(number.subtract.mock.calls.length, 0);
+         *   assert.strictEqual(number.subtract(3), 2);
+         *   assert.strictEqual(number.subtract.mock.calls.length, 1);
+         *
+         *   const call = number.subtract.mock.calls[0];
+         *
+         *   assert.deepStrictEqual(call.arguments, [3]);
+         *   assert.strictEqual(call.result, 2);
+         *   assert.strictEqual(call.error, undefined);
+         *   assert.strictEqual(call.target, undefined);
+         *   assert.strictEqual(call.this, number);
+         * });
+         * ```
+         * @since v19.1.0, v18.13.0
          * @param object The object whose method is being mocked.
          * @param methodName The identifier of the method on `object` to mock. If `object[methodName]` is not a function, an error is thrown.
          * @param implementation An optional function used as the mock implementation for `object[methodName]`.
-         * @param options Optional configuration options for the mock method.
+         * @param options Optional configuration options for the mock method. The following properties are supported:
+         * @return The mocked method. The mocked method contains a special `mock` property, which is an instance of {@link MockFunctionContext}, and can be used for inspecting and changing the
+         * behavior of the mocked method.
          */
         method<
             MockedObject extends object,
@@ -547,7 +789,8 @@ declare module 'node:test' {
         ): Mock<Function>;
 
         /**
-         * This function is syntax sugar for {@link MockTracker.method} with `options.getter` set to `true`.
+         * This function is syntax sugar for `MockTracker.method` with `options.getter`set to `true`.
+         * @since v19.3.0, v18.13.0
          */
         getter<
             MockedObject extends object,
@@ -568,7 +811,8 @@ declare module 'node:test' {
             options?: MockFunctionOptions,
         ): Mock<(() => MockedObject[MethodName]) | Implementation>;
         /**
-         * This function is syntax sugar for {@link MockTracker.method} with `options.setter` set to `true`.
+         * This function is syntax sugar for `MockTracker.method` with `options.setter`set to `true`.
+         * @since v19.3.0, v18.13.0
          */
         setter<
             MockedObject extends object,
@@ -589,17 +833,21 @@ declare module 'node:test' {
             options?: MockFunctionOptions,
         ): Mock<((value: MockedObject[MethodName]) => void) | Implementation>;
         /**
-         * This function restores the default behavior of all mocks that were previously created by this `MockTracker`
-         * and disassociates the mocks from the `MockTracker` instance. Once disassociated, the mocks can still be used,
-         * but the `MockTracker` instance can no longer be used to reset their behavior or otherwise interact with them.
+         * This function restores the default behavior of all mocks that were previously
+         * created by this `MockTracker` and disassociates the mocks from the`MockTracker` instance. Once disassociated, the mocks can still be used, but the`MockTracker` instance can no longer be
+         * used to reset their behavior or
+         * otherwise interact with them.
          *
-         * After each test completes, this function is called on the test context's `MockTracker`.
-         * If the global `MockTracker` is used extensively, calling this function manually is recommended.
+         * After each test completes, this function is called on the test context's`MockTracker`. If the global `MockTracker` is used extensively, calling this
+         * function manually is recommended.
+         * @since v19.1.0, v18.13.0
          */
         reset(): void;
         /**
-         * This function restores the default behavior of all mocks that were previously created by this `MockTracker`.
-         * Unlike `mock.reset()`, `mock.restoreAll()` does not disassociate the mocks from the `MockTracker` instance.
+         * This function restores the default behavior of all mocks that were previously
+         * created by this `MockTracker`. Unlike `mock.reset()`, `mock.restoreAll()` does
+         * not disassociate the mocks from the `MockTracker` instance.
+         * @since v19.1.0, v18.13.0
          */
         restoreAll(): void;
     }
@@ -645,38 +893,103 @@ declare module 'node:test' {
          */
         this: unknown;
     }
-    interface MockFunctionContext<F extends Function> {
+    /**
+     * The `MockFunctionContext` class is used to inspect or manipulate the behavior of
+     * mocks created via the `MockTracker` APIs.
+     * @since v19.1.0, v18.13.0
+     */
+    class MockFunctionContext<F extends Function> {
         /**
-         * A getter that returns a copy of the internal array used to track calls to the mock.
+         * A getter that returns a copy of the internal array used to track calls to the
+         * mock. Each entry in the array is an object with the following properties.
+         * @since v19.1.0, v18.13.0
          */
         readonly calls: Array<MockFunctionCall<F>>;
         /**
-         * This function returns the number of times that this mock has been invoked.
-         * This function is more efficient than checking `ctx.calls.length`
-         * because `ctx.calls` is a getter that creates a copy of the internal call tracking array.
+         * This function returns the number of times that this mock has been invoked. This
+         * function is more efficient than checking `ctx.calls.length` because `ctx.calls`is a getter that creates a copy of the internal call tracking array.
+         * @since v19.1.0, v18.13.0
+         * @return The number of times that this mock has been invoked.
          */
         callCount(): number;
         /**
          * This function is used to change the behavior of an existing mock.
+         *
+         * The following example creates a mock function using `t.mock.fn()`, calls the
+         * mock function, and then changes the mock implementation to a different function.
+         *
+         * ```js
+         * test('changes a mock behavior', (t) => {
+         *   let cnt = 0;
+         *
+         *   function addOne() {
+         *     cnt++;
+         *     return cnt;
+         *   }
+         *
+         *   function addTwo() {
+         *     cnt += 2;
+         *     return cnt;
+         *   }
+         *
+         *   const fn = t.mock.fn(addOne);
+         *
+         *   assert.strictEqual(fn(), 1);
+         *   fn.mock.mockImplementation(addTwo);
+         *   assert.strictEqual(fn(), 3);
+         *   assert.strictEqual(fn(), 5);
+         * });
+         * ```
+         * @since v19.1.0, v18.13.0
          * @param implementation The function to be used as the mock's new implementation.
          */
         mockImplementation(implementation: Function): void;
         /**
-         * This function is used to change the behavior of an existing mock for a single invocation.
-         * Once invocation `onCall` has occurred, the mock will revert to whatever behavior
-         * it would have used had `mockImplementationOnce()` not been called.
+         * This function is used to change the behavior of an existing mock for a single
+         * invocation. Once invocation `onCall` has occurred, the mock will revert to
+         * whatever behavior it would have used had `mockImplementationOnce()` not been
+         * called.
+         *
+         * The following example creates a mock function using `t.mock.fn()`, calls the
+         * mock function, changes the mock implementation to a different function for the
+         * next invocation, and then resumes its previous behavior.
+         *
+         * ```js
+         * test('changes a mock behavior once', (t) => {
+         *   let cnt = 0;
+         *
+         *   function addOne() {
+         *     cnt++;
+         *     return cnt;
+         *   }
+         *
+         *   function addTwo() {
+         *     cnt += 2;
+         *     return cnt;
+         *   }
+         *
+         *   const fn = t.mock.fn(addOne);
+         *
+         *   assert.strictEqual(fn(), 1);
+         *   fn.mock.mockImplementationOnce(addTwo);
+         *   assert.strictEqual(fn(), 3);
+         *   assert.strictEqual(fn(), 4);
+         * });
+         * ```
+         * @since v19.1.0, v18.13.0
          * @param implementation The function to be used as the mock's implementation for the invocation number specified by `onCall`.
-         * @param onCall The invocation number that will use `implementation`.
-         *  If the specified invocation has already occurred then an exception is thrown.
+         * @param onCall The invocation number that will use `implementation`. If the specified invocation has already occurred then an exception is thrown.
          */
         mockImplementationOnce(implementation: Function, onCall?: number): void;
         /**
          * Resets the call history of the mock function.
+         * @since v19.3.0, v18.13.0
          */
         resetCalls(): void;
         /**
-         * Resets the implementation of the mock function to its original behavior.
-         * The mock can still be used after calling this function.
+         * Resets the implementation of the mock function to its original behavior. The
+         * mock can still be used after calling this function.
+         * @since v19.1.0, v18.13.0
          */
         restore(): void;
     }

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -363,9 +363,9 @@ async function testPromisify() {
     let buffers: Promise<Buffer[]>;
     let entries: Promise<fs.Dirent[]>;
 
-    names = fs.promises.readdir('/path/to/dir', { encoding: 'utf8', withFileTypes: false });
-    buffers = fs.promises.readdir('/path/to/dir', { encoding: 'buffer', withFileTypes: false });
-    entries = fs.promises.readdir('/path/to/dir', { encoding: 'utf8', withFileTypes: true });
+    names = fs.promises.readdir('/path/to/dir', { encoding: 'utf8', withFileTypes: false, recursive: true });
+    buffers = fs.promises.readdir('/path/to/dir', { encoding: 'buffer', withFileTypes: false, recursive: true });
+    entries = fs.promises.readdir('/path/to/dir', { encoding: 'utf8', withFileTypes: true, recursive: true });
 }
 
 {
@@ -434,16 +434,19 @@ async function testPromisify() {
     const dirEntProm: Promise<fs.Dir> = fs.promises.opendir('test', {
         encoding: 'utf8',
         bufferSize: 42,
+        recursive: false,
     });
 
     const dirEntBufferProm: Promise<fs.Dir> = fs.promises.opendir(Buffer.from('test'), {
         encoding: 'utf8',
         bufferSize: 42,
+        recursive: false,
     });
 
     const dirEntUrlProm: Promise<fs.Dir> = fs.promises.opendir(new URL(`file://${__dirname}`), {
         encoding: 'utf8',
         bufferSize: 42,
+        recursive: false,
     });
 }
 

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -18,6 +18,7 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    testNamePatterns: ['executed'],
 });
 
 // TestsStream should be a NodeJS.ReadableStream
@@ -78,6 +79,8 @@ test(undefined, undefined, t => {
     t.afterEach(() => {});
     // $ExpectType void
     t.beforeEach(() => {});
+    // $ExpectType void
+    t.before(() => {});
 });
 
 // Test the subtest approach.

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -6,7 +6,7 @@
  * The timer functions within Node.js implement a similar API as the timers API
  * provided by Web Browsers but use a different internal implementation that is
  * built around the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout).
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/timers.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/timers.js)
  */
 declare module 'timers' {
     import { Abortable } from 'node:events';

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const tls = require('node:tls');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/tls.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/tls.js)
  */
 declare module 'tls' {
     import { X509Certificate } from 'node:crypto';
@@ -637,7 +637,8 @@ declare module 'tls' {
          * used.
          * @since v0.5.3
          * @param hostname A SNI host name or wildcard (e.g. `'*'`)
-         * @param context An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc).
+         * @param context An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc), or a TLS context object created
+         * with {@link createSecureContext} itself.
          */
         addContext(hostname: string, context: SecureContextOptions): void;
         /**

--- a/types/node/trace_events.d.ts
+++ b/types/node/trace_events.d.ts
@@ -94,7 +94,7 @@
  *
  * The features from this module are not available in `Worker` threads.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/trace_events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/trace_events.js)
  */
 declare module 'trace_events' {
     /**

--- a/types/node/ts4.8/assert.d.ts
+++ b/types/node/ts4.8/assert.d.ts
@@ -1,7 +1,7 @@
 /**
  * The `node:assert` module provides a set of assertion functions for verifying
  * invariants.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/assert.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/assert.js)
  */
 declare module 'assert' {
     /**
@@ -35,9 +35,10 @@ declare module 'assert' {
             });
         }
         /**
-         * This feature is currently experimental and behavior might still change.
+         * This feature is deprecated and will be removed in a future version.
+         * Please consider using alternatives such as the `mock` helper function.
          * @since v14.2.0, v12.19.0
-         * @experimental
+         * @deprecated Deprecated
          */
         class CallTracker {
             /**
@@ -81,7 +82,7 @@ declare module 'assert' {
              * ```
              * @since v18.8.0, v16.18.0
              * @param fn
-             * @return An Array with the calls to a tracked function.
+             * @return An Array with all the calls to a tracked function.
              */
             getCalls(fn: Function): CallTrackerCall[];
             /**

--- a/types/node/ts4.8/async_hooks.d.ts
+++ b/types/node/ts4.8/async_hooks.d.ts
@@ -12,7 +12,7 @@
  * import async_hooks from 'node:async_hooks';
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/async_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/async_hooks.js)
  */
 declare module 'async_hooks' {
     /**
@@ -278,9 +278,7 @@ declare module 'async_hooks' {
             fn: Func,
             type?: string,
             thisArg?: ThisArg
-        ): Func & {
-            asyncResource: AsyncResource;
-        };
+        ): Func;
         /**
          * Binds the given function to execute to this `AsyncResource`'s scope.
          * @since v14.8.0, v12.19.0
@@ -288,9 +286,7 @@ declare module 'async_hooks' {
          */
         bind<Func extends (...args: any[]) => any>(
             fn: Func
-        ): Func & {
-            asyncResource: AsyncResource;
-        };
+        ): Func;
         /**
          * Call the provided function with the provided arguments in the execution context
          * of the async resource. This will establish the context, trigger the AsyncHooks
@@ -378,9 +374,7 @@ declare module 'async_hooks' {
          */
         static bind<Func extends (...args: any[]) => any>(
             fn: Func
-        ): Func & {
-            asyncResource: AsyncResource;
-        };
+        ): Func;
         /**
          * Captures the current execution context and returns a function that accepts a
          * function as an argument. Whenever the returned function is called, it
@@ -410,9 +404,7 @@ declare module 'async_hooks' {
          * @experimental
          * @return A new function with the signature `(fn: (...args) : R, ...args) : R`.
          */
-        static snapshot(): (<R, TArgs extends any[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R) & {
-            asyncResource: AsyncResource;
-        };
+        static snapshot(): <R, TArgs extends any[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R;
         /**
          * Disables the instance of `AsyncLocalStorage`. All subsequent calls
          * to `asyncLocalStorage.getStore()` will return `undefined` until`asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()` is called again.

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -41,7 +41,7 @@
  * // Creates a Buffer containing the Latin-1 bytes [0x74, 0xe9, 0x73, 0x74].
  * const buf7 = Buffer.from('tést', 'latin1');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/buffer.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/buffer.js)
  */
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
@@ -446,7 +446,7 @@ declare module 'buffer' {
              *
              * ```js
              * const u16 = new Uint16Array([0, 0xffff]);
-             * const buf = Buffer.copyBytesFrom(u16, 0, 1);
+             * const buf = Buffer.copyBytesFrom(u16, 1, 1);
              * u16[1] = 0;
              * console.log(buf.length); // 2
              * console.log(buf[0]); // 255
@@ -488,7 +488,7 @@ declare module 'buffer' {
              * // Prints: <Buffer 00 00 00 00 00>
              * ```
              *
-             * If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown.
+             * If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown.
              *
              * If `fill` is specified, the allocated `Buffer` will be initialized by calling `buf.fill(fill)`.
              *
@@ -525,7 +525,7 @@ declare module 'buffer' {
              */
             alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
             /**
-             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown.
+             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown.
              *
              * The underlying memory for `Buffer` instances created in this way is _not_
              * _initialized_. The contents of the newly created `Buffer` are unknown and _may contain sensitive data_. Use `Buffer.alloc()` instead to initialize`Buffer` instances with zeroes.
@@ -562,8 +562,8 @@ declare module 'buffer' {
              */
             allocUnsafe(size: number): Buffer;
             /**
-             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_INVALID_ARG_VALUE` is thrown. A zero-length `Buffer` is created
-             * if `size` is 0.
+             * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown. A zero-length `Buffer` is created if
+             * `size` is 0.
              *
              * The underlying memory for `Buffer` instances created in this way is _not_
              * _initialized_. The contents of the newly created `Buffer` are unknown and _may contain sensitive data_. Use `buf.fill(0)` to initialize

--- a/types/node/ts4.8/child_process.d.ts
+++ b/types/node/ts4.8/child_process.d.ts
@@ -63,7 +63,7 @@
  * For certain use cases, such as automating shell scripts, the `synchronous counterparts` may be more convenient. In many cases, however,
  * the synchronous methods can have significant impact on performance due to
  * stalling the event loop while spawned processes complete.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/child_process.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/child_process.js)
  */
 declare module 'child_process' {
     import { ObjectEncodingOptions } from 'node:fs';

--- a/types/node/ts4.8/cluster.d.ts
+++ b/types/node/ts4.8/cluster.d.ts
@@ -50,7 +50,7 @@
  * ```
  *
  * On Windows, it is not yet possible to set up a named pipe server in a worker.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/cluster.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/cluster.js)
  */
 declare module 'cluster' {
     import * as child from 'node:child_process';

--- a/types/node/ts4.8/console.d.ts
+++ b/types/node/ts4.8/console.d.ts
@@ -53,7 +53,7 @@
  * myConsole.warn(`Danger ${name}! Danger!`);
  * // Prints: Danger Will Robinson! Danger!, to err
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/console.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/console.js)
  */
 declare module 'console' {
     import console = require('node:console');

--- a/types/node/ts4.8/crypto.d.ts
+++ b/types/node/ts4.8/crypto.d.ts
@@ -14,7 +14,7 @@
  * // Prints:
  * //   c0fa1bc00531bd78ef38c628449c5102aeabd49b5dc3a2a516ea6ea959d6658e
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/crypto.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/crypto.js)
  */
 declare module 'crypto' {
     import * as stream from 'node:stream';

--- a/types/node/ts4.8/dgram.d.ts
+++ b/types/node/ts4.8/dgram.d.ts
@@ -23,7 +23,7 @@
  * server.bind(41234);
  * // Prints: server listening 0.0.0.0:41234
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/dgram.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/dgram.js)
  */
 declare module 'dgram' {
     import { AddressInfo } from 'node:net';

--- a/types/node/ts4.8/diagnostics_channel.d.ts
+++ b/types/node/ts4.8/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @since v15.1.0, v14.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/diagnostics_channel.js)
  */
 declare module 'diagnostics_channel' {
     /**

--- a/types/node/ts4.8/dns.d.ts
+++ b/types/node/ts4.8/dns.d.ts
@@ -42,7 +42,7 @@
  * ```
  *
  * See the `Implementation considerations section` for more information.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/dns.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/dns.js)
  */
 declare module 'dns' {
     import * as dnsPromises from 'node:dns/promises';
@@ -484,6 +484,14 @@ declare module 'dns' {
      * @since v0.1.16
      */
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
+    /**
+     * Get the default value for `verbatim` in {@link lookup} and `dnsPromises.lookup()`. The value could be:
+     *
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
+     * @since v20.1.0
+     */
+    export function getDefaultResultOrder(): 'ipv4first' | 'verbatim';
     /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted

--- a/types/node/ts4.8/domain.d.ts
+++ b/types/node/ts4.8/domain.d.ts
@@ -12,7 +12,7 @@
  * will be notified, rather than losing the context of the error in the`process.on('uncaughtException')` handler, or causing the program to
  * exit immediately with an error code.
  * @deprecated Since v1.4.2 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/domain.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/domain.js)
  */
 declare module 'domain' {
     import EventEmitter = require('node:events');
@@ -56,7 +56,7 @@ declare module 'domain' {
         exit(): void;
         /**
          * Run the supplied function in the context of the domain, implicitly
-         * binding all event emitters, timers, and lowlevel requests that are
+         * binding all event emitters, timers, and low-level requests that are
          * created in that context. Optionally, arguments can be passed to
          * the function.
          *

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -32,7 +32,7 @@
  * });
  * myEmitter.emit('event');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/events.js)
  */
 declare module 'events' {
     // NOTE: This class is in the docs but is **not actually exported** by Node.

--- a/types/node/ts4.8/fs/promises.d.ts
+++ b/types/node/ts4.8/fs/promises.d.ts
@@ -14,6 +14,7 @@ declare module 'fs/promises' {
     import { ReadableStream } from 'node:stream/web';
     import {
         BigIntStats,
+        BigIntStatsFs,
         BufferEncodingOption,
         constants as fsConstants,
         CopyOptions,
@@ -30,7 +31,9 @@ declare module 'fs/promises' {
         RmDirOptions,
         RmOptions,
         StatOptions,
+        StatFsOptions,
         Stats,
+        StatsFs,
         TimeLike,
         WatchEventType,
         WatchOptions,
@@ -639,6 +642,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -654,6 +658,7 @@ declare module 'fs/promises' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Promise<Buffer[]>;
@@ -667,6 +672,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -680,6 +686,7 @@ declare module 'fs/promises' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Promise<Dirent[]>;
     /**
@@ -756,6 +763,23 @@ declare module 'fs/promises' {
         }
     ): Promise<BigIntStats>;
     function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
+    /**
+     * @since v19.6.0, v18.15.0
+     * @return Fulfills with the {fs.StatFs} object for the given `path`.
+     */
+    function statfs(
+        path: PathLike,
+        opts?: StatFsOptions & {
+            bigint?: false | undefined;
+        }
+    ): Promise<StatsFs>;
+    function statfs(
+        path: PathLike,
+        opts: StatFsOptions & {
+            bigint: true;
+        }
+    ): Promise<BigIntStatsFs>;
+    function statfs(path: PathLike, opts?: StatFsOptions): Promise<StatsFs | BigIntStatsFs>;
     /**
      * Creates a new link from the `existingPath` to the `newPath`. See the POSIX [`link(2)`](http://man7.org/linux/man-pages/man2/link.2.html) documentation for more detail.
      * @since v10.0.0

--- a/types/node/ts4.8/globals.d.ts
+++ b/types/node/ts4.8/globals.d.ts
@@ -45,42 +45,42 @@ declare var gc: undefined | (() => void);
 // from https://github.com/microsoft/TypeScript/blob/38da7c600c83e7b31193a62495239a0fe478cb67/lib/lib.webworker.d.ts#L633 until moved to separate lib
 /** A controller object that allows you to abort one or more DOM requests as and when desired. */
 interface AbortController {
-  /**
-   * Returns the AbortSignal object associated with this object.
-   */
+    /**
+     * Returns the AbortSignal object associated with this object.
+     */
 
-  readonly signal: AbortSignal;
-  /**
-   * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
-   */
-  abort(reason?: any): void;
+    readonly signal: AbortSignal;
+    /**
+     * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
+     */
+    abort(reason?: any): void;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
 interface AbortSignal extends EventTarget {
-  /**
-   * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
-   */
-  readonly aborted: boolean;
-  readonly reason: any;
-  onabort: null | ((this: AbortSignal, event: Event) => any);
+    /**
+     * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
+     */
+    readonly aborted: boolean;
+    readonly reason: any;
+    onabort: null | ((this: AbortSignal, event: Event) => any);
 }
 
 declare var AbortController: typeof globalThis extends {onmessage: any; AbortController: infer T}
-  ? T
-  : {
-      prototype: AbortController;
-      new(): AbortController;
-  };
+    ? T
+    : {
+        prototype: AbortController;
+        new(): AbortController;
+    };
 
 declare var AbortSignal: typeof globalThis extends {onmessage: any; AbortSignal: infer T}
-  ? T
-  : {
-      prototype: AbortSignal;
-      new(): AbortSignal;
-      abort(reason?: any): AbortSignal;
-      timeout(milliseconds: number): AbortSignal;
-  };
+    ? T
+    : {
+        prototype: AbortSignal;
+        new(): AbortSignal;
+        abort(reason?: any): AbortSignal;
+        timeout(milliseconds: number): AbortSignal;
+    };
 //#endregion borrowed
 
 //#region ArrayLike.at()
@@ -94,6 +94,7 @@ interface RelativeIndexable<T> {
 }
 interface String extends RelativeIndexable<string> {}
 interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
 interface Int8Array extends RelativeIndexable<number> {}
 interface Uint8Array extends RelativeIndexable<number> {}
 interface Uint8ClampedArray extends RelativeIndexable<number> {}
@@ -158,7 +159,7 @@ declare namespace NodeJS {
         /**
          * Name of the script [if this function was defined in a script]
          */
-        getFileName(): string | null;
+        getFileName(): string | undefined;
 
         /**
          * Current line number [if this function was defined in a script]

--- a/types/node/ts4.8/http2.d.ts
+++ b/types/node/ts4.8/http2.d.ts
@@ -6,7 +6,7 @@
  * const http2 = require('node:http2');
  * ```
  * @since v8.4.0
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/http2.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/http2.js)
  */
 declare module 'http2' {
     import EventEmitter = require('node:events');

--- a/types/node/ts4.8/https.d.ts
+++ b/types/node/ts4.8/https.d.ts
@@ -1,7 +1,7 @@
 /**
  * HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a
  * separate module.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/https.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/https.js)
  */
 declare module 'https' {
     import { Duplex } from 'node:stream';

--- a/types/node/ts4.8/inspector.d.ts
+++ b/types/node/ts4.8/inspector.d.ts
@@ -22,7 +22,7 @@
  * ```js
  * import * as inspector from 'node:inspector';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/inspector.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/inspector.js)
  */
 declare module 'inspector' {
     import EventEmitter = require('node:events');

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -10,7 +10,7 @@
  * ```js
  * const net = require('node:net');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/net.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/net.js)
  */
 declare module 'net' {
     import * as stream from 'node:stream';
@@ -267,6 +267,12 @@ declare module 'net' {
          */
         readonly connecting: boolean;
         /**
+         * This is `true` if the socket is not connected yet, either because `.connect()`has not yet been called or because it is still in the process of connecting
+         * (see `socket.connecting`).
+         * @since v11.2.0, v10.16.0
+         */
+        readonly pending: boolean;
+        /**
          * See `writable.destroyed` for further details.
          */
         readonly destroyed: boolean;
@@ -287,12 +293,6 @@ declare module 'net' {
          * @since v18.8.0, v16.18.0
          */
         readonly localFamily?: string;
-        /**
-         * This is `true` if the socket is not connected yet, either because `.connect()`has not yet been called or because it is still in the process of connecting
-         * (see `socket.connecting`).
-         * @since v11.2.0, v10.16.0
-         */
-        readonly pending: boolean;
         /**
          * This property represents the state of the connection as a string.
          *

--- a/types/node/ts4.8/node-tests.ts
+++ b/types/node/ts4.8/node-tests.ts
@@ -163,7 +163,7 @@ import * as trace_events from 'node:trace_events';
         const func: Function | undefined  = frame.getFunction();
         const funcName: string | null = frame.getFunctionName();
         const meth: string | null  = frame.getMethodName();
-        const fname: string | null  = frame.getFileName();
+        const fname: string | undefined  = frame.getFileName();
         const lineno: number | null  = frame.getLineNumber();
         const colno: number | null  = frame.getColumnNumber();
         const evalOrigin: string | undefined  = frame.getEvalOrigin();

--- a/types/node/ts4.8/os.d.ts
+++ b/types/node/ts4.8/os.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * const os = require('node:os');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/os.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/os.js)
  */
 declare module 'os' {
     interface CpuInfo {

--- a/types/node/ts4.8/path.d.ts
+++ b/types/node/ts4.8/path.d.ts
@@ -13,7 +13,7 @@ declare module 'path/win32' {
  * ```js
  * const path = require('node:path');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/path.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/path.js)
  */
 declare module 'path' {
     namespace path {

--- a/types/node/ts4.8/perf_hooks.d.ts
+++ b/types/node/ts4.8/perf_hooks.d.ts
@@ -27,7 +27,7 @@
  *   performance.measure('A to B', 'A', 'B');
  * });
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/perf_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/perf_hooks.js)
  */
 declare module 'perf_hooks' {
     import { AsyncResource } from 'node:async_hooks';

--- a/types/node/ts4.8/punycode.d.ts
+++ b/types/node/ts4.8/punycode.d.ts
@@ -24,7 +24,7 @@
  * made available to developers as a convenience. Fixes or other modifications to
  * the module must be directed to the [Punycode.js](https://github.com/bestiejs/punycode.js) project.
  * @deprecated Since v7.0.0 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/punycode.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/punycode.js)
  */
 declare module 'punycode' {
     /**

--- a/types/node/ts4.8/querystring.d.ts
+++ b/types/node/ts4.8/querystring.d.ts
@@ -9,7 +9,7 @@
  * `querystring` is more performant than `URLSearchParams` but is not a
  * standardized API. Use `URLSearchParams` when performance is not critical or
  * when compatibility with browser code is desirable.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/querystring.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/querystring.js)
  */
 declare module 'querystring' {
     interface StringifyOptions {

--- a/types/node/ts4.8/readline.d.ts
+++ b/types/node/ts4.8/readline.d.ts
@@ -30,7 +30,7 @@
  *
  * Once this code is invoked, the Node.js application will not terminate until the`readline.Interface` is closed because the interface waits for data to be
  * received on the `input` stream.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/readline.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/readline.js)
  */
 declare module 'readline' {
     import { Abortable, EventEmitter } from 'node:events';

--- a/types/node/ts4.8/repl.d.ts
+++ b/types/node/ts4.8/repl.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const repl = require('node:repl');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/repl.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/repl.js)
  */
 declare module 'repl' {
     import { Interface, Completer, AsyncCompleter } from 'node:readline';

--- a/types/node/ts4.8/stream.d.ts
+++ b/types/node/ts4.8/stream.d.ts
@@ -14,7 +14,7 @@
  *
  * The `node:stream` module is useful for creating new types of stream instances.
  * It is usually not necessary to use the `node:stream` module to consume streams.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/stream.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/stream.js)
  */
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
@@ -1131,6 +1131,20 @@ declare module 'stream' {
          * @param stream a stream to attach a signal to
          */
         function addAbortSignal<T extends Stream>(signal: AbortSignal, stream: T): T;
+        /**
+         * Returns the default highWaterMark used by streams.
+         * Defaults to `16384` (16 KiB), or `16` for `objectMode`.
+         * @since v19.9.0
+         * @param objectMode
+         */
+        function getDefaultHighWaterMark(objectMode: boolean): number;
+        /**
+         * Sets the default highWaterMark used by streams.
+         * @since v19.9.0
+         * @param objectMode
+         * @param value highWaterMark value
+         */
+        function setDefaultHighWaterMark(objectMode: boolean, value: number): void;
         interface FinishedOptions extends Abortable {
             error?: boolean | undefined;
             readable?: boolean | undefined;

--- a/types/node/ts4.8/string_decoder.d.ts
+++ b/types/node/ts4.8/string_decoder.d.ts
@@ -36,7 +36,7 @@
  * decoder.write(Buffer.from([0x82]));
  * console.log(decoder.end(Buffer.from([0xAC])));
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/string_decoder.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/string_decoder.js)
  */
 declare module 'string_decoder' {
     class StringDecoder {

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -18,6 +18,7 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    testNamePatterns: ['executed'],
 });
 
 // TestsStream should be a NodeJS.ReadableStream
@@ -78,6 +79,8 @@ test(undefined, undefined, t => {
     t.afterEach(() => {});
     // $ExpectType void
     t.beforeEach(() => {});
+    // $ExpectType void
+    t.before(() => {});
 });
 
 // Test the subtest approach.

--- a/types/node/ts4.8/timers.d.ts
+++ b/types/node/ts4.8/timers.d.ts
@@ -6,7 +6,7 @@
  * The timer functions within Node.js implement a similar API as the timers API
  * provided by Web Browsers but use a different internal implementation that is
  * built around the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout).
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/timers.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/timers.js)
  */
 declare module 'timers' {
     import { Abortable } from 'node:events';
@@ -62,6 +62,13 @@ declare module 'timers' {
                 [Symbol.toPrimitive](): number;
             }
         }
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
+         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * @since v0.0.1
+         */
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return

--- a/types/node/ts4.8/tls.d.ts
+++ b/types/node/ts4.8/tls.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const tls = require('node:tls');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/tls.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/tls.js)
  */
 declare module 'tls' {
     import { X509Certificate } from 'node:crypto';
@@ -637,7 +637,8 @@ declare module 'tls' {
          * used.
          * @since v0.5.3
          * @param hostname A SNI host name or wildcard (e.g. `'*'`)
-         * @param context An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc).
+         * @param context An object containing any of the possible properties from the {@link createSecureContext} `options` arguments (e.g. `key`, `cert`, `ca`, etc), or a TLS context object created
+         * with {@link createSecureContext} itself.
          */
         addContext(hostname: string, context: SecureContextOptions): void;
         /**

--- a/types/node/ts4.8/trace_events.d.ts
+++ b/types/node/ts4.8/trace_events.d.ts
@@ -94,7 +94,7 @@
  *
  * The features from this module are not available in `Worker` threads.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/trace_events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/trace_events.js)
  */
 declare module 'trace_events' {
     /**

--- a/types/node/ts4.8/tty.d.ts
+++ b/types/node/ts4.8/tty.d.ts
@@ -21,7 +21,7 @@
  *
  * In most cases, there should be little to no reason for an application to
  * manually create instances of the `tty.ReadStream` and `tty.WriteStream`classes.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/tty.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/tty.js)
  */
 declare module 'tty' {
     import * as net from 'node:net';

--- a/types/node/ts4.8/url.d.ts
+++ b/types/node/ts4.8/url.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * import url from 'node:url';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/url.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/url.js)
  */
 declare module 'url' {
     import { Blob as NodeBlob } from 'node:buffer';

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const util = require('node:util');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/util.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/util.js)
  */
 declare module 'util' {
     import * as types from 'node:util/types';
@@ -1834,7 +1834,7 @@ declare module 'util/types' {
      * ```js
      * const vm = require('node:vm');
      * const context = vm.createContext({});
-     * const myError = vm.runInContext('new Error', context);
+     * const myError = vm.runInContext('new Error()', context);
      * console.log(util.types.isNativeError(myError)); // true
      * console.log(myError instanceof Error); // false
      * ```

--- a/types/node/ts4.8/v8.d.ts
+++ b/types/node/ts4.8/v8.d.ts
@@ -4,7 +4,7 @@
  * ```js
  * const v8 = require('node:v8');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/v8.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/v8.js)
  */
 declare module 'v8' {
     import { Readable } from 'node:stream';
@@ -29,6 +29,9 @@ declare module 'v8' {
         does_zap_garbage: DoesZapCodeSpaceFlag;
         number_of_native_contexts: number;
         number_of_detached_contexts: number;
+        total_global_handles_size: number;
+        used_global_handles_size: number;
+        external_memory: number;
     }
     interface HeapCodeStatistics {
         code_and_metadata_size: number;

--- a/types/node/ts4.8/vm.d.ts
+++ b/types/node/ts4.8/vm.d.ts
@@ -34,7 +34,7 @@
  *
  * console.log(x); // 1; y is not defined.
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/vm.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/vm.js)
  */
 declare module 'vm' {
     interface Context extends NodeJS.Dict<any> {}

--- a/types/node/ts4.8/wasi.d.ts
+++ b/types/node/ts4.8/wasi.d.ts
@@ -62,7 +62,7 @@
  * $ wat2wasm demo.wat
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/wasi.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/wasi.js)
  */
 declare module 'wasi' {
     interface WASIOptions {
@@ -85,11 +85,11 @@ declare module 'wasi' {
          */
         preopens?: NodeJS.Dict<string> | undefined;
         /**
-         * By default, WASI applications terminate the Node.js
-         * process via the `__wasi_proc_exit()` function. Setting this option to `true`
-         * causes `wasi.start()` to return the exit code rather than terminate the
-         * process.
-         * @default false
+         * By default, when WASI applications call `__wasi_proc_exit()`
+         *  `wasi.start()` will return with the exit code specified rather than terminatng the process.
+         * Setting this option to `false` will cause the Node.js process to exit with
+         * the specified exit code instead.
+         * @default true
          */
         returnOnExit?: boolean | undefined;
         /**

--- a/types/node/ts4.8/worker_threads.d.ts
+++ b/types/node/ts4.8/worker_threads.d.ts
@@ -49,7 +49,7 @@
  *
  * Worker threads inherit non-process-specific options by default. Refer to `Worker constructor options` to know how to customize worker thread options,
  * specifically `argv` and `execArgv` options.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/worker_threads.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/worker_threads.js)
  */
 declare module 'worker_threads' {
     import { Blob } from 'node:buffer';

--- a/types/node/ts4.8/zlib.d.ts
+++ b/types/node/ts4.8/zlib.d.ts
@@ -88,7 +88,7 @@
  *   });
  * ```
  * @since v0.5.8
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/zlib.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/zlib.js)
  */
 declare module 'zlib' {
     import * as stream from 'node:stream';

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -21,7 +21,7 @@
  *
  * In most cases, there should be little to no reason for an application to
  * manually create instances of the `tty.ReadStream` and `tty.WriteStream`classes.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/tty.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/tty.js)
  */
 declare module 'tty' {
     import * as net from 'node:net';

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * import url from 'node:url';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/url.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/url.js)
  */
 declare module 'url' {
     import { Blob as NodeBlob } from 'node:buffer';

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const util = require('node:util');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/util.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/util.js)
  */
 declare module 'util' {
     import * as types from 'node:util/types';
@@ -1842,7 +1842,7 @@ declare module 'util/types' {
      * ```js
      * const vm = require('node:vm');
      * const context = vm.createContext({});
-     * const myError = vm.runInContext('new Error', context);
+     * const myError = vm.runInContext('new Error()', context);
      * console.log(util.types.isNativeError(myError)); // true
      * console.log(myError instanceof Error); // false
      * ```

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -4,7 +4,7 @@
  * ```js
  * const v8 = require('node:v8');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/v8.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/v8.js)
  */
 declare module 'v8' {
     import { Readable } from 'node:stream';

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -34,7 +34,7 @@
  *
  * console.log(x); // 1; y is not defined.
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/vm.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/vm.js)
  */
 declare module 'vm' {
     interface Context extends NodeJS.Dict<any> {}

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -62,7 +62,7 @@
  * $ wat2wasm demo.wat
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/wasi.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/wasi.js)
  */
 declare module 'wasi' {
     interface WASIOptions {
@@ -85,11 +85,11 @@ declare module 'wasi' {
          */
         preopens?: NodeJS.Dict<string> | undefined;
         /**
-         * By default, WASI applications terminate the Node.js
-         * process via the `__wasi_proc_exit()` function. Setting this option to `true`
-         * causes `wasi.start()` to return the exit code rather than terminate the
-         * process.
-         * @default false
+         * By default, when WASI applications call `__wasi_proc_exit()`
+         *  `wasi.start()` will return with the exit code specified rather than terminatng the process.
+         * Setting this option to `false` will cause the Node.js process to exit with
+         * the specified exit code instead.
+         * @default true
          */
         returnOnExit?: boolean | undefined;
         /**

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -49,7 +49,7 @@
  *
  * Worker threads inherit non-process-specific options by default. Refer to `Worker constructor options` to know how to customize worker thread options,
  * specifically `argv` and `execArgv` options.
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/worker_threads.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/worker_threads.js)
  */
 declare module 'worker_threads' {
     import { Blob } from 'node:buffer';

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -88,7 +88,7 @@
  *   });
  * ```
  * @since v0.5.8
- * @see [source](https://github.com/nodejs/node/blob/v20.0.0/lib/zlib.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.1.0/lib/zlib.js)
  */
 declare module 'zlib' {
     import * as stream from 'node:stream';


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.1.0

- assert: deprecate `CallTracker`
- dns: expose `getDefaultResultOrder`
- fs: add recursive option to readdir and opendir
- fs: add support for mode flag to specify the copy behavior of the `cp` methods
- http: add highWaterMark option http.createServer
- test_runner: add testNamePatterns to run API
- test_runner: execute before hook on test
- wasi: make `returnOnExit` true by default

Also fixed generating docs for `node:test` module. And updated modules in `ts4.8` folder.

-------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v20.x/docs/api/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
