### PR TITLE
Add union ordering fix for luxon in 5.2

### DIFF
--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -143,6 +143,7 @@ dt.toSQLTime(); // $ExpectType string
 dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
+// tslint:disable-next-line max-line-length
 dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number> || Record<"year" | "month" | "day" | "hour" | "minute" | "second" | "millisecond", number>
 // @ts-expect-error
 dt.toObject().locale;

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -143,7 +143,7 @@ dt.toSQLTime(); // $ExpectType string
 dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
-dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number>
+dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number> || Record<"year" | "month" | "day" | "hour" | "minute" | "second" | "millisecond", number>
 // @ts-expect-error
 dt.toObject().locale;
 dt.toObject({ includeConfig: true }); // $ExpectType _ToObjectOutput<true>


### PR DESCRIPTION
This failed in nightly; the union order is unstable so just allow both.

https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=156562&view=logs&j=6399d89d-3d30-5fff-3e92-07bbaf7ebe2f&t=482eae7c-85d2-5e8a-ea70-a5ab41e9bc13