### PR TITLE
fix(react-dom): use arrow functions instead of `this: void`

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -39,10 +39,8 @@ export interface RenderToPipeableStreamOptions {
 }
 
 export interface PipeableStream {
-    // tslint:disable-next-line:void-return
-    abort(this: void): void;
-    // tslint:disable-next-line:void-return
-    pipe<Writable extends NodeJS.WritableStream>(this: void, destination: Writable): Writable;
+    abort: () => void;
+    pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
 }
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [n/a] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Follow-up of @ngbrown's #65407 as @JoshuaKGoldberg (one of the maintainers of @typescript-eslint) mentioned this would be more common to do in https://github.com/remix-run/remix/pull/6330#discussion_r1186723774
