### PR TITLE
[matter-js] Fixed/Added ability to pass an array to Composite.remove

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1385,7 +1385,7 @@ declare namespace Matter {
          * Triggers `beforeRemove` and `afterRemove` events on the `composite`.
          * @method remove
          * @param {Composite} composite
-         * @param object
+         * @param {Body | Composite | Constraint | MouseConstraint | (Body | Composite | Constraint | MouseConstraint)[]} object
          * @param {boolean} [deep=false]
          * @returns {Composite} The original composite with the objects removed
          */

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1389,7 +1389,16 @@ declare namespace Matter {
          * @param {boolean} [deep=false]
          * @returns {Composite} The original composite with the objects removed
          */
-        static remove(composite: Composite, object: Body | Composite | Constraint, deep?: boolean): Composite;
+         static remove(
+            composite: Composite, 
+            object:
+                | Body
+                | Composite
+                | Constraint
+                | MouseConstraint
+                | Array<Body | Composite | Constraint | MouseConstraint>, 
+            deep?: boolean,
+        ): Composite;
 
         /**
          * Translates all children in the composite by a given vector relative to their current positions,

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1385,7 +1385,7 @@ declare namespace Matter {
          * Triggers `beforeRemove` and `afterRemove` events on the `composite`.
          * @method remove
          * @param {Composite} composite
-         * @param {Body | Composite | Constraint | MouseConstraint | (Body | Composite | Constraint | MouseConstraint)[]} object
+         * @param {Body | Composite | Constraint | MouseConstraint | Array<Body | Composite | Constraint | MouseConstraint>} object
          * @param {boolean} [deep=false]
          * @returns {Composite} The original composite with the objects removed
          */

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1385,7 +1385,7 @@ declare namespace Matter {
          * Triggers `beforeRemove` and `afterRemove` events on the `composite`.
          * @method remove
          * @param {Composite} composite
-         * @param {any} object
+         * @param object
          * @param {boolean} [deep=false]
          * @returns {Composite} The original composite with the objects removed
          */

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1390,13 +1390,13 @@ declare namespace Matter {
          * @returns {Composite} The original composite with the objects removed
          */
          static remove(
-            composite: Composite, 
+            composite: Composite,
             object:
                 | Body
                 | Composite
                 | Constraint
                 | MouseConstraint
-                | Array<Body | Composite | Constraint | MouseConstraint>, 
+                | Array<Body | Composite | Constraint | MouseConstraint>,
             deep?: boolean,
         ): Composite;
 

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -193,6 +193,8 @@ Composite.add(composite1, constraint1);
 Composite.add(composite1, mouseConstraint);
 // $ExpectType Composite
 Composite.add(composite3, [box1, composite2, constraint1, mouseConstraint]);
+// $ExpectType Composite
+Composite.remove(composite3, [box1, composite2, constraint1, mouseContraint]);
 
 // Pairs
 // $ExpectType Pairs

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -194,7 +194,7 @@ Composite.add(composite1, mouseConstraint);
 // $ExpectType Composite
 Composite.add(composite3, [box1, composite2, constraint1, mouseConstraint]);
 // $ExpectType Composite
-Composite.remove(composite3, [box1, composite2, constraint1, mouseContraint]);
+Composite.remove(composite3, [box1, composite2, constraint1, mouseConstraint]);
 
 // Pairs
 // $ExpectType Pairs


### PR DESCRIPTION
Added ability to pass Body/Composite/Constraint/MouseConstraint array to Composite.remove. 

Composite.add has this ability and functions the same

Has been tested.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source Code](https://github.com/liabru/matter-js/blob/master/src/body/Composite.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
