### PR TITLE
fix: update passport-facebook to 3.0

### DIFF
--- a/types/passport-facebook/index.d.ts
+++ b/types/passport-facebook/index.d.ts
@@ -1,20 +1,24 @@
-// Type definitions for passport-facebook 2.1
+// Type definitions for passport-facebook 3.0
 // Project: https://github.com/jaredhanson/passport-facebook
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>, Lucas Acosta <https://github.com/lucasmacosta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import passport = require('passport');
-import express = require('express');
+import * as passport from 'passport';
+import * as express from 'express';
+import * as oauth2 from 'passport-oauth2';
+import { OutgoingHttpHeaders } from 'http';
 
 export interface Profile extends passport.Profile {
     id: string;
     displayName: string;
     gender?: string | undefined;
-    ageRange?: {
+    ageRange?:
+    | {
         min: number;
         max?: number | undefined;
-    } | undefined;
+    }
+    | undefined;
     profileUrl?: string | undefined;
     username?: string | undefined;
     birthday: string;
@@ -27,12 +31,21 @@ export interface AuthenticateOptions extends passport.AuthenticateOptions {
     authType?: string | undefined;
 }
 
-export interface StrategyOption {
+export interface StrategyOptions {
+    passReqToCallback?: false | undefined;
     clientID: string;
     clientSecret: string;
     callbackURL: string;
 
+    customHeaders?: OutgoingHttpHeaders | undefined;
+    scope?: string | string[] | undefined;
     scopeSeparator?: string | undefined;
+    sessionKey?: string | undefined;
+    store?: oauth2.StateStore | undefined;
+    state?: any;
+    skipUserProfile?: any;
+    pkce?: boolean | undefined;
+    proxy?: any;
     enableProof?: boolean | undefined;
     profileFields?: string[] | undefined;
 
@@ -40,27 +53,38 @@ export interface StrategyOption {
     tokenURL?: string | undefined;
     profileURL?: string | undefined;
     graphAPIVersion?: string | undefined;
+}
 
+export interface AuthorizationParamsOptions {
     display?: 'page' | 'popup' | 'touch' | undefined;
-
     authType?: 'reauthenticate' | undefined;
     authNonce?: string | undefined;
 }
 
-export interface StrategyOptionWithRequest extends StrategyOption {
+export interface StrategyOptionsWithRequest extends Omit<StrategyOptions, 'passReqToCallback'> {
     passReqToCallback: true;
 }
 
-export type VerifyFunction =
-    (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
+export type VerifyFunction = (
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: (error: any, user?: any, info?: any) => void,
+) => void;
 
-export type VerifyFunctionWithRequest =
-    (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
+export type VerifyFunctionWithRequest = (
+    req: express.Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: (error: any, user?: any, info?: any) => void,
+) => void;
 
-export class Strategy implements passport.Strategy {
-    constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
-    constructor(options: StrategyOption, verify: VerifyFunction);
+export class Strategy extends oauth2.Strategy {
+    constructor(options: StrategyOptions, verify: VerifyFunction);
+    constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
 
     name: string;
     authenticate(req: express.Request, options?: object): void;
+    authorizationParams(options: AuthorizationParamsOptions): object;
 }

--- a/types/passport-facebook/passport-facebook-tests.ts
+++ b/types/passport-facebook/passport-facebook-tests.ts
@@ -1,50 +1,98 @@
 /**
  * Created by jcabresos on 4/19/2014.
  */
-import passport = require('passport');
-import facebook = require('passport-facebook');
-import express = require('express');
+import * as passport from 'passport';
+import * as facebook from 'passport-facebook';
+import * as express from 'express';
 
 // just some test model
 const User = {
     findOrCreate(id: string, provider: string, callback: (err: any, user: any) => void): void {
         callback(null, { username: 'james' });
-    }
+    },
 };
 
-passport.use(new facebook.Strategy({
-            clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
-            clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
-            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL
-    },
-    (accessToken: string, refreshToken: string, profile: facebook.Profile, done: (error: any, user?: any) => void) => {
-         User.findOrCreate(profile.id, profile.provider, (err, user) => {
-             if (err) done(err);
-             else done(null, user);
-         });
-    })
-);
-
-passport.use(new facebook.Strategy({
+passport.use(
+    new facebook.Strategy(
+        {
             clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
             clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
             callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL,
-            passReqToCallback: true
-    },
-    (req: express.Request, accessToken: string, refreshToken: string, profile: facebook.Profile, done: (error: any, user?: any) => void) => {
-         User.findOrCreate(profile.id, profile.provider, (err, user) => {
-             if (err) done(err);
-             else done(null, user);
-         });
-    })
+        },
+        (
+            accessToken: string,
+            refreshToken: string,
+            profile: facebook.Profile,
+            done: (error: any, user?: any) => void,
+        ) => {
+            User.findOrCreate(profile.id, profile.provider, (err, user) => {
+                if (err) done(err);
+                else done(null, user);
+            });
+        },
+    ),
 );
 
-passport.use(new facebook.Strategy({
+passport.use(
+    new facebook.Strategy(
+        {
             clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
             clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
-            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL
-    },
-    (accessToken: string, refreshToken: string, profile: facebook.Profile, done: (error: any, user?: any, info?: any) => void) => {
-         done(null, false, { message: 'Some error.' });
-    })
+            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL,
+            passReqToCallback: true,
+        },
+        (
+            req: express.Request,
+            accessToken: string,
+            refreshToken: string,
+            profile: facebook.Profile,
+            done: (error: any, user?: any) => void,
+        ) => {
+            User.findOrCreate(profile.id, profile.provider, (err, user) => {
+                if (err) done(err);
+                else done(null, user);
+            });
+        },
+    ),
+);
+
+passport.use(
+    new facebook.Strategy(
+        {
+            clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
+            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL,
+            passReqToCallback: true,
+        },
+        (
+            req: express.Request,
+            accessToken: string,
+            refreshToken: string,
+            profile: facebook.Profile,
+            done: (error: any, user?: any) => void,
+        ) => {
+            User.findOrCreate(profile.id, profile.provider, (err, user) => {
+                if (err) done(err);
+                else done(null, user);
+            });
+        },
+    ),
+);
+
+passport.use(
+    new facebook.Strategy(
+        {
+            clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
+            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL,
+        },
+        (
+            accessToken: string,
+            refreshToken: string,
+            profile: facebook.Profile,
+            done: (error: any, user?: any, info?: any) => void,
+        ) => {
+            done(null, false, { message: 'Some error.' });
+        },
+    ),
 );


### PR DESCRIPTION
## Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Summary

passport-facebook's `StrategyOption` constructor param ultimately gets passed to `OAuth2Strategy`.

https://github.com/jaredhanson/passport-facebook/blob/586d535e7db6b972d4c36618762cd0e8125faddb/lib/strategy.js#L56

Depending on the value of `options.state` the `OAuth2Strategy` constructor will set `_stateStore` to either an instance of `PKCEStateStore` or `NonceStore`.

https://github.com/jaredhanson/passport-oauth2/blob/ea9e99adda82dff67502654347589866fea80eb2/lib/strategy.js#L110

This change also updates package to use exports instead of namespaces.