### PR TITLE
Update @babel/traverse: new version of @babel/types

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -79,7 +79,7 @@ const v1: Visitor = {
         if (path.isReferencedIdentifier()) {
             // ...
         }
-        if (t.isQualifiedTypeIdentifier(path.node, path.parent)) {
+        if (t.isQualifiedTypeIdentifier(path.node)) {
             // ...
         }
     },

--- a/types/babel__traverse/ts4.3/babel__traverse-tests.ts
+++ b/types/babel__traverse/ts4.3/babel__traverse-tests.ts
@@ -79,7 +79,7 @@ const v1: Visitor = {
         if (path.isReferencedIdentifier()) {
             // ...
         }
-        if (t.isQualifiedTypeIdentifier(path.node, path.parent)) {
+        if (t.isQualifiedTypeIdentifier(path.node)) {
             // ...
         }
     },


### PR DESCRIPTION
The tests need to update because isQualifiedTypeIdentifier no longer requires a parent node.