### PR TITLE
[node] Improve documentation, add missed types

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -15,10 +15,25 @@ declare module 'assert' {
          * Indicates the failure of an assertion. All errors thrown by the `node:assert`module will be instances of the `AssertionError` class.
          */
         class AssertionError extends Error {
+            /**
+             * Set to the `actual` argument for methods such as {@link assert.strictEqual()}.
+             */
             actual: unknown;
+            /**
+             * Set to the `expected` argument for methods such as {@link assert.strictEqual()}.
+             */
             expected: unknown;
+            /**
+             * Set to the passed in operator value.
+             */
             operator: string;
+            /**
+             * Indicates if the message was auto-generated (`true`) or not.
+             */
             generatedMessage: boolean;
+            /**
+             * Value is always `ERR_ASSERTION` to show that the error is an assertion error.
+             */
             code: 'ERR_ASSERTION';
             constructor(options?: {
                 /** If provided, the error message is set to this value. */

--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -274,19 +274,13 @@ declare module 'async_hooks' {
          * @param fn The function to bind to the current execution context.
          * @param type An optional name to associate with the underlying `AsyncResource`.
          */
-        static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(
-            fn: Func,
-            type?: string,
-            thisArg?: ThisArg
-        ): Func;
+        static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(fn: Func, type?: string, thisArg?: ThisArg): Func;
         /**
          * Binds the given function to execute to this `AsyncResource`'s scope.
          * @since v14.8.0, v12.19.0
          * @param fn The function to bind to the current `AsyncResource`.
          */
-        bind<Func extends (...args: any[]) => any>(
-            fn: Func
-        ): Func;
+        bind<Func extends (...args: any[]) => any>(fn: Func): Func;
         /**
          * Call the provided function with the provided arguments in the execution context
          * of the async resource. This will establish the context, trigger the AsyncHooks
@@ -372,9 +366,7 @@ declare module 'async_hooks' {
          * @param fn The function to bind to the current execution context.
          * @return A new function that calls `fn` within the captured execution context.
          */
-        static bind<Func extends (...args: any[]) => any>(
-            fn: Func
-        ): Func;
+        static bind<Func extends (...args: any[]) => any>(fn: Func): Func;
         /**
          * Captures the current execution context and returns a function that accepts a
          * function as an argument. Whenever the returned function is called, it

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -96,7 +96,7 @@ declare module 'crypto' {
         verifySpkac(spkac: NodeJS.ArrayBufferView): boolean;
     }
     namespace constants {
-        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+        // https://nodejs.org/dist/latest-v20.x/docs/api/crypto.html#crypto-constants
         const OPENSSL_VERSION_NUMBER: number;
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
         const SSL_OP_ALL: number;

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -633,6 +633,7 @@ declare module 'dns' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -344,6 +344,49 @@ declare module 'dns/promises' {
      * @param order must be `'ipv4first'` or `'verbatim'`.
      */
     function setDefaultResultOrder(order: 'ipv4first' | 'verbatim'): void;
+    /**
+     * An independent resolver for DNS requests.
+     *
+     * Creating a new resolver uses the default server settings. Setting
+     * the servers used for a resolver using `resolver.setServers()` does not affect
+     * other resolvers:
+     *
+     * ```js
+     * const { Resolver } = require('node:dns').promises;
+     * const resolver = new Resolver();
+     * resolver.setServers(['4.4.4.4']);
+     *
+     * // This request will use the server at 4.4.4.4, independent of global settings.
+     * resolver.resolve4('example.org').then((addresses) => {
+     *   // ...
+     * });
+     *
+     * // Alternatively, the same code can be written using async-await style.
+     * (async function() {
+     *   const addresses = await resolver.resolve4('example.org');
+     * })();
+     * ```
+     *
+     * The following methods from the `dnsPromises` API are available:
+     *
+     * * `resolver.getServers()`
+     * * `resolver.resolve()`
+     * * `resolver.resolve4()`
+     * * `resolver.resolve6()`
+     * * `resolver.resolveAny()`
+     * * `resolver.resolveCaa()`
+     * * `resolver.resolveCname()`
+     * * `resolver.resolveMx()`
+     * * `resolver.resolveNaptr()`
+     * * `resolver.resolveNs()`
+     * * `resolver.resolvePtr()`
+     * * `resolver.resolveSoa()`
+     * * `resolver.resolveSrv()`
+     * * `resolver.resolveTxt()`
+     * * `resolver.reverse()`
+     * * `resolver.setServers()`
+     * @since v10.6.0
+     */
     class Resolver {
         constructor(options?: ResolverOptions);
         cancel(): void;
@@ -352,6 +395,7 @@ declare module 'dns/promises' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -310,21 +310,63 @@ declare module 'events' {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
-         * This symbol shall be used to install a listener for only monitoring `'error'`
-         * events. Listeners installed using this symbol are called before the regular
-         * `'error'` listeners are called.
+         * This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
          *
-         * Installing a listener using this symbol does not change the behavior once an
-         * `'error'` event is emitted, therefore the process will still crash if no
+         * Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
          * regular `'error'` listener is installed.
+         * @since v13.6.0, v12.17.0
          */
         static readonly errorMonitor: unique symbol;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         *
+         * See how to write a custom `rejection handler`.
+         * @since v13.4.0, v12.16.0
+         */
         static readonly captureRejectionSymbol: unique symbol;
         /**
-         * Sets or gets the default captureRejection value for all emitters.
+         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+         *
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
          */
-        // TODO: These should be described using static getter/setter pairs:
         static captureRejections: boolean;
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_`EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+         * temporarily avoid this warning:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
         static defaultMaxListeners: number;
     }
     import internal = require('node:events');

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -149,12 +149,38 @@ declare module 'fs' {
     }
     export interface StatsFs extends StatsFsBase<number> {}
     /**
-     * Provides information about a mounted file system
+     * Provides information about a mounted file system.
      *
-     * Objects returned from {@link statfs} and {@link statfsSync} are of this type.
-     * If `bigint` in the `options` passed to those methods is true, the numeric values
-     * will be `bigint` instead of `number`.
-     * @since  v18.15.0
+     * Objects returned from {@link statfs} and its synchronous counterpart are of
+     * this type. If `bigint` in the `options` passed to those methods is `true`, the
+     * numeric values will be `bigint` instead of `number`.
+     *
+     * ```console
+     * StatFs {
+     *   type: 1397114950,
+     *   bsize: 4096,
+     *   blocks: 121938943,
+     *   bfree: 61058895,
+     *   bavail: 61058895,
+     *   files: 999,
+     *   ffree: 1000000
+     * }
+     * ```
+     *
+     * `bigint` version:
+     *
+     * ```console
+     * StatFs {
+     *   type: 1397114950n,
+     *   bsize: 4096n,
+     *   blocks: 121938943n,
+     *   bfree: 61058895n,
+     *   bavail: 61058895n,
+     *   files: 999n,
+     *   ffree: 1000000n
+     * }
+     * ```
+     * @since v19.6.0, v18.15.0
      */
     export class StatsFs {}
     export interface BigIntStatsFs extends StatsFsBase<bigint> {}
@@ -214,6 +240,11 @@ declare module 'fs' {
          * @since v10.10.0
          */
         name: string;
+        /**
+         * The base path that this `fs.Dirent` object refers to.
+         * @since v20.1.0
+         */
+        path: string;
     }
     /**
      * A class representing a directory stream.

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -35,7 +35,6 @@
 declare module 'readline' {
     import { Abortable, EventEmitter } from 'node:events';
     import * as promises from 'node:readline/promises';
-
     export { promises };
     export interface Key {
         sequence?: string | undefined;
@@ -74,7 +73,7 @@ declare module 'readline' {
          * const showResults = debounce(() => {
          *   console.log(
          *     '\n',
-         *     values.filter((val) => val.startsWith(rl.line)).join(' ')
+         *     values.filter((val) => val.startsWith(rl.line)).join(' '),
          *   );
          * }, 300);
          * process.stdin.on('keypress', (c, k) => {
@@ -100,7 +99,7 @@ declare module 'readline' {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
          */
         protected constructor(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean);
         /**
@@ -109,12 +108,12 @@ declare module 'readline' {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
          */
         protected constructor(options: ReadLineOptions);
         /**
          * The `rl.getPrompt()` method returns the current prompt used by `rl.prompt()`.
-         * @since v15.3.0
+         * @since v15.3.0, v14.17.0
          * @return the current prompt string
          */
         getPrompt(): string;
@@ -124,13 +123,13 @@ declare module 'readline' {
          */
         setPrompt(prompt: string): void;
         /**
-         * The `rl.prompt()` method writes the `readline.Interface` instances configured`prompt` to a new line in `output` in order to provide a user with a new
+         * The `rl.prompt()` method writes the `Interface` instances configured`prompt` to a new line in `output` in order to provide a user with a new
          * location at which to provide input.
          *
          * When called, `rl.prompt()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the prompt is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the prompt is not written.
          * @since v0.1.98
          * @param preserveCursor If `true`, prevents the cursor placement from being reset to `0`.
          */
@@ -142,11 +141,13 @@ declare module 'readline' {
          * When called, `rl.question()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
          *
          * The `callback` function passed to `rl.question()` does not follow the typical
          * pattern of accepting an `Error` object or `null` as the first argument.
          * The `callback` is called with the provided answer as the only argument.
+         *
+         * An error will be thrown if calling `rl.question()` after `rl.close()`.
          *
          * Example usage:
          *
@@ -172,25 +173,6 @@ declare module 'readline' {
          *
          * setTimeout(() => ac.abort(), 10000);
          * ```
-         *
-         * If this method is invoked as it's util.promisify()ed version, it returns a
-         * Promise that fulfills with the answer. If the question is canceled using
-         * an `AbortController` it will reject with an `AbortError`.
-         *
-         * ```js
-         * const util = require('util');
-         * const question = util.promisify(rl.question).bind(rl);
-         *
-         * async function questionExample() {
-         *   try {
-         *     const answer = await question('What is you favorite food? ');
-         *     console.log(`Oh, so your favorite food is ${answer}`);
-         *   } catch (err) {
-         *     console.error('Question rejected', err);
-         *   }
-         * }
-         * questionExample();
-         * ```
          * @since v0.3.3
          * @param query A statement or query to write to `output`, prepended to the prompt.
          * @param callback A callback function that is invoked with the user's input in response to the `query`.
@@ -201,7 +183,7 @@ declare module 'readline' {
          * The `rl.pause()` method pauses the `input` stream, allowing it to be resumed
          * later if necessary.
          *
-         * Calling `rl.pause()` does not immediately pause other events (including`'line'`) from being emitted by the `readline.Interface` instance.
+         * Calling `rl.pause()` does not immediately pause other events (including`'line'`) from being emitted by the `Interface` instance.
          * @since v0.3.4
          */
         pause(): this;
@@ -211,12 +193,12 @@ declare module 'readline' {
          */
         resume(): this;
         /**
-         * The `rl.close()` method closes the `readline.Interface` instance and
+         * The `rl.close()` method closes the `Interface` instance and
          * relinquishes control over the `input` and `output` streams. When called,
          * the `'close'` event will be emitted.
          *
          * Calling `rl.close()` does not immediately stop other events (including `'line'`)
-         * from being emitted by the `readline.Interface` instance.
+         * from being emitted by the `Interface` instance.
          * @since v0.1.98
          */
         close(): void;
@@ -231,7 +213,7 @@ declare module 'readline' {
          * When called, `rl.write()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the `data` and `key` are not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `data` and `key` are not written.
          *
          * ```js
          * rl.write('Delete this!');
@@ -351,10 +333,10 @@ declare module 'readline' {
      * The `readline.createInterface()` method creates a new `readline.Interface`instance.
      *
      * ```js
-     * const readline = require('readline');
+     * const readline = require('node:readline');
      * const rl = readline.createInterface({
      *   input: process.stdin,
-     *   output: process.stdout
+     *   output: process.stdout,
      * });
      * ```
      *
@@ -373,14 +355,8 @@ declare module 'readline' {
      * (`process.stdout` does this automatically when it is a TTY).
      *
      * When creating a `readline.Interface` using `stdin` as input, the program
-     * will not terminate until it receives `EOF` (Ctrl+D on
-     * Linux/macOS, Ctrl+Z followed by Return on
-     * Windows).
-     * If you want your application to exit without waiting for user input, you can `unref()` the standard input stream:
-     *
-     * ```js
-     * process.stdin.unref();
-     * ```
+     * will not terminate until it receives an [EOF character](https://en.wikipedia.org/wiki/End-of-file#EOF_character). To exit without
+     * waiting for user input, call `process.stdin.unref()`.
      * @since v0.1.98
      */
     export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
@@ -539,109 +515,6 @@ declare module 'readline' {
     /**
      * The `readline.moveCursor()` method moves the cursor _relative_ to its current
      * position in a given `TTY` `stream`.
-     *
-     * ## Example: Tiny CLI
-     *
-     * The following example illustrates the use of `readline.Interface` class to
-     * implement a small command-line interface:
-     *
-     * ```js
-     * const readline = require('readline');
-     * const rl = readline.createInterface({
-     *   input: process.stdin,
-     *   output: process.stdout,
-     *   prompt: 'OHAI> '
-     * });
-     *
-     * rl.prompt();
-     *
-     * rl.on('line', (line) => {
-     *   switch (line.trim()) {
-     *     case 'hello':
-     *       console.log('world!');
-     *       break;
-     *     default:
-     *       console.log(`Say what? I might have heard '${line.trim()}'`);
-     *       break;
-     *   }
-     *   rl.prompt();
-     * }).on('close', () => {
-     *   console.log('Have a great day!');
-     *   process.exit(0);
-     * });
-     * ```
-     *
-     * ## Example: Read file stream line-by-Line
-     *
-     * A common use case for `readline` is to consume an input file one line at a
-     * time. The easiest way to do so is leveraging the `fs.ReadStream` API as
-     * well as a `for await...of` loop:
-     *
-     * ```js
-     * const fs = require('fs');
-     * const readline = require('readline');
-     *
-     * async function processLineByLine() {
-     *   const fileStream = fs.createReadStream('input.txt');
-     *
-     *   const rl = readline.createInterface({
-     *     input: fileStream,
-     *     crlfDelay: Infinity
-     *   });
-     *   // Note: we use the crlfDelay option to recognize all instances of CR LF
-     *   // ('\r\n') in input.txt as a single line break.
-     *
-     *   for await (const line of rl) {
-     *     // Each line in input.txt will be successively available here as `line`.
-     *     console.log(`Line from file: ${line}`);
-     *   }
-     * }
-     *
-     * processLineByLine();
-     * ```
-     *
-     * Alternatively, one could use the `'line'` event:
-     *
-     * ```js
-     * const fs = require('fs');
-     * const readline = require('readline');
-     *
-     * const rl = readline.createInterface({
-     *   input: fs.createReadStream('sample.txt'),
-     *   crlfDelay: Infinity
-     * });
-     *
-     * rl.on('line', (line) => {
-     *   console.log(`Line from file: ${line}`);
-     * });
-     * ```
-     *
-     * Currently, `for await...of` loop can be a bit slower. If `async` / `await`flow and speed are both essential, a mixed approach can be applied:
-     *
-     * ```js
-     * const { once } = require('events');
-     * const { createReadStream } = require('fs');
-     * const { createInterface } = require('readline');
-     *
-     * (async function processLineByLine() {
-     *   try {
-     *     const rl = createInterface({
-     *       input: createReadStream('big-file.txt'),
-     *       crlfDelay: Infinity
-     *     });
-     *
-     *     rl.on('line', (line) => {
-     *       // Process the line.
-     *     });
-     *
-     *     await once(rl, 'close');
-     *
-     *     console.log('File processed.');
-     *   } catch (err) {
-     *     console.error(err);
-     *   }
-     * })();
-     * ```
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.

--- a/types/node/readline/promises.d.ts
+++ b/types/node/readline/promises.d.ts
@@ -1,22 +1,28 @@
 /**
- * The `readline/promise` module provides an API for reading lines of input from a Readable stream one line at a time.
- *
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/readline/promises.js)
  * @since v17.0.0
+ * @experimental
  */
 declare module 'readline/promises' {
     import { Interface as _Interface, ReadLineOptions, Completer, AsyncCompleter, Direction } from 'node:readline';
     import { Abortable } from 'node:events';
+    /**
+     * Instances of the `readlinePromises.Interface` class are constructed using the`readlinePromises.createInterface()` method. Every instance is associated with a
+     * single `input` `Readable` stream and a single `output` `Writable` stream.
+     * The `output` stream is used to print prompts for user input that arrives on,
+     * and is read from, the `input` stream.
+     * @since v17.0.0
+     */
     class Interface extends _Interface {
         /**
-         * The rl.question() method displays the query by writing it to the output, waits for user input to be provided on input,
-         * then invokes the callback function passing the provided input as the first argument.
+         * The `rl.question()` method displays the `query` by writing it to the `output`,
+         * waits for user input to be provided on `input`, then invokes the `callback`function passing the provided input as the first argument.
          *
-         * When called, rl.question() will resume the input stream if it has been paused.
+         * When called, `rl.question()` will resume the `input` stream if it has been
+         * paused.
          *
-         * If the readlinePromises.Interface was created with output set to null or undefined the query is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
          *
-         * If the question is called after rl.close(), it returns a rejected promise.
+         * If the question is called after `rl.close()`, it returns a rejected promise.
          *
          * Example usage:
          *
@@ -25,7 +31,7 @@ declare module 'readline/promises' {
          * console.log(`Oh, so your favorite food is ${answer}`);
          * ```
          *
-         * Using an AbortSignal to cancel a question.
+         * Using an `AbortSignal` to cancel a question.
          *
          * ```js
          * const signal = AbortSignal.timeout(10_000);
@@ -37,13 +43,16 @@ declare module 'readline/promises' {
          * const answer = await rl.question('What is your favorite food? ', { signal });
          * console.log(`Oh, so your favorite food is ${answer}`);
          * ```
-         *
          * @since v17.0.0
-         * @param query A statement or query to write to output, prepended to the prompt.
+         * @param query A statement or query to write to `output`, prepended to the prompt.
+         * @return A promise that is fulfilled with the user's input in response to the `query`.
          */
         question(query: string): Promise<string>;
         question(query: string, options: Abortable): Promise<string>;
     }
+    /**
+     * @since v17.0.0
+     */
     class Readline {
         /**
          * @param stream A TTY stream.
@@ -55,46 +64,66 @@ declare module 'readline/promises' {
             }
         );
         /**
-         * The `rl.clearLine()` method adds to the internal list of pending action an action that clears current line of the associated `stream` in a specified direction identified by `dir`.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.clearLine()` method adds to the internal list of pending action an
+         * action that clears current line of the associated `stream` in a specified
+         * direction identified by `dir`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         clearLine(dir: Direction): this;
         /**
-         * The `rl.clearScreenDown()` method adds to the internal list of pending action an action that clears the associated `stream` from the current position of the cursor down.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.clearScreenDown()` method adds to the internal list of pending action an
+         * action that clears the associated stream from the current position of the
+         * cursor down.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         clearScreenDown(): this;
         /**
-         * The `rl.commit()` method sends all the pending actions to the associated `stream` and clears the internal list of pending actions.
+         * The `rl.commit()` method sends all the pending actions to the associated`stream` and clears the internal list of pending actions.
+         * @since v17.0.0
          */
         commit(): Promise<void>;
         /**
-         * The `rl.cursorTo()` method adds to the internal list of pending action an action that moves cursor to the specified position in the associated `stream`.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.cursorTo()` method adds to the internal list of pending action an action
+         * that moves cursor to the specified position in the associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         cursorTo(x: number, y?: number): this;
         /**
-         * The `rl.moveCursor()` method adds to the internal list of pending action an action that moves the cursor relative to its current position in the associated `stream`.
-         * Call `rl.commit()` to see the effect of this method, unless autoCommit: true was passed to the constructor.
+         * The `rl.moveCursor()` method adds to the internal list of pending action an
+         * action that moves the cursor _relative_ to its current position in the
+         * associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         moveCursor(dx: number, dy: number): this;
         /**
-         * The `rl.rollback()` method clears the internal list of pending actions without sending it to the associated `stream`.
+         * The `rl.rollback` methods clears the internal list of pending actions without
+         * sending it to the associated `stream`.
+         * @since v17.0.0
+         * @return this
          */
         rollback(): this;
     }
     /**
-     * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
+     * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface`instance.
      *
      * ```js
      * const readlinePromises = require('node:readline/promises');
      * const rl = readlinePromises.createInterface({
      *   input: process.stdin,
-     *   output: process.stdout
+     *   output: process.stdout,
      * });
      * ```
      *
-     * Once the `readlinePromises.Interface` instance is created, the most common case is to listen for the `'line'` event:
+     * Once the `readlinePromises.Interface` instance is created, the most common case
+     * is to listen for the `'line'` event:
      *
      * ```js
      * rl.on('line', (line) => {
@@ -102,42 +131,13 @@ declare module 'readline/promises' {
      * });
      * ```
      *
-     * If `terminal` is `true` for this instance then the `output` stream will get the best compatibility if it defines an `output.columns` property,
-     * and emits a `'resize'` event on the `output`, if or when the columns ever change (`process.stdout` does this automatically when it is a TTY).
-     *
-     * ## Use of the `completer` function
-     *
-     * The `completer` function takes the current line entered by the user as an argument, and returns an `Array` with 2 entries:
-     *
-     * - An Array with matching entries for the completion.
-     * - The substring that was used for the matching.
-     *
-     * For instance: `[[substr1, substr2, ...], originalsubstring]`.
-     *
-     * ```js
-     * function completer(line) {
-     *   const completions = '.help .error .exit .quit .q'.split(' ');
-     *   const hits = completions.filter((c) => c.startsWith(line));
-     *   // Show all completions if none found
-     *   return [hits.length ? hits : completions, line];
-     * }
-     * ```
-     *
-     * The `completer` function can also returns a `Promise`, or be asynchronous:
-     *
-     * ```js
-     * async function completer(linePartial) {
-     *   await someAsyncWork();
-     *   return [['123'], linePartial];
-     * }
-     * ```
+     * If `terminal` is `true` for this instance then the `output` stream will get
+     * the best compatibility if it defines an `output.columns` property and emits
+     * a `'resize'` event on the `output` if or when the columns ever change
+     * (`process.stdout` does this automatically when it is a TTY).
+     * @since v17.0.0
      */
-    function createInterface(
-        input: NodeJS.ReadableStream,
-        output?: NodeJS.WritableStream,
-        completer?: Completer | AsyncCompleter,
-        terminal?: boolean,
-    ): Interface;
+    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
     function createInterface(options: ReadLineOptions): Interface;
 }
 declare module 'node:readline/promises' {

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -41,8 +41,8 @@ declare module 'repl' {
          * error with `repl.Recoverable` to indicate the input was incomplete and prompt for
          * additional lines.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_default_evaluation
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
         eval?: REPLEval | undefined;
         /**
@@ -74,13 +74,13 @@ declare module 'repl' {
          * The function to invoke to format the output of each command before writing to `output`.
          * Default: a wrapper for `util.inspect`.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_customizing_repl_output
          */
         writer?: REPLWriter | undefined;
         /**
          * An optional function used for custom Tab auto completion.
          *
-         * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
         completer?: Completer | AsyncCompleter | undefined;
         /**
@@ -162,33 +162,33 @@ declare module 'repl' {
         /**
          * A value indicating whether the REPL is currently in "editor mode".
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_commands_and_special_keys
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_commands_and_special_keys
          */
         readonly editorMode: boolean;
         /**
          * A value indicating whether the `_` variable has been assigned.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly underscoreAssigned: boolean;
         /**
          * The last evaluation result from the REPL (assigned to the `_` variable inside of the REPL).
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly last: any;
         /**
          * A value indicating whether the `_error` variable has been assigned.
          *
          * @since v9.8.0
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly underscoreErrAssigned: boolean;
         /**
          * The last error raised inside the REPL (assigned to the `_error` variable inside of the REPL).
          *
          * @since v9.8.0
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly lastError: any;
         /**
@@ -240,7 +240,7 @@ declare module 'repl' {
          *
          * `REPLServer` cannot be subclassed due to implementation specifics in NodeJS.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_class_replserver
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_class_replserver
          */
         private constructor();
         /**
@@ -412,7 +412,7 @@ declare module 'repl' {
     /**
      * Indicates a recoverable error that a `REPLServer` can use to support multi-line input.
      *
-     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_recoverable_errors
+     * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_recoverable_errors
      */
     class Recoverable extends SyntaxError {
         err: Error;

--- a/types/node/scripts/generate-docs/ast-processing.ts
+++ b/types/node/scripts/generate-docs/ast-processing.ts
@@ -199,7 +199,7 @@ class TagHelper {
         const tags: JSDocTag[] = [];
         for (const param of sigDoc.params) {
             if (param.desc || param.default) {
-                tags.push(this.createParamTag(param.name.replaceAll('.', ''), param.desc ?? '', param.default));
+                tags.push(this.createParamTag((param.name || '').replaceAll('.', ''), param.desc ?? '', param.default));
             }
         }
         if (sigDoc.return?.desc) {
@@ -303,7 +303,9 @@ export class NodeProcessingContext {
                 };
             }
 
-            properties = classDoc.properties;
+            if (classDoc.properties) {
+                properties = classDoc.properties;
+            }
         }
 
         const propertyDoc = properties?.find(m => {
@@ -520,6 +522,7 @@ export class NodeProcessingContext {
             const newNode = removeCommentsRecursive(node, transformationContext, typeChecker);
             addSyntheticLeadingComment(newNode, SyntaxKind.MultiLineCommentTrivia, jsdoc, true);
         } else {
+            //console.log(node)
             nodeWarning(node, `Could not match doc for symbol`);
         }
     }

--- a/types/node/scripts/generate-docs/node-doc-processing.ts
+++ b/types/node/scripts/generate-docs/node-doc-processing.ts
@@ -133,6 +133,17 @@ function fixupModuleStructure(node: DocRoot): void {
         node.modules.find(({ name }) => name === oldName)!.name = newName;
     }
 
+    function renameClass(module: ModuleDocNode | DocRoot, oldName: string, newName: string): void {
+        const moduleClass = getClass(module, oldName);
+        moduleClass.name = newName;
+        moduleClass.methods?.forEach((method) => {
+            method.desc = method.desc?.replaceAll(oldName, newName)
+        })
+        moduleClass.properties?.forEach((property) => {
+            property.desc = property.desc?.replaceAll(oldName, newName)
+        })
+    }
+
     function unnestSubmodule(modName: string, subs: string[][], allowMisc = false): ModuleDocNode {
         const module = getModule(node, modName);
         module.methods ??= [];
@@ -172,6 +183,21 @@ function fixupModuleStructure(node: DocRoot): void {
         a.classes = a.classes.concat(b.classes ?? []);
         a.methods = a.methods.concat(b.methods ?? []);
         a.properties = a.properties.concat(b.properties ?? []);
+    }
+
+    function mergeClasses(module: ModuleDocNode | DocRoot, target: string, other: string): void {
+        const a = getClass(module, target);
+        const b = getClass(module, other);
+        a.methods ??= [];
+        a.methods = a.methods.concat(b.methods ?? []);
+        a.methods.forEach((method) => {
+            method.desc = method.desc?.replaceAll(other, target)
+        })
+        a.properties ??= [];
+        a.properties = a.properties.concat(b.properties ?? []);
+        a.properties.forEach((property) => {
+            property.desc = property.desc?.replaceAll(other, target)
+        })
     }
 
     // un-nest dgram module
@@ -255,6 +281,8 @@ function fixupModuleStructure(node: DocRoot): void {
     eventEmitterClass.classMethods = eventsModule.methods;
 
     unnestModule(['timers', 'timers_promises_api'], 'timers/promises');
+    unnestSubmodule('timers', [['scheduling_timers'], ['cancelling_timers']]);
+
     unnestModule(['dns', 'dns_promises_api'], 'dns/promises');
     // unnestModule(['stream', 'types_of_streams', 'streams_promises_api'], 'stream/promises');
     unnestSubmodule('stream', [
@@ -263,6 +291,22 @@ function fixupModuleStructure(node: DocRoot): void {
         ['API for stream consumers', 'duplex_and_transform_streams'],
         ['API for stream implementers', 'implementing_a_transform_stream']
     ], true);
+
+    const dnsPromises = getModule(node, 'dns/promises');
+    renameClass(dnsPromises, 'dnsPromises.Resolver', 'Resolver');
+
+    const fs = getModule(node, 'fs');
+    renameClass(fs, 'fs.StatFs', 'StatsFs');
+
+    unnestSubmodule('readline', [['callback_api']]);
+    const readline = getModule(node, 'readline');
+    mergeClasses(readline, 'readline.Interface', 'InterfaceConstructor');
+    renameClass(readline, 'readline.Interface', 'Interface');
+
+    unnestModule(['readline', 'promises_api'], 'readline/promises');
+    const readlinePromises = getModule(node, 'readline/promises');
+    renameClass(readlinePromises, 'readlinePromises.Interface', 'Interface');
+    renameClass(readlinePromises, 'readlinePromises.Readline', 'Readline');
 
     // `process` is not really a class or interface but a bunch of exports in global, we declare it as an interface in types though
     const process = node.globals.find(({ name }) => name === 'Process');

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -33,7 +33,35 @@ declare module 'timers' {
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
             }
-            interface Immediate extends RefCounted {
+            /**
+             * This object is created internally and is returned from `setImmediate()`. It
+             * can be passed to `clearImmediate()` in order to cancel the scheduled
+             * actions.
+             *
+             * By default, when an immediate is scheduled, the Node.js event loop will continue
+             * running as long as the immediate is active. The `Immediate` object returned by `setImmediate()` exports both `immediate.ref()` and `immediate.unref()`functions that can be used to
+             * control this default behavior.
+             */
+            class Immediate implements RefCounted {
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the`Immediate` is active. Calling `immediate.ref()` multiple times will have no
+                 * effect.
+                 *
+                 * By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
+                 * to call `immediate.ref()` unless `immediate.unref()` had been called previously.
+                 * @since v9.7.0
+                 * @return a reference to `immediate`
+                 */
+                ref(): this;
+                /**
+                 * When called, the active `Immediate` object will not require the Node.js event
+                 * loop to remain active. If there is no other activity keeping the event loop
+                 * running, the process may exit before the `Immediate` object's callback is
+                 * invoked. Calling `immediate.unref()` multiple times will have no effect.
+                 * @since v9.7.0
+                 * @return a reference to `immediate`
+                 */
+                unref(): this;
                 /**
                  * If true, the `Immediate` object will keep the Node.js event loop active.
                  * @since v11.0.0
@@ -41,7 +69,33 @@ declare module 'timers' {
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
             }
-            interface Timeout extends Timer {
+            /**
+             * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
+             * scheduled actions.
+             *
+             * By default, when a timer is scheduled using either `setTimeout()` or `setInterval()`, the Node.js event loop will continue running as long as the
+             * timer is active. Each of the `Timeout` objects returned by these functions
+             * export both `timeout.ref()` and `timeout.unref()` functions that can be used to
+             * control this default behavior.
+             */
+            class Timeout implements Timer {
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the`Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
+                 *
+                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
+                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * @since v0.9.1
+                 * @return a reference to `timeout`
+                 */
+                ref(): this;
+                /**
+                 * When called, the active `Timeout` object will not require the Node.js event loop
+                 * to remain active. If there is no other activity keeping the event loop running,
+                 * the process may exit before the `Timeout` object's callback is invoked. Calling`timeout.unref()` multiple times will have no effect.
+                 * @since v0.9.1
+                 * @return a reference to `timeout`
+                 */
+                unref(): this;
                 /**
                  * If true, the `Timeout` object will keep the Node.js event loop active.
                  * @since v11.0.0
@@ -63,11 +117,23 @@ declare module 'timers' {
             }
         }
         /**
-         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
-         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
-         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * Schedules execution of a one-time `callback` after `delay` milliseconds.
+         *
+         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
+         * nor of their ordering. The callback will be called as close as possible to the
+         * time specified.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay`will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setTimeout()`.
          * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearTimeout}
          */
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
@@ -76,7 +142,27 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
+        /**
+         * Cancels a `Timeout` object created by `setTimeout()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by {@link setTimeout} or the `primitive` of the `Timeout` object as a string or a number.
+         */
         function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Schedules repeated execution of `callback` every `delay` milliseconds.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
+         * set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setInterval()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearInterval}
+         */
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -84,7 +170,30 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
+        /**
+         * Cancels a `Timeout` object created by `setInterval()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by {@link setInterval} or the `primitive` of the `Timeout` object as a string or a number.
+         */
         function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Schedules the "immediate" execution of the `callback` after I/O events'
+         * callbacks.
+         *
+         * When multiple calls to `setImmediate()` are made, the `callback` functions are
+         * queued for execution in the order in which they are created. The entire callback
+         * queue is processed every event loop iteration. If an immediate timer is queued
+         * from inside an executing callback, that timer will not be triggered until the
+         * next event loop iteration.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setImmediate()`.
+         * @since v0.9.1
+         * @param callback The function to call at the end of this turn of the Node.js `Event Loop`
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearImmediate}
+         */
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -92,6 +201,11 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
+        /**
+         * Cancels an `Immediate` object created by `setImmediate()`.
+         * @since v0.9.1
+         * @param immediate An `Immediate` object as returned by {@link setImmediate}.
+         */
         function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }

--- a/types/node/ts4.8/assert.d.ts
+++ b/types/node/ts4.8/assert.d.ts
@@ -15,10 +15,25 @@ declare module 'assert' {
          * Indicates the failure of an assertion. All errors thrown by the `node:assert`module will be instances of the `AssertionError` class.
          */
         class AssertionError extends Error {
+            /**
+             * Set to the `actual` argument for methods such as {@link assert.strictEqual()}.
+             */
             actual: unknown;
+            /**
+             * Set to the `expected` argument for methods such as {@link assert.strictEqual()}.
+             */
             expected: unknown;
+            /**
+             * Set to the passed in operator value.
+             */
             operator: string;
+            /**
+             * Indicates if the message was auto-generated (`true`) or not.
+             */
             generatedMessage: boolean;
+            /**
+             * Value is always `ERR_ASSERTION` to show that the error is an assertion error.
+             */
             code: 'ERR_ASSERTION';
             constructor(options?: {
                 /** If provided, the error message is set to this value. */

--- a/types/node/ts4.8/async_hooks.d.ts
+++ b/types/node/ts4.8/async_hooks.d.ts
@@ -274,19 +274,13 @@ declare module 'async_hooks' {
          * @param fn The function to bind to the current execution context.
          * @param type An optional name to associate with the underlying `AsyncResource`.
          */
-        static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(
-            fn: Func,
-            type?: string,
-            thisArg?: ThisArg
-        ): Func;
+        static bind<Func extends (this: ThisArg, ...args: any[]) => any, ThisArg>(fn: Func, type?: string, thisArg?: ThisArg): Func;
         /**
          * Binds the given function to execute to this `AsyncResource`'s scope.
          * @since v14.8.0, v12.19.0
          * @param fn The function to bind to the current `AsyncResource`.
          */
-        bind<Func extends (...args: any[]) => any>(
-            fn: Func
-        ): Func;
+        bind<Func extends (...args: any[]) => any>(fn: Func): Func;
         /**
          * Call the provided function with the provided arguments in the execution context
          * of the async resource. This will establish the context, trigger the AsyncHooks
@@ -372,9 +366,7 @@ declare module 'async_hooks' {
          * @param fn The function to bind to the current execution context.
          * @return A new function that calls `fn` within the captured execution context.
          */
-        static bind<Func extends (...args: any[]) => any>(
-            fn: Func
-        ): Func;
+        static bind<Func extends (...args: any[]) => any>(fn: Func): Func;
         /**
          * Captures the current execution context and returns a function that accepts a
          * function as an argument. Whenever the returned function is called, it

--- a/types/node/ts4.8/crypto.d.ts
+++ b/types/node/ts4.8/crypto.d.ts
@@ -96,7 +96,7 @@ declare module 'crypto' {
         verifySpkac(spkac: NodeJS.ArrayBufferView): boolean;
     }
     namespace constants {
-        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+        // https://nodejs.org/dist/latest-v20.x/docs/api/crypto.html#crypto-constants
         const OPENSSL_VERSION_NUMBER: number;
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
         const SSL_OP_ALL: number;

--- a/types/node/ts4.8/dns.d.ts
+++ b/types/node/ts4.8/dns.d.ts
@@ -633,6 +633,7 @@ declare module 'dns' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/ts4.8/dns/promises.d.ts
+++ b/types/node/ts4.8/dns/promises.d.ts
@@ -344,6 +344,49 @@ declare module 'dns/promises' {
      * @param order must be `'ipv4first'` or `'verbatim'`.
      */
     function setDefaultResultOrder(order: 'ipv4first' | 'verbatim'): void;
+    /**
+     * An independent resolver for DNS requests.
+     *
+     * Creating a new resolver uses the default server settings. Setting
+     * the servers used for a resolver using `resolver.setServers()` does not affect
+     * other resolvers:
+     *
+     * ```js
+     * const { Resolver } = require('node:dns').promises;
+     * const resolver = new Resolver();
+     * resolver.setServers(['4.4.4.4']);
+     *
+     * // This request will use the server at 4.4.4.4, independent of global settings.
+     * resolver.resolve4('example.org').then((addresses) => {
+     *   // ...
+     * });
+     *
+     * // Alternatively, the same code can be written using async-await style.
+     * (async function() {
+     *   const addresses = await resolver.resolve4('example.org');
+     * })();
+     * ```
+     *
+     * The following methods from the `dnsPromises` API are available:
+     *
+     * * `resolver.getServers()`
+     * * `resolver.resolve()`
+     * * `resolver.resolve4()`
+     * * `resolver.resolve6()`
+     * * `resolver.resolveAny()`
+     * * `resolver.resolveCaa()`
+     * * `resolver.resolveCname()`
+     * * `resolver.resolveMx()`
+     * * `resolver.resolveNaptr()`
+     * * `resolver.resolveNs()`
+     * * `resolver.resolvePtr()`
+     * * `resolver.resolveSoa()`
+     * * `resolver.resolveSrv()`
+     * * `resolver.resolveTxt()`
+     * * `resolver.reverse()`
+     * * `resolver.setServers()`
+     * @since v10.6.0
+     */
     class Resolver {
         constructor(options?: ResolverOptions);
         cancel(): void;
@@ -352,6 +395,7 @@ declare module 'dns/promises' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -310,21 +310,63 @@ declare module 'events' {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
-         * This symbol shall be used to install a listener for only monitoring `'error'`
-         * events. Listeners installed using this symbol are called before the regular
-         * `'error'` listeners are called.
+         * This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
          *
-         * Installing a listener using this symbol does not change the behavior once an
-         * `'error'` event is emitted, therefore the process will still crash if no
+         * Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
          * regular `'error'` listener is installed.
+         * @since v13.6.0, v12.17.0
          */
         static readonly errorMonitor: unique symbol;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         *
+         * See how to write a custom `rejection handler`.
+         * @since v13.4.0, v12.16.0
+         */
         static readonly captureRejectionSymbol: unique symbol;
         /**
-         * Sets or gets the default captureRejection value for all emitters.
+         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+         *
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
          */
-        // TODO: These should be described using static getter/setter pairs:
         static captureRejections: boolean;
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_`EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+         * temporarily avoid this warning:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
         static defaultMaxListeners: number;
     }
     import internal = require('node:events');

--- a/types/node/ts4.8/fs.d.ts
+++ b/types/node/ts4.8/fs.d.ts
@@ -149,12 +149,38 @@ declare module 'fs' {
     }
     export interface StatsFs extends StatsFsBase<number> {}
     /**
-     * Provides information about a mounted file system
+     * Provides information about a mounted file system.
      *
-     * Objects returned from {@link statfs} and {@link statfsSync} are of this type.
-     * If `bigint` in the `options` passed to those methods is true, the numeric values
-     * will be `bigint` instead of `number`.
-     * @since  v18.15.0
+     * Objects returned from {@link statfs} and its synchronous counterpart are of
+     * this type. If `bigint` in the `options` passed to those methods is `true`, the
+     * numeric values will be `bigint` instead of `number`.
+     *
+     * ```console
+     * StatFs {
+     *   type: 1397114950,
+     *   bsize: 4096,
+     *   blocks: 121938943,
+     *   bfree: 61058895,
+     *   bavail: 61058895,
+     *   files: 999,
+     *   ffree: 1000000
+     * }
+     * ```
+     *
+     * `bigint` version:
+     *
+     * ```console
+     * StatFs {
+     *   type: 1397114950n,
+     *   bsize: 4096n,
+     *   blocks: 121938943n,
+     *   bfree: 61058895n,
+     *   bavail: 61058895n,
+     *   files: 999n,
+     *   ffree: 1000000n
+     * }
+     * ```
+     * @since v19.6.0, v18.15.0
      */
     export class StatsFs {}
     export interface BigIntStatsFs extends StatsFsBase<bigint> {}
@@ -214,6 +240,11 @@ declare module 'fs' {
          * @since v10.10.0
          */
         name: string;
+        /**
+         * The base path that this `fs.Dirent` object refers to.
+         * @since v20.1.0
+         */
+        path: string;
     }
     /**
      * A class representing a directory stream.

--- a/types/node/ts4.8/readline.d.ts
+++ b/types/node/ts4.8/readline.d.ts
@@ -35,7 +35,6 @@
 declare module 'readline' {
     import { Abortable, EventEmitter } from 'node:events';
     import * as promises from 'node:readline/promises';
-
     export { promises };
     export interface Key {
         sequence?: string | undefined;
@@ -74,7 +73,7 @@ declare module 'readline' {
          * const showResults = debounce(() => {
          *   console.log(
          *     '\n',
-         *     values.filter((val) => val.startsWith(rl.line)).join(' ')
+         *     values.filter((val) => val.startsWith(rl.line)).join(' '),
          *   );
          * }, 300);
          * process.stdin.on('keypress', (c, k) => {
@@ -100,7 +99,7 @@ declare module 'readline' {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
          */
         protected constructor(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean);
         /**
@@ -109,12 +108,12 @@ declare module 'readline' {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
          */
         protected constructor(options: ReadLineOptions);
         /**
          * The `rl.getPrompt()` method returns the current prompt used by `rl.prompt()`.
-         * @since v15.3.0
+         * @since v15.3.0, v14.17.0
          * @return the current prompt string
          */
         getPrompt(): string;
@@ -124,13 +123,13 @@ declare module 'readline' {
          */
         setPrompt(prompt: string): void;
         /**
-         * The `rl.prompt()` method writes the `readline.Interface` instances configured`prompt` to a new line in `output` in order to provide a user with a new
+         * The `rl.prompt()` method writes the `Interface` instances configured`prompt` to a new line in `output` in order to provide a user with a new
          * location at which to provide input.
          *
          * When called, `rl.prompt()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the prompt is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the prompt is not written.
          * @since v0.1.98
          * @param preserveCursor If `true`, prevents the cursor placement from being reset to `0`.
          */
@@ -142,11 +141,13 @@ declare module 'readline' {
          * When called, `rl.question()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
          *
          * The `callback` function passed to `rl.question()` does not follow the typical
          * pattern of accepting an `Error` object or `null` as the first argument.
          * The `callback` is called with the provided answer as the only argument.
+         *
+         * An error will be thrown if calling `rl.question()` after `rl.close()`.
          *
          * Example usage:
          *
@@ -172,25 +173,6 @@ declare module 'readline' {
          *
          * setTimeout(() => ac.abort(), 10000);
          * ```
-         *
-         * If this method is invoked as it's util.promisify()ed version, it returns a
-         * Promise that fulfills with the answer. If the question is canceled using
-         * an `AbortController` it will reject with an `AbortError`.
-         *
-         * ```js
-         * const util = require('util');
-         * const question = util.promisify(rl.question).bind(rl);
-         *
-         * async function questionExample() {
-         *   try {
-         *     const answer = await question('What is you favorite food? ');
-         *     console.log(`Oh, so your favorite food is ${answer}`);
-         *   } catch (err) {
-         *     console.error('Question rejected', err);
-         *   }
-         * }
-         * questionExample();
-         * ```
          * @since v0.3.3
          * @param query A statement or query to write to `output`, prepended to the prompt.
          * @param callback A callback function that is invoked with the user's input in response to the `query`.
@@ -201,7 +183,7 @@ declare module 'readline' {
          * The `rl.pause()` method pauses the `input` stream, allowing it to be resumed
          * later if necessary.
          *
-         * Calling `rl.pause()` does not immediately pause other events (including`'line'`) from being emitted by the `readline.Interface` instance.
+         * Calling `rl.pause()` does not immediately pause other events (including`'line'`) from being emitted by the `Interface` instance.
          * @since v0.3.4
          */
         pause(): this;
@@ -211,12 +193,12 @@ declare module 'readline' {
          */
         resume(): this;
         /**
-         * The `rl.close()` method closes the `readline.Interface` instance and
+         * The `rl.close()` method closes the `Interface` instance and
          * relinquishes control over the `input` and `output` streams. When called,
          * the `'close'` event will be emitted.
          *
          * Calling `rl.close()` does not immediately stop other events (including `'line'`)
-         * from being emitted by the `readline.Interface` instance.
+         * from being emitted by the `Interface` instance.
          * @since v0.1.98
          */
         close(): void;
@@ -231,7 +213,7 @@ declare module 'readline' {
          * When called, `rl.write()` will resume the `input` stream if it has been
          * paused.
          *
-         * If the `readline.Interface` was created with `output` set to `null` or`undefined` the `data` and `key` are not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `data` and `key` are not written.
          *
          * ```js
          * rl.write('Delete this!');
@@ -351,10 +333,10 @@ declare module 'readline' {
      * The `readline.createInterface()` method creates a new `readline.Interface`instance.
      *
      * ```js
-     * const readline = require('readline');
+     * const readline = require('node:readline');
      * const rl = readline.createInterface({
      *   input: process.stdin,
-     *   output: process.stdout
+     *   output: process.stdout,
      * });
      * ```
      *
@@ -373,14 +355,8 @@ declare module 'readline' {
      * (`process.stdout` does this automatically when it is a TTY).
      *
      * When creating a `readline.Interface` using `stdin` as input, the program
-     * will not terminate until it receives `EOF` (Ctrl+D on
-     * Linux/macOS, Ctrl+Z followed by Return on
-     * Windows).
-     * If you want your application to exit without waiting for user input, you can `unref()` the standard input stream:
-     *
-     * ```js
-     * process.stdin.unref();
-     * ```
+     * will not terminate until it receives an [EOF character](https://en.wikipedia.org/wiki/End-of-file#EOF_character). To exit without
+     * waiting for user input, call `process.stdin.unref()`.
      * @since v0.1.98
      */
     export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
@@ -539,109 +515,6 @@ declare module 'readline' {
     /**
      * The `readline.moveCursor()` method moves the cursor _relative_ to its current
      * position in a given `TTY` `stream`.
-     *
-     * ## Example: Tiny CLI
-     *
-     * The following example illustrates the use of `readline.Interface` class to
-     * implement a small command-line interface:
-     *
-     * ```js
-     * const readline = require('readline');
-     * const rl = readline.createInterface({
-     *   input: process.stdin,
-     *   output: process.stdout,
-     *   prompt: 'OHAI> '
-     * });
-     *
-     * rl.prompt();
-     *
-     * rl.on('line', (line) => {
-     *   switch (line.trim()) {
-     *     case 'hello':
-     *       console.log('world!');
-     *       break;
-     *     default:
-     *       console.log(`Say what? I might have heard '${line.trim()}'`);
-     *       break;
-     *   }
-     *   rl.prompt();
-     * }).on('close', () => {
-     *   console.log('Have a great day!');
-     *   process.exit(0);
-     * });
-     * ```
-     *
-     * ## Example: Read file stream line-by-Line
-     *
-     * A common use case for `readline` is to consume an input file one line at a
-     * time. The easiest way to do so is leveraging the `fs.ReadStream` API as
-     * well as a `for await...of` loop:
-     *
-     * ```js
-     * const fs = require('fs');
-     * const readline = require('readline');
-     *
-     * async function processLineByLine() {
-     *   const fileStream = fs.createReadStream('input.txt');
-     *
-     *   const rl = readline.createInterface({
-     *     input: fileStream,
-     *     crlfDelay: Infinity
-     *   });
-     *   // Note: we use the crlfDelay option to recognize all instances of CR LF
-     *   // ('\r\n') in input.txt as a single line break.
-     *
-     *   for await (const line of rl) {
-     *     // Each line in input.txt will be successively available here as `line`.
-     *     console.log(`Line from file: ${line}`);
-     *   }
-     * }
-     *
-     * processLineByLine();
-     * ```
-     *
-     * Alternatively, one could use the `'line'` event:
-     *
-     * ```js
-     * const fs = require('fs');
-     * const readline = require('readline');
-     *
-     * const rl = readline.createInterface({
-     *   input: fs.createReadStream('sample.txt'),
-     *   crlfDelay: Infinity
-     * });
-     *
-     * rl.on('line', (line) => {
-     *   console.log(`Line from file: ${line}`);
-     * });
-     * ```
-     *
-     * Currently, `for await...of` loop can be a bit slower. If `async` / `await`flow and speed are both essential, a mixed approach can be applied:
-     *
-     * ```js
-     * const { once } = require('events');
-     * const { createReadStream } = require('fs');
-     * const { createInterface } = require('readline');
-     *
-     * (async function processLineByLine() {
-     *   try {
-     *     const rl = createInterface({
-     *       input: createReadStream('big-file.txt'),
-     *       crlfDelay: Infinity
-     *     });
-     *
-     *     rl.on('line', (line) => {
-     *       // Process the line.
-     *     });
-     *
-     *     await once(rl, 'close');
-     *
-     *     console.log('File processed.');
-     *   } catch (err) {
-     *     console.error(err);
-     *   }
-     * })();
-     * ```
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.

--- a/types/node/ts4.8/readline/promises.d.ts
+++ b/types/node/ts4.8/readline/promises.d.ts
@@ -1,22 +1,28 @@
 /**
- * The `readline/promise` module provides an API for reading lines of input from a Readable stream one line at a time.
- *
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/readline/promises.js)
  * @since v17.0.0
+ * @experimental
  */
 declare module 'readline/promises' {
     import { Interface as _Interface, ReadLineOptions, Completer, AsyncCompleter, Direction } from 'node:readline';
     import { Abortable } from 'node:events';
+    /**
+     * Instances of the `readlinePromises.Interface` class are constructed using the`readlinePromises.createInterface()` method. Every instance is associated with a
+     * single `input` `Readable` stream and a single `output` `Writable` stream.
+     * The `output` stream is used to print prompts for user input that arrives on,
+     * and is read from, the `input` stream.
+     * @since v17.0.0
+     */
     class Interface extends _Interface {
         /**
-         * The rl.question() method displays the query by writing it to the output, waits for user input to be provided on input,
-         * then invokes the callback function passing the provided input as the first argument.
+         * The `rl.question()` method displays the `query` by writing it to the `output`,
+         * waits for user input to be provided on `input`, then invokes the `callback`function passing the provided input as the first argument.
          *
-         * When called, rl.question() will resume the input stream if it has been paused.
+         * When called, `rl.question()` will resume the `input` stream if it has been
+         * paused.
          *
-         * If the readlinePromises.Interface was created with output set to null or undefined the query is not written.
+         * If the `Interface` was created with `output` set to `null` or`undefined` the `query` is not written.
          *
-         * If the question is called after rl.close(), it returns a rejected promise.
+         * If the question is called after `rl.close()`, it returns a rejected promise.
          *
          * Example usage:
          *
@@ -25,7 +31,7 @@ declare module 'readline/promises' {
          * console.log(`Oh, so your favorite food is ${answer}`);
          * ```
          *
-         * Using an AbortSignal to cancel a question.
+         * Using an `AbortSignal` to cancel a question.
          *
          * ```js
          * const signal = AbortSignal.timeout(10_000);
@@ -37,13 +43,16 @@ declare module 'readline/promises' {
          * const answer = await rl.question('What is your favorite food? ', { signal });
          * console.log(`Oh, so your favorite food is ${answer}`);
          * ```
-         *
          * @since v17.0.0
-         * @param query A statement or query to write to output, prepended to the prompt.
+         * @param query A statement or query to write to `output`, prepended to the prompt.
+         * @return A promise that is fulfilled with the user's input in response to the `query`.
          */
         question(query: string): Promise<string>;
         question(query: string, options: Abortable): Promise<string>;
     }
+    /**
+     * @since v17.0.0
+     */
     class Readline {
         /**
          * @param stream A TTY stream.
@@ -55,46 +64,66 @@ declare module 'readline/promises' {
             }
         );
         /**
-         * The `rl.clearLine()` method adds to the internal list of pending action an action that clears current line of the associated `stream` in a specified direction identified by `dir`.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.clearLine()` method adds to the internal list of pending action an
+         * action that clears current line of the associated `stream` in a specified
+         * direction identified by `dir`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         clearLine(dir: Direction): this;
         /**
-         * The `rl.clearScreenDown()` method adds to the internal list of pending action an action that clears the associated `stream` from the current position of the cursor down.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.clearScreenDown()` method adds to the internal list of pending action an
+         * action that clears the associated stream from the current position of the
+         * cursor down.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         clearScreenDown(): this;
         /**
-         * The `rl.commit()` method sends all the pending actions to the associated `stream` and clears the internal list of pending actions.
+         * The `rl.commit()` method sends all the pending actions to the associated`stream` and clears the internal list of pending actions.
+         * @since v17.0.0
          */
         commit(): Promise<void>;
         /**
-         * The `rl.cursorTo()` method adds to the internal list of pending action an action that moves cursor to the specified position in the associated `stream`.
-         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         * The `rl.cursorTo()` method adds to the internal list of pending action an action
+         * that moves cursor to the specified position in the associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         cursorTo(x: number, y?: number): this;
         /**
-         * The `rl.moveCursor()` method adds to the internal list of pending action an action that moves the cursor relative to its current position in the associated `stream`.
-         * Call `rl.commit()` to see the effect of this method, unless autoCommit: true was passed to the constructor.
+         * The `rl.moveCursor()` method adds to the internal list of pending action an
+         * action that moves the cursor _relative_ to its current position in the
+         * associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true`was passed to the constructor.
+         * @since v17.0.0
+         * @return this
          */
         moveCursor(dx: number, dy: number): this;
         /**
-         * The `rl.rollback()` method clears the internal list of pending actions without sending it to the associated `stream`.
+         * The `rl.rollback` methods clears the internal list of pending actions without
+         * sending it to the associated `stream`.
+         * @since v17.0.0
+         * @return this
          */
         rollback(): this;
     }
     /**
-     * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
+     * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface`instance.
      *
      * ```js
      * const readlinePromises = require('node:readline/promises');
      * const rl = readlinePromises.createInterface({
      *   input: process.stdin,
-     *   output: process.stdout
+     *   output: process.stdout,
      * });
      * ```
      *
-     * Once the `readlinePromises.Interface` instance is created, the most common case is to listen for the `'line'` event:
+     * Once the `readlinePromises.Interface` instance is created, the most common case
+     * is to listen for the `'line'` event:
      *
      * ```js
      * rl.on('line', (line) => {
@@ -102,42 +131,13 @@ declare module 'readline/promises' {
      * });
      * ```
      *
-     * If `terminal` is `true` for this instance then the `output` stream will get the best compatibility if it defines an `output.columns` property,
-     * and emits a `'resize'` event on the `output`, if or when the columns ever change (`process.stdout` does this automatically when it is a TTY).
-     *
-     * ## Use of the `completer` function
-     *
-     * The `completer` function takes the current line entered by the user as an argument, and returns an `Array` with 2 entries:
-     *
-     * - An Array with matching entries for the completion.
-     * - The substring that was used for the matching.
-     *
-     * For instance: `[[substr1, substr2, ...], originalsubstring]`.
-     *
-     * ```js
-     * function completer(line) {
-     *   const completions = '.help .error .exit .quit .q'.split(' ');
-     *   const hits = completions.filter((c) => c.startsWith(line));
-     *   // Show all completions if none found
-     *   return [hits.length ? hits : completions, line];
-     * }
-     * ```
-     *
-     * The `completer` function can also returns a `Promise`, or be asynchronous:
-     *
-     * ```js
-     * async function completer(linePartial) {
-     *   await someAsyncWork();
-     *   return [['123'], linePartial];
-     * }
-     * ```
+     * If `terminal` is `true` for this instance then the `output` stream will get
+     * the best compatibility if it defines an `output.columns` property and emits
+     * a `'resize'` event on the `output` if or when the columns ever change
+     * (`process.stdout` does this automatically when it is a TTY).
+     * @since v17.0.0
      */
-    function createInterface(
-        input: NodeJS.ReadableStream,
-        output?: NodeJS.WritableStream,
-        completer?: Completer | AsyncCompleter,
-        terminal?: boolean,
-    ): Interface;
+    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
     function createInterface(options: ReadLineOptions): Interface;
 }
 declare module 'node:readline/promises' {

--- a/types/node/ts4.8/repl.d.ts
+++ b/types/node/ts4.8/repl.d.ts
@@ -41,8 +41,8 @@ declare module 'repl' {
          * error with `repl.Recoverable` to indicate the input was incomplete and prompt for
          * additional lines.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_default_evaluation
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
         eval?: REPLEval | undefined;
         /**
@@ -74,13 +74,13 @@ declare module 'repl' {
          * The function to invoke to format the output of each command before writing to `output`.
          * Default: a wrapper for `util.inspect`.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_customizing_repl_output
          */
         writer?: REPLWriter | undefined;
         /**
          * An optional function used for custom Tab auto completion.
          *
-         * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
         completer?: Completer | AsyncCompleter | undefined;
         /**
@@ -162,33 +162,33 @@ declare module 'repl' {
         /**
          * A value indicating whether the REPL is currently in "editor mode".
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_commands_and_special_keys
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_commands_and_special_keys
          */
         readonly editorMode: boolean;
         /**
          * A value indicating whether the `_` variable has been assigned.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly underscoreAssigned: boolean;
         /**
          * The last evaluation result from the REPL (assigned to the `_` variable inside of the REPL).
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly last: any;
         /**
          * A value indicating whether the `_error` variable has been assigned.
          *
          * @since v9.8.0
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly underscoreErrAssigned: boolean;
         /**
          * The last error raised inside the REPL (assigned to the `_error` variable inside of the REPL).
          *
          * @since v9.8.0
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
          */
         readonly lastError: any;
         /**
@@ -240,7 +240,7 @@ declare module 'repl' {
          *
          * `REPLServer` cannot be subclassed due to implementation specifics in NodeJS.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_class_replserver
+         * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_class_replserver
          */
         private constructor();
         /**
@@ -412,7 +412,7 @@ declare module 'repl' {
     /**
      * Indicates a recoverable error that a `REPLServer` can use to support multi-line input.
      *
-     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_recoverable_errors
+     * @see https://nodejs.org/dist/latest-v20.x/docs/api/repl.html#repl_recoverable_errors
      */
     class Recoverable extends SyntaxError {
         err: Error;

--- a/types/node/ts4.8/timers.d.ts
+++ b/types/node/ts4.8/timers.d.ts
@@ -33,7 +33,35 @@ declare module 'timers' {
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
             }
-            interface Immediate extends RefCounted {
+            /**
+             * This object is created internally and is returned from `setImmediate()`. It
+             * can be passed to `clearImmediate()` in order to cancel the scheduled
+             * actions.
+             *
+             * By default, when an immediate is scheduled, the Node.js event loop will continue
+             * running as long as the immediate is active. The `Immediate` object returned by `setImmediate()` exports both `immediate.ref()` and `immediate.unref()`functions that can be used to
+             * control this default behavior.
+             */
+            class Immediate implements RefCounted {
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the`Immediate` is active. Calling `immediate.ref()` multiple times will have no
+                 * effect.
+                 *
+                 * By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
+                 * to call `immediate.ref()` unless `immediate.unref()` had been called previously.
+                 * @since v9.7.0
+                 * @return a reference to `immediate`
+                 */
+                ref(): this;
+                /**
+                 * When called, the active `Immediate` object will not require the Node.js event
+                 * loop to remain active. If there is no other activity keeping the event loop
+                 * running, the process may exit before the `Immediate` object's callback is
+                 * invoked. Calling `immediate.unref()` multiple times will have no effect.
+                 * @since v9.7.0
+                 * @return a reference to `immediate`
+                 */
+                unref(): this;
                 /**
                  * If true, the `Immediate` object will keep the Node.js event loop active.
                  * @since v11.0.0
@@ -41,7 +69,33 @@ declare module 'timers' {
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
             }
-            interface Timeout extends Timer {
+            /**
+             * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
+             * scheduled actions.
+             *
+             * By default, when a timer is scheduled using either `setTimeout()` or `setInterval()`, the Node.js event loop will continue running as long as the
+             * timer is active. Each of the `Timeout` objects returned by these functions
+             * export both `timeout.ref()` and `timeout.unref()` functions that can be used to
+             * control this default behavior.
+             */
+            class Timeout implements Timer {
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the`Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
+                 *
+                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
+                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * @since v0.9.1
+                 * @return a reference to `timeout`
+                 */
+                ref(): this;
+                /**
+                 * When called, the active `Timeout` object will not require the Node.js event loop
+                 * to remain active. If there is no other activity keeping the event loop running,
+                 * the process may exit before the `Timeout` object's callback is invoked. Calling`timeout.unref()` multiple times will have no effect.
+                 * @since v0.9.1
+                 * @return a reference to `timeout`
+                 */
+                unref(): this;
                 /**
                  * If true, the `Timeout` object will keep the Node.js event loop active.
                  * @since v11.0.0
@@ -63,11 +117,23 @@ declare module 'timers' {
             }
         }
         /**
-         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
-         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
-         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * Schedules execution of a one-time `callback` after `delay` milliseconds.
+         *
+         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
+         * nor of their ordering. The callback will be called as close as possible to the
+         * time specified.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay`will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setTimeout()`.
          * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearTimeout}
          */
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
@@ -76,7 +142,27 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
+        /**
+         * Cancels a `Timeout` object created by `setTimeout()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by {@link setTimeout} or the `primitive` of the `Timeout` object as a string or a number.
+         */
         function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Schedules repeated execution of `callback` every `delay` milliseconds.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
+         * set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setInterval()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearInterval}
+         */
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -84,7 +170,30 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
+        /**
+         * Cancels a `Timeout` object created by `setInterval()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by {@link setInterval} or the `primitive` of the `Timeout` object as a string or a number.
+         */
         function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Schedules the "immediate" execution of the `callback` after I/O events'
+         * callbacks.
+         *
+         * When multiple calls to `setImmediate()` are made, the `callback` functions are
+         * queued for execution in the order in which they are created. The entire callback
+         * queue is processed every event loop iteration. If an immediate timer is queued
+         * from inside an executing callback, that timer will not be triggered until the
+         * next event loop iteration.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using `timersPromises.setImmediate()`.
+         * @since v0.9.1
+         * @param callback The function to call at the end of this turn of the Node.js `Event Loop`
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @return for use with {@link clearImmediate}
+         */
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -92,6 +201,11 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
+        /**
+         * Cancels an `Immediate` object created by `setImmediate()`.
+         * @since v0.9.1
+         * @param immediate An `Immediate` object as returned by {@link setImmediate}.
+         */
         function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }

--- a/types/node/v16/dns.d.ts
+++ b/types/node/v16/dns.d.ts
@@ -620,6 +620,7 @@ declare module 'dns' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/v16/dns/promises.d.ts
+++ b/types/node/v16/dns/promises.d.ts
@@ -350,6 +350,7 @@ declare module 'dns/promises' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/v18/dns.d.ts
+++ b/types/node/v18/dns.d.ts
@@ -625,6 +625,7 @@ declare module 'dns' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;

--- a/types/node/v18/ts4.8/dns.d.ts
+++ b/types/node/v18/ts4.8/dns.d.ts
@@ -625,6 +625,7 @@ declare module 'dns' {
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
         resolveAny: typeof resolveAny;
+        resolveCaa: typeof resolveCaa;
         resolveCname: typeof resolveCname;
         resolveMx: typeof resolveMx;
         resolveNaptr: typeof resolveNaptr;


### PR DESCRIPTION
- docs: improve generating some modules/classes
- dns: add missed `Resolver.resolveCaa` method
- fs: add missed `Dirent.path` field

Close #65456