### PR TITLE
[@types/passport-oauth2] allow boolean for `_StrategyOptionsBase.store`

### DIFF
--- a/types/ottomated__passport-streamlabs/index.d.ts
+++ b/types/ottomated__passport-streamlabs/index.d.ts
@@ -38,7 +38,7 @@ declare namespace Strategy {
         scope?: string | string[] | undefined;
         scopeSeparator?: string | undefined;
         sessionKey?: string | undefined;
-        store?: oauth2.StateStore | undefined;
+        store?: oauth2.StateStore | boolean | undefined;
         state?: any;
     }
 

--- a/types/ottomated__passport-twitch/index.d.ts
+++ b/types/ottomated__passport-twitch/index.d.ts
@@ -37,7 +37,7 @@ declare namespace Strategy {
         scope?: string | string[] | undefined;
         scopeSeparator?: string | undefined;
         sessionKey?: string | undefined;
-        store?: oauth2.StateStore | undefined;
+        store?: oauth2.StateStore | boolean | undefined;
         state?: any;
     }
 

--- a/types/passport-discord/index.d.ts
+++ b/types/passport-discord/index.d.ts
@@ -39,7 +39,7 @@ declare namespace Strategy {
         scope?: string | string[] | undefined;
         scopeSeparator?: string | undefined;
         sessionKey?: string | undefined;
-        store?: oauth2.StateStore | undefined;
+        store?: oauth2.StateStore | boolean | undefined;
         state?: any;
     }
 

--- a/types/passport-github/index.d.ts
+++ b/types/passport-github/index.d.ts
@@ -37,7 +37,7 @@ declare namespace Strategy {
         scope?: string | string[] | undefined;
         scopeSeparator?: string | undefined;
         sessionKey?: string | undefined;
-        store?: oauth2.StateStore | undefined;
+        store?: oauth2.StateStore | boolean | undefined;
         state?: string | undefined;
         userAgent?: string | undefined;
         userProfileURL?: string | undefined;

--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -91,7 +91,7 @@ declare namespace OAuth2Strategy {
         scope?: string | string[] | undefined;
         scopeSeparator?: string | undefined;
         sessionKey?: string | undefined;
-        store?: StateStore | undefined;
+        store?: StateStore | boolean | undefined;
         state?: any;
         skipUserProfile?: any;
         pkce?: boolean | undefined;

--- a/types/passport-oauth2/passport-oauth2-tests.ts
+++ b/types/passport-oauth2/passport-oauth2-tests.ts
@@ -146,3 +146,11 @@ const providerSpecificVerifyFunctionWithRequest: OAuth2Strategy.VerifyFunctionWi
     results.someProviderResultField;
     profile.someProviderProfileField;
 };
+
+const strategyOptions4: StrategyOptions = {
+    authorizationURL: 'http://www.example.com/auth',
+    clientID: 'dummy',
+    clientSecret: 'secret',
+    tokenURL: 'http://www.example.com/token',
+    store: true,
+};


### PR DESCRIPTION
Allow `_StrategyOptionsBase.store` to be `boolean` to satisfy usage in [`passport-oauth2/lib/strategy.js`](https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L107-L108) referenced in #65449 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [reference code](https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L107-L108)