### PR TITLE
Extending interface CircleMarkerOptions from MarkerOptions to allow access 'repeatMode' option

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ryan Blace <https://github.com/reblace>
 //                 Yun Shi <https://github.com/YunS-Stacy>
 //                 Kevin Richter <https://github.com/beschoenen>
+//                 Antonio Vida <https://github.com/antoniovlx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -358,7 +359,7 @@ declare module 'leaflet' {
             nautic?: boolean | undefined;
         }
 
-        interface CircleMarkerOptions {
+        interface CircleMarkerOptions extends MarkerOptions {
             /**
              * Whether to draw stroke around the circle marker.
              *

--- a/types/leaflet-draw/leaflet-draw-tests.ts
+++ b/types/leaflet-draw/leaflet-draw-tests.ts
@@ -30,7 +30,10 @@ const drawControl = new L.Control.Draw({
             shapeOptions: {
                 color: '#662d91'
             }
-        }
+        },
+        circlemarker:{
+            repeatMode: true
+        },
     },
     edit: {
         featureGroup: drawnItems

--- a/types/leaflet-draw/leaflet-draw-tests.ts
+++ b/types/leaflet-draw/leaflet-draw-tests.ts
@@ -31,7 +31,7 @@ const drawControl = new L.Control.Draw({
                 color: '#662d91'
             }
         },
-        circlemarker:{
+        circlemarker: {
             repeatMode: true
         },
     },


### PR DESCRIPTION
If user wants to keep a circleMarker enabled after drawing it, it is necessary to access to 'repeatMode' in MarkerOptions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
