### PR TITLE
[prettier] Add `preprocess` to Printer interface

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -9,6 +9,7 @@
 //                 Georgii Dolzhykov <https://github.com/thorn0>
 //                 JounQin <https://github.com/JounQin>
 //                 Chuah Chee Shian <https://github.com/shian15810>
+//                 Marc Gibbons <https://github.com/marcgibbons>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.2
 
@@ -383,6 +384,7 @@ export interface Printer<T = any> {
               options: ParserOptions<T>,
           ) => Doc | null)
         | undefined;
+    preprocess?: ((ast: AST, options: ParserOptions<T>) => AST) | undefined;
     insertPragma?: ((text: string) => string) | undefined;
     /**
      * @returns `null` if you want to remove this node

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -156,6 +156,10 @@ const plugin: prettier.Plugin<PluginAST> = {
                 const comment = commentPath.getValue();
                 return comment.value;
             },
+            preprocess(ast, options) {
+                ast; // $ExpectType any
+                options; // $ExpectType ParserOptions<PluginAST>
+            }
         },
     },
     options: {


### PR DESCRIPTION
`preprocess` is not defined on the interface but is used and documented.

Ref: https://github.com/prettier/prettier/blob/2.8.8/docs/plugins.md#the-printing-process

`options: object` in practice is `options: ParserOptions`, like other methods.

This appears to be changing slightly in 3.0.0 alpha
Ref: https://github.com/prettier/prettier/blob/3.0.0-alpha.6/docs/plugins.md#the-printing-process

--- 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/blob/2.8.8/docs/plugins.md#the-printing-process)

Other ref: https://github.com/prettier/prettier/issues/12683
