### PR TITLE
Update superagent ResponseError with optional timeout property

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -89,9 +89,9 @@ declare namespace request {
     }
 
     interface ResponseError extends Error {
-        status?: number;
-        response?: Response;
-        timeout?: boolean;
+        status?: number | undefined;
+        response?: Response | undefined;
+        timeout?: boolean | undefined;
     }
 
     interface HTTPError extends Error {

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -89,8 +89,9 @@ declare namespace request {
     }
 
     interface ResponseError extends Error {
-        status?: number | undefined;
-        response?: Response | undefined;
+        status?: number;
+        response?: Response;
+        timeout?: boolean;
     }
 
     interface HTTPError extends Error {


### PR DESCRIPTION
Adds the timeout property to `ResponseError`

See this test from the superagent project which expects `.timeout` on the error object
https://github.com/ladjs/superagent/blob/92b1435f4fd02193b12c6cf14f6ef4ca02b22bd6/test/timeout.js#L24

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
