### PR TITLE
[minio]: add myself to maintainer

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for minio 7.0
+// Type definitions for minio 7.1
 // Project: https://github.com/minio/minio-js#readme
 // Definitions by: Barin Britva <https://github.com/barinbritva>
 //                 Lubomir Kaplan <https://github.com/castorw>

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -5,6 +5,7 @@
 //                 Panagiotis Kapros <https://github.com/loremaps>
 //                 Ben Watkins <https://github.com/OutdatedVersion>
 //                 Seohyun Yoon <https://github.com/seohyun0120>
+//                 Trim21 <https://github.com/trim21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
I'm [converting minio to typescript](https://github.com/minio/minio-js/pull/1137), in the meanwhile I'd like to maintain the type defs.

type defs are already included in minio-js, but I'm not sure when it will be released, so `@types/minio` are still needed.

https://github.com/minio/minio-js/blob/master/types/minio.d.ts


Also upgrade minio version to 7.1