### PR TITLE
node: Add tests and types for new Node test runner todo shorthands (skip and todo)

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.1
+// Type definitions for non-npm package Node.js 20.2.0
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.2.0
+// Type definitions for non-npm package Node.js 20.2
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -150,6 +150,13 @@ declare module 'node:test' {
         function todo(name?: string, fn?: SuiteFn): void;
         function todo(options?: TestOptions, fn?: SuiteFn): void;
         function todo(fn?: SuiteFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `test([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * The `describe()` function imported from the `node:test` module. Each
@@ -180,6 +187,13 @@ declare module 'node:test' {
         function todo(name?: string, fn?: SuiteFn): void;
         function todo(options?: TestOptions, fn?: SuiteFn): void;
         function todo(fn?: SuiteFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * Shorthand for `test()`.
@@ -202,6 +216,13 @@ declare module 'node:test' {
         function todo(name?: string, fn?: TestFn): void;
         function todo(options?: TestOptions, fn?: TestFn): void;
         function todo(fn?: TestFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `it([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * The type of a function under test. The first argument to this function is a

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -139,24 +139,24 @@ declare module 'node:test' {
         /**
          * Shorthand for skipping a suite, same as `test([name], { skip: true }[, fn])`.
          */
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function skip(name?: string, fn?: SuiteFn): void;
-        function skip(options?: TestOptions, fn?: SuiteFn): void;
-        function skip(fn?: SuiteFn): void;
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function skip(name?: string, fn?: TestFn): void;
+        function skip(options?: TestOptions, fn?: TestFn): void;
+        function skip(fn?: TestFn): void;
         /**
          * Shorthand for marking a suite as `TODO`, same as `test([name], { todo: true }[, fn])`.
          */
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function todo(name?: string, fn?: SuiteFn): void;
-        function todo(options?: TestOptions, fn?: SuiteFn): void;
-        function todo(fn?: SuiteFn): void;
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function todo(name?: string, fn?: TestFn): void;
+        function todo(options?: TestOptions, fn?: TestFn): void;
+        function todo(fn?: TestFn): void;
         /**
          * Shorthand for marking a suite as `TODO`, same as `test([name], { only: true }[, fn])`.
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function only(name?: string, fn?: SuiteFn): void;
-        function only(options?: TestOptions, fn?: SuiteFn): void;
-        function only(fn?: SuiteFn): void;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function only(name?: string, fn?: TestFn): void;
+        function only(options?: TestOptions, fn?: TestFn): void;
+        function only(fn?: TestFn): void;
     }
     /**
      * The `describe()` function imported from the `node:test` module. Each
@@ -219,10 +219,10 @@ declare module 'node:test' {
         /**
          * Shorthand for marking a suite as `TODO`, same as `it([name], { only: true }[, fn])`.
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function only(name?: string, fn?: SuiteFn): void;
-        function only(options?: TestOptions, fn?: SuiteFn): void;
-        function only(fn?: SuiteFn): void;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function only(name?: string, fn?: TestFn): void;
+        function only(options?: TestOptions, fn?: TestFn): void;
+        function only(fn?: TestFn): void;
     }
     /**
      * The type of a function under test. The first argument to this function is a

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -135,6 +135,22 @@ declare module 'node:test' {
     function test(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(fn?: TestFn): Promise<void>;
+    namespace test {
+        /**
+         * Shorthand for skipping a suite, same as `test([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function skip(name?: string, fn?: SuiteFn): void;
+        function skip(options?: TestOptions, fn?: SuiteFn): void;
+        function skip(fn?: SuiteFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `test([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function todo(name?: string, fn?: SuiteFn): void;
+        function todo(options?: TestOptions, fn?: SuiteFn): void;
+        function todo(fn?: SuiteFn): void;
+    }
     /**
      * The `describe()` function imported from the `node:test` module. Each
      * invocation of this function results in the creation of a Subtest.

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -138,20 +138,32 @@ describe.skip('skip shorthand', {
     signal: new AbortController().signal,
     timeout: Infinity,
 });
-it.skip('todo shorthand', {
+it.skip('skip shorthand', {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+test.skip('skip shorthand', {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,
     timeout: Infinity,
 });
 
-describe.todo('skip shorthand', {
+describe.todo('test shorthand', {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,
     timeout: Infinity,
 });
 it.todo('todo shorthand', {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+test.todo('todo shorthand', {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -151,7 +151,7 @@ test.skip('skip shorthand', {
     timeout: Infinity,
 });
 
-describe.todo('test shorthand', {
+describe.todo('todo shorthand', {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,
@@ -164,6 +164,24 @@ it.todo('todo shorthand', {
     timeout: Infinity,
 });
 test.todo('todo shorthand', {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+describe.only('only shorthand', {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+it.only('only shorthand', {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+test.only('only shorthand', {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -135,6 +135,29 @@ declare module 'node:test' {
     function test(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(fn?: TestFn): Promise<void>;
+    namespace test {
+        /**
+         * Shorthand for skipping a suite, same as `test([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function skip(name?: string, fn?: TestFn): void;
+        function skip(options?: TestOptions, fn?: TestFn): void;
+        function skip(fn?: TestFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `test([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function todo(name?: string, fn?: TestFn): void;
+        function todo(options?: TestOptions, fn?: TestFn): void;
+        function todo(fn?: TestFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `test([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function only(name?: string, fn?: TestFn): void;
+        function only(options?: TestOptions, fn?: TestFn): void;
+        function only(fn?: TestFn): void;
+    }
     /**
      * The `describe()` function imported from the `node:test` module. Each
      * invocation of this function results in the creation of a Subtest.
@@ -164,6 +187,13 @@ declare module 'node:test' {
         function todo(name?: string, fn?: SuiteFn): void;
         function todo(options?: TestOptions, fn?: SuiteFn): void;
         function todo(fn?: SuiteFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * Shorthand for `test()`.
@@ -186,6 +216,13 @@ declare module 'node:test' {
         function todo(name?: string, fn?: ItFn): void;
         function todo(options?: TestOptions, fn?: ItFn): void;
         function todo(fn?: ItFn): void;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `it([name], { only: true }[, fn])`.
+         */
+        function only(name?: string, options?: TestOptions, fn?: ItFn): void;
+        function only(name?: string, fn?: ItFn): void;
+        function only(options?: TestOptions, fn?: ItFn): void;
+        function only(fn?: ItFn): void;
     }
     /**
      * The type of a function under test. The first argument to this function is a


### PR DESCRIPTION
Node introduced these recently: https://github.com/nodejs/node/pull/47909

I noticed the types are missing the `only` shorthand for all of `it`, `describe` and `test`. Should I add them in this PR or in a new one once this is merged?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.