### PR TITLE
[oauth2orize] add more functions with different arities

### DIFF
--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for oauth2orize 1.8
+// Type definitions for oauth2orize 1.11
 // Project: https://github.com/jaredhanson/oauth2orize/
 // Definitions by: Wonshik Kim <https://github.com/wokim>, Kei Son <https://github.com/heycalmdown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -239,7 +239,7 @@ export namespace exchange {
   function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
   function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction;
 
-  var code: typeof authorizationCode;
+  const code: typeof authorizationCode;
 
   // arity == 5; issue(client, scope, req.body, req.authInfo, issued);
   function clientCredentials(options: Options, issue: (client: any, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void): MiddlewareFunction;

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -140,7 +140,12 @@ export type SerializeClientDoneFunction = (err: Error | null, id: string) => voi
 export type DeserializeClientFunction = (id: string, done: DeserializeClientDoneFunction) => void;
 export type DeserializeClientDoneFunction = (err: Error | null, client?: any | boolean) => void;
 
-export type IssueGrantCodeFunction = (client: any, redirectUri: string, user: any, res: any, issued: (err: Error | null, code?: string) => void) => void;
+export type IssueGrantCodeDoneFunction = (err: Error | null, code?: string) => void;
+
+export type IssueGrantCodeFunctionArity7 = (client: any, redirectUri: string, user: any, res: any, req: OAuth2Req, locals: any, issued: IssueGrantCodeDoneFunction) => void;
+export type IssueGrantCodeFunctionArity6 = (client: any, redirectUri: string, user: any, res: any, req: OAuth2Req, issued: IssueGrantCodeDoneFunction) => void;
+export type IssueGrantCodeFunction = (client: any, redirectUri: string, user: any, res: any, issued: IssueGrantCodeDoneFunction) => void;
+export type IssueGrantCodeFunctionArity4 = (client: any, redirectUri: string, user: any, issued: IssueGrantCodeDoneFunction) => void;
 
 export type IssueGrantTokenFunction = (client: any, user: any, ares: any, issued: (err: Error | null, code?: string, params?: any) => void) => void;
 
@@ -188,8 +193,14 @@ export namespace grant {
     scopeSeparator?: string | undefined;
   }
 
+  function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
+  function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
   function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction;
+  function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
+  function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
+  function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
   function code(issue: IssueGrantCodeFunction): MiddlewareFunction;
+  function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
 
   function token(options: Options, issue: IssueGrantTokenFunction): MiddlewareFunction;
   function token(issue: IssueGrantTokenFunction): MiddlewareFunction;

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -128,7 +128,11 @@ export type MiddlewareErrorFunction = (err: Error, req: MiddlewareRequest, res: 
 
 export type MiddlewareNextFunction = (err?: Error) => void;
 
-export type ValidateFunction = (clientId: string, redirectURI: string, validated: (err: Error | null, client?: any, redirectURI?: string) => void) => void;
+export type ValidateDoneFunction = (err: Error | null, client?: any, redirectURI?: string) => void;
+export type ValidateFunctionArity5 = (clientId: string, redirectURI: string, scope: string[], type: string, validated: ValidateDoneFunction) => void;
+export type ValidateFunctionArity4 = (clientId: string, redirectURI: string, scope: string[], validated: ValidateDoneFunction) => void;
+export type ValidateFunction = (clientId: string, redirectURI: string, validated: ValidateDoneFunction) => void;
+export type ValidateFunctionArity2 = (areq: OAuth2Req, validated: ValidateDoneFunction) => void;
 
 export type ImmediateFunction = (client: any, user: any, scope: string[], type: string, areq: any, done: (err: Error | null, allow: boolean, info: any, locals: any) => void) => void;
 
@@ -162,8 +166,14 @@ export class OAuth2Server {
   exchange(type: string, fn: MiddlewareFunction): OAuth2Server;
   exchange(fn: MiddlewareFunction): OAuth2Server;
 
+  authorize(options: AuthorizeOptions, validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(options: AuthorizeOptions, validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction;
   authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(options: AuthorizeOptions, validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction;
   authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction;
 
   authorization: OAuth2Server["authorize"];
 

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -149,6 +149,8 @@ export type IssueGrantCodeFunctionArity4 = (client: any, redirectUri: string, us
 
 export type IssueGrantTokenFunction = (client: any, user: any, ares: any, issued: (err: Error | null, code?: string, params?: any) => void) => void;
 
+export type IssueExchangeCodeFunctionArity6 = (client: any, code: string, redirectURI: string, body: Record<string, unknown>, authInfo: any, issued: ExchangeDoneFunction) => void;
+export type IssueExchangeCodeFunctionArity5 = (client: any, code: string, redirectURI: string, body: Record<string, unknown>, issued: ExchangeDoneFunction) => void;
 export type IssueExchangeCodeFunction = (client: any, code: string, redirectURI: string, issued: ExchangeDoneFunction) => void;
 
 export type ExchangeDoneFunction = (err: Error | null, accessToken?: string | boolean, refreshToken?: string, params?: any) => void;
@@ -220,11 +222,14 @@ export namespace exchange {
     scopeSeparator?: string | undefined;
   }
 
+  function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
+  function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
   function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction;
+  function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
+  function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
   function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction;
 
-  function code(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction;
-  function code(issue: IssueExchangeCodeFunction): MiddlewareFunction;
+  var code: typeof authorizationCode;
 
   // arity == 5; issue(client, scope, req.body, req.authInfo, issued);
   function clientCredentials(options: Options, issue: (client: any, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void): MiddlewareFunction;

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -29,7 +29,7 @@ export interface OAuth2 {
 export interface OAuth2Req {
   clientID: string;
   redirectURI: string;
-  scope: string;
+  scope: string[];
   state: string;
   type: string;
   transactionID: string;

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -177,7 +177,10 @@ export class OAuth2Server {
 
 export namespace grant {
   interface Options {
-    // For maximum flexibility, multiple scope spearators can optionally be
+    modes?: {
+      query?: (txn: OAuth2, res: ServerResponse, params: Record<string, unknown>) => void;
+    };
+    // For maximum flexibility, multiple scope separators can optionally be
     // allowed.  This allows the server to accept clients that separate scope
     // with either space or comma (' ', ',').  This violates the specification,
     // but achieves compatibility with existing client libraries that are already
@@ -198,7 +201,7 @@ export namespace exchange {
     // of the token endpoint, the property will contain the OAuth 2.0 client.
     userProperty?: string | undefined;
 
-    // For maximum flexibility, multiple scope spearators can optionally be
+    // For maximum flexibility, multiple scope separators can optionally be
     // allowed.  This allows the server to accept clients that separate scope
     // with either space or comma (' ', ',').  This violates the specification,
     // but achieves compatibility with existing client libraries that are already

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -155,11 +155,10 @@ export class OAuth2Server {
   exchange(type: string, fn: MiddlewareFunction): OAuth2Server;
   exchange(fn: MiddlewareFunction): OAuth2Server;
 
-  authorize(options: AuthorizeOptions, validate: ValidateFunction): MiddlewareFunction;
-  authorize(validate: ValidateFunction): MiddlewareFunction;
+  authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
 
-  authorization(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
-  authorization(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+  authorization: OAuth2Server["authorize"];
 
   decision(options: DecisionOptions, parse: DecisionParseFunction): MiddlewareFunction;
   decision(parse: DecisionParseFunction): MiddlewareFunction;

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -31,6 +31,7 @@ server.grant(oauth2orize.grant.code({
 }, (client, redirectURI, user, ares, done) => {}));
 
 server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, areq, locals, done) => {
+    areq.scope // $ExpectType string[]
     done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
 }));
 server.grant(oauth2orize.grant.code(((client, redirectURI, user, ares, areq, done) => {

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -70,6 +70,8 @@ class Clients {
   };
 // );
 
+server.authorization((clientId, redirectURI, done) => {});
+
 // Session Serialization
 server.serializeClient((client, done) => {
   done(null, client.id);

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -87,7 +87,7 @@ class Clients {
 
 // app.get('/dialog/authorize',
   // login.ensureLoggedIn(),
-  server.authorize((clientID, redirectURI, done) => {
+  server.authorize(((clientID, redirectURI, done) => {
     Clients.findOne(clientID, (err, client) => {
       if (err) {
         done(err);
@@ -99,12 +99,22 @@ class Clients {
         done(null, client, client.redirectURI);
       }
     });
-  });
+  }) as oauth2orize.ValidateFunction);
   (req: http.IncomingMessage, res: http.ServerResponse) => {
     // res.render('dialog', { transactionID: req.oauth2.transactionID,
     //                        user: req.user, client: req.oauth2.client });
   };
 // );
+
+server.authorize((clientID, redirectURI, scope, type, done) => {
+    done // $ExpectType oauthorize.ValidateDoneFunction
+});
+server.authorize(((clientID, redirectURI, scope, done) => {
+    done // $ExpectType oauthorize.ValidateDoneFunction
+}) as oauth2orize.ValidateFunctionArity4);
+server.authorize(((areq, done) => {
+    done // $ExpectType oauthorize.ValidateDoneFunction
+}) as oauth2orize.ValidateFunctionArity2);
 
 server.authorization((clientId, redirectURI, done) => {});
 

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -16,7 +16,7 @@ server.grant(oauth2orize.grant.code(((client, redirectURI, user, ares, done) => 
   //   return done(null, code);
   // });
 
-  done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+  done; // $ExpectType IssueGrantCodeDoneFunction
 }) as oauth2orize.IssueGrantCodeFunction));
 
 server.grant(oauth2orize.grant.code({
@@ -31,14 +31,14 @@ server.grant(oauth2orize.grant.code({
 }, (client, redirectURI, user, ares, done) => {}));
 
 server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, areq, locals, done) => {
-    areq.scope // $ExpectType string[]
-    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+    areq.scope; // $ExpectType string[]
+    done; // $ExpectType IssueGrantCodeDoneFunction
 }));
 server.grant(oauth2orize.grant.code(((client, redirectURI, user, ares, areq, done) => {
-    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+    done; // $ExpectType IssueGrantCodeDoneFunction
 }) as oauth2orize.IssueGrantCodeFunctionArity6));
 server.grant(oauth2orize.grant.code(((client, redirectURI, user, done) => {
-    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+    done; // $ExpectType IssueGrantCodeDoneFunction
 }) as oauth2orize.IssueGrantCodeFunctionArity4));
 
 // Register Exchanges
@@ -47,7 +47,7 @@ function findOne(code: string, callback: (err: Error, code: {
 }) => void): void {}
 
 server.exchange(oauth2orize.exchange.code(((client, code, redirectURI, done) => {
-  done // $ExpectType oauth2orize.ExchangeDoneFunction
+  done; // $ExpectType ExchangeDoneFunction
   findOne(code, (err, code) => {
     if (err) {
       done(err);
@@ -67,14 +67,14 @@ server.exchange(oauth2orize.exchange.code(((client, code, redirectURI, done) => 
 }) as oauth2orize.IssueExchangeCodeFunction));
 
 server.exchange(oauth2orize.exchange.code((client, code, redirectURI, body, authInfo, done) => {
-  done // $ExpectType oauth2orize.ExchangeDoneFunction
+  done; // $ExpectType ExchangeDoneFunction
 }));
 server.exchange(oauth2orize.exchange.code(((client, code, redirectURI, body, done) => {
-  done // $ExpectType oauth2orize.ExchangeDoneFunction
+  done; // $ExpectType ExchangeDoneFunction
 }) as oauth2orize.IssueExchangeCodeFunctionArity5));
 
 server.exchange(oauth2orize.exchange.authorizationCode(((client, code, redirectURI, done) => {
-  done // $ExpectType oauth2orize.ExchangeDoneFunction
+  done; // $ExpectType ExchangeDoneFunction
 }) as oauth2orize.IssueExchangeCodeFunction));
 
 // Implement Authorization Endpoint
@@ -107,13 +107,13 @@ class Clients {
 // );
 
 server.authorize((clientID, redirectURI, scope, type, done) => {
-    done // $ExpectType oauthorize.ValidateDoneFunction
+    done; // $ExpectType ValidateDoneFunction
 });
 server.authorize(((clientID, redirectURI, scope, done) => {
-    done // $ExpectType oauthorize.ValidateDoneFunction
+    done; // $ExpectType ValidateDoneFunction
 }) as oauth2orize.ValidateFunctionArity4);
 server.authorize(((areq, done) => {
-    done // $ExpectType oauthorize.ValidateDoneFunction
+    done; // $ExpectType ValidateDoneFunction
 }) as oauth2orize.ValidateFunctionArity2);
 
 server.authorization((clientId, redirectURI, done) => {});

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -17,6 +17,17 @@ server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, done) => {
   // });
 }));
 
+server.grant(oauth2orize.grant.code({
+    modes: {
+        query: (txn, res, params) => {
+            txn.redirectURI;
+            Object.entries(params);
+            res.write('');
+        }
+    },
+    scopeSeparator: " ",
+}, (client, redirectURI, user, ares, done) => {}));
+
 // Register Exchanges
 function findOne(code: string, callback: (err: Error, code: {
   clientId: string, userId: string, redirectURI: string, scope: string

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -45,7 +45,8 @@ function findOne(code: string, callback: (err: Error, code: {
   clientId: string, userId: string, redirectURI: string, scope: string
 }) => void): void {}
 
-server.exchange(oauth2orize.exchange.code((client, code, redirectURI, done) => {
+server.exchange(oauth2orize.exchange.code(((client, code, redirectURI, done) => {
+  done // $ExpectType oauth2orize.ExchangeDoneFunction
   findOne(code, (err, code) => {
     if (err) {
       done(err);
@@ -62,7 +63,18 @@ server.exchange(oauth2orize.exchange.code((client, code, redirectURI, done) => {
     //   return done(null, token);
     // });
   });
+}) as oauth2orize.IssueExchangeCodeFunction));
+
+server.exchange(oauth2orize.exchange.code((client, code, redirectURI, body, authInfo, done) => {
+  done // $ExpectType oauth2orize.ExchangeDoneFunction
 }));
+server.exchange(oauth2orize.exchange.code(((client, code, redirectURI, body, done) => {
+  done // $ExpectType oauth2orize.ExchangeDoneFunction
+}) as oauth2orize.IssueExchangeCodeFunctionArity5));
+
+server.exchange(oauth2orize.exchange.authorizationCode(((client, code, redirectURI, done) => {
+  done // $ExpectType oauth2orize.ExchangeDoneFunction
+}) as oauth2orize.IssueExchangeCodeFunction));
 
 // Implement Authorization Endpoint
 class Clients {

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -7,7 +7,7 @@ import * as http from 'http';
 const server = oauth2orize.createServer();
 
 // Register Grants
-server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, done) => {
+server.grant(oauth2orize.grant.code(((client, redirectURI, user, ares, done) => {
   // var code = utils.uid(16);
 
   // var ac = new AuthorizationCode(code, client.id, redirectURI, user.id, ares.scope);
@@ -15,7 +15,9 @@ server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, done) => {
   //   if (err) { return done(err); }
   //   return done(null, code);
   // });
-}));
+
+  done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+}) as oauth2orize.IssueGrantCodeFunction));
 
 server.grant(oauth2orize.grant.code({
     modes: {
@@ -27,6 +29,16 @@ server.grant(oauth2orize.grant.code({
     },
     scopeSeparator: " ",
 }, (client, redirectURI, user, ares, done) => {}));
+
+server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, areq, locals, done) => {
+    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+}));
+server.grant(oauth2orize.grant.code(((client, redirectURI, user, ares, areq, done) => {
+    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+}) as oauth2orize.IssueGrantCodeFunctionArity6));
+server.grant(oauth2orize.grant.code(((client, redirectURI, user, done) => {
+    done // $ExpectType oauth2orize.IssueGrantCodeDoneFunction
+}) as oauth2orize.IssueGrantCodeFunctionArity4));
 
 // Register Exchanges
 function findOne(code: string, callback: (err: Error, code: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    * ValidateFunction: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/middleware/authorization.js#L229-L236
    * IssueGrantCodeFunction: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/grant/code.js#L178-L186
    * IssueExchangeCodeFunction: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/exchange/authorizationCode.js#L103-L109
    * `modes.query`: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/grant/code.js#L67-L70
    * `scope` being an array: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/grant/code.js#L102-L109
    * `server.authorization === server.authorize`: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/server.js#L135-L138
    * `grant.code === grant.authorizationCode`: https://github.com/jaredhanson/oauth2orize/blob/1ffdd85feea087e478e748e1d59f7e7821853cfb/lib/index.js#L48
    * Why expose `ArityN` functions?: Because TypeScript cannot properly resolve the correct function signature and always matches to the longest one. One would need to either just use the longest signature or use explicit type cast with new ArityN functions. See also https://github.com/Microsoft/TypeScript/issues/14107.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

There are more things to be fixed but these are in my current scope.