### PR TITLE
[detect-port] Port is optional and will be random by default

### DIFF
--- a/types/detect-port/detect-port-tests.ts
+++ b/types/detect-port/detect-port-tests.ts
@@ -6,15 +6,20 @@ const hostname = 'localhost';
 /**
  * callback usage
  */
+detect(undefined, (err: Error, _port: number) => {});
 detect(port, (err: Error, _port: number) => {});
 
 function* yieldSyntax() {
-    const _port: number = yield detect(port);
+    const _port: number = yield detect();
+    const _port2: number = yield detect(port);
 }
 
 /**
  * use as a promise
  */
+detect()
+    .then((_port: number) => {})
+    .catch(err => {});
 detect(port)
     .then((_port: number) => {})
     .catch(err => {});
@@ -22,8 +27,11 @@ detect(port)
 /**
  * port config usage
  */
+detect({ hostname, callback: (err: Error, _port: number) => {} });
 detect({ port, hostname, callback: (err: Error, _port: number) => {} });
-
+detect({ hostname })
+    .then((_port: number) => {})
+    .catch(err => {});
 detect({ port, hostname })
     .then((_port: number) => {})
     .catch(err => {});

--- a/types/detect-port/index.d.ts
+++ b/types/detect-port/index.d.ts
@@ -6,14 +6,14 @@
 type DetectPortCallback = (err: Error, _port: number) => void;
 
 interface PortConfig {
-    port: number;
+    port?: number;
     hostname?: string | undefined;
     callback?: DetectPortCallback | undefined;
 }
 
 interface DetectPort {
-    (port: number | PortConfig, callback: DetectPortCallback): void;
-    (port: number | PortConfig): Promise<number>;
+    (port: number | PortConfig | undefined, callback: DetectPortCallback): void;
+    (port?: number | PortConfig): Promise<number>;
 }
 declare const detectPort: DetectPort;
 export = detectPort;


### PR DESCRIPTION
This default port to 0 which will then pick a random port (tested) https://github.com/node-modules/detect-port/blob/1.3.0/lib/detect-port.js#L21

This change is applicable to 1.3.0
Although there is a new one which has more functionality, here I'm not trying to add those, but just fix a bug in the old types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

