### PR TITLE
[node] Create `@legacy` tag instead of `@deprecated` for legacy API

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -2309,7 +2309,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2325,7 +2325,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/scripts/generate-docs/ast-processing.ts
+++ b/types/node/scripts/generate-docs/ast-processing.ts
@@ -134,6 +134,10 @@ class TagHelper {
         return this.createUnknownTag('deprecated', this.fixupCommentFormatting(text, 'deprecated'));
     }
 
+    createLegacyTag(text: string): JSDocUnknownTag {
+        return this.createUnknownTag('legacy', this.fixupCommentFormatting(text, 'legacy'));
+    }
+
     createSeeLinkTag(url: string, text: string): JSDocSeeTag {
         const { factory } = this.docContext.transformationContext;
         return this.docContext.transformationContext.factory.createJSDocSeeTag(
@@ -185,7 +189,7 @@ class TagHelper {
                 tags.push(this.createExperimentalTag());
                 break;
             case Stability.Legacy:
-                tags.push(this.createDeprecatedTag(stabilityText?.replace('Legacy. ', '') ?? 'Legacy API'));
+                tags.push(this.createLegacyTag(stabilityText?.replace('Legacy: ', '').replace('Legacy. ', '') ?? 'Legacy API'));
                 break;
         }
         return tags;
@@ -388,7 +392,7 @@ export class NodeProcessingContext {
         return {
             status: JSDocMatchResult.Ok,
             data: {
-                text: this.fixupDescriptionFormatting(desc,  moduleDocs.name),
+                text: this.fixupDescriptionFormatting(desc, moduleDocs.name),
                 tags,
             }
         };
@@ -516,9 +520,9 @@ export class NodeProcessingContext {
                 transformationContext.factory.createJSDocComment(processRes.data.text, processRes.data.tags),
                 node.getSourceFile(),
             )
-            .replaceAll('/**', '')
-            .replaceAll('*/', '')
-            .replaceAll(/&lt;(.*?)&gt;/g, '$1');
+                .replaceAll('/**', '')
+                .replaceAll('*/', '')
+                .replaceAll(/&lt;(.*?)&gt;/g, '$1');
             const newNode = removeCommentsRecursive(node, transformationContext, typeChecker);
             addSyntheticLeadingComment(newNode, SyntaxKind.MultiLineCommentTrivia, jsdoc, true);
         } else {

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -2309,7 +2309,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2325,7 +2325,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/ts4.8/url.d.ts
+++ b/types/node/ts4.8/url.d.ts
@@ -129,7 +129,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: URL, options?: URLFormatOptions): string;
@@ -193,7 +193,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -226,7 +226,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The base URL to use if `to` is a relative URL.
      * @param to The target URL to resolve.
      */

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -575,7 +575,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -129,7 +129,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: URL, options?: URLFormatOptions): string;
@@ -193,7 +193,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -226,7 +226,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The base URL to use if `to` is a relative URL.
      * @param to The target URL to resolve.
      */

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -575,7 +575,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;

--- a/types/node/v16/buffer.d.ts
+++ b/types/node/v16/buffer.d.ts
@@ -2206,7 +2206,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2222,7 +2222,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/v16/ts4.8/buffer.d.ts
+++ b/types/node/v16/ts4.8/buffer.d.ts
@@ -2206,7 +2206,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2222,7 +2222,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/v16/ts4.8/url.d.ts
+++ b/types/node/v16/ts4.8/url.d.ts
@@ -159,7 +159,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -192,7 +192,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The Base URL being resolved against.
      * @param to The HREF URL being resolved.
      */

--- a/types/node/v16/ts4.8/util.d.ts
+++ b/types/node/v16/ts4.8/util.d.ts
@@ -472,7 +472,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;

--- a/types/node/v16/url.d.ts
+++ b/types/node/v16/url.d.ts
@@ -159,7 +159,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -192,7 +192,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The Base URL being resolved against.
      * @param to The HREF URL being resolved.
      */

--- a/types/node/v16/util.d.ts
+++ b/types/node/v16/util.d.ts
@@ -472,7 +472,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -2280,7 +2280,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2296,7 +2296,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/v18/ts4.8/buffer.d.ts
+++ b/types/node/v18/ts4.8/buffer.d.ts
@@ -2280,7 +2280,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `Buffer.from(data, 'base64')` instead.
+         * @legacy Use `Buffer.from(data, 'base64')` instead.
          * @param data The Base64-encoded input string.
          */
         function atob(data: string): string;
@@ -2296,7 +2296,7 @@ declare module 'buffer' {
          * **For code running using Node.js APIs, converting between base64-encoded strings**
          * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
          * @since v15.13.0, v14.17.0
-         * @deprecated Use `buf.toString('base64')` instead.
+         * @legacy Use `buf.toString('base64')` instead.
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;

--- a/types/node/v18/ts4.8/url.d.ts
+++ b/types/node/v18/ts4.8/url.d.ts
@@ -135,7 +135,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: URL, options?: URLFormatOptions): string;
@@ -199,7 +199,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -232,7 +232,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The base URL to use if `to` is a relative URL.
      * @param to The target URL to resolve.
      */

--- a/types/node/v18/ts4.8/util.d.ts
+++ b/types/node/v18/ts4.8/util.d.ts
@@ -556,7 +556,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;

--- a/types/node/v18/url.d.ts
+++ b/types/node/v18/url.d.ts
@@ -135,7 +135,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: URL, options?: URLFormatOptions): string;
@@ -199,7 +199,7 @@ declare module 'url' {
      * string, an `Error` is thrown.
      * * `result` is returned.
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param urlObject A URL object (as returned by `url.parse()` or constructed otherwise). If a string, it is converted to an object by passing it to `url.parse()`.
      */
     function format(urlObject: UrlObject | string): string;
@@ -232,7 +232,7 @@ declare module 'url' {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
+     * @legacy Use the WHATWG URL API instead.
      * @param from The base URL to use if `to` is a relative URL.
      * @param to The target URL to resolve.
      */

--- a/types/node/v18/util.d.ts
+++ b/types/node/v18/util.d.ts
@@ -556,7 +556,7 @@ declare module 'util' {
      * stream.write('With ES6');
      * ```
      * @since v0.3.0
-     * @deprecated Legacy: Use ES2015 class syntax and `extends` keyword instead.
+     * @legacy Use ES2015 class syntax and `extends` keyword instead.
      */
     export function inherits(constructor: unknown, superConstructor: unknown): void;
     export type DebugLoggerFunction = (msg: string, ...param: unknown[]) => void;


### PR DESCRIPTION
The `legacy` is totally not the same as `deprecated` - https://nodejs.org/dist/latest-v20.x/docs/api/documentation.html#stability-index

This change is necessary so as not to confuse users or create inconvenience when using tools such as [gund/eslint-plugin-deprecation](https://github.com/gund/eslint-plugin-deprecation).

Close #65494