### PR TITLE
Add sshOptions to DockerOptions

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -18,7 +18,8 @@
 import * as stream from 'stream';
 import * as events from 'events';
 import * as DockerModem from 'docker-modem';
-
+import { ConnectConfig } from 'ssh2';
+    
 declare namespace Dockerode {
     class Container {
         constructor(modem: any, id: string);
@@ -33,7 +34,6 @@ declare namespace Dockerode {
         rename(options: {}, callback: Callback<any>): void;
         rename(options: {}): Promise<any>;
 
-        update(options: {}, callback: Callback<any>): void;
         update(options: {}): Promise<any>;
 
         top(options: {}, callback: Callback<any>): void;
@@ -1184,6 +1184,7 @@ declare namespace Dockerode {
         timeout?: number | undefined;
         version?: string | undefined;
         sshAuthAgent?: string | undefined;
+        sshOptions?: ConnectConfig | undefined;
         Promise?: typeof Promise | undefined;
     }
 


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d6a6e90b142d6eeb4b0f3fe595987d5cce3d2d8f/types/docker-modem/index.d.ts#L34 shows that docker modems (which dockerode uses for new `Docker()` instances) now support passing through custom ssh options. It looks like this wasn't added when the change was previously implemented unless I'm mistaken.

Additional Info:
https://github.com/apocas/docker-modem/pull/119#issuecomment-703002880

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (not sure if required)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

