### PR TITLE
Update eslint.FlatConfig to remove string alternatives from files and ignores

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -923,4 +923,32 @@ ruleTester.run('simple-valid-test', rule, {
     }
 });
 
+(): Linter.FlatConfig => ({ files: ["abc"] });
+(): Linter.FlatConfig => ({ files: [(path) => false] });
+(): Linter.FlatConfig => ({ files: [["abc"]]});
+(): Linter.FlatConfig => ({ files: [[(path) => false]] });
+(): Linter.FlatConfig => ({ files: [["abc", (path) => false]] });
+(): Linter.FlatConfig => ({ files: ["abc", (path) => false, ["abc"], [(path) => false], ["abc", (path) => false]] });
+
+// @ts-expect-error // Second level of nesting is not allowed
+(): Linter.FlatConfig => ({ files: ["abc", (path) => false, ["abc"], [(path) => false], ["abc", (path) => false], [["abc"], [(path) => false]]] });
+
+(): Linter.FlatConfig => ({ ignores: ["abc"] });
+(): Linter.FlatConfig => ({ ignores: [(path) => false] });
+(): Linter.FlatConfig => ({ ignores: ["abc", (path) => false] });
+
+// @ts-expect-error // No nesting
+(): Linter.FlatConfig => ({ ignores: ["abc", (path) => false, ["abc"], [(path) => false], ["abc", (path) => false]] });
+
+// @ts-expect-error // Must be an array
+(): Linter.FlatConfig => ({ files: "abc" });
+
+// @ts-expect-error // Must be an array
+(): Linter.FlatConfig => ({ ignores: "abc" });
+
+// The following _should_ be an error, but we can't enforce on consumers
+// as it requires exactOptionalPropertyTypes: true
+// (): Linter.FlatConfig => ({ files: undefined });
+// (): Linter.FlatConfig => ({ ignores: undefined });
+
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -915,19 +915,22 @@ export namespace Linter {
         preprocess?(text: string, filename: string): T[];
         postprocess?(messages: LintMessage[][], filename: string): LintMessage[];
     }
+
+    type FlatConfigFileSpec = string | ((filePath: string) => boolean);
+
     interface FlatConfig {
       /**
        * An array of glob patterns indicating the files that the configuration
        * object should apply to. If not specified, the configuration object applies
        * to all files
        */
-      files?: string | string[];
+      files?: Array<FlatConfigFileSpec | FlatConfigFileSpec[]>;
       /**
        * An array of glob patterns indicating the files that the configuration
        * object should not apply to. If not specified, the configuration object
        * applies to all files matched by files
        */
-      ignores?: string | string[];
+      ignores?: FlatConfigFileSpec[];
       /**
        * An object containing settings related to how JavaScript is configured for
        * linting.


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The new `FlatConfig` is more strict with globs than the old style config, and setting `files` or `ignores` to anything other than an array results in an error when `eslint` loads the config.

The runtime restrictions I've gathered are:
- `files`
  - [must be an array](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/base-schema.js#L64)
  - [must not be empty](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/config-array.js#L50)
  - [must not be defined at all otherwise](https://github.com/humanwhocodes/object-schema/blob/172be9682e71d35336a3b541617694bd2fe56c2a/src/object-schema.js#L199) (`undefined` is not a valid value)
  - can contain:
    -  [`string`](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/base-schema.js#L70)
    - [`(filePath: string) => boolean`](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/config-array.js#L282)
    - [An array of `string` or `(filePath: string) => boolean`](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/base-schema.js#L69) (only one level of nesting)
- `ignores`
  - [must be an array](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/base-schema.js#LL82C30-L82C30)
  - [must not be defined at all otherwise](https://github.com/humanwhocodes/object-schema/blob/172be9682e71d35336a3b541617694bd2fe56c2a/src/object-schema.js#L199) (`undefined` is not a valid value)
  - can contain:
    -  [`string`](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/base-schema.js#L31)
    - [`(filePath: string) => boolean`](https://github.com/humanwhocodes/config-array/blob/613eb737b90b0658d7753eb9d8a42af8e558c4e4/src/config-array.js#L282)

Notably, the underlying `config-array` library actually allows a few extra types (such as nested arrays and functions), but these aren't documented by `eslint` (though the [`FlatCompat`](https://github.com/eslint/eslintrc/blob/66bc3bc32d0486de7ae5c426b0cfd90035478d4b/lib/flat-compat.js#L121) converter does use the function feature). I've added these options to the types, as they are accepted and generated by `eslint` itself, even if it isn't a documented behaviour - it's possible to come across the other kinds of values in the wild, so the types should account for them.

Preventing setting the properties to `undefined` does require the `exactOptionalPropertyTypes` compiler flag, but afaik, we can't force consumers to have it on, so the typings won't be exactly accurate for them.

I have considered whether it's feasible to use some form of non-empty array type for `files`, but all the examples I could find dotted around have some pretty nasty corners that make them a mess to use in practice, so I think it's best to leave it as just `string[]`.