### PR TITLE
[react-big-calendar] Add children to EventWrapperProps

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -303,6 +303,7 @@ export interface EventWrapperProps<TEvent extends object = Event> {
     label: string;
     continuesEarlier: boolean;
     continuesLater: boolean;
+    children: React.ReactNode;
 }
 
 export interface Messages {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -525,6 +525,7 @@ function EventWrapper(props: EventWrapperProps<CalendarEvent>) {
             <div>
                 {continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}
             </div>
+            {props.children}
         </div>
     );
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/react-big-calendar/blob/c7cd908936fefc989b86ed48d5c6248f87733af5/src/EventCell.js#L62
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

eventWrapper needs access to children in order to wrap them