### PR TITLE
Add Promise<void> return to tape TestCase

### DIFF
--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -24,7 +24,7 @@ declare function tape(opts: tape.TestOptions, cb: tape.TestCase): void;
 
 declare namespace tape {
     interface TestCase {
-        (test: Test): void;
+        (test: Test): void | Promise<void>;
     }
 
     /**

--- a/types/tape/tape-tests.ts
+++ b/types/tape/tape-tests.ts
@@ -16,6 +16,10 @@ tape(name, (test: tape.Test) => {
     t = test;
 });
 
+tape(name, async (test: tape.Test) => {
+    t = test;
+});
+
 tape.skip(cb);
 tape.skip(name, cb);
 tape.skip(topts, cb);


### PR DESCRIPTION
This PR changes the signature of `TestCase` from `(Test) => void` to `(Test) => void | Promise<void>`. This is because [tape](https://github.com/ljharb/tape) has special handling for promise-returning/async test cases.

> If `cb` returns a Promise, it will be implicitly awaited. If that promise rejects, the test will be failed; if it fulfills, the test will end.

This shouldn't affect `tsc` since `() => Promise<void>` is assignable to `() => void`, but it will affect other tooling. Specifically, I was running into a situation where the `@typescript-eslint/no-misused-promises` rule in [typescript-eslint](https://typescript-eslint.io) was getting set off, because a `TestCase` isn’t supposed to return a promise. This change will properly communicate that async functions are expected in this context.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ljharb/tape#testname-opts-cb
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
