### PR TITLE
[@types/mvdan-sh] Fix Mismatching Type Declaration of `mvdan-sh`

### DIFF
--- a/types/mvdan-sh/index.d.ts
+++ b/types/mvdan-sh/index.d.ts
@@ -3,108 +3,112 @@
 // Definitions by: JounQin <https://github.com/JounQin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export enum LangVariant {
+// eslint-disable-next-line no-const-enum
+declare const enum LangVariant {
     LangBash = 0,
     LangPOSIX = 1,
     LangMirBSDKorn = 2,
     LangBats = 3,
 }
 
-export interface Pos {
-    After(p: Pos): boolean;
-    Col(): number;
-    IsValid(): boolean;
-    Line(): number;
-    Offset(): number;
-    String(): string;
+declare namespace sh {
+    export interface Pos {
+        After(p: Pos): boolean;
+        Col(): number;
+        IsValid(): boolean;
+        Line(): number;
+        Offset(): number;
+        String(): string;
+    }
+
+    export interface Node {
+        Pos(): Pos;
+        End(): Pos;
+    }
+
+    export interface Command extends Node {
+        OpPos: Pos;
+    }
+
+    export type WordPart = Node;
+
+    export interface Word extends Node {
+        Parts: WordPart[];
+        Lit(): string;
+    }
+
+    export interface Lit extends Node {
+        ValuePos: Pos;
+        ValueEnd: Pos;
+        Value: string;
+    }
+
+    export interface Stmt extends Node {
+        Comments: Comment[];
+        Cmd: Command;
+        Position: Pos;
+        Semicolon: Pos;
+        Negated: boolean;
+        Background: boolean;
+        Coprocess: boolean;
+    }
+
+    export interface Comment extends Node {
+        Hash: Pos;
+        Text: string;
+    }
+
+    export interface File extends Node {
+        Name: string;
+        Stmts?: Stmt[] | undefined;
+        Last: Stmt[];
+    }
+
+    export type ParserOption = (parser: Parser) => void;
+
+    export type PrinterOption = (printer: Printer) => void;
+
+    export interface Parser {
+        Parse(text: string, path?: string): File;
+    }
+
+    export interface Printer {
+        Print(node: Node): string;
+    }
+
+    export interface ShellScript {
+        LangVariant: typeof LangVariant;
+        syntax: {
+            // variant
+            LangBash: LangVariant.LangBash;
+            LangPOSIX: LangVariant.LangPOSIX;
+            LangMirBSDKorn: LangVariant.LangMirBSDKorn;
+
+            // parser
+            NewParser(...options: ParserOption[]): Parser;
+            KeepComments(enabled?: boolean): ParserOption;
+            StopAt(word: string): ParserOption;
+            Variant(lang: LangVariant): ParserOption;
+
+            // printer
+            NewPrinter(...options: PrinterOption[]): Printer;
+            Indent(spaces: number): PrinterOption;
+            BinaryNextLine(enabled: boolean): PrinterOption;
+            SwitchCaseIndent(enabled: boolean): PrinterOption;
+            SpaceRedirects(enabled: boolean): PrinterOption;
+            KeepPadding(enabled: boolean): PrinterOption;
+            Minify(enabled: boolean): PrinterOption;
+            FunctionNextLine(enabled: boolean): PrinterOption;
+
+            // helpers and utils
+            DebugPrint(node: Node): void;
+            NodeType(node: Node): string;
+            SplitBraces<T = {}>(word: T): T
+            Walk(node: Node, walker: (node: Node) => boolean): void;
+        };
+    }
 }
 
-export interface Node {
-    Pos(): Pos;
-    End(): Pos;
-}
+declare const sh: sh.ShellScript;
 
-export interface Command extends Node {
-    OpPos: Pos;
-}
-
-export type WordPart = Node;
-
-export interface Word extends Node {
-    Parts: WordPart[];
-    Lit(): string;
-}
-
-export interface Lit extends Node {
-    ValuePos: Pos;
-    ValueEnd: Pos;
-    Value: string;
-}
-
-export interface Stmt extends Node {
-    Comments: Comment[];
-    Cmd: Command;
-    Position: Pos;
-    Semicolon: Pos;
-    Negated: boolean;
-    Background: boolean;
-    Coprocess: boolean;
-}
-
-export interface Comment extends Node {
-    Hash: Pos;
-    Text: string;
-}
-
-export interface File extends Node {
-    Name: string;
-    Stmts?: Stmt[] | undefined;
-    Last: Stmt[];
-}
-
-export type ParserOption = (parser: Parser) => void;
-
-export type PrinterOption = (printer: Printer) => void;
-
-export interface Parser {
-    Parse(text: string, path?: string): File;
-}
-
-export interface Printer {
-    Print(node: Node): string;
-}
-
-export interface ShellScript {
-    syntax: {
-        // variant
-        LangBash: LangVariant.LangBash;
-        LangPOSIX: LangVariant.LangPOSIX;
-        LangMirBSDKorn: LangVariant.LangMirBSDKorn;
-
-        // parser
-        NewParser(...options: ParserOption[]): Parser;
-        KeepComments(enabled?: boolean): ParserOption;
-        StopAt(word: string): ParserOption;
-        Variant(lang: LangVariant): ParserOption;
-
-        // printer
-        NewPrinter(...options: PrinterOption[]): Printer;
-        Indent(spaces: number): PrinterOption;
-        BinaryNextLine(enabled: boolean): PrinterOption;
-        SwitchCaseIndent(enabled: boolean): PrinterOption;
-        SpaceRedirects(enabled: boolean): PrinterOption;
-        KeepPadding(enabled: boolean): PrinterOption;
-        Minify(enabled: boolean): PrinterOption;
-        FunctionNextLine(enabled: boolean): PrinterOption;
-
-        // helpers and utils
-        DebugPrint(node: Node): void;
-        NodeType(node: Node): string;
-        SplitBraces<T = {}>(word: T): T
-        Walk(node: Node, walker: (node: Node) => boolean): void;
-    };
-}
-
-declare const sh: ShellScript;
-
-export default sh;
+export = sh;

--- a/types/mvdan-sh/index.d.ts
+++ b/types/mvdan-sh/index.d.ts
@@ -12,7 +12,7 @@ declare const enum LangVariant {
 }
 
 declare namespace sh {
-    export interface Pos {
+    interface Pos {
         After(p: Pos): boolean;
         Col(): number;
         IsValid(): boolean;
@@ -21,29 +21,29 @@ declare namespace sh {
         String(): string;
     }
 
-    export interface Node {
+    interface Node {
         Pos(): Pos;
         End(): Pos;
     }
 
-    export interface Command extends Node {
+    interface Command extends Node {
         OpPos: Pos;
     }
 
-    export type WordPart = Node;
+    type WordPart = Node;
 
-    export interface Word extends Node {
+    interface Word extends Node {
         Parts: WordPart[];
         Lit(): string;
     }
 
-    export interface Lit extends Node {
+    interface Lit extends Node {
         ValuePos: Pos;
         ValueEnd: Pos;
         Value: string;
     }
 
-    export interface Stmt extends Node {
+    interface Stmt extends Node {
         Comments: Comment[];
         Cmd: Command;
         Position: Pos;
@@ -53,30 +53,30 @@ declare namespace sh {
         Coprocess: boolean;
     }
 
-    export interface Comment extends Node {
+    interface Comment extends Node {
         Hash: Pos;
         Text: string;
     }
 
-    export interface File extends Node {
+    interface File extends Node {
         Name: string;
         Stmts?: Stmt[] | undefined;
         Last: Stmt[];
     }
 
-    export type ParserOption = (parser: Parser) => void;
+    type ParserOption = (parser: Parser) => void;
 
-    export type PrinterOption = (printer: Printer) => void;
+    type PrinterOption = (printer: Printer) => void;
 
-    export interface Parser {
+    interface Parser {
         Parse(text: string, path?: string): File;
     }
 
-    export interface Printer {
+    interface Printer {
         Print(node: Node): string;
     }
 
-    export interface ShellScript {
+    interface ShellScript {
         LangVariant: typeof LangVariant;
         syntax: {
             // variant

--- a/types/mvdan-sh/mvdan-sh-tests.ts
+++ b/types/mvdan-sh/mvdan-sh-tests.ts
@@ -1,9 +1,19 @@
-import sh, { LangVariant, Node } from 'mvdan-sh';
+import sh = require('mvdan-sh');
+import { LangVariant, Node } from 'mvdan-sh';
+
+// LangVariant isn't really exported by `mvdan-sh`.
+// Therefore, it's value is expected to not be accessible.
+// This statement should cause an error:
+// @ts-expect-error
+LangVariant;
+
+// However, this statement should work:
+const variant = LangVariant.LangBash;
 
 const { syntax } = sh;
 
 const node: Node = syntax
-    .NewParser(syntax.KeepComments(true), syntax.StopAt('$$'), syntax.Variant(LangVariant.LangBash))
+    .NewParser(syntax.KeepComments(true), syntax.StopAt('$$'), syntax.Variant(variant))
     .Parse(`yarn`);
 
 syntax


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mvdan/sh/tree/v3.6.0/_js#mvdan-sh> 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As stated in the `README` of `mvdan-sh`, `mvdan-sh` is exported using an export equals assignment.
However, the current type declarations indicate, that `mvdan-sh` is default-exported. The type declarations of `mvdan-sh` therefore mismatch their actual types and cannot be used properly.

You can also verify this by running the following in node:
```js
console.log(Object.keys(require("mvdan-sh")));
```

Notice the absence of `default`. Rather, a key called `syntax` is exposed.

Changes made in this PR address this issue and convert the default-export to an export-assignment.