### PR TITLE
[node-red__editor-client] Extended TypedInput List Options

### DIFF
--- a/types/node-red__editor-client/index.d.ts
+++ b/types/node-red__editor-client/index.d.ts
@@ -1680,7 +1680,7 @@ declare namespace editorClient {
         /** An icon to display in the type menu */
         icon?: string | undefined;
         /** If the type has a fixed set of values, this is an array of string options for the value. For example, ["true","false"] for the boolean type. */
-        options?: string[] | undefined;
+        options?: string[] | Array<{ value: string; label: string; }> | undefined;
         /** Set to false if there is no value associated with the type. */
         hasValue?: boolean | undefined;
         /** A function to validate the value for the type. */

--- a/types/node-red__editor-client/index.d.ts
+++ b/types/node-red__editor-client/index.d.ts
@@ -1680,7 +1680,7 @@ declare namespace editorClient {
         /** An icon to display in the type menu */
         icon?: string | undefined;
         /** If the type has a fixed set of values, this is an array of string options for the value. For example, ["true","false"] for the boolean type. */
-        options?: string[] | Array<{ value: string; label: string; }> | undefined;
+        options?: string[] | Array<{ value: string; label: string }> | undefined;
         /** Set to false if there is no value associated with the type. */
         hasValue?: boolean | undefined;
         /** A function to validate the value for the type. */

--- a/types/node-red__editor-client/node-red__editor-client-tests.ts
+++ b/types/node-red__editor-client/node-red__editor-client-tests.ts
@@ -323,12 +323,19 @@ function widgetTypedInputTests() {
         label: 'label',
         options: ['opt1', 'opt2'],
     };
+    const goodTypeListOptionsDef: editorClient.WidgetTypedInputTypeDefinition = {
+        value: 'mytype',
+        hasValue: false,
+        icon: 'icon',
+        label: 'label',
+        options: [{ value: 'val1', label: 'label1' }, { value: 'val2', label: 'label2' }],
+    };
     const wrongTypeDef: editorClient.WidgetTypedInputTypeDefinition = {
         // @ts-expect-error
         wrongKey: 'value',
     };
     $('#inputId').typedInput({
-        types: [goodType, wrongType, goodTypeDef, wrongTypeDef],
+        types: [goodType, wrongType, goodTypeDef, wrongTypeDef, goodTypeListOptionsDef],
     });
     $('#inputId').typedInput({
         types: ['msg', 'flow', 'global', 'str', 'num', 'bool', 'json', 'bin', 're', 'date', 'jsonata', 'env'],

--- a/types/node-red__editor-client/node-red__editor-client-tests.ts
+++ b/types/node-red__editor-client/node-red__editor-client-tests.ts
@@ -328,7 +328,10 @@ function widgetTypedInputTests() {
         hasValue: false,
         icon: 'icon',
         label: 'label',
-        options: [{ value: 'val1', label: 'label1' }, { value: 'val2', label: 'label2' }],
+        options: [
+            { value: 'val1', label: 'label1' },
+            { value: 'val2', label: 'label2' },
+        ],
     };
     const wrongTypeDef: editorClient.WidgetTypedInputTypeDefinition = {
         // @ts-expect-error


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  <https://nodered.org/docs/api/ui/typedInput/#examples>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.     @ofirsnb: It does not.


### Hello folks! 

Started to use the `node-red` types (thanks for that BTW :) ),   
found out that in the `TypedInput Widget`, there's an `options` prop,
which can **also** accept array of "list options",  as can be seen here:
![Screenshot 2023-05-21 at 21 43 54](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/20570295/55ef4f84-ebc9-436a-b9d4-cf18c737230e)


Currently `options` allows only `string[]`,   this PR allows also array of `{ value: string; label: string; }`, as per the documentation above.

Thanks again:)


