### PR TITLE
[chrome-remote-interface] support opt `sessionId` param of commands

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -22,11 +22,14 @@ function assertType<T>(value: T): T {
         const { Network, Page, Runtime } = client;
         await Network.enable();
         await Network.enable({});
+        await Network.enable({}, 'sessionId'); // Should be Network.enable('sessionId')
         // @ts-expect-error
         await Network.setAcceptedEncodings();
         await Network.setAcceptedEncodings({encodings: []});
         await Page.enable();
         await Page.navigate({ url: 'https://github.com' });
+        await client.Runtime.runIfWaitingForDebugger('sessionId');
+        await client.Fetch.enable({patterns: []}, 'sessionId');
         let loadEvent = await Page.loadEventFired();
         loadEvent = await client['Page.loadEventFired']();
         loadEvent.timestamp;

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Khairul Azhar Kasmiran <https://github.com/kazarmy>
 //                 Seth Westphal <https://github.com/westy92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.9
+// Minimum TypeScript Version: 4.0
 
 import type ProtocolProxyApi from 'devtools-protocol/types/protocol-proxy-api';
 import type ProtocolMappingApi from 'devtools-protocol/types/protocol-mapping';
@@ -182,7 +182,15 @@ declare namespace CDP {
             T[key]
     };
 
-    type ImproveAPI<T> = {[key in keyof T]: DoEventObj<key> & OptIfParamNullable<T[key]>};
+    type AddOptParams<T> = {
+        [key in keyof T]: key extends 'on' ?
+            T[key] :
+            T[key] extends (...args: infer P) => infer R ?
+                (...args: [...curArgs: P, sessionId?: string]) => R :
+                T[key];
+    };
+
+    type ImproveAPI<T> = {[key in keyof T]: DoEventObj<key> & AddOptParams<OptIfParamNullable<T[key]>>};
     interface StableDomains {
         Browser: ProtocolProxyApi.BrowserApi;
         Debugger: ProtocolProxyApi.DebuggerApi;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface/issues/534#issue-1719863807
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Fixes cyrus-and/chrome-remote-interface#534. The minimum TypeScript version was bumped to 4.0 since this PR uses [labeled tuple elements](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements).