### PR TITLE
[braintree] Fix typo in `additionalProcessorResponse`

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -120,8 +120,16 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     };
     const response = await gateway.transaction.sale(transactionRequest).catch(console.error);
     if (!response) return;
-    const { amount, billing, escrowStatus, gatewayRejectionReason, type, status, id }: Transaction =
-        response.transaction;
+    const {
+        additionalProcessorResponse,
+        amount,
+        billing,
+        escrowStatus,
+        gatewayRejectionReason,
+        type,
+        status,
+        id,
+    }: Transaction = response.transaction;
 
     // Assert overlap between transaction type and static field
     type === Transaction.Type.Credit;

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1450,7 +1450,7 @@ declare namespace braintree {
         };
 
         addOns?: AddOn[] | undefined;
-        additionalProccessorResponse: string;
+        additionalProcessorResponse: string;
         amount: string;
         androidPayCard?:
             | {


### PR DESCRIPTION
Related discussion: #65478

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.paypal.com/braintree/docs/reference/response/transaction/php#additional_processor_response>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
