### PR TITLE
[react] Add support for legacy context in JSXElementConstructor 

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -77,6 +77,13 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement<any, any> | null)
+        | ((
+              props: P,
+              /**
+               * @deprecated https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-stateless-function-components
+               */
+              deprecatedLegacyContext: any,
+          ) => ReactElement<any, any> | null)
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -76,13 +76,12 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
-        | ((props: P) => ReactElement<any, any> | null)
         | ((
               props: P,
               /**
                * @deprecated https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-stateless-function-components
                */
-              deprecatedLegacyContext: any,
+              deprecatedLegacyContext?: any,
           ) => ReactElement<any, any> | null)
         | (new (props: P) => Component<any, any>);
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -812,6 +812,12 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     Wrapper = (props: ExactProps) => null;
     Wrapper = class Wider extends React.Component<WiderProps> {};
     Wrapper = (props: WiderProps) => null;
+    Wrapper = (props, legacyContext) => {
+        // $ExpectType any
+        legacyContext;
+        return null;
+    };
+    Wrapper = (props, legacyContext: { foo: number }) => null;
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -684,6 +684,15 @@ function elementTypeTests() {
         }
     }
 
+    const ReturnWithLegacyContext = (props: { foo: string }, context: { bar: number }) => {
+        return (
+            <div>
+                foo: {props.foo}, bar: {context.bar}
+            </div>
+        );
+    };
+    const FCWithLegacyContext: React.FC<{ foo: string }> = ReturnWithLegacyContext;
+
     // Desired behavior.
     // @ts-expect-error
     <ReturnVoid />;
@@ -764,6 +773,9 @@ function elementTypeTests() {
     <RenderPromise />;
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(RenderPromise);
+
+    <ReturnWithLegacyContext foo="one" />;
+    React.createElement(ReturnWithLegacyContext, {foo: 'one'});
 }
 
 function managingRefs() {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -44,13 +44,12 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
-        | ((props: P) => ReactElement<any, any> | null)
         | ((
               props: P,
               /**
                * @deprecated https://legacy.react/ts5.0js.org/docs/legacy-context.html#referencing-context-in-stateless-function-components
                */
-              deprecatedLegacyContext: any,
+              deprecatedLegacyContext?: any,
           ) => ReactElement<any, any> | null)
         | (new (props: P) => Component<any, any>);
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -45,6 +45,13 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement<any, any> | null)
+        | ((
+              props: P,
+              /**
+               * @deprecated https://legacy.react/ts5.0js.org/docs/legacy-context.html#referencing-context-in-stateless-function-components
+               */
+              deprecatedLegacyContext: any,
+          ) => ReactElement<any, any> | null)
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -812,6 +812,12 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     Wrapper = (props: ExactProps) => null;
     Wrapper = class Wider extends React.Component<WiderProps> {};
     Wrapper = (props: WiderProps) => null;
+    Wrapper = (props, legacyContext) => {
+        // $ExpectType any
+        legacyContext;
+        return null;
+    };
+    Wrapper = (props, legacyContext: { foo: number }) => null;
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -684,6 +684,15 @@ function elementTypeTests() {
         }
     }
 
+    const ReturnWithLegacyContext = (props: { foo: string }, context: { bar: number }) => {
+        return (
+            <div>
+                foo: {props.foo}, bar: {context.bar}
+            </div>
+        );
+    };
+    const FCWithLegacyContext: React.FC<{ foo: string }> = ReturnWithLegacyContext;
+
     // Desired behavior.
     // @ts-expect-error
     <ReturnVoid />;
@@ -764,6 +773,9 @@ function elementTypeTests() {
     <RenderPromise />;
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(RenderPromise);
+
+    <ReturnWithLegacyContext foo="one" />;
+    React.createElement(ReturnWithLegacyContext, {foo: 'one'});
 }
 
 function managingRefs() {


### PR DESCRIPTION
This matches how we type `FunctionComponent` today.
We need support for legacy context in `JSX.ElementType` anyway (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135#issuecomment-1556547411)
and `React.JSXElementConstructor` is the designated type for `JSX.ElementType