### PR TITLE
Added definitions for "git-init" (supersedes #65055).

### DIFF
--- a/types/git-init/git-init-tests.ts
+++ b/types/git-init/git-init-tests.ts
@@ -1,0 +1,15 @@
+// @ts-ignore
+import * as init from './';
+
+// $ExpectType void
+init((err: Error | null, stdout: any, stderr: any) => {
+    // something here
+});
+// $ExpectType void
+init('./something/', (err: Error | null, stdout: any, stderr: any) => {
+    // something here
+});
+// @ts-expect-error
+init(5);
+// @ts-expect-error
+init('./something', 5);

--- a/types/git-init/git-init-tests.ts
+++ b/types/git-init/git-init-tests.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import * as init from './';
+import init = require('git-init');
 
 // $ExpectType void
 init((err: Error | null, stdout: any, stderr: any) => {

--- a/types/git-init/index.d.ts
+++ b/types/git-init/index.d.ts
@@ -2,49 +2,9 @@
 // Project: https://github.com/yoshuawuyts/git-init#readme
 // Definitions by: Santi <https://github.com/santi100a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-interface Signals {
-    SIGABRT: string;
-    SIGALRM: string;
-    SIGBUS: string;
-    SIGCHLD: string;
-    SIGCONT: string;
-    SIGFPE: string;
-    SIGHUP: string;
-    SIGILL: string;
-    SIGINT: string;
-    SIGIO: string;
-    SIGIOT: string;
-    SIGKILL: string;
-    SIGPIPE: string;
-    SIGPOLL: string;
-    SIGPROF: string;
-    SIGPWR: string;
-    SIGQUIT: string;
-    SIGSEGV: string;
-    SIGSTKFLT: string;
-    SIGSTOP: string;
-    SIGSYS: string;
-    SIGTERM: string;
-    SIGTRAP: string;
-    SIGTSTP: string;
-    SIGTTIN: string;
-    SIGTTOU: string;
-    SIGUNUSED: string;
-    SIGURG: string;
-    SIGUSR1: string;
-    SIGUSR2: string;
-    SIGVTALRM: string;
-    SIGWINCH: string;
-    SIGXCPU: string;
-    SIGXFSZ: string;
-}
 
-interface ExecException extends Error {
-    cmd?: string | undefined;
-    killed?: boolean | undefined;
-    code?: number | undefined;
-    signal?: Signals | undefined;
-}
+/// <reference types="node" />
+import type { ExecException } from 'node:child_process';
 
 type ExecCallback = (error: ExecException | null, stdout: string, stderr: string) => void;
 /**

--- a/types/git-init/index.d.ts
+++ b/types/git-init/index.d.ts
@@ -49,15 +49,15 @@ interface ExecException extends Error {
 type ExecCallback = (error: ExecException | null, stdout: string, stderr: string) => void;
 /**
  * Initializes a new Git repo in `path` asynchronously.
- * 
+ *
  * @param path The path of the folder to be initialized as a Git repo.
  * @param cb An `exec`-compatible callback defined in {@link ExecCallback}.
  */
-declare function init(path: string, cb: ExecCallback): string;
+declare function init(path: string, cb: ExecCallback): void;
 /**
  * Initializes a new Git repo in the current directory asynchronously.
- * 
+ *
  * @param cb An `exec`-compatible callback defined in {@link ExecCallback}.
  */
-declare function init(cb: ExecCallback): string;
+declare function init(cb: ExecCallback): void;
 export = init;

--- a/types/git-init/index.d.ts
+++ b/types/git-init/index.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for git-init 1.0
+// Project: https://github.com/yoshuawuyts/git-init#readme
+// Definitions by: Santi <https://github.com/santi100a>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+interface Signals {
+    SIGABRT: string;
+    SIGALRM: string;
+    SIGBUS: string;
+    SIGCHLD: string;
+    SIGCONT: string;
+    SIGFPE: string;
+    SIGHUP: string;
+    SIGILL: string;
+    SIGINT: string;
+    SIGIO: string;
+    SIGIOT: string;
+    SIGKILL: string;
+    SIGPIPE: string;
+    SIGPOLL: string;
+    SIGPROF: string;
+    SIGPWR: string;
+    SIGQUIT: string;
+    SIGSEGV: string;
+    SIGSTKFLT: string;
+    SIGSTOP: string;
+    SIGSYS: string;
+    SIGTERM: string;
+    SIGTRAP: string;
+    SIGTSTP: string;
+    SIGTTIN: string;
+    SIGTTOU: string;
+    SIGUNUSED: string;
+    SIGURG: string;
+    SIGUSR1: string;
+    SIGUSR2: string;
+    SIGVTALRM: string;
+    SIGWINCH: string;
+    SIGXCPU: string;
+    SIGXFSZ: string;
+}
+
+interface ExecException extends Error {
+    cmd?: string | undefined;
+    killed?: boolean | undefined;
+    code?: number | undefined;
+    signal?: Signals | undefined;
+}
+
+type ExecCallback = (error: ExecException | null, stdout: string, stderr: string) => void;
+/**
+ * Initializes a new Git repo in `path` asynchronously.
+ * 
+ * @param path The path of the folder to be initialized as a Git repo.
+ * @param cb An `exec`-compatible callback defined in {@link ExecCallback}.
+ */
+declare function init(path: string, cb: ExecCallback): string;
+/**
+ * Initializes a new Git repo in the current directory asynchronously.
+ * 
+ * @param cb An `exec`-compatible callback defined in {@link ExecCallback}.
+ */
+declare function init(cb: ExecCallback): string;
+export = init;

--- a/types/git-init/tsconfig.json
+++ b/types/git-init/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "git-init-tests.ts"
+    ]
+}

--- a/types/git-init/tslint.json
+++ b/types/git-init/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

