### PR TITLE
expressjs_multer/support-for-unicode-headers

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -218,6 +218,9 @@ declare namespace multer {
         } | undefined;
         /** Preserve the full path of the original filename rather than the basename. (Default: false) */
         preservePath?: boolean | undefined;
+        /** For multipart forms, the default character set to use for values of part header parameters (e.g. filename)
+         * that are not extended parameters (that contain an explicit charset). (Default: latin1) */
+        defParamCharset?: string | undefined;
         /**
          * Optional function to control which files are uploaded. This is called
          * for every file that is processed.

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -218,8 +218,11 @@ declare namespace multer {
         } | undefined;
         /** Preserve the full path of the original filename rather than the basename. (Default: false) */
         preservePath?: boolean | undefined;
-        /** For multipart forms, the default character set to use for values of part header parameters (e.g. filename)
-         * that are not extended parameters (that contain an explicit charset). (Default: latin1) */
+        /**
+         * For multipart forms, the default character set to use for values of
+         * part header parameters (e.g. filename) that are not extended
+         * parameters (that contain an explicit charset). (Default: latin1)
+         */
         defParamCharset?: string | undefined;
         /**
          * Optional function to control which files are uploaded. This is called


### PR DESCRIPTION
[ExpressJS Multer](https://github.com/expressjs/multer) `multer.Options` update for `defParamCharset` field
Supports unicode in requests headers such as `filename`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[PR](https://github.com/expressjs/multer/pull/1210/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R144)>
