### PR TITLE
Add optional param to react-tagsinput validate

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for react-tagsinput 3.19
+// Type definitions for react-tagsinput 3.20.1
 // Project: https://github.com/olahol/react-tagsinput
 // Definitions by: Michael Macnair <https://github.com/mykter>
 //                 Richard Tan <https://github.com/chardos>
+//                 Prakhar Goel <https://github.com/Prakhargoel8c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -53,6 +54,7 @@ declare namespace TagsInput {
         currentValue?: string | undefined;
         inputValue?: string | undefined;
         onlyUnique?: boolean | undefined;
+        validate: ((tag: Tag) => boolean) | undefined;
         validationRegex?: RegExp | undefined;
         onValidationReject?: ((tags: string[]) => void) | undefined;
         disabled?: boolean | undefined;

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tagsinput 3.20.1
+// Type definitions for react-tagsinput 3.20
 // Project: https://github.com/olahol/react-tagsinput
 // Definitions by: Michael Macnair <https://github.com/mykter>
 //                 Richard Tan <https://github.com/chardos>


### PR DESCRIPTION
This Pr adds validate prop to [react-tagsinput](https://www.npmjs.com/package/react-tagsinput#validate)
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.