### PR TITLE
[webpack-env] Fix module.id typings

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -10,8 +10,10 @@
  */
 
 declare namespace __WebpackModuleApi {
+    type ModuleId = string|number;
+
     interface RequireResolve {
-        (id: string): string | number;
+        (id: string): ModuleId;
     }
 
     interface RequireContext {
@@ -20,7 +22,7 @@ declare namespace __WebpackModuleApi {
         <T>(id: string): T;
         resolve(id: string): string;
         /** The module id of the context module. This may be useful for module.hot.accept. */
-        id: string;
+        id: ModuleId;
     }
 
     interface RequireFunction {
@@ -50,7 +52,7 @@ declare namespace __WebpackModuleApi {
         /**
          * Like require.resolve, but doesn’t include the module into the bundle. It’s a weak dependency.
          */
-        resolveWeak(path: string): number | string;
+        resolveWeak(path: string): ModuleId;
         /**
          * Ensures that the dependency is available, but don’t execute it. This can be use for optimizing the position of a module in the chunks.
          */
@@ -65,14 +67,13 @@ declare namespace __WebpackModuleApi {
 
     interface Module {
         exports: any;
-        id: string;
+        id: ModuleId;
         filename: string;
         loaded: boolean;
         parent: NodeModule | null | undefined;
         children: NodeModule[];
         hot?: Hot | undefined;
     }
-    type ModuleId = string|number;
 
     interface HotNotifierInfo {
         type:

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -13,7 +13,7 @@ otherModule.otherMethod();
 let context = require.context('./somePath', true);
 let contextModule = context<SomeModule>('./someModule');
 
-const contextId: string = require.context('./somePath').id;
+const contextId: string | number = require.context('./somePath').id;
 
 require(['./someModule', './otherModule'], (someModule: SomeModule, otherModule: any) => {
 
@@ -145,5 +145,5 @@ if (importMeta.webpack >= 5 && importMeta.webpackContext) {
     let context = importMeta.webpackContext('./somePath', { recursive: true, regExp: /some/, include: /someModule/, exclude: /noNeedModuel/, preload: true, prefetch: true, chunkName: "[request]", exports: "default", mode: "weak" });
     let contextModule = context<SomeModule>('./someModule');
 
-    const contextId: string = importMeta.webpackContext('./somePath').id;
+    const contextId: string | number = importMeta.webpackContext('./somePath').id;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/optimization/#optimizationmoduleids

---

`module.id` and some related types are incorrectly defined as `string`. According to [documentation](https://webpack.js.org/configuration/optimization/#optimizationmoduleids) those can either be `string` or `number` depending on `optimization.moduleIds` config setting.

There are might be other places, where `string` is used instead of `ModuleId` type (primarily in `__WebpackModuleApi.Hot`), but I changed only those that I am sure about.

As long as `webpack-env-test.ts` uses `/// <reference types="node"/>` it is impossible to correctly test those types, because NodeJS's `require` and `module` variable types are not overridden.
See related issue - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11324

`parcel-env` types should also be updated, but I suppose this is out of scope of this PR.

Also, the description of methods are out of sync with [webpack documentation](https://webpack.js.org/api/module-methods), but it's nothing too important.
