### PR TITLE
Add union ordering fix for artillery in 5.2

### DIFF
--- a/types/artillery/artillery-tests.ts
+++ b/types/artillery/artillery-tests.ts
@@ -398,7 +398,7 @@ const afterResponseFn: AfterResponseFn = (requestConfig, response, context, ee, 
     requestConfig.json; // $ExpectType Record<string, any> | undefined
     requestConfig.form; // $ExpectType Record<string, any> | undefined
     requestConfig.https; // $ExpectType HTTPSOptions | undefined
-    requestConfig.body; // $ExpectType string | Buffer | Readable | undefined
+    requestConfig.body; // $ExpectType string | Buffer | Readable | undefined || string | Readable | Buffer | undefined
     requestConfig.followRedirect; // $ExpectType boolean | undefined
     requestConfig.foo; // $ExpectType unknown
 


### PR DESCRIPTION
This failed in nightly; the union order is unstable so just allow both.

https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=156562&view=logs&j=9d906afe-3eb5-5d79-316d-86f3f3fa360c&t=09716206-abc7-5ba2-2ea2-6c6fe97a3aad