### PR TITLE
fix: add options arguments to esquery methods, add missing traverse method, make ancestry arg optional

### DIFF
--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -16,7 +16,7 @@ const selector = esquery.parse(s);
 // $ExpectType Node[]
 const nodes = esquery.query(AST, s);
 
-// $ExpectType Node[]
+// $ExpectType void
 esquery.traverse(AST, s, (node, parent, ancestry) => {});
 
 // $ExpectType Node[]

--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -17,6 +17,9 @@ const selector = esquery.parse(s);
 const nodes = esquery.query(AST, s);
 
 // $ExpectType Node[]
+esquery.traverse(AST, s, (node, parent, ancestry) => {});
+
+// $ExpectType Node[]
 esquery(AST, s);
 
 // @ts-expect-error

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -37,7 +37,7 @@ declare namespace query {
         selector: string,
         visitor: (node: Node, parent: Node, ancestry: Node[]) => void,
         options?: ESQueryOptions,
-    ): Node[];
+    ): void
 
     //
     // Unions

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -37,7 +37,7 @@ declare namespace query {
         selector: string,
         visitor: (node: Node, parent: Node, ancestry: Node[]) => void,
         options?: ESQueryOptions,
-    ): void
+    ): void;
 
     //
     // Unions

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for esquery 1.0
+// Type definitions for esquery 1.5
 // Project: https://github.com/jrfeenst/esquery
 // Definitions by: cherryblossom000 <https://github.com/cherryblossom000>
 //                 Brad Zacher <https://github.com/bradzacher>
+//                 Brett Zamir <https://github.com/brettz9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Node } from 'estree';
@@ -14,19 +15,35 @@ export = query;
 declare function query(ast: Node, selector: string): Node[];
 
 declare namespace query {
+    interface ESQueryOptions {
+        nodeTypeKey?: string;
+        visitorKeys?: { [nodeType: string]: readonly string[] };
+        fallback?: (node: Node) => string[];
+        matchClass?: (className: string, node: Node, ancestry: Node[]) => boolean;
+    }
+
     /** Parse a selector and return its AST. */
     function parse(selector: string): Selector;
     /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
-    function match(ast: Node, selector: Selector): Node[];
+    function match(ast: Node, selector: Selector, options?: ESQueryOptions): Node[];
     /** Given a `node` and its ancestors, determine if `node` is matched by `selector`. */
-    function matches(node: Node, selector: Selector, ancestry: Node[]): boolean;
+    function matches(node: Node, selector: Selector, ancestry?: Node[] | null, options?: ESQueryOptions): boolean;
     /** Query the code AST using the selector string. */
-    function query(ast: Node, selector: string): Node[];
+    function query(ast: Node, selector: string, options?: ESQueryOptions): Node[];
+
+    /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
+    function traverse(
+        ast: Node,
+        selector: string,
+        visitor: (node: Node, parent: Node, ancestry: Node[]) => void,
+        options?: ESQueryOptions,
+    ): Node[];
 
     //
     // Unions
     //
-    type Selector =  Field
+    type Selector =
+        | Field
         | Type
         | Sequence
         | Identifier
@@ -42,24 +59,11 @@ declare namespace query {
         | Matches
         | Has
         | Class;
-    type MultiSelector = Sequence
-        | Negation
-        | Matches
-        | Has;
-    type BinarySelector = Descendant
-        | Child
-        | Sibling
-        | Adjacent;
-    type NthSelector = NthChild
-        | NthLastChild;
-    type SubjectSelector = NthSelector
-        | BinarySelector
-        | MultiSelector
-        | Identifier
-        | Wildcard
-        | Attribute;
-    type Literal = StringLiteral
-        | NumericLiteral;
+    type MultiSelector = Sequence | Negation | Matches | Has;
+    type BinarySelector = Descendant | Child | Sibling | Adjacent;
+    type NthSelector = NthChild | NthLastChild;
+    type SubjectSelector = NthSelector | BinarySelector | MultiSelector | Identifier | Wildcard | Attribute;
+    type Literal = StringLiteral | NumericLiteral;
 
     //
     // Base Atoms

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -27,7 +27,7 @@ declare namespace query {
     /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
     function match(ast: Node, selector: Selector, options?: ESQueryOptions): Node[];
     /** Given a `node` and its ancestors, determine if `node` is matched by `selector`. */
-    function matches(node: Node, selector: Selector, ancestry?: Node[] | null, options?: ESQueryOptions): boolean;
+    function matches(node: Node, selector: Selector, ancestry?: Node[], options?: ESQueryOptions): boolean;
     /** Query the code AST using the selector string. */
     function query(ast: Node, selector: string, options?: ESQueryOptions): Node[];
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estools/esquery/blob/master/esquery.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
