### PR TITLE
[node] fix `ExecFileException` having `code?: undefined`

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -980,7 +980,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -70,6 +70,19 @@ import { URL } from 'node:url';
     childProcess.execFile("npm", (err) => {
         if (err && err.errno) assert(err.code === 'ENOENT');
     });
+    childProcess.execFile('npm', (err) => {
+        if (err !== null) {
+            if (typeof err.code === 'string') {
+                console.log(err.code.charCodeAt(0));
+            } else if (typeof err.code === 'number') {
+                console.log(err.code.toExponential());
+            } else if (err.code === null) {
+                // @ts-expect-error -- since err.code is null, this assignment has a type error
+                const x: string = err.code;
+                console.log(x);
+            }
+        }
+    });
 }
 
 {

--- a/types/node/ts4.8/child_process.d.ts
+++ b/types/node/ts4.8/child_process.d.ts
@@ -980,7 +980,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -338,7 +338,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
 
     function execFile(file: string): ChildProcess;
     function execFile(file: string, options: (BaseEncodingOptions & ExecFileOptions) | undefined | null): ChildProcess;

--- a/types/node/v14/test/child_process.ts
+++ b/types/node/v14/test/child_process.ts
@@ -43,6 +43,19 @@ import { Writable, Readable, Pipe } from 'node:stream';
     childProcess.execFile("npm", (err) => {
         if (err && err.errno) assert(err.code === 'ENOENT');
     });
+    childProcess.execFile('npm', (err) => {
+        if (err !== null) {
+            if (typeof err.code === 'string') {
+                console.log(err.code.charCodeAt(0));
+            } else if (typeof err.code === 'number') {
+                console.log(err.code.toExponential());
+            } else if (err.code === null) {
+                // @ts-expect-error -- since err.code is null, this assignment has a type error
+                const x: string = err.code;
+                console.log(x);
+            }
+        }
+    });
 }
 
 {

--- a/types/node/v14/ts4.8/child_process.d.ts
+++ b/types/node/v14/ts4.8/child_process.d.ts
@@ -338,7 +338,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
 
     function execFile(file: string): ChildProcess;
     function execFile(file: string, options: (BaseEncodingOptions & ExecFileOptions) | undefined | null): ChildProcess;

--- a/types/node/v16/child_process.d.ts
+++ b/types/node/v16/child_process.d.ts
@@ -981,7 +981,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more

--- a/types/node/v16/test/child_process.ts
+++ b/types/node/v16/test/child_process.ts
@@ -70,6 +70,19 @@ import { URL } from 'node:url';
     childProcess.execFile("npm", (err) => {
         if (err && err.errno) assert(err.code === 'ENOENT');
     });
+    childProcess.execFile('npm', (err) => {
+        if (err !== null) {
+            if (typeof err.code === 'string') {
+                console.log(err.code.charCodeAt(0));
+            } else if (typeof err.code === 'number') {
+                console.log(err.code.toExponential());
+            } else if (err.code === null) {
+                // @ts-expect-error -- since err.code is null, this assignment has a type error
+                const x: string = err.code;
+                console.log(x);
+            }
+        }
+    });
 }
 
 {

--- a/types/node/v16/ts4.8/child_process.d.ts
+++ b/types/node/v16/ts4.8/child_process.d.ts
@@ -981,7 +981,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more

--- a/types/node/v18/child_process.d.ts
+++ b/types/node/v18/child_process.d.ts
@@ -984,7 +984,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more

--- a/types/node/v18/test/child_process.ts
+++ b/types/node/v18/test/child_process.ts
@@ -16,13 +16,13 @@ import { URL } from 'node:url';
     childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
     childProcess.spawn("echo", ["test"], { stdio: [0xdeadbeef, "inherit", undefined, "pipe"] });
     childProcess.spawnSync("echo test");
-    childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
-    childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
-    childProcess.spawnSync("echo test", {input: new Uint8Array([])});
-    childProcess.spawnSync("echo test", {input: new DataView(new ArrayBuffer(1))});
+    childProcess.spawnSync("echo test", { windowsVerbatimArguments: false });
+    childProcess.spawnSync("echo test", { windowsVerbatimArguments: false, argv0: "echo-test" });
+    childProcess.spawnSync("echo test", { input: new Uint8Array([]) });
+    childProcess.spawnSync("echo test", { input: new DataView(new ArrayBuffer(1)) });
     childProcess.spawnSync("echo test", { encoding: 'utf-8' });
     childProcess.spawnSync("echo test", { encoding: 'buffer' });
-    childProcess.spawnSync("echo test", { cwd: new URL('file://aaaaaaaa')});
+    childProcess.spawnSync("echo test", { cwd: new URL('file://aaaaaaaa') });
 
     childProcess.spawnSync("echo test").output; // $ExpectType (Buffer | null)[]
     childProcess.spawnSync("echo test", {}).output; // $ExpectType (Buffer | null)[]
@@ -58,17 +58,30 @@ import { URL } from 'node:url';
 }
 
 {
-    childProcess.execFile("npm", () => {});
-    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal(), }, () => {});
-    childProcess.execFile("npm", { shell: true }, () => {});
-    childProcess.execFile("npm", { shell: '/bin/sh' }, () => {});
-    childProcess.execFile("npm", ["-v"] as ReadonlyArray<string>, () => {});
+    childProcess.execFile("npm", () => { });
+    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal(), }, () => { });
+    childProcess.execFile("npm", { shell: true }, () => { });
+    childProcess.execFile("npm", { shell: '/bin/sh' }, () => { });
+    childProcess.execFile("npm", ["-v"] as ReadonlyArray<string>, () => { });
     childProcess.execFile("npm", ["-v"] as ReadonlyArray<string>, { windowsHide: true, encoding: 'utf-8' }, (stdout, stderr) => { assert(stdout instanceof String); });
     childProcess.execFile("npm", ["-v"] as ReadonlyArray<string>, { windowsHide: true, encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
     childProcess.execFile("npm", { encoding: 'utf-8' }, (stdout, stderr) => { assert(stdout instanceof String); });
     childProcess.execFile("npm", { encoding: 'buffer' }, (stdout, stderr) => { assert(stdout instanceof Buffer); });
     childProcess.execFile("npm", (err) => {
         if (err && err.errno) assert(err.code === 'ENOENT');
+    });
+    childProcess.execFile('npm', (err) => {
+        if (err !== null) {
+            if (typeof err.code === 'string') {
+                console.log(err.code.charCodeAt(0));
+            } else if (typeof err.code === 'number') {
+                console.log(err.code.toExponential());
+            } else if (err.code === null) {
+                // @ts-expect-error -- since err.code is null, this assignment has a type error
+                const x: string = err.code;
+                console.log(x);
+            }
+        }
     });
 }
 
@@ -78,17 +91,17 @@ import { URL } from 'node:url';
 }
 
 {
-    childProcess.execFileSync("echo test", {input: new Uint8Array([])});
-    childProcess.execFileSync("echo test", {input: new DataView(new ArrayBuffer(1))});
+    childProcess.execFileSync("echo test", { input: new Uint8Array([]) });
+    childProcess.execFileSync("echo test", { input: new DataView(new ArrayBuffer(1)) });
 
     childProcess.execFileSync("echo test"); // $ExpectType Buffer
     childProcess.execFileSync("echo test", {}); // $ExpectType Buffer
-    childProcess.execFileSync("echo test", {encoding: 'buffer'}); // $ExpectType Buffer
-    childProcess.execFileSync("echo test", {encoding: 'utf8'}); // $ExpectType string
+    childProcess.execFileSync("echo test", { encoding: 'buffer' }); // $ExpectType Buffer
+    childProcess.execFileSync("echo test", { encoding: 'utf8' }); // $ExpectType string
     childProcess.execFileSync("echo test", ['test']); // $ExpectType Buffer
     childProcess.execFileSync("echo test", ['test'], {}); // $ExpectType Buffer
-    childProcess.execFileSync("echo test", ['test'], {encoding: 'buffer'}); // $ExpectType Buffer
-    childProcess.execFileSync("echo test", ['test'], {encoding: 'utf8'}); // $ExpectType string
+    childProcess.execFileSync("echo test", ['test'], { encoding: 'buffer' }); // $ExpectType Buffer
+    childProcess.execFileSync("echo test", ['test'], { encoding: 'utf8' }); // $ExpectType string
     ((opts?: childProcess.ExecFileSyncOptions) => childProcess.execFileSync('echo test', ['args'], opts))(); // $ExpectType string | Buffer
 }
 
@@ -192,8 +205,8 @@ async function testPromisify() {
     _boolean = cp.send({
         type: 'test'
     }, _socket, {
-            keepOpen: true
-        });
+        keepOpen: true
+    });
 
     _boolean = cp.send(1, _socket, {
         keepOpen: true
@@ -208,10 +221,10 @@ async function testPromisify() {
     _boolean = cp.send({
         type: 'test'
     }, _socket, {
-            keepOpen: true
-        }, (error) => {
-            const _err: Error | null = error;
-        });
+        keepOpen: true
+    }, (error) => {
+        const _err: Error | null = error;
+    });
 
     _boolean = cp.send(1, _server);
     _boolean = cp.send('one', _server);
@@ -240,8 +253,8 @@ async function testPromisify() {
     _boolean = cp.send({
         type: 'test'
     }, _server, {
-            keepOpen: true
-        });
+        keepOpen: true
+    });
 
     _boolean = cp.send(1, _server, {
         keepOpen: true
@@ -256,10 +269,10 @@ async function testPromisify() {
     _boolean = cp.send({
         type: 'test'
     }, _server, {
-            keepOpen: true
-        }, (error) => {
-            const _err: Error | null = error;
-        });
+        keepOpen: true
+    }, (error) => {
+        const _err: Error | null = error;
+    });
 
     const stdin: Writable | null = cp.stdio[0];
     const stdout: Readable | null = cp.stdio[1];

--- a/types/node/v18/ts4.8/child_process.d.ts
+++ b/types/node/v18/ts4.8/child_process.d.ts
@@ -984,7 +984,10 @@ declare module 'child_process' {
     interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    type ExecFileException = ExecException & NodeJS.ErrnoException;
+    type ExecFileException =
+        & Omit<ExecException, 'code'>
+        & Omit<NodeJS.ErrnoException, 'code'>
+        & { code?: string | number | undefined | null };
     /**
      * The `child_process.execFile()` function is similar to {@link exec} except that it does not spawn a shell by default. Rather, the specified
      * executable `file` is spawned directly as a new process making it slightly more


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/nodejs/node/blob/43d167a262d0772a73ec1e21316e722bad71e4f8/lib/child_process.js#L420
<!-- - [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -->

-------

The error parameter of `execFile`'s callback has a property `code`, which can have various types:
- string when a system call failed
  - `execFile('notexistingcommand', (err) => console.error(err))` → `code: 'ENOENT'`
- number when the child process exited with a non-zero status code
  - `execFile('false', (err) => console.error(err))` → `code: 1`
- null when killed
  - `execFile('sleep', ['5'], (err) => console.error(err)).kill()` → `code: null`

However, `ExecFileException` in the previous type definition has `code?: undefined` because it is an intersection of `code?: number | undefined` from `ExecException` and `code?: string | undefined` from `NodeJs.ErrnoException`.

To fix this, `ExecFileException` is now an intersection of `ExecException` and `NodeJs.ErrnoException` without the `code` property, and a dedicated object type for the `code` property.

I haven't found conditions under which the `code` property is missing or the value is undefined. However, I defined its type as `code?: string | number | undefined | null` in order to make it compatible with the previous definition `code?: undefined`.

This change may introduce new type errors to existing code. For example, the following code has a type error because it tries to assign `err.code: null` to `x: string`, but it previously didn't have type errors because `err.code` has the `never` type (which comes from the intersection `undefined & null`) in the `if` statement.

```ts
    childProcess.execFile('npm', (err) => {
        if (err !== null && err.code === null) {
              const x: string = err.code;
              console.log(x);
        }
    });