### PR TITLE
[@types/node] Types for listeners on fs.watchFile/fs.unwatchFile

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3020,7 +3020,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -3029,13 +3029,13 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -3048,7 +3048,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -3056,6 +3057,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -240,6 +240,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -228,6 +228,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/ts4.8/fs.d.ts
+++ b/types/node/ts4.8/fs.d.ts
@@ -3020,7 +3020,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -3029,13 +3029,13 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -3048,7 +3048,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -3056,6 +3057,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/ts4.8/test/fs.ts
+++ b/types/node/ts4.8/test/fs.ts
@@ -240,6 +240,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/ts4.8/test/fs.ts
+++ b/types/node/ts4.8/test/fs.ts
@@ -228,6 +228,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v16/fs.d.ts
+++ b/types/node/v16/fs.d.ts
@@ -2825,7 +2825,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -2834,13 +2834,14 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * @param listener The callback listener will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -2853,7 +2854,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -2861,6 +2863,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -218,6 +218,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -230,6 +230,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v16/ts4.8/fs.d.ts
+++ b/types/node/v16/ts4.8/fs.d.ts
@@ -2825,7 +2825,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -2834,13 +2834,13 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -2853,7 +2853,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -2861,6 +2862,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/v16/ts4.8/test/fs.ts
+++ b/types/node/v16/ts4.8/test/fs.ts
@@ -218,6 +218,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v16/ts4.8/test/fs.ts
+++ b/types/node/v16/ts4.8/test/fs.ts
@@ -230,6 +230,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2999,7 +2999,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -3008,13 +3008,14 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * @param listener The callback listener will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -3027,7 +3028,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -3035,6 +3037,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/v18/test/fs.ts
+++ b/types/node/v18/test/fs.ts
@@ -240,6 +240,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v18/test/fs.ts
+++ b/types/node/v18/test/fs.ts
@@ -228,6 +228,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v18/ts4.8/fs.d.ts
+++ b/types/node/v18/ts4.8/fs.d.ts
@@ -2899,7 +2899,7 @@ declare module 'fs' {
                   bigint?: false | undefined;
               })
             | undefined,
-        listener: (curr: Stats, prev: Stats) => void
+        listener: StatsListener
     ): StatWatcher;
     export function watchFile(
         filename: PathLike,
@@ -2908,7 +2908,7 @@ declare module 'fs' {
                   bigint: true;
               })
             | undefined,
-        listener: (curr: BigIntStats, prev: BigIntStats) => void
+        listener: BigIntStatsListener
     ): StatWatcher;
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
@@ -2927,7 +2927,8 @@ declare module 'fs' {
      * @since v0.1.31
      * @param listener Optional, a listener previously attached using `fs.watchFile()`
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
+    export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | 'buffer' | undefined;
         persistent?: boolean | undefined;
@@ -2935,6 +2936,8 @@ declare module 'fs' {
     }
     export type WatchEventType = 'rename' | 'change';
     export type WatchListener<T> = (event: WatchEventType, filename: T) => void;
+    export type StatsListener = (curr: Stats, prev: Stats) => void;
+    export type BigIntStatsListener = (curr: BigIntStats, prev: BigIntStats) => void;
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a
      * directory.

--- a/types/node/v18/ts4.8/test/fs.ts
+++ b/types/node/v18/ts4.8/test/fs.ts
@@ -240,6 +240,31 @@ async function testPromisify() {
 }
 
 {
+    // @ts-expect-error
+    const invalidStatsListener: fs.StatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    // @ts-expect-error
+    const invalidBigIntStatsListener: fs.BigIntStatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+}
+
+{
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    const statsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', bigIntStatsListener);
+    // @ts-expect-error
+    fs.watchFile('/tmp/file', { bigint: true }, statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });

--- a/types/node/v18/ts4.8/test/fs.ts
+++ b/types/node/v18/ts4.8/test/fs.ts
@@ -228,6 +228,18 @@ async function testPromisify() {
 }
 
 {
+    const bigIntStatsListener: fs.BigIntStatsListener = (current: fs.BigIntStats, previous: fs.BigIntStats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', bigIntStatsListener);
+
+    const statsListener: fs.StatsListener = (current: fs.Stats, previous: fs.Stats) => {
+        console.log(current, previous);
+    };
+    fs.unwatchFile('/tmp/file', statsListener);
+}
+
+{
     fs.access('/path/to/folder', (err) => { });
 
     fs.access(Buffer.from(''), (err) => { });


### PR DESCRIPTION
`@types/node@16.x.x` and `@types/node@18.x.x` doesn't support specification for `fs.watchFile`
Docs tells us, that `fs.watchFile` as like as `fs.unwatchFile` can accept listener function as an argument, which can be different and depend on `fs.watchFile` options(`bigint: boolean`).
This feature brings new extracted types for listeners(DRY principle) and new polymorph declaration for `fs.unwatchFile` which compatible with BigInt'ed listener on `fs.watchFile`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [fs.watchFile spec](https://nodejs.org/api/fs.html#fswatchfilefilename-options-listener)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
