### PR TITLE
[@type/react-syntax-highlighter] add missing stackoverflow-dark and stackoverflow-light styles in styles/hljs

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -211,6 +211,8 @@ declare module 'react-syntax-highlighter/dist/esm/styles/hljs' {
     export { default as solarizedDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark';
     export { default as solarizedLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-light';
     export { default as srcery } from 'react-syntax-highlighter/dist/esm/styles/hljs/srcery';
+    export { default as stackoverflowDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark';
+    export { default as stackoverflowLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light';
     export { default as sunburst } from 'react-syntax-highlighter/dist/esm/styles/hljs/sunburst';
     export { default as tomorrowNightBlue } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-blue';
     export { default as tomorrowNightBright } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-bright';
@@ -640,6 +642,16 @@ declare module 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-light' {
 }
 
 declare module 'react-syntax-highlighter/dist/esm/styles/hljs/srcery' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light' {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
@@ -3168,6 +3180,8 @@ declare module 'react-syntax-highlighter/dist/cjs/styles/hljs' {
     export { default as solarizedDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-dark';
     export { default as solarizedLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light';
     export { default as srcery } from 'react-syntax-highlighter/dist/cjs/styles/hljs/srcery';
+    export { default as stackoverflowDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark';
+    export { default as stackoverflowLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light';
     export { default as sunburst } from 'react-syntax-highlighter/dist/cjs/styles/hljs/sunburst';
     export { default as tomorrowNightBlue } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-blue';
     export { default as tomorrowNightBright } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-bright';
@@ -3597,6 +3611,16 @@ declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light' {
 }
 
 declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/srcery' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light' {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [stackoverflow-dark](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/hljs/stackoverflow-dark.js)
- [stackoverflow-light](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/hljs/stackoverflow-light.js)
