### PR TITLE
[oojs-ui] TagMultiselectWidget: cfg `placeholder`

### DIFF
--- a/types/oojs-ui/TagMultiselectWidget.d.ts
+++ b/types/oojs-ui/TagMultiselectWidget.d.ts
@@ -69,6 +69,11 @@ declare namespace OO.ui {
              */
             inputPosition?: 'inline' | 'outline' | 'none';
 
+            /**
+             * Placeholder text for the input box
+             */
+            placeholder?: string;
+
             /** Allow editing of the tags by clicking them */
             allowEditTags?: boolean;
 

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -2256,6 +2256,7 @@
 
     const instance = new OO.ui.MenuTagMultiselectWidget({
         inputPosition: 'outline',
+        placeholder: 'I am placeholder text!',
         options: [
             { data: 'option1', label: 'Option 1', icon: 'tag' },
             { data: 'option2', label: 'Option 2' },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://w.wiki/6k2r>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *(skipped)*

----

Add the previously-undocumented `placeholder` config option for TagMultiselectWidget. The `placeholder` config option is used to add placeholder text to the underlying TextInputWidget.

Parallel change to oojs-ui docs can be found at https://w.wiki/6k2r.