### PR TITLE
@types/node - NodeJS.BufferEncoding

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -216,6 +216,9 @@ declare module 'buffer' {
     // the copy below in a Node environment.
     type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding =
             | 'ascii'

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -2,7 +2,6 @@
 import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
-    BufferEncoding as ImportedBufferEncoding,
     File,
     constants,
     isUtf8,
@@ -270,9 +269,9 @@ b.fill('a').fill('b');
     b.writeUInt8(0, 6);
 }
 
-// Imported BufferEncoding from buffer module works properly
+// NodeJS.BufferEncoding works properly
 {
-    const encoding: ImportedBufferEncoding = 'ascii';
+    const encoding: NodeJS.BufferEncoding = 'ascii';
     const b = new ImportedBuffer('123', encoding);
     b.writeUInt8(0, 6);
 }

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -2,7 +2,6 @@
 import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
-    BufferConstructor as ImportedBufferConstructor,
     BufferEncoding as ImportedBufferEncoding,
     File,
     constants,
@@ -268,13 +267,6 @@ b.fill('a').fill('b');
     const b = new ImportedBuffer('123');
     b.writeUInt8(0, 6);
     const sb = new ImportedSlowBuffer(43);
-    b.writeUInt8(0, 6);
-}
-
-// Imported BufferConstructor from buffer module works properly
-{
-    const ctor: ImportedBufferConstructor = ImportedBuffer;
-    const b = new ctor('123');
     b.writeUInt8(0, 6);
 }
 

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -2,6 +2,8 @@
 import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
+    BufferConstructor as ImportedBufferConstructor,
+    BufferEncoding as ImportedBufferEncoding,
     File,
     constants,
     isUtf8,
@@ -266,6 +268,20 @@ b.fill('a').fill('b');
     const b = new ImportedBuffer('123');
     b.writeUInt8(0, 6);
     const sb = new ImportedSlowBuffer(43);
+    b.writeUInt8(0, 6);
+}
+
+// Imported BufferConstructor from buffer module works properly
+{
+    const ctor: ImportedBufferConstructor = ImportedBuffer;
+    const b = new ctor('123');
+    b.writeUInt8(0, 6);
+}
+
+// Imported BufferEncoding from buffer module works properly
+{
+    const encoding: ImportedBufferEncoding = 'ascii';
+    const b = new ImportedBuffer('123', encoding);
     b.writeUInt8(0, 6);
 }
 

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -113,7 +113,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -216,6 +216,9 @@ declare module 'buffer' {
     // the copy below in a Node environment.
     type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding =
             | 'ascii'

--- a/types/node/v16/buffer.d.ts
+++ b/types/node/v16/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/v16/buffer.d.ts
+++ b/types/node/v16/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -167,6 +167,9 @@ declare module 'buffer' {
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
         type WithImplicitCoercion<T> =

--- a/types/node/v16/buffer.d.ts
+++ b/types/node/v16/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/v16/ts4.8/buffer.d.ts
+++ b/types/node/v16/ts4.8/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/v16/ts4.8/buffer.d.ts
+++ b/types/node/v16/ts4.8/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -167,6 +167,9 @@ declare module 'buffer' {
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
         type WithImplicitCoercion<T> =

--- a/types/node/v16/ts4.8/buffer.d.ts
+++ b/types/node/v16/ts4.8/buffer.d.ts
@@ -95,7 +95,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -202,6 +202,9 @@ declare module 'buffer' {
     // the copy below in a Node environment.
     type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding =
             | 'ascii'

--- a/types/node/v18/ts4.8/buffer.d.ts
+++ b/types/node/v18/ts4.8/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, BufferEncoding, BufferConstructor };
     /**
      * @experimental
      */

--- a/types/node/v18/ts4.8/buffer.d.ts
+++ b/types/node/v18/ts4.8/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding, BufferConstructor };
+    export { Buffer, BufferEncoding };
     /**
      * @experimental
      */

--- a/types/node/v18/ts4.8/buffer.d.ts
+++ b/types/node/v18/ts4.8/buffer.d.ts
@@ -97,7 +97,7 @@ declare module 'buffer' {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, BufferEncoding };
+    export { Buffer };
     /**
      * @experimental
      */
@@ -202,6 +202,9 @@ declare module 'buffer' {
     // the copy below in a Node environment.
     type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
+        namespace NodeJS {
+            export { BufferEncoding };
+        }
         // Buffer class
         type BufferEncoding =
             | 'ascii'


### PR DESCRIPTION
This change ~~exports `BufferEncoding` and `BufferConstructor` from `node:buffer`~~ adds a `NodeJS.BufferEncoding` type which is the same as the `BufferEncoding` global. The reason is because in Deno these Node.js global types (except `NodeJS`) are not accessible globally in Deno typescript code, so they need to be imported.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
