### PR TITLE
Fix identifier typo in nova-editor-node

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package nova-editor-node 4.1
+// Type definitions for non-npm package nova-editor-node 5.0
 // Project: https://docs.nova.app/api-reference/
 // Definitions by: Cameron Little <https://github.com/apexskier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -31,7 +31,7 @@ interface AssistantsRegistry {
         object: IssueAssistant,
         options?: { event: 'onChange' | 'onSave' },
     ): Disposable;
-    registerTaskAssistant(object: TaskAssistant, options?: { identifer: string; name: string }): Disposable;
+    registerTaskAssistant(object: TaskAssistant, options?: { identifier: string; name: string }): Disposable;
 }
 
 type AssistantArray<T> = ReadonlyArray<T> | Promise<ReadonlyArray<T>>;

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -475,3 +475,9 @@ nova.config.observe('apexskier.testConfig', (newValue: string, oldValue: string)
     // $ExpectType undefined
     this;
 });
+
+const tasks: TaskAssistant = { provideTasks: () => [] };
+nova.assistants.registerTaskAssistant(tasks, {
+    identifier: 'com.my-command',
+    name: 'My command',
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.nova.app/api-reference/assistants-registry/#registertaskassistantobject-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The assistant registry's `registerTaskAssistant` takes an `options` parameter. The option keys are `identifier` and `name`. The types here misspelled `identifier` as `identifer`. Who among us has not typed a technical word incorrectly from time to time? This fixes that spelling.

Because this changes a key that others may be using, it seems like a breaking change, so I bumped the version to 5.0.

https://docs.nova.app/api-reference/assistants-registry/#registertaskassistantobject-options