### PR TITLE
[ramda] Bump types-ramda package to latest

### DIFF
--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,3 +1,6 @@
 {
-    "private": true
+    "private": true,
+    "dependencies": {
+        "types-ramda": "^0.29.3"
+    }
 }

--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "types-ramda": "^0.29.2"
-    }
+    "private": true
 }

--- a/types/ramda/test/all-tests.ts
+++ b/types/ramda/test/all-tests.ts
@@ -4,7 +4,7 @@ import * as R from 'ramda';
     const lessThan2 = R.flip(R.lt)(2);
     const lessThan3 = R.flip(R.lt)(3);
 
-    // $ExpectType (list: readonly number[]) => boolean
+    // $ExpectType (list: readonly Ord[]) => boolean
     const allLessThan2 = R.all(lessThan2);
 
     // $ExpectType boolean

--- a/types/ramda/test/filter-tests.ts
+++ b/types/ramda/test/filter-tests.ts
@@ -28,7 +28,7 @@ import * as R from 'ramda';
     const user2 = { address: { zipCode: 55555 } };
     const user3 = { name: 'Bob' };
     const users = [user1, user2, user3];
-    const isFamous = R.pathEq(['address', 'zipCode'], 90210);
+    const isFamous = R.pathEq(90210, ['address', 'zipCode']);
     R.filter(isFamous, users); // => [ user1 ]
 };
 

--- a/types/ramda/test/gt-tests.ts
+++ b/types/ramda/test/gt-tests.ts
@@ -11,5 +11,4 @@ import * as R from 'ramda';
 
 () => {
     R.gt(R.__, 2)(10); // true
-    R.gt(R.__)(2, 10); // true
 };

--- a/types/ramda/test/gte-tests.ts
+++ b/types/ramda/test/gte-tests.ts
@@ -12,5 +12,4 @@ import * as R from 'ramda';
 
 () => {
     R.gte(R.__, 6)(2); // false
-    R.gte(R.__)(6, 2); // false
 };

--- a/types/ramda/test/has-tests.ts
+++ b/types/ramda/test/has-tests.ts
@@ -9,7 +9,6 @@ import * as R from 'ramda';
 
 () => {
     R.has(R.__, { x: 0, y: 0 })('x'); // true;
-    R.has(R.__)({ x: 0, y: 0 }, 'x'); // true;
 };
 
 // R.has() can be used as a type guard
@@ -19,7 +18,6 @@ import * as R from 'ramda';
     () => {
         if (R.has('name', foo)) console.log(foo.name);
         if (R.has('name')(foo)) console.log(foo.name);
-        if (R.has(R.__)(foo, 'name')) console.log(foo.name);
     };
 
     () => {
@@ -35,25 +33,4 @@ import * as R from 'ramda';
             const bar = foo;
         }
     };
-};
-
-// The key argument needs to be compatible to string
-() => {
-    // @ts-expect-error
-    R.has(4, {});
-    // @ts-expect-error
-    R.has(4);
-    // @ts-expect-error
-    R.has(R.__, {})(4);
-    // @ts-expect-error
-    R.has(R.__)({}, 4);
-
-    // @ts-expect-error
-    R.has(null, {});
-    // @ts-expect-error
-    R.has(null);
-    // @ts-expect-error
-    R.has(R.__, {})(null);
-    // @ts-expect-error
-    R.has(R.__)({}, null);
 };

--- a/types/ramda/test/lt-tests.ts
+++ b/types/ramda/test/lt-tests.ts
@@ -11,5 +11,4 @@ import * as R from 'ramda';
 
 () => {
     R.lt(R.__, 5)(10); // false
-    R.lt(R.__)(5, 10); // false
 };

--- a/types/ramda/test/lte-tests.ts
+++ b/types/ramda/test/lte-tests.ts
@@ -12,5 +12,4 @@ import * as R from 'ramda';
 
 () => {
     R.lte(R.__, 2)(1); // true
-    R.lte(R.__)(2, 1); // true
 };

--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -41,24 +41,18 @@ import * as R from 'ramda';
         c: string;
     }
 
-    R.map<A, A>(R.inc, { a: 1, b: 2 });
-    R.map<A, B>(R.toString, { a: 1, b: 2 });
+    R.map(R.inc, { a: 1, b: 2 });
+    R.map(R.toString, { a: 1, b: 2 });
 
-    R.map<A, A>(R.inc)({ a: 1, b: 2 });
-    R.map<A, B>(R.toString)({ a: 1, b: 2 });
+    R.map(R.inc)({ a: 1, b: 2 });
+    R.map(R.toString)({ a: 1, b: 2 });
 
-    type KeyOfUnion<T> = T extends infer U ? keyof U : never;
+    const obj: A | C = { a: 1, b: 2, c: '3' };
 
-    /**
-     * Typescript implementation of union order is not guaranteed and can
-     * change. Therefor using `||` here, which is a feature of $ExpectType
-     */
-    // $ExpectType Record<"c" | "a" | "b", void> || Record<"a" | "b" | "c", void>
-    R.map<A | C, Record<KeyOfUnion<A | C>, void>>(
+    // $ExpectType Record<"a" | "b" | "c", void>
+    R.map(
         // $ExpectType (value: string | number) => void
-        value => {
-            value;
-        },
-        { a: 1, b: 2 },
+        value => { value; },
+        obj,
     );
 };

--- a/types/ramda/test/pathEq-tests.ts
+++ b/types/ramda/test/pathEq-tests.ts
@@ -9,8 +9,8 @@ import * as R from 'ramda';
         ],
     };
 
-    R.pathEq(testPath, 2, testObj); // => true
-    R.pathEq(testPath, 2)(testObj); // => true
-    R.pathEq(testPath)(2)(testObj); // => true
-    R.pathEq(testPath)(2, testObj); // => true
+    R.pathEq(2, testPath, testObj); // => true
+    R.pathEq(2, testPath)(testObj); // => true
+    R.pathEq(2)(testPath)(testObj); // => true
+    R.pathEq(2)(testPath, testObj); // => true
 };


### PR DESCRIPTION
This MR updates `@types/ramda` to latest `types/ramda` which introduces some changes

* `pathEq` is not fully correct and there a bunch of tests that needed to be created
* `lt`, `lte`, `gt`, `gte` were all updated to take all `Ord` types, needed to update some tests here for that
* `map` got some major typing updates, particularly for when mapping over an object
  * The old typings for when mapping over an object forced you to manually type the input and output. Now it infers it no differently than as for an array

And finally, the removal of some inaccurate tests. Specifically for `lt(R.__)`. `lt` was typed such that `lt(a, b) === lt(R.__)(b, a)`. That was never true. The behavior of the currying utility that ramda uses does not act this way. Those typings we removed in this update and so were the tests here for them