### PR TITLE
[imap-simple] expose imap field type

### DIFF
--- a/types/imap-simple/imap-simple-tests.ts
+++ b/types/imap-simple/imap-simple-tests.ts
@@ -117,6 +117,7 @@ imaps.connect(config).then(connection => {
 
 imaps.connect(config).then(function (connection) {
     connection.openBox('INBOX').then(function () {
+        console.log("Connection state:", connection.imap.state);
         const searchCriteria = ['ALL'];
         const fetchOptions = { bodies: ['TEXT'], struct: true };
         return connection.search(searchCriteria, fetchOptions);

--- a/types/imap-simple/index.d.ts
+++ b/types/imap-simple/index.d.ts
@@ -39,6 +39,9 @@ export interface Message {
 
 export class ImapSimple extends EventEmitter {
     constructor(imap: Imap);
+    
+    /** Access underlying `node-imap` instance */
+    imap: Imap; // https://github.com/chadxz/imap-simple/blob/master/lib/imapSimple.js#L22
 
     /** Open a mailbox, calling the provided callback with signature (err, boxName), or resolves the returned promise with boxName. */
     openBox(boxName: string, callback: (err: Error, boxName: string) => void): void;

--- a/types/imap-simple/index.d.ts
+++ b/types/imap-simple/index.d.ts
@@ -39,7 +39,7 @@ export interface Message {
 
 export class ImapSimple extends EventEmitter {
     constructor(imap: Imap);
-    
+
     /** Access underlying `node-imap` instance */
     imap: Imap; // https://github.com/chadxz/imap-simple/blob/master/lib/imapSimple.js#L22
 


### PR DESCRIPTION
imap-simple allows to access the underlying `node-imap` instance, but the types were not including it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/chadxz/imap-simple/blob/master/README.md?plain=1#L258)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

