### PR TITLE
Fix convert() function signatures on Carbone (carbone.io) types

### DIFF
--- a/types/carbone/carbone-tests.ts
+++ b/types/carbone/carbone-tests.ts
@@ -135,3 +135,10 @@ carbone.renderXML('<xml>', data, (err, result: Buffer | string) => {});
 
 carbone.convert(buffer, {convertTo, extension: 'docx'}, (err, result: Buffer) => {});
 carbone.convert(buffer, {extension: 'docx'}, (err, result: Buffer) => {});
+
+// Encoded filenames are <prefix><22-random-chars><encodedReportName.extension>
+carbone.decodeRenderedFilename("./0000000000000000000000template.odf");
+// This is with prefix length of 2
+carbone.decodeRenderedFilename("./ab0000000000000000000000template.odf", 2);
+
+carbone.getFileExtension("./template.odf", (err, extension) => {})

--- a/types/carbone/carbone-tests.ts
+++ b/types/carbone/carbone-tests.ts
@@ -133,5 +133,5 @@ carbone.render('./template.odf', data, (err, result: Buffer | string, reportName
 carbone.renderXML('<xml>', data, renderXMLOptions, (err, result: Buffer | string) => {});
 carbone.renderXML('<xml>', data, (err, result: Buffer | string) => {});
 
-carbone.convert(buffer, 'pdf', {}, (err, result: Buffer) => {});
-carbone.convert(buffer, 'pdf', (err, result: Buffer) => {});
+carbone.convert(buffer, {convertTo, extension: 'docx'}, (err, result: Buffer) => {});
+carbone.convert(buffer, {extension: 'docx'}, (err, result: Buffer) => {});

--- a/types/carbone/carbone-tests.ts
+++ b/types/carbone/carbone-tests.ts
@@ -141,4 +141,4 @@ carbone.decodeRenderedFilename("./0000000000000000000000template.odf");
 // This is with prefix length of 2
 carbone.decodeRenderedFilename("./ab0000000000000000000000template.odf", 2);
 
-carbone.getFileExtension("./template.odf", (err, extension) => {})
+carbone.getFileExtension("./template.odf", (err, extension) => {});

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -96,3 +96,12 @@ export function render(templatePath: string, data: object, callback: RenderCallb
 
 export type ConvertCallback = (err: NodeJS.ErrnoException | null, result: Buffer) => void;
 export function convert(data: Buffer, options: RenderOptions & { extension: string }, callback: ConvertCallback): void;
+
+export interface DecodedFilenameResult {
+    reportName: string;
+    extension: string;
+}
+export function decodeRenderedFilename(pathOrFilename: string, prefixLength: int = 0): DecodedFilenameResult;
+
+export type GetFileExtensionCallback = (err: NodeJS.ErrnoException | null, extension: string) => void;
+export function getFileExtension(filePath: string, callback: GetFileExtensionCallback);

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -95,5 +95,5 @@ export function render(templatePath: string, data: object, options: RenderOption
 export function render(templatePath: string, data: object, callback: RenderCallback): void;
 
 export type ConvertCallback = (err: NodeJS.ErrnoException | null, result: Buffer) => void;
-export function convert(data: Buffer, convertTo: string, options: object, callback: ConvertCallback): void;
-export function convert(data: Buffer, convertTo: string, callback: ConvertCallback): void;
+export function convert(data: Buffer, callback: ConvertCallback): void;
+export function convert(data: Buffer, options: RenderOptions & { extension: string }, callback: ConvertCallback): void;

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -101,7 +101,7 @@ export interface DecodedFilenameResult {
     reportName: string;
     extension: string;
 }
-export function decodeRenderedFilename(pathOrFilename: string, prefixLength: int = 0): DecodedFilenameResult;
+export function decodeRenderedFilename(pathOrFilename: string, prefixLength: number): DecodedFilenameResult;
 
 export type GetFileExtensionCallback = (err: NodeJS.ErrnoException | null, extension: string) => void;
-export function getFileExtension(filePath: string, callback: GetFileExtensionCallback);
+export function getFileExtension(filePath: string, callback: GetFileExtensionCallback): void;

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -101,7 +101,7 @@ export interface DecodedFilenameResult {
     reportName: string;
     extension: string;
 }
-export function decodeRenderedFilename(pathOrFilename: string, prefixLength: number): DecodedFilenameResult;
+export function decodeRenderedFilename(pathOrFilename: string, prefixLength?: number): DecodedFilenameResult;
 
 export type GetFileExtensionCallback = (err: NodeJS.ErrnoException | null, extension: string) => void;
 export function getFileExtension(filePath: string, callback: GetFileExtensionCallback): void;

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -95,5 +95,4 @@ export function render(templatePath: string, data: object, options: RenderOption
 export function render(templatePath: string, data: object, callback: RenderCallback): void;
 
 export type ConvertCallback = (err: NodeJS.ErrnoException | null, result: Buffer) => void;
-export function convert(data: Buffer, callback: ConvertCallback): void;
 export function convert(data: Buffer, options: RenderOptions & { extension: string }, callback: ConvertCallback): void;


### PR DESCRIPTION
Removes convertTo parameter on convert() functions
API change happened on [Carbone commit bb858ce](https://github.com/carboneio/carbone/commit/bb858ceee5a30cfa7f136522dd3d7d9e12128fbe), Dec 6, 2020, released on tag 3.1.0

Also adds typings to the `decodeRenderedFilename` and `getFileExtension` functions, because they were requested by the Danger bot

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/carboneio/carbone/commit/bb858ceee5a30cfa7f136522dd3d7d9e12128fbe> (near the end of the extended commit message)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
