### PR TITLE
Narrow function type of ESLint.IPlugin.rules

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -308,6 +308,31 @@ reference.isReadWrite();
 
 //#region Rule
 
+let mixedRule: Rule.OldStyleRule | Rule.RuleModule;
+
+mixedRule = {
+    create(context) {
+        return {};
+    },
+};
+
+mixedRule = (context) => ({});
+
+let oldStyleRule: Rule.OldStyleRule;
+
+oldStyleRule = (context) => ({});
+
+// @ts-expect-error
+oldStyleRule.schema = [];
+// @ts-expect-error
+oldStyleRule.schema = {};
+
+// @ts-expect-error
+oldStyleRule.meta = {};
+
+// @ts-expect-error
+oldStyleRule.create = (context) => ({});
+
 let rule: Rule.RuleModule;
 
 rule = {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -432,6 +432,10 @@ export namespace SourceCode {
 //#endregion
 
 export namespace Rule {
+    /**
+     * TODO: Old style rules are planned to be removed in v9, remove this type then (https://github.com/eslint/rfcs/blob/main/designs/2021-schema-object-rules/README.md)
+     * @deprecated Use `RuleModule` instead.
+     */
     type OldStyleRule = RuleModule["create"];
 
     interface RuleModule {
@@ -658,6 +662,7 @@ export namespace Rule {
         /**
          * Specifies the [options](https://eslint.org/docs/latest/developer-guide/working-with-rules#options-schemas)
          * so ESLint can prevent invalid [rule configurations](https://eslint.org/docs/latest/user-guide/configuring/rules#configuring-rules).
+         * TODO: schema is potentially planned to be no longer be optional in v9 (https://github.com/eslint/rfcs/blob/main/designs/2021-schema-object-rules/README.md)
          */
         schema?: JSONSchema4 | JSONSchema4[] | undefined;
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -435,6 +435,7 @@ export namespace Rule {
     interface RuleModule {
         create(context: RuleContext): RuleListener;
         meta?: RuleMetaData | undefined;
+        schema?: RuleMetaData["schema"];
     }
 
     type NodeTypes = ESTree.Node["type"];

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -432,6 +432,8 @@ export namespace SourceCode {
 //#endregion
 
 export namespace Rule {
+    type OldStyleRule = RuleModule["create"];
+
     interface RuleModule {
         create(context: RuleContext): RuleListener;
         meta?: RuleMetaData | undefined;
@@ -1049,7 +1051,7 @@ export namespace ESLint {
         configs?: Record<string, ConfigData> | undefined;
         environments?: Record<string, Environment> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;
-        rules?: Record<string, ((...args: any[]) => any) | Rule.RuleModule> | undefined;
+        rules?: Record<string, Rule.OldStyleRule | Rule.RuleModule> | undefined;
     }
 
     interface Options {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Following up on #60595, ESLint expects a more specific function shape - the old style of declaring plugins had what is now the `create` function being set as the plugin itself, with the plugin metadata hanging off the function, as documented [here](https://github.com/eslint/eslint/blob/v1.0.0/docs/developer-guide/working-with-rules.md#working-with-rules). ESLint will still accept this old style of plugin creation for backwards compatibility purposes by [normalizing](https://github.com/eslint/eslint/blob/37432f27dc15817d66cf42377792197dc2aeb8b2/lib/config/flat-config-helpers.js#L59) to `{ create: pluginFunc }`, eliminating any metadata.
