### PR TITLE
feat(node): add jsdoc for stdio options

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -630,6 +630,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1191,6 +1200,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1291,6 +1309,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit, or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/ts4.8/child_process.d.ts
+++ b/types/node/ts4.8/child_process.d.ts
@@ -630,6 +630,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1191,6 +1200,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1291,6 +1309,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -154,6 +154,15 @@ declare module 'child_process' {
 
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -434,6 +443,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -472,6 +490,15 @@ declare module 'child_process' {
 
     interface ExecSyncOptions extends CommonOptions {
         input?: string | Uint8Array | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: string | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
@@ -491,6 +518,15 @@ declare module 'child_process' {
 
     interface ExecFileSyncOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v14/ts4.8/child_process.d.ts
+++ b/types/node/v14/ts4.8/child_process.d.ts
@@ -154,6 +154,15 @@ declare module 'child_process' {
 
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -434,6 +443,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -472,6 +490,15 @@ declare module 'child_process' {
 
     interface ExecSyncOptions extends CommonOptions {
         input?: string | Uint8Array | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: string | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
@@ -491,6 +518,15 @@ declare module 'child_process' {
 
     interface ExecFileSyncOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v16/child_process.d.ts
+++ b/types/node/v16/child_process.d.ts
@@ -631,6 +631,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1192,6 +1201,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1292,6 +1310,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v16/ts4.8/child_process.d.ts
+++ b/types/node/v16/ts4.8/child_process.d.ts
@@ -631,6 +631,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1192,6 +1201,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1292,6 +1310,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v18/child_process.d.ts
+++ b/types/node/v18/child_process.d.ts
@@ -634,6 +634,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1195,6 +1204,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1295,6 +1313,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;

--- a/types/node/v18/ts4.8/child_process.d.ts
+++ b/types/node/v18/ts4.8/child_process.d.ts
@@ -634,6 +634,15 @@ declare module 'child_process' {
     }
     interface CommonSpawnOptions extends CommonOptions, MessagingOptions, Abortable {
         argv0?: string | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         shell?: boolean | string | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1195,6 +1204,15 @@ declare module 'child_process' {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
         windowsVerbatimArguments?: boolean | undefined;
@@ -1295,6 +1313,15 @@ declare module 'child_process' {
     function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<string | Buffer>;
     interface CommonExecOptions extends CommonOptions {
         input?: string | NodeJS.ArrayBufferView | undefined;
+        /**
+         * Can be set to 'pipe', 'inherit', 'overlapped', or 'ignore', or an array of these strings.
+         * If passed as an array, the first element is used for `stdin`, the second for
+         * `stdout`, and the third for `stderr`. A fourth element can be used to
+         * specify the `stdio` behavior beyond the standard streams. See
+         * {@link ChildProcess.stdio} for more information.
+         *
+         * @default 'pipe'
+         */
         stdio?: StdioOptions | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
         maxBuffer?: number | undefined;


### PR DESCRIPTION
## Motivation

@types/node does not provide any context for the options passed in to stdio for exec, spawn, or fork. These are easy to forget, and we provide jsdoc for other stuff, so this adds a helpful hint for devs.

See: https://nodejs.org/api/child_process.html#optionsstdio

## Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. -- there were no tests added, because this only added a comment.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
