### PR TITLE
Add newrelic obfuscateSql, setErrorGroupCallback & update noticeError

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for newrelic 9.13
+// Type definitions for newrelic 9.14
 // Project: https://github.com/newrelic/node-newrelic
 // Definitions by: Matt R. Wilson <https://github.com/mastermatt>
 //                 Brooks Patton <https://github.com/brookspatton>
@@ -101,10 +101,36 @@ export function addCustomSpanAttributes(atts: { [key: string]: string | number |
  * Send errors to New Relic that you've already handled yourself.
  *
  * NOTE: Errors that are recorded using this method do _not_ obey the `ignore_status_codes` configuration.
+ */
+export function noticeError(error: Error, expected?: boolean): void;
+
+/**
+ * Send errors to New Relic that you've already handled yourself.
+ *
+ * NOTE: Errors that are recorded using this method do _not_ obey the `ignore_status_codes` configuration.
  *
  *  Optional. Any custom attributes to be displayed in the New Relic UI.
  */
-export function noticeError(error: Error, customAttributes?: { [key: string]: string | number | boolean }): void;
+export function noticeError(error: Error, customAttributes?: { [key: string]: string | number | boolean }, expected?: boolean): void;
+
+interface ErrorGroupCallbackFuncParams {
+    customAttributes: { [key: string]: string | number | boolean };
+    'request.uri': string;
+    'http.statusCode': string;
+    'http.method': string;
+    error?: Error;
+    'error.expected': boolean;
+}
+
+type ErrorGroupCallbackFunc = (metadata: ErrorGroupCallbackFuncParams) => string;
+
+/**
+ * This method lets you define a custom callback to generate error group names, which will be used by
+ * errors inbox to group similar errors together via the error.group.name agent attribute.
+ *
+ * Calling this function multiple times will replace previously defined versions of this callback function.
+ */
+export function setErrorGroupCallback(callback: ErrorGroupCallbackFunc): void;
 
 /**
  * Sends an application log message to New Relic. The agent already
@@ -399,6 +425,11 @@ export function getTraceMetadata(): TraceMetadata;
  * Returns a function with identical signature to the provided handler function.
  */
 export function setLambdaHandler<T extends (...args: any[]) => any>(handler: T): T;
+
+/**
+ * Obfuscates SQL for a given database engine.
+ */
+export function obfuscateSql(sql: string, dialect?: 'mysql' | 'postgres' | 'cassandra' | 'oracle'): string;
 
 export interface Instrument {
     (opts: { moduleName: string; onRequire: () => void; onError?: ((err: Error) => void) | undefined }): void;

--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -113,24 +113,20 @@ export function noticeError(error: Error, expected?: boolean): void;
  */
 export function noticeError(error: Error, customAttributes?: { [key: string]: string | number | boolean }, expected?: boolean): void;
 
-interface ErrorGroupCallbackFuncParams {
-    customAttributes: { [key: string]: string | number | boolean };
-    'request.uri': string;
-    'http.statusCode': string;
-    'http.method': string;
-    error?: Error;
-    'error.expected': boolean;
-}
-
-type ErrorGroupCallbackFunc = (metadata: ErrorGroupCallbackFuncParams) => string;
-
 /**
  * This method lets you define a custom callback to generate error group names, which will be used by
  * errors inbox to group similar errors together via the error.group.name agent attribute.
  *
  * Calling this function multiple times will replace previously defined versions of this callback function.
  */
-export function setErrorGroupCallback(callback: ErrorGroupCallbackFunc): void;
+export function setErrorGroupCallback(callback: (metadata: {
+    customAttributes: { [key: string]: string | number | boolean };
+    'request.uri': string;
+    'http.statusCode': string;
+    'http.method': string;
+    error?: Error;
+    'error.expected': boolean;
+}) => string): void;
 
 /**
  * Sends an application log message to New Relic. The agent already

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -32,20 +32,10 @@ newrelic.noticeError(Error('Oh no!'), { foo: 42 }); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), { foo: true }); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), true); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), false); // $ExpectType void
-newrelic.noticeError(Error('Oh no!'), { foo: 'bar' }), true; // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: 'bar' }, true); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), { foo: 42 }, false); // $ExpectType void
 
-newrelic.setErrorGroupCallback((errMetadata) => {
-    let errorGroup;
-
-    if (errMetadata['error.expected'] === true) {
-        errorGroup = 'Expected Error';
-    } else {
-        errorGroup = 'Unexpected Error';
-    }
-
-    return errorGroup;
-}); // $ExpectType void
+newrelic.setErrorGroupCallback((errMetadata) => errMetadata['error.expected'] ? 'Expected Error' : 'Unexpected Error'); // $ExpectType void
 
 newrelic.recordLogEvent({ message: '' }); // $ExpectType void
 newrelic.recordLogEvent({ message: '', timestamp: 1 }); // $ExpectType void

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -30,6 +30,22 @@ newrelic.noticeError(Error('Oh no!')); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), { foo: 'bar' }); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), { foo: 42 }); // $ExpectType void
 newrelic.noticeError(Error('Oh no!'), { foo: true }); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), true); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), false); // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: 'bar' }), true; // $ExpectType void
+newrelic.noticeError(Error('Oh no!'), { foo: 42 }, false); // $ExpectType void
+
+newrelic.setErrorGroupCallback((errMetadata) => {
+    let errorGroup;
+
+    if (errMetadata['error.expected'] === true) {
+        errorGroup = 'Expected Error';
+    } else {
+        errorGroup = 'Unexpected Error';
+    }
+
+    return errorGroup;
+}); // $ExpectType void
 
 newrelic.recordLogEvent({ message: '' }); // $ExpectType void
 newrelic.recordLogEvent({ message: '', timestamp: 1 }); // $ExpectType void
@@ -136,3 +152,5 @@ newrelic.setLambdaHandler(() => void 0); // $ExpectType () => undefined
 newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: "Hello!" })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
 // @ts-expect-error
 newrelic.setLambdaHandler({some: "object"});
+
+newrelic.obfuscateSql('SELECT * FROM USERS', 'postgres'); // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* `ofuscateSql` added in v9.10.0:
** https://github.com/newrelic/node-newrelic/releases/tag/v9.10.0
* `noticeError` added in v9.12.1:
** https://github.com/newrelic/node-newrelic/releases/tag/v9.12.1
 ** https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#noticeError 
* `setErrorGroupCallback` added in v9.14.0:
** https://github.com/newrelic/node-newrelic/releases/tag/v9.14.0
** https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setErrorGroupCallback
** https://github.com/newrelic/newrelic-node-examples/tree/main/error-fingerprinting
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
