### PR TITLE
[phoenix | absinthe__socket] Update `Socket` types

### DIFF
--- a/types/absinthe__socket/tsconfig.json
+++ b/types/absinthe__socket/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": [
+            "es6",
+            "dom"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -77,10 +77,10 @@ export class Socket {
   log(kind: string, message: string, data: any): void;
   hasLogger(): boolean;
 
-  onOpen(callback: (cb: any) => void | Promise<void>): MessageRef;
-  onClose(callback: (cb: any) => void | Promise<void>): MessageRef;
-  onError(callback: (cb: any) => void | Promise<void>): MessageRef;
-  onMessage(callback: (cb: any) => void | Promise<void>): MessageRef;
+  onOpen(callback: () => void | Promise<void>): MessageRef;
+  onClose(callback: (event: CloseEvent) => void | Promise<void>): MessageRef;
+  onError(callback: (error: Event | string | number, transport: new (endpoint: string) => object, establishedConnections: number) => void | Promise<void>): MessageRef;
+  onMessage(callback: (message: object) => void | Promise<void>): MessageRef;
 
   makeRef(): MessageRef;
   off(refs: MessageRef[]): void;

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -68,6 +68,7 @@ export class Socket {
   disconnect(callback?: () => void | Promise<void>, code?: number, reason?: string): void;
   connectionState(): ConnectionState;
   isConnected(): boolean;
+  replaceTransport(transport: new (endpoint: string) => object): void;
 
   remove(channel: Channel): void;
   channel(topic: string, chanParams?: object): Channel;

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for phoenix 1.5
+// Type definitions for phoenix 1.6
 // Project: https://github.com/phoenixframework/phoenix
 // Definitions by: Mirosław Ciastek <https://github.com/mciastek>
 //                 John Goff <https://github.com/John-Goff>


### PR DESCRIPTION
# Context

`replaceTransport` is a method that was introduced in 1.6 as a way to facilitate fallbacks to long polling in the Phoenix JS library (please, take a look at [this discussion](https://github.com/phoenixframework/phoenix/issues/2914)). However, types were never updated in order to support this new method.
- Note that for the transport parameter I'm using `transport: new (endpoint: string) => object` since it was recommended by @princemaple in a previous PR (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56184#pullrequestreview-770799737)

Regarding event handlers (`onOpen`, `onClose`, etc.), their types are not updated as well. I'm updating them to match 1.6.
- Note that I had to update the `absinthe__package` to add the `dom` library because otherwise I wouldn't be able to use interfaces like `Event` or `CloseEvent`.

To validate type changes, please take a look at the [`socket.js` file](https://github.com/phoenixframework/phoenix/blob/v1.6.0/assets/js/phoenix/socket.js).

# Concerns

- Seems like `@types/phoenix` maintenance is not tied to the actual Phoenix library. A common pattern I've seen is that the type library version should match the library version that it supports, but seems like this is not the case. Types are not updated often enough but I still wonder what would be the best way of handling this since I'm jumping to 1.6 already.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/phoenixframework/phoenix/blob/v1.6.0/assets/js/phoenix/socket.js.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.