### PR TITLE
Require TS 5.1 for next-pwa

### DIFF
--- a/types/next-pwa/index.d.ts
+++ b/types/next-pwa/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/shadowwalker/next-pwa#readme
 // Definitions by: Nivaldo Farias <https://github.com/NivaldoFarias>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.5
+// Minimum TypeScript Version: 5.1
 
 /// <reference types="react"/>
 


### PR DESCRIPTION
This is a requirement relevant mainly for testing on DT; DT uses `typeRoots` to redirect packages like react to `@types/react`. But versions previous to 5.1 had a triple-slash resolution bug when typeRoots was set [that was only fixed in
5.1](https://github.com/microsoft/TypeScript/pull/51715).

The triple-slash references occur in `next`; the main reason they haven't got a bug report about it is that, I believe, few people use `typeRoots`.

An alternative fix is to move react/experimental.d.ts to react/experimental/index.d.ts (and the same for react-dom), but I doubt this bug affects anybody but people who need to change next-pwa on DT, so I think it's easier to change next-pwa instead.