### PR TITLE
[jsonwebtoken]: fix cjs export

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -19,13 +19,13 @@
 import { KeyObject } from 'crypto';
 
 declare namespace jwt {
-    export class JsonWebTokenError extends Error {
+    class JsonWebTokenError extends Error {
         inner: Error;
 
         constructor(message: string, error?: Error);
     }
 
-    export class TokenExpiredError extends JsonWebTokenError {
+    class TokenExpiredError extends JsonWebTokenError {
         expiredAt: Date;
 
         constructor(message: string, expiredAt: Date);
@@ -34,13 +34,13 @@ declare namespace jwt {
     /**
      * Thrown if current time is before the nbf claim.
      */
-    export class NotBeforeError extends JsonWebTokenError {
+    class NotBeforeError extends JsonWebTokenError {
         date: Date;
 
         constructor(message: string, date: Date);
     }
 
-    export interface SignOptions {
+    interface SignOptions {
         /**
          * Signature algorithm. Could be one of these values :
          * - HS256:    HMAC using SHA-256 hash algorithm (default)
@@ -72,7 +72,7 @@ declare namespace jwt {
         allowInvalidAsymmetricKeyTypes?: boolean | undefined;
     }
 
-    export interface VerifyOptions {
+    interface VerifyOptions {
         algorithms?: Algorithm[] | undefined;
         audience?: string | RegExp | Array<string | RegExp> | undefined;
         clockTimestamp?: number | undefined;
@@ -93,20 +93,20 @@ declare namespace jwt {
         allowInvalidAsymmetricKeyTypes?: boolean | undefined;
     }
 
-    export interface DecodeOptions {
+    interface DecodeOptions {
         complete?: boolean | undefined;
         json?: boolean | undefined;
     }
-    export type VerifyErrors = JsonWebTokenError | NotBeforeError | TokenExpiredError;
-    export type VerifyCallback<T = Jwt | JwtPayload | string> = (
+    type VerifyErrors = JsonWebTokenError | NotBeforeError | TokenExpiredError;
+    type VerifyCallback<T = Jwt | JwtPayload | string> = (
         error: VerifyErrors | null,
         decoded: T | undefined,
     ) => void;
 
-    export type SignCallback = (error: Error | null, encoded: string | undefined) => void;
+    type SignCallback = (error: Error | null, encoded: string | undefined) => void;
 
     // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
-    export interface JwtHeader {
+    interface JwtHeader {
         alg: string | Algorithm;
         typ?: string | undefined;
         cty?: string | undefined;
@@ -120,7 +120,7 @@ declare namespace jwt {
     }
 
     // standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
-    export interface JwtPayload {
+    interface JwtPayload {
         [key: string]: any;
         iss?: string | undefined;
         sub?: string | undefined;
@@ -131,14 +131,14 @@ declare namespace jwt {
         jti?: string | undefined;
     }
 
-    export interface Jwt {
+    interface Jwt {
         header: JwtHeader;
         payload: JwtPayload | string;
         signature: string;
     }
 
     // https://github.com/auth0/node-jsonwebtoken#algorithms-supported
-    export type Algorithm =
+    type Algorithm =
         | 'HS256'
         | 'HS384'
         | 'HS512'
@@ -153,11 +153,11 @@ declare namespace jwt {
         | 'PS512'
         | 'none';
 
-    export type SigningKeyCallback = (error: Error | null, signingKey?: Secret) => void;
+    type SigningKeyCallback = (error: Error | null, signingKey?: Secret) => void;
 
-    export type GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => void;
+    type GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => void;
 
-    export type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
+    type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
 
     /**
      * Synchronously sign the given payload into a JSON Web Token string
@@ -166,8 +166,8 @@ declare namespace jwt {
      * [options] - Options for the signature
      * returns - The JSON Web Token string
      */
-    export function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
-    export function sign(
+    function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
+    function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: null,
         options?: SignOptions & { algorithm: 'none' },
@@ -180,14 +180,14 @@ declare namespace jwt {
      * [options] - Options for the signature
      * callback - Callback to get the encoded token on
      */
-    export function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
-    export function sign(
+    function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
+    function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: Secret,
         options: SignOptions,
         callback: SignCallback,
     ): void;
-    export function sign(
+    function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: null,
         options: SignOptions & { algorithm: 'none' },
@@ -201,15 +201,15 @@ declare namespace jwt {
      * [options] - Options for the verification
      * returns - The decoded token.
      */
-    export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-    export function verify(
+    function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
+    function verify(
         token: string,
         secretOrPublicKey: Secret,
         options?: VerifyOptions & {
             complete?: false;
         },
     ): JwtPayload | string;
-    export function verify(
+    function verify(
         token: string,
         secretOrPublicKey: Secret,
         options?: VerifyOptions,
@@ -224,24 +224,24 @@ declare namespace jwt {
      * [options] - Options for the verification
      * callback - Callback to get the decoded token on
      */
-    export function verify(
+    function verify(
         token: string,
         secretOrPublicKey: Secret | GetPublicKeyOrSecret,
         callback?: VerifyCallback<JwtPayload | string>,
     ): void;
-    export function verify(
+    function verify(
         token: string,
         secretOrPublicKey: Secret | GetPublicKeyOrSecret,
         options: VerifyOptions & { complete: true },
         callback?: VerifyCallback<Jwt>,
     ): void;
-    export function verify(
+    function verify(
         token: string,
         secretOrPublicKey: Secret | GetPublicKeyOrSecret,
         options?: VerifyOptions & { complete?: false },
         callback?: VerifyCallback<JwtPayload | string>,
     ): void;
-    export function verify(
+    function verify(
         token: string,
         secretOrPublicKey: Secret | GetPublicKeyOrSecret,
         options?: VerifyOptions,
@@ -254,9 +254,10 @@ declare namespace jwt {
      * [options] - Options for decoding
      * returns - The decoded Token
      */
-    export function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
-    export function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
-    export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
+    function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
+    function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
+    function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
 }
 
+// eslint-disable-next-line export-just-namespace
 export = jwt;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -96,19 +96,10 @@ interface DecodeOptions {
     complete?: boolean | undefined;
     json?: boolean | undefined;
 }
-type VerifyErrors =
-    | JsonWebTokenError
-    | NotBeforeError
-    | TokenExpiredError;
-type VerifyCallback<T = Jwt | JwtPayload | string> = (
-    error: VerifyErrors | null,
-    decoded: T | undefined,
-) => void;
+type VerifyErrors = JsonWebTokenError | NotBeforeError | TokenExpiredError;
+type VerifyCallback<T = Jwt | JwtPayload | string> = (error: VerifyErrors | null, decoded: T | undefined) => void;
 
-type SignCallback = (
-    error: Error | null,
-    encoded: string | undefined,
-) => void;
+type SignCallback = (error: Error | null, encoded: string | undefined) => void;
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
 interface JwtHeader {
@@ -144,27 +135,25 @@ interface Jwt {
 
 // https://github.com/auth0/node-jsonwebtoken#algorithms-supported
 type Algorithm =
-    "HS256" | "HS384" | "HS512" |
-    "RS256" | "RS384" | "RS512" |
-    "ES256" | "ES384" | "ES512" |
-    "PS256" | "PS384" | "PS512" |
-    "none";
+    | 'HS256'
+    | 'HS384'
+    | 'HS512'
+    | 'RS256'
+    | 'RS384'
+    | 'RS512'
+    | 'ES256'
+    | 'ES384'
+    | 'ES512'
+    | 'PS256'
+    | 'PS384'
+    | 'PS512'
+    | 'none';
 
-type SigningKeyCallback = (
-    error: Error | null,
-    signingKey?: Secret
-) => void;
+type SigningKeyCallback = (error: Error | null, signingKey?: Secret) => void;
 
-type GetPublicKeyOrSecret = (
-    header: JwtHeader,
-    callback: SigningKeyCallback
-) => void;
+type GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => void;
 
-type Secret =
-    | string
-    | Buffer
-    | KeyObject
-    | { key: string | Buffer; passphrase: string };
+type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
 
 /**
  * Synchronously sign the given payload into a JSON Web Token string
@@ -173,15 +162,11 @@ type Secret =
  * [options] - Options for the signature
  * returns - The JSON Web Token string
  */
-declare function sign(
-    payload: string | Buffer | object,
-    secretOrPrivateKey: Secret,
-    options?: SignOptions,
-): string;
+declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
 declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: null,
-    options?: SignOptions & { algorithm: "none" },
+    options?: SignOptions & { algorithm: 'none' },
 ): string;
 
 /**
@@ -191,11 +176,7 @@ declare function sign(
  * [options] - Options for the signature
  * callback - Callback to get the encoded token on
  */
-declare function sign(
-    payload: string | Buffer | object,
-    secretOrPrivateKey: Secret,
-    callback: SignCallback,
-): void;
+declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
 declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
@@ -205,7 +186,7 @@ declare function sign(
 declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: null,
-    options: SignOptions & { algorithm: "none" },
+    options: SignOptions & { algorithm: 'none' },
     callback: SignCallback,
 ): void;
 
@@ -217,9 +198,13 @@ declare function sign(
  * returns - The decoded token.
  */
 declare function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-declare function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & {
-    complete?: false
-}): JwtPayload | string;
+declare function verify(
+    token: string,
+    secretOrPublicKey: Secret,
+    options?: VerifyOptions & {
+        complete?: false;
+    },
+): JwtPayload | string;
 declare function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
 
 /**
@@ -266,12 +251,14 @@ declare function decode(token: string, options: DecodeOptions & { json: true }):
 declare function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
 
 interface JWTStatic {
-    decode: typeof decode,
-    verify: typeof verify,
-    sign: typeof sign,
-    JsonWebTokenError: typeof JsonWebTokenError,
-    NotBeforeError: typeof NotBeforeError,
-    TokenExpiredError: typeof TokenExpiredError,
+    decode: typeof decode;
+    verify: typeof verify;
+    sign: typeof sign;
+    JsonWebTokenError: typeof JsonWebTokenError;
+    NotBeforeError: typeof NotBeforeError;
+    TokenExpiredError: typeof TokenExpiredError;
 }
 
-export = JWTStatic
+declare const jwtStatic: JWTStatic;
+
+export = jwtStatic;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -19,8 +19,6 @@
 import { KeyObject } from 'crypto';
 
 declare namespace jwt {
-
-
     export class JsonWebTokenError extends Error {
         inner: Error;
 
@@ -99,21 +97,15 @@ declare namespace jwt {
         complete?: boolean | undefined;
         json?: boolean | undefined;
     }
-    export type VerifyErrors =
-        | JsonWebTokenError
-        | NotBeforeError
-        | TokenExpiredError;
+    export type VerifyErrors = JsonWebTokenError | NotBeforeError | TokenExpiredError;
     export type VerifyCallback<T = Jwt | JwtPayload | string> = (
         error: VerifyErrors | null,
         decoded: T | undefined,
     ) => void;
 
-    export type SignCallback = (
-        error: Error | null,
-        encoded: string | undefined,
-    ) => void;
+    export type SignCallback = (error: Error | null, encoded: string | undefined) => void;
 
-// standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
+    // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
     export interface JwtHeader {
         alg: string | Algorithm;
         typ?: string | undefined;
@@ -127,7 +119,7 @@ declare namespace jwt {
         x5c?: string | string[] | undefined;
     }
 
-// standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+    // standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
     export interface JwtPayload {
         [key: string]: any;
         iss?: string | undefined;
@@ -145,29 +137,27 @@ declare namespace jwt {
         signature: string;
     }
 
-// https://github.com/auth0/node-jsonwebtoken#algorithms-supported
+    // https://github.com/auth0/node-jsonwebtoken#algorithms-supported
     export type Algorithm =
-        "HS256" | "HS384" | "HS512" |
-        "RS256" | "RS384" | "RS512" |
-        "ES256" | "ES384" | "ES512" |
-        "PS256" | "PS384" | "PS512" |
-        "none";
+        | 'HS256'
+        | 'HS384'
+        | 'HS512'
+        | 'RS256'
+        | 'RS384'
+        | 'RS512'
+        | 'ES256'
+        | 'ES384'
+        | 'ES512'
+        | 'PS256'
+        | 'PS384'
+        | 'PS512'
+        | 'none';
 
-    export type SigningKeyCallback = (
-        error: Error | null,
-        signingKey?: Secret
-    ) => void;
+    export type SigningKeyCallback = (error: Error | null, signingKey?: Secret) => void;
 
-    export type GetPublicKeyOrSecret = (
-        header: JwtHeader,
-        callback: SigningKeyCallback
-    ) => void;
+    export type GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => void;
 
-    export type Secret =
-        | string
-        | Buffer
-        | KeyObject
-        | { key: string | Buffer; passphrase: string };
+    export type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
 
     /**
      * Synchronously sign the given payload into a JSON Web Token string
@@ -176,15 +166,11 @@ declare namespace jwt {
      * [options] - Options for the signature
      * returns - The JSON Web Token string
      */
-    export function sign(
-        payload: string | Buffer | object,
-        secretOrPrivateKey: Secret,
-        options?: SignOptions,
-    ): string;
+    export function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
     export function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: null,
-        options?: SignOptions & { algorithm: "none" },
+        options?: SignOptions & { algorithm: 'none' },
     ): string;
 
     /**
@@ -194,11 +180,7 @@ declare namespace jwt {
      * [options] - Options for the signature
      * callback - Callback to get the encoded token on
      */
-    export function sign(
-        payload: string | Buffer | object,
-        secretOrPrivateKey: Secret,
-        callback: SignCallback,
-    ): void;
+    export function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
     export function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: Secret,
@@ -208,7 +190,7 @@ declare namespace jwt {
     export function sign(
         payload: string | Buffer | object,
         secretOrPrivateKey: null,
-        options: SignOptions & { algorithm: "none" },
+        options: SignOptions & { algorithm: 'none' },
         callback: SignCallback,
     ): void;
 
@@ -220,10 +202,18 @@ declare namespace jwt {
      * returns - The decoded token.
      */
     export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-    export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & {
-        complete?: false
-    }): JwtPayload | string;
-    export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret,
+        options?: VerifyOptions & {
+            complete?: false;
+        },
+    ): JwtPayload | string;
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret,
+        options?: VerifyOptions,
+    ): Jwt | JwtPayload | string;
 
     /**
      * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -269,4 +259,4 @@ declare namespace jwt {
     export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
 }
 
-export = jwt
+export = jwt;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -18,13 +18,13 @@
 
 import { KeyObject } from 'crypto';
 
-export class JsonWebTokenError extends Error {
+declare class JsonWebTokenError extends Error {
     inner: Error;
 
     constructor(message: string, error?: Error);
 }
 
-export class TokenExpiredError extends JsonWebTokenError {
+declare class TokenExpiredError extends JsonWebTokenError {
     expiredAt: Date;
 
     constructor(message: string, expiredAt: Date);
@@ -33,13 +33,13 @@ export class TokenExpiredError extends JsonWebTokenError {
 /**
  * Thrown if current time is before the nbf claim.
  */
-export class NotBeforeError extends JsonWebTokenError {
+declare class NotBeforeError extends JsonWebTokenError {
     date: Date;
 
     constructor(message: string, date: Date);
 }
 
-export interface SignOptions {
+interface SignOptions {
     /**
      * Signature algorithm. Could be one of these values :
      * - HS256:    HMAC using SHA-256 hash algorithm (default)
@@ -71,7 +71,7 @@ export interface SignOptions {
     allowInvalidAsymmetricKeyTypes?: boolean | undefined;
 }
 
-export interface VerifyOptions {
+interface VerifyOptions {
     algorithms?: Algorithm[] | undefined;
     audience?: string | RegExp | Array<string | RegExp> | undefined;
     clockTimestamp?: number | undefined;
@@ -92,26 +92,26 @@ export interface VerifyOptions {
     allowInvalidAsymmetricKeyTypes?: boolean | undefined;
 }
 
-export interface DecodeOptions {
+interface DecodeOptions {
     complete?: boolean | undefined;
     json?: boolean | undefined;
 }
-export type VerifyErrors =
+type VerifyErrors =
     | JsonWebTokenError
     | NotBeforeError
     | TokenExpiredError;
-export type VerifyCallback<T = Jwt | JwtPayload | string> = (
+type VerifyCallback<T = Jwt | JwtPayload | string> = (
     error: VerifyErrors | null,
     decoded: T | undefined,
 ) => void;
 
-export type SignCallback = (
+type SignCallback = (
     error: Error | null,
     encoded: string | undefined,
 ) => void;
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
-export interface JwtHeader {
+interface JwtHeader {
     alg: string | Algorithm;
     typ?: string | undefined;
     cty?: string | undefined;
@@ -125,7 +125,7 @@ export interface JwtHeader {
 }
 
 // standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
-export interface JwtPayload {
+interface JwtPayload {
     [key: string]: any;
     iss?: string | undefined;
     sub?: string | undefined;
@@ -136,31 +136,31 @@ export interface JwtPayload {
     jti?: string | undefined;
 }
 
-export interface Jwt {
+interface Jwt {
     header: JwtHeader;
     payload: JwtPayload | string;
     signature: string;
 }
 
 // https://github.com/auth0/node-jsonwebtoken#algorithms-supported
-export type Algorithm =
+type Algorithm =
     "HS256" | "HS384" | "HS512" |
     "RS256" | "RS384" | "RS512" |
     "ES256" | "ES384" | "ES512" |
     "PS256" | "PS384" | "PS512" |
     "none";
 
-export type SigningKeyCallback = (
+type SigningKeyCallback = (
     error: Error | null,
     signingKey?: Secret
 ) => void;
 
-export type GetPublicKeyOrSecret = (
+type GetPublicKeyOrSecret = (
     header: JwtHeader,
     callback: SigningKeyCallback
 ) => void;
 
-export type Secret =
+type Secret =
     | string
     | Buffer
     | KeyObject
@@ -173,12 +173,12 @@ export type Secret =
  * [options] - Options for the signature
  * returns - The JSON Web Token string
  */
-export function sign(
+declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
     options?: SignOptions,
 ): string;
-export function sign(
+declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: null,
     options?: SignOptions & { algorithm: "none" },
@@ -191,18 +191,18 @@ export function sign(
  * [options] - Options for the signature
  * callback - Callback to get the encoded token on
  */
-export function sign(
+declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
     callback: SignCallback,
 ): void;
-export function sign(
+declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
     options: SignOptions,
     callback: SignCallback,
 ): void;
-export function sign(
+declare function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: null,
     options: SignOptions & { algorithm: "none" },
@@ -216,9 +216,11 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & { complete?: false }): JwtPayload | string;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
+declare function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
+declare function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & {
+    complete?: false
+}): JwtPayload | string;
+declare function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -229,24 +231,24 @@ export function verify(token: string, secretOrPublicKey: Secret, options?: Verif
  * [options] - Options for the verification
  * callback - Callback to get the decoded token on
  */
-export function verify(
+declare function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     callback?: VerifyCallback<JwtPayload | string>,
 ): void;
-export function verify(
+declare function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     options: VerifyOptions & { complete: true },
     callback?: VerifyCallback<Jwt>,
 ): void;
-export function verify(
+declare function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     options?: VerifyOptions & { complete?: false },
     callback?: VerifyCallback<JwtPayload | string>,
 ): void;
-export function verify(
+declare function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     options?: VerifyOptions,
@@ -259,6 +261,17 @@ export function verify(
  * [options] - Options for decoding
  * returns - The decoded Token
  */
-export function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
-export function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
-export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
+declare function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
+declare function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
+declare function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
+
+interface JWTStatic {
+    decode: typeof decode,
+    verify: typeof verify,
+    sign: typeof sign,
+    JsonWebTokenError: typeof JsonWebTokenError,
+    NotBeforeError: typeof NotBeforeError,
+    TokenExpiredError: typeof TokenExpiredError,
+}
+
+export = JWTStatic

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -18,247 +18,255 @@
 
 import { KeyObject } from 'crypto';
 
-declare class JsonWebTokenError extends Error {
-    inner: Error;
+declare namespace jwt {
 
-    constructor(message: string, error?: Error);
-}
 
-declare class TokenExpiredError extends JsonWebTokenError {
-    expiredAt: Date;
+    export class JsonWebTokenError extends Error {
+        inner: Error;
 
-    constructor(message: string, expiredAt: Date);
-}
+        constructor(message: string, error?: Error);
+    }
 
-/**
- * Thrown if current time is before the nbf claim.
- */
-declare class NotBeforeError extends JsonWebTokenError {
-    date: Date;
+    export class TokenExpiredError extends JsonWebTokenError {
+        expiredAt: Date;
 
-    constructor(message: string, date: Date);
-}
+        constructor(message: string, expiredAt: Date);
+    }
 
-interface SignOptions {
     /**
-     * Signature algorithm. Could be one of these values :
-     * - HS256:    HMAC using SHA-256 hash algorithm (default)
-     * - HS384:    HMAC using SHA-384 hash algorithm
-     * - HS512:    HMAC using SHA-512 hash algorithm
-     * - RS256:    RSASSA using SHA-256 hash algorithm
-     * - RS384:    RSASSA using SHA-384 hash algorithm
-     * - RS512:    RSASSA using SHA-512 hash algorithm
-     * - ES256:    ECDSA using P-256 curve and SHA-256 hash algorithm
-     * - ES384:    ECDSA using P-384 curve and SHA-384 hash algorithm
-     * - ES512:    ECDSA using P-521 curve and SHA-512 hash algorithm
-     * - none:     No digital signature or MAC value included
+     * Thrown if current time is before the nbf claim.
      */
-    algorithm?: Algorithm | undefined;
-    keyid?: string | undefined;
-    /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
-    expiresIn?: string | number | undefined;
-    /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
-    notBefore?: string | number | undefined;
-    audience?: string | string[] | undefined;
-    subject?: string | undefined;
-    issuer?: string | undefined;
-    jwtid?: string | undefined;
-    mutatePayload?: boolean | undefined;
-    noTimestamp?: boolean | undefined;
-    header?: JwtHeader | undefined;
-    encoding?: string | undefined;
-    allowInsecureKeySizes?: boolean | undefined;
-    allowInvalidAsymmetricKeyTypes?: boolean | undefined;
-}
+    export class NotBeforeError extends JsonWebTokenError {
+        date: Date;
 
-interface VerifyOptions {
-    algorithms?: Algorithm[] | undefined;
-    audience?: string | RegExp | Array<string | RegExp> | undefined;
-    clockTimestamp?: number | undefined;
-    clockTolerance?: number | undefined;
-    /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
-    complete?: boolean | undefined;
-    issuer?: string | string[] | undefined;
-    ignoreExpiration?: boolean | undefined;
-    ignoreNotBefore?: boolean | undefined;
-    jwtid?: string | undefined;
-    /**
-     * If you want to check `nonce` claim, provide a string value here.
-     * It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
-     */
-    nonce?: string | undefined;
-    subject?: string | undefined;
-    maxAge?: string | number | undefined;
-    allowInvalidAsymmetricKeyTypes?: boolean | undefined;
-}
+        constructor(message: string, date: Date);
+    }
 
-interface DecodeOptions {
-    complete?: boolean | undefined;
-    json?: boolean | undefined;
-}
-type VerifyErrors = JsonWebTokenError | NotBeforeError | TokenExpiredError;
-type VerifyCallback<T = Jwt | JwtPayload | string> = (error: VerifyErrors | null, decoded: T | undefined) => void;
+    export interface SignOptions {
+        /**
+         * Signature algorithm. Could be one of these values :
+         * - HS256:    HMAC using SHA-256 hash algorithm (default)
+         * - HS384:    HMAC using SHA-384 hash algorithm
+         * - HS512:    HMAC using SHA-512 hash algorithm
+         * - RS256:    RSASSA using SHA-256 hash algorithm
+         * - RS384:    RSASSA using SHA-384 hash algorithm
+         * - RS512:    RSASSA using SHA-512 hash algorithm
+         * - ES256:    ECDSA using P-256 curve and SHA-256 hash algorithm
+         * - ES384:    ECDSA using P-384 curve and SHA-384 hash algorithm
+         * - ES512:    ECDSA using P-521 curve and SHA-512 hash algorithm
+         * - none:     No digital signature or MAC value included
+         */
+        algorithm?: Algorithm | undefined;
+        keyid?: string | undefined;
+        /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
+        expiresIn?: string | number | undefined;
+        /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
+        notBefore?: string | number | undefined;
+        audience?: string | string[] | undefined;
+        subject?: string | undefined;
+        issuer?: string | undefined;
+        jwtid?: string | undefined;
+        mutatePayload?: boolean | undefined;
+        noTimestamp?: boolean | undefined;
+        header?: JwtHeader | undefined;
+        encoding?: string | undefined;
+        allowInsecureKeySizes?: boolean | undefined;
+        allowInvalidAsymmetricKeyTypes?: boolean | undefined;
+    }
 
-type SignCallback = (error: Error | null, encoded: string | undefined) => void;
+    export interface VerifyOptions {
+        algorithms?: Algorithm[] | undefined;
+        audience?: string | RegExp | Array<string | RegExp> | undefined;
+        clockTimestamp?: number | undefined;
+        clockTolerance?: number | undefined;
+        /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
+        complete?: boolean | undefined;
+        issuer?: string | string[] | undefined;
+        ignoreExpiration?: boolean | undefined;
+        ignoreNotBefore?: boolean | undefined;
+        jwtid?: string | undefined;
+        /**
+         * If you want to check `nonce` claim, provide a string value here.
+         * It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
+         */
+        nonce?: string | undefined;
+        subject?: string | undefined;
+        maxAge?: string | number | undefined;
+        allowInvalidAsymmetricKeyTypes?: boolean | undefined;
+    }
+
+    export interface DecodeOptions {
+        complete?: boolean | undefined;
+        json?: boolean | undefined;
+    }
+    export type VerifyErrors =
+        | JsonWebTokenError
+        | NotBeforeError
+        | TokenExpiredError;
+    export type VerifyCallback<T = Jwt | JwtPayload | string> = (
+        error: VerifyErrors | null,
+        decoded: T | undefined,
+    ) => void;
+
+    export type SignCallback = (
+        error: Error | null,
+        encoded: string | undefined,
+    ) => void;
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
-interface JwtHeader {
-    alg: string | Algorithm;
-    typ?: string | undefined;
-    cty?: string | undefined;
-    crit?: Array<string | Exclude<keyof JwtHeader, 'crit'>> | undefined;
-    kid?: string | undefined;
-    jku?: string | undefined;
-    x5u?: string | string[] | undefined;
-    'x5t#S256'?: string | undefined;
-    x5t?: string | undefined;
-    x5c?: string | string[] | undefined;
-}
+    export interface JwtHeader {
+        alg: string | Algorithm;
+        typ?: string | undefined;
+        cty?: string | undefined;
+        crit?: Array<string | Exclude<keyof JwtHeader, 'crit'>> | undefined;
+        kid?: string | undefined;
+        jku?: string | undefined;
+        x5u?: string | string[] | undefined;
+        'x5t#S256'?: string | undefined;
+        x5t?: string | undefined;
+        x5c?: string | string[] | undefined;
+    }
 
 // standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
-interface JwtPayload {
-    [key: string]: any;
-    iss?: string | undefined;
-    sub?: string | undefined;
-    aud?: string | string[] | undefined;
-    exp?: number | undefined;
-    nbf?: number | undefined;
-    iat?: number | undefined;
-    jti?: string | undefined;
-}
+    export interface JwtPayload {
+        [key: string]: any;
+        iss?: string | undefined;
+        sub?: string | undefined;
+        aud?: string | string[] | undefined;
+        exp?: number | undefined;
+        nbf?: number | undefined;
+        iat?: number | undefined;
+        jti?: string | undefined;
+    }
 
-interface Jwt {
-    header: JwtHeader;
-    payload: JwtPayload | string;
-    signature: string;
-}
+    export interface Jwt {
+        header: JwtHeader;
+        payload: JwtPayload | string;
+        signature: string;
+    }
 
 // https://github.com/auth0/node-jsonwebtoken#algorithms-supported
-type Algorithm =
-    | 'HS256'
-    | 'HS384'
-    | 'HS512'
-    | 'RS256'
-    | 'RS384'
-    | 'RS512'
-    | 'ES256'
-    | 'ES384'
-    | 'ES512'
-    | 'PS256'
-    | 'PS384'
-    | 'PS512'
-    | 'none';
+    export type Algorithm =
+        "HS256" | "HS384" | "HS512" |
+        "RS256" | "RS384" | "RS512" |
+        "ES256" | "ES384" | "ES512" |
+        "PS256" | "PS384" | "PS512" |
+        "none";
 
-type SigningKeyCallback = (error: Error | null, signingKey?: Secret) => void;
+    export type SigningKeyCallback = (
+        error: Error | null,
+        signingKey?: Secret
+    ) => void;
 
-type GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => void;
+    export type GetPublicKeyOrSecret = (
+        header: JwtHeader,
+        callback: SigningKeyCallback
+    ) => void;
 
-type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
+    export type Secret =
+        | string
+        | Buffer
+        | KeyObject
+        | { key: string | Buffer; passphrase: string };
 
-/**
- * Synchronously sign the given payload into a JSON Web Token string
- * payload - Payload to sign, could be an literal, buffer or string
- * secretOrPrivateKey - Either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
- * [options] - Options for the signature
- * returns - The JSON Web Token string
- */
-declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
-declare function sign(
-    payload: string | Buffer | object,
-    secretOrPrivateKey: null,
-    options?: SignOptions & { algorithm: 'none' },
-): string;
+    /**
+     * Synchronously sign the given payload into a JSON Web Token string
+     * payload - Payload to sign, could be an literal, buffer or string
+     * secretOrPrivateKey - Either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
+     * [options] - Options for the signature
+     * returns - The JSON Web Token string
+     */
+    export function sign(
+        payload: string | Buffer | object,
+        secretOrPrivateKey: Secret,
+        options?: SignOptions,
+    ): string;
+    export function sign(
+        payload: string | Buffer | object,
+        secretOrPrivateKey: null,
+        options?: SignOptions & { algorithm: "none" },
+    ): string;
 
-/**
- * Sign the given payload into a JSON Web Token string
- * payload - Payload to sign, could be an literal, buffer or string
- * secretOrPrivateKey - Either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
- * [options] - Options for the signature
- * callback - Callback to get the encoded token on
- */
-declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
-declare function sign(
-    payload: string | Buffer | object,
-    secretOrPrivateKey: Secret,
-    options: SignOptions,
-    callback: SignCallback,
-): void;
-declare function sign(
-    payload: string | Buffer | object,
-    secretOrPrivateKey: null,
-    options: SignOptions & { algorithm: 'none' },
-    callback: SignCallback,
-): void;
+    /**
+     * Sign the given payload into a JSON Web Token string
+     * payload - Payload to sign, could be an literal, buffer or string
+     * secretOrPrivateKey - Either the secret for HMAC algorithms, or the PEM encoded private key for RSA and ECDSA.
+     * [options] - Options for the signature
+     * callback - Callback to get the encoded token on
+     */
+    export function sign(
+        payload: string | Buffer | object,
+        secretOrPrivateKey: Secret,
+        callback: SignCallback,
+    ): void;
+    export function sign(
+        payload: string | Buffer | object,
+        secretOrPrivateKey: Secret,
+        options: SignOptions,
+        callback: SignCallback,
+    ): void;
+    export function sign(
+        payload: string | Buffer | object,
+        secretOrPrivateKey: null,
+        options: SignOptions & { algorithm: "none" },
+        callback: SignCallback,
+    ): void;
 
-/**
- * Synchronously verify given token using a secret or a public key to get a decoded token
- * token - JWT string to verify
- * secretOrPublicKey - Either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
- * [options] - Options for the verification
- * returns - The decoded token.
- */
-declare function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-declare function verify(
-    token: string,
-    secretOrPublicKey: Secret,
-    options?: VerifyOptions & {
-        complete?: false;
-    },
-): JwtPayload | string;
-declare function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
+    /**
+     * Synchronously verify given token using a secret or a public key to get a decoded token
+     * token - JWT string to verify
+     * secretOrPublicKey - Either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
+     * [options] - Options for the verification
+     * returns - The decoded token.
+     */
+    export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
+    export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & {
+        complete?: false
+    }): JwtPayload | string;
+    export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
 
-/**
- * Asynchronously verify given token using a secret or a public key to get a decoded token
- * token - JWT string to verify
- * secretOrPublicKey - A string or buffer containing either the secret for HMAC algorithms,
- * or the PEM encoded public key for RSA and ECDSA. If jwt.verify is called asynchronous,
- * secretOrPublicKey can be a function that should fetch the secret or public key
- * [options] - Options for the verification
- * callback - Callback to get the decoded token on
- */
-declare function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    callback?: VerifyCallback<JwtPayload | string>,
-): void;
-declare function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options: VerifyOptions & { complete: true },
-    callback?: VerifyCallback<Jwt>,
-): void;
-declare function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options?: VerifyOptions & { complete?: false },
-    callback?: VerifyCallback<JwtPayload | string>,
-): void;
-declare function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options?: VerifyOptions,
-    callback?: VerifyCallback,
-): void;
+    /**
+     * Asynchronously verify given token using a secret or a public key to get a decoded token
+     * token - JWT string to verify
+     * secretOrPublicKey - A string or buffer containing either the secret for HMAC algorithms,
+     * or the PEM encoded public key for RSA and ECDSA. If jwt.verify is called asynchronous,
+     * secretOrPublicKey can be a function that should fetch the secret or public key
+     * [options] - Options for the verification
+     * callback - Callback to get the decoded token on
+     */
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+        callback?: VerifyCallback<JwtPayload | string>,
+    ): void;
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+        options: VerifyOptions & { complete: true },
+        callback?: VerifyCallback<Jwt>,
+    ): void;
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+        options?: VerifyOptions & { complete?: false },
+        callback?: VerifyCallback<JwtPayload | string>,
+    ): void;
+    export function verify(
+        token: string,
+        secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+        options?: VerifyOptions,
+        callback?: VerifyCallback,
+    ): void;
 
-/**
- * Returns the decoded payload without verifying if the signature is valid.
- * token - JWT string to decode
- * [options] - Options for decoding
- * returns - The decoded Token
- */
-declare function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
-declare function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
-declare function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
-
-interface JWTStatic {
-    decode: typeof decode;
-    verify: typeof verify;
-    sign: typeof sign;
-    JsonWebTokenError: typeof JsonWebTokenError;
-    NotBeforeError: typeof NotBeforeError;
-    TokenExpiredError: typeof TokenExpiredError;
+    /**
+     * Returns the decoded payload without verifying if the signature is valid.
+     * token - JWT string to decode
+     * [options] - Options for decoding
+     * returns - The decoded Token
+     */
+    export function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
+    export function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
+    export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
 }
 
-declare const jwtStatic: JWTStatic;
-
-export = jwtStatic;
+export = jwt

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -4,9 +4,9 @@
  * Created by using code samples from https://github.com/auth0/node-jsonwebtoken.
  */
 
-import jwt = require("jsonwebtoken");
-import fs = require("fs");
-import { createSecretKey, KeyObject } from "crypto";
+import jwt = require('jsonwebtoken');
+import fs = require('fs');
+import { createSecretKey, KeyObject } from 'crypto';
 
 let token: string;
 let cert: Buffer;
@@ -17,38 +17,38 @@ interface TestObject {
 }
 
 const testBoolean = true as boolean;
-const testObject = { foo: "bar" };
+const testObject = { foo: 'bar' };
 
 /**
  * jwt.sign
  * https://github.com/auth0/node-jsonwebtoken#usage
  */
 // sign with default (HMAC SHA256)
-token = jwt.sign(testObject, "shhhhh");
+token = jwt.sign(testObject, 'shhhhh');
 
 // sign with default (HMAC SHA256) and single audience
-token = jwt.sign(testObject, "shhhhh", { audience: "theAudience" });
+token = jwt.sign(testObject, 'shhhhh', { audience: 'theAudience' });
 
 // sign with default (HMAC SHA256) and multiple audiences
-token = jwt.sign(testObject, "shhhhh", {
-    audience: ["audience1", "audience2"],
+token = jwt.sign(testObject, 'shhhhh', {
+    audience: ['audience1', 'audience2'],
 });
 
 // sign with default (HMAC SHA256) and a keyid
-token = jwt.sign(testObject, "shhhhh", { keyid: "theKeyId" });
+token = jwt.sign(testObject, 'shhhhh', { keyid: 'theKeyId' });
 
 // sign with RSA SHA256
-cert = fs.readFileSync("private.key"); // get private key
-token = jwt.sign(testObject, cert, { algorithm: "RS256" });
+cert = fs.readFileSync('private.key'); // get private key
+token = jwt.sign(testObject, cert, { algorithm: 'RS256' });
 
 // sign with encrypted RSA SHA256 private key (only PEM encoding is supported)
-const privKey: Buffer = fs.readFileSync("encrypted_private.key"); // get private key
-const secret = { key: privKey.toString(), passphrase: "keypwd" };
-token = jwt.sign(testObject, secret, { algorithm: "RS256" }); // the algorithm option is mandatory in this case
-token = jwt.sign(testObject, { key: privKey, passphrase: 'keypwd' }, { algorithm: "RS256" });
+const privKey: Buffer = fs.readFileSync('encrypted_private.key'); // get private key
+const secret = { key: privKey.toString(), passphrase: 'keypwd' };
+token = jwt.sign(testObject, secret, { algorithm: 'RS256' }); // the algorithm option is mandatory in this case
+token = jwt.sign(testObject, { key: privKey, passphrase: 'keypwd' }, { algorithm: 'RS256' });
 
 // sign with secret key (KeyObject)
-secretKey = createSecretKey("shhhhh", "utf-8");
+secretKey = createSecretKey('shhhhh', 'utf-8');
 token = jwt.sign(testObject, secretKey);
 
 // sign with insecure key size
@@ -58,15 +58,12 @@ token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInsecureKe
 token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
 
 // sign with algorithm none
-token = jwt.sign(testObject, null, { algorithm: "none" });
+token = jwt.sign(testObject, null, { algorithm: 'none' });
 // @ts-expect-error
 token = jwt.sign({ foo: 'bar' }, null, { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
 
 // sign asynchronously
-jwt.sign(testObject, cert, { algorithm: "RS256" }, (
-    err: Error | null,
-    token: string | undefined,
-) => {
+jwt.sign(testObject, cert, { algorithm: 'RS256' }, (err: Error | null, token: string | undefined) => {
     if (err) {
         console.log(err);
         return;
@@ -76,10 +73,7 @@ jwt.sign(testObject, cert, { algorithm: "RS256" }, (
 });
 
 // sign asynchronously with algorithm none
-jwt.sign(testObject, null, { algorithm: "none" }, (
-    err: Error | null,
-    token: string | undefined,
-) => {
+jwt.sign(testObject, null, { algorithm: 'none' }, (err: Error | null, token: string | undefined) => {
     if (err) {
         console.log(err);
         return;
@@ -88,10 +82,7 @@ jwt.sign(testObject, null, { algorithm: "none" }, (
     console.log(token);
 });
 // @ts-expect-error
-jwt.sign(testObject, null, { algorithm: "RS256" }, (
-    err: Error | null,
-    token: string | undefined,
-) => {
+jwt.sign(testObject, null, { algorithm: 'RS256' }, (err: Error | null, token: string | undefined) => {
     if (err) {
         console.log(err);
         return;
@@ -108,7 +99,7 @@ jwt.sign(testObject, null, { algorithm: "RS256" }, (
 jwt.verify(token, secretKey);
 
 // verify a token symmetric
-jwt.verify(token, "shhhhh", (err, decoded) => {
+jwt.verify(token, 'shhhhh', (err, decoded) => {
     const result = decoded as TestObject;
 
     console.log(result.foo); // bar
@@ -122,7 +113,7 @@ jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
 });
 
 // invalid token
-jwt.verify(token, "wrong-secret", (err, decoded) => {
+jwt.verify(token, 'wrong-secret', (err, decoded) => {
     // err
     // decoded undefined
 });
@@ -142,7 +133,7 @@ jwt.verify(token, secret, { allowInvalidAsymmetricKeyTypes: true }, (err, decode
 });
 
 // verify a token asymmetric
-cert = fs.readFileSync("public.pem"); // get public key
+cert = fs.readFileSync('public.pem'); // get public key
 jwt.verify(token, cert, (err, decoded) => {
     const result = decoded as TestObject;
 
@@ -171,34 +162,31 @@ jwt.verify(token, getKeyFailed, (err, decoded) => {
 });
 
 // verify audience
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { audience: "urn:foo" }, (err, decoded) => {
+cert = fs.readFileSync('public.pem'); // get public key
+jwt.verify(token, cert, { audience: 'urn:foo' }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
 jwt.verify(token, cert, { audience: /urn:f[o]{2}/ }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
-jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded) => {
+jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, 'urn:bar'] }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
 
 // verify issuer
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
-    err,
-    decoded,
-) => {
+cert = fs.readFileSync('public.pem'); // get public key
+jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer' }, (err, decoded) => {
     // if issuer mismatch, err == invalid issuer
 });
 
 // verify algorithm
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { algorithms: ["RS256"] }, (err, decoded) => {
+cert = fs.readFileSync('public.pem'); // get public key
+jwt.verify(token, cert, { algorithms: ['RS256'] }, (err, decoded) => {
     // if algorithm mismatch, err == invalid algorithm
 });
 
 // verify without expiration check
-cert = fs.readFileSync("public.pem"); // get public key
+cert = fs.readFileSync('public.pem'); // get public key
 jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
     // if ignoreExpration == false and token is expired, err == expired token
 });

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -143,7 +143,7 @@ jwt.verify(token, cert, (err, decoded) => {
 // verify a token assymetric with async key fetch function
 jwt.verify(
     token,
-    function (header, callback) {
+    (header, callback) => {
         cert = fs.readFileSync('public.pem');
         console.log(header.alg);
         callback(null, cert);
@@ -157,7 +157,7 @@ jwt.verify(
 
 jwt.verify(
     token,
-    function (header, callback) {
+    (header, callback) => {
         cert = fs.readFileSync('public.pem');
         console.log(header.alg);
 

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -141,25 +141,32 @@ jwt.verify(token, cert, (err, decoded) => {
 });
 
 // verify a token assymetric with async key fetch function
-function getKeySuccess(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
-    cert = fs.readFileSync('public.pem');
+jwt.verify(
+    token,
+    function (header, callback) {
+        cert = fs.readFileSync('public.pem');
+        console.log(header.alg);
+        callback(null, cert);
+    },
+    (err, decoded) => {
+        const result = decoded as TestObject;
 
-    callback(null, cert);
-}
-jwt.verify(token, getKeySuccess, (err, decoded) => {
-    const result = decoded as TestObject;
+        console.log(result.foo); // bar
+    },
+);
 
-    console.log(result.foo); // bar
-});
+jwt.verify(
+    token,
+    function (header, callback) {
+        cert = fs.readFileSync('public.pem');
+        console.log(header.alg);
 
-function getKeyFailed(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
-    cert = fs.readFileSync('public.pem');
-
-    callback(new Error('FAILED_KEY_RETRIEVAL'), cert);
-}
-jwt.verify(token, getKeyFailed, (err, decoded) => {
-    console.error(err); // new JsonWebTokenError('error in secret or public key callback: FAILED_KEY_RETRIEVAL')
-});
+        callback(new Error('FAILED_KEY_RETRIEVAL'), cert);
+    },
+    (err, decoded) => {
+        console.error(err); // new JsonWebTokenError('error in secret or public key callback: FAILED_KEY_RETRIEVAL')
+    },
+);
 
 // verify audience
 cert = fs.readFileSync('public.pem'); // get public key

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -4,9 +4,9 @@
  * Created by using code samples from https://github.com/auth0/node-jsonwebtoken.
  */
 
-import jwt = require('jsonwebtoken');
-import fs = require('fs');
-import { createSecretKey, KeyObject } from 'crypto';
+import jwt = require("jsonwebtoken");
+import fs = require("fs");
+import { createSecretKey, KeyObject } from "crypto";
 
 let token: string;
 let cert: Buffer;
@@ -17,38 +17,38 @@ interface TestObject {
 }
 
 const testBoolean = true as boolean;
-const testObject = { foo: 'bar' };
+const testObject = { foo: "bar" };
 
 /**
  * jwt.sign
  * https://github.com/auth0/node-jsonwebtoken#usage
  */
 // sign with default (HMAC SHA256)
-token = jwt.sign(testObject, 'shhhhh');
+token = jwt.sign(testObject, "shhhhh");
 
 // sign with default (HMAC SHA256) and single audience
-token = jwt.sign(testObject, 'shhhhh', { audience: 'theAudience' });
+token = jwt.sign(testObject, "shhhhh", { audience: "theAudience" });
 
 // sign with default (HMAC SHA256) and multiple audiences
-token = jwt.sign(testObject, 'shhhhh', {
-    audience: ['audience1', 'audience2'],
+token = jwt.sign(testObject, "shhhhh", {
+    audience: ["audience1", "audience2"],
 });
 
 // sign with default (HMAC SHA256) and a keyid
-token = jwt.sign(testObject, 'shhhhh', { keyid: 'theKeyId' });
+token = jwt.sign(testObject, "shhhhh", { keyid: "theKeyId" });
 
 // sign with RSA SHA256
-cert = fs.readFileSync('private.key'); // get private key
-token = jwt.sign(testObject, cert, { algorithm: 'RS256' });
+cert = fs.readFileSync("private.key"); // get private key
+token = jwt.sign(testObject, cert, { algorithm: "RS256" });
 
 // sign with encrypted RSA SHA256 private key (only PEM encoding is supported)
-const privKey: Buffer = fs.readFileSync('encrypted_private.key'); // get private key
-const secret = { key: privKey.toString(), passphrase: 'keypwd' };
-token = jwt.sign(testObject, secret, { algorithm: 'RS256' }); // the algorithm option is mandatory in this case
-token = jwt.sign(testObject, { key: privKey, passphrase: 'keypwd' }, { algorithm: 'RS256' });
+const privKey: Buffer = fs.readFileSync("encrypted_private.key"); // get private key
+const secret = { key: privKey.toString(), passphrase: "keypwd" };
+token = jwt.sign(testObject, secret, { algorithm: "RS256" }); // the algorithm option is mandatory in this case
+token = jwt.sign(testObject, { key: privKey, passphrase: 'keypwd' }, { algorithm: "RS256" });
 
 // sign with secret key (KeyObject)
-secretKey = createSecretKey('shhhhh', 'utf-8');
+secretKey = createSecretKey("shhhhh", "utf-8");
 token = jwt.sign(testObject, secretKey);
 
 // sign with insecure key size
@@ -58,12 +58,15 @@ token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInsecureKe
 token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
 
 // sign with algorithm none
-token = jwt.sign(testObject, null, { algorithm: 'none' });
+token = jwt.sign(testObject, null, { algorithm: "none" });
 // @ts-expect-error
 token = jwt.sign({ foo: 'bar' }, null, { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
 
 // sign asynchronously
-jwt.sign(testObject, cert, { algorithm: 'RS256' }, (err: Error | null, token: string | undefined) => {
+jwt.sign(testObject, cert, { algorithm: "RS256" }, (
+    err: Error | null,
+    token: string | undefined,
+) => {
     if (err) {
         console.log(err);
         return;
@@ -73,7 +76,10 @@ jwt.sign(testObject, cert, { algorithm: 'RS256' }, (err: Error | null, token: st
 });
 
 // sign asynchronously with algorithm none
-jwt.sign(testObject, null, { algorithm: 'none' }, (err: Error | null, token: string | undefined) => {
+jwt.sign(testObject, null, { algorithm: "none" }, (
+    err: Error | null,
+    token: string | undefined,
+) => {
     if (err) {
         console.log(err);
         return;
@@ -82,7 +88,10 @@ jwt.sign(testObject, null, { algorithm: 'none' }, (err: Error | null, token: str
     console.log(token);
 });
 // @ts-expect-error
-jwt.sign(testObject, null, { algorithm: 'RS256' }, (err: Error | null, token: string | undefined) => {
+jwt.sign(testObject, null, { algorithm: "RS256" }, (
+    err: Error | null,
+    token: string | undefined,
+) => {
     if (err) {
         console.log(err);
         return;
@@ -99,7 +108,7 @@ jwt.sign(testObject, null, { algorithm: 'RS256' }, (err: Error | null, token: st
 jwt.verify(token, secretKey);
 
 // verify a token symmetric
-jwt.verify(token, 'shhhhh', (err, decoded) => {
+jwt.verify(token, "shhhhh", (err, decoded) => {
     const result = decoded as TestObject;
 
     console.log(result.foo); // bar
@@ -113,7 +122,7 @@ jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
 });
 
 // invalid token
-jwt.verify(token, 'wrong-secret', (err, decoded) => {
+jwt.verify(token, "wrong-secret", (err, decoded) => {
     // err
     // decoded undefined
 });
@@ -133,7 +142,7 @@ jwt.verify(token, secret, { allowInvalidAsymmetricKeyTypes: true }, (err, decode
 });
 
 // verify a token asymmetric
-cert = fs.readFileSync('public.pem'); // get public key
+cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {
     const result = decoded as TestObject;
 
@@ -141,59 +150,55 @@ jwt.verify(token, cert, (err, decoded) => {
 });
 
 // verify a token assymetric with async key fetch function
-jwt.verify(
-    token,
-    (header, callback) => {
-        cert = fs.readFileSync('public.pem');
-        console.log(header.alg);
-        callback(null, cert);
-    },
-    (err, decoded) => {
-        const result = decoded as TestObject;
+function getKeySuccess(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
+    cert = fs.readFileSync('public.pem');
 
-        console.log(result.foo); // bar
-    },
-);
+    callback(null, cert);
+}
+jwt.verify(token, getKeySuccess, (err, decoded) => {
+    const result = decoded as TestObject;
 
-jwt.verify(
-    token,
-    (header, callback) => {
-        cert = fs.readFileSync('public.pem');
-        console.log(header.alg);
+    console.log(result.foo); // bar
+});
 
-        callback(new Error('FAILED_KEY_RETRIEVAL'), cert);
-    },
-    (err, decoded) => {
-        console.error(err); // new JsonWebTokenError('error in secret or public key callback: FAILED_KEY_RETRIEVAL')
-    },
-);
+function getKeyFailed(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
+    cert = fs.readFileSync('public.pem');
+
+    callback(new Error('FAILED_KEY_RETRIEVAL'), cert);
+}
+jwt.verify(token, getKeyFailed, (err, decoded) => {
+    console.error(err); // new JsonWebTokenError('error in secret or public key callback: FAILED_KEY_RETRIEVAL')
+});
 
 // verify audience
-cert = fs.readFileSync('public.pem'); // get public key
-jwt.verify(token, cert, { audience: 'urn:foo' }, (err, decoded) => {
+cert = fs.readFileSync("public.pem"); // get public key
+jwt.verify(token, cert, { audience: "urn:foo" }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
 jwt.verify(token, cert, { audience: /urn:f[o]{2}/ }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
-jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, 'urn:bar'] }, (err, decoded) => {
+jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
 
 // verify issuer
-cert = fs.readFileSync('public.pem'); // get public key
-jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer' }, (err, decoded) => {
+cert = fs.readFileSync("public.pem"); // get public key
+jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
+    err,
+    decoded,
+) => {
     // if issuer mismatch, err == invalid issuer
 });
 
 // verify algorithm
-cert = fs.readFileSync('public.pem'); // get public key
-jwt.verify(token, cert, { algorithms: ['RS256'] }, (err, decoded) => {
+cert = fs.readFileSync("public.pem"); // get public key
+jwt.verify(token, cert, { algorithms: ["RS256"] }, (err, decoded) => {
     // if algorithm mismatch, err == invalid algorithm
 });
 
 // verify without expiration check
-cert = fs.readFileSync('public.pem'); // get public key
+cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
     // if ignoreExpration == false and token is expired, err == expired token
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

https://github.com/auth0/node-jsonwebtoken/blob/master/index.js

I don't want to use `// eslint-disable-next-line export-just-namespace` here but this package need to export both types and values.