### PR TITLE
[types/snapsvg] Fix Paper.g

### DIFF
--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -280,7 +280,7 @@ declare namespace Snap {
         el(name:string, attr:Object):Snap.Element;
         filter(filstr:string):Snap.Element;
         gradient(gradient:string):Snap.Gradient;
-        g(varargs?:any):Snap.Paper;
+        g(...els:any[]):Snap.Paper;
         group(...els:any[]):Snap.Paper;
         mask(varargs:any):Object;
         ptrn(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;
@@ -296,7 +296,9 @@ declare namespace Snap {
         line(x1:number,y1:number,x2:number,y2:number):Snap.Element;
         path(pathSpec: string | (string | number)[][]): Snap.Element;
         polygon(varargs:any[]):Snap.Element;
+        polygon(...varargs:any[]):Snap.Element;
         polyline(varargs:any[]):Snap.Element;
+        polyline(...varargs:any[]):Snap.Element;
         rect(x:number,y:number,width:number,height:number,rx?:number,ry?:number):Snap.Element;
         text(x:number,y:number,text:string|number):Snap.Element;
         text(x:number,y:number,text:Array<string|number>):Snap.Element;


### PR DESCRIPTION
Fix Paper.g: There is currently a mismatch between the documentation of Paper.g and the code.
Update Paper.polygon and Paper.polyline with a missing overload

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/adobe-webplatform/Snap.svg/blob/master/src/paper.js)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
