### PR TITLE
Dedupe dtslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "devDependencies": {
         "@definitelytyped/definitions-parser": "latest",
-        "@definitelytyped/dtslint": "^0.0.162",
+        "@definitelytyped/dtslint": "latest",
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/utils": "latest",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "devDependencies": {
         "@definitelytyped/definitions-parser": "latest",
-        "@definitelytyped/dtslint": "^0.0.161",
+        "@definitelytyped/dtslint": "^0.0.162",
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/utils": "latest",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "devDependencies": {
         "@definitelytyped/definitions-parser": "latest",
-        "@definitelytyped/dtslint": "^0.0.159",
+        "@definitelytyped/dtslint": "^0.0.161",
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/utils": "latest",


### PR DESCRIPTION
Tried to debug 
```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(minIdx >= 0)

    at range (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:261:3)
    at getLintConfig (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:239:28)
    at lint (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:40:18)
    at testTypesVersion (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/index.ts:233:15)
    at runTests (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/index.ts:197:7)
Error: Process completed with exit code 1.
```
in https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/5030923969/jobs/9023668157?pr=65135#step:6:1920

but that isn't fixed with this PR. Should still land it since it reduces install sizes.

```diff

 npm ls @definitelytyped/dtslint
 definitely-typed@0.0.3 /Users/sebastian.silbermann/DefinitelyTyped
 ├─┬ @definitelytyped/dtslint-runner@0.0.162
-│ └── @definitelytyped/dtslint@0.0.162
+│ └── @definitelytyped/dtslint@0.0.162 deduped
-└── @definitelytyped/dtslint@0.0.159
+└── @definitelytyped/dtslint@0.0.162
```

