### PR TITLE
Extend node-telegram-bot-api TelegramBot.setWebHook options paramer with secret_tokent option

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -148,6 +148,7 @@ declare namespace TelegramBot {
         certificate?: string | Stream | undefined;
         max_connections?: number | undefined;
         allowed_updates?: string[] | undefined;
+        secret_token?: string;
     }
 
     interface GetUpdatesOptions {

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -14,6 +14,7 @@ MyTelegramBot.logOut();
 MyTelegramBot.close();
 MyTelegramBot.setWebHook('http://typescriptlang.org');
 MyTelegramBot.setWebHook('http://typescriptlang.org', { max_connections: 100 });
+MyTelegramBot.setWebHook('http://typescriptlang.org', { secret_token: 'secret' });
 MyTelegramBot.setWebHook(
     'http://typescriptlang.org',
     { max_connections: 100 },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://core.telegram.org/bots/api#setwebhook
  - https://github.com/yagop/node-telegram-bot-api/pull/1084
