### PR TITLE
AlpineJS: Fix types for custom directives

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -6,7 +6,7 @@
  * are not intended as functional tests.
  */
 
-import Alpine, { AlpineComponent } from 'alpinejs';
+import Alpine, { AlpineComponent, DirectiveParameters, DirectiveUtilities } from 'alpinejs';
 import { reactive, effect, stop, toRaw } from '@vue/reactivity';
 
 { // Alpine.reactive
@@ -87,7 +87,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
             expression;
             // $ExpectType string[]
             modifiers;
-            // $ExpectType () => void
+            // $ExpectType (cb: () => void) => void
             effect;
             // $ExpectType (expression: string) => (result: unknown) => void
             evaluateLater;
@@ -281,11 +281,28 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         expression;
         // $ExpectType Alpine
         Alpine;
-        // $ExpectType () => void
+        // $ExpectType (cb: () => void) => void
         effect;
-        // $ExpectType () => void
+        // $ExpectType (cb: () => void) => void
         cleanup;
     });
+
+    (el: Node, { value, modifiers, expression }: DirectiveParameters, { Alpine, effect, cleanup }: DirectiveUtilities) => {
+      // $ExpectType Node
+      el;
+      // $ExpectType string
+      value;
+      // $ExpectType string[]
+      modifiers;
+      // $ExpectType string
+      expression;
+      // $ExpectType Alpine
+      Alpine;
+      // $ExpectType (cb: () => void) => void
+      effect;
+      // $ExpectType (cb: () => void) => void
+      cleanup;
+  };
 }
 
 { // Alpine.throttle

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -35,8 +35,8 @@ type XData = XDataContext | string | number | boolean;
 
 export interface DirectiveUtilities {
     Alpine: Alpine;
-    effect: () => void;
-    cleanup: () => void;
+    effect: (cb: () => void) => void;
+    cleanup: (cb: () => void) => void;
     evaluate: (expression: string) => unknown;
     evaluateLater: (expression: string) => (result: unknown) => void;
 }

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -33,14 +33,14 @@ interface XDataContext {
 }
 type XData = XDataContext | string | number | boolean;
 
-interface DirectiveUtilities {
+export interface DirectiveUtilities {
     Alpine: Alpine;
     effect: () => void;
     cleanup: () => void;
     evaluate: (expression: string) => unknown;
     evaluateLater: (expression: string) => (result: unknown) => void;
 }
-interface DirectiveParameters {
+export interface DirectiveParameters {
     value: string;
     modifiers: string[];
     expression: string;
@@ -48,7 +48,7 @@ interface DirectiveParameters {
     type: string;
 }
 
-interface AlpineMagics<T> {
+export interface AlpineMagics<T> {
     /**
      * Access to current Alpine data.
      */


### PR DESCRIPTION
Currently only `Alpine` and `AlpineComponent` are exported which makes it impossible to create properly typed directive functions without the usage of `Alpine.directive`, I realize this is a bit of an edge case but it's one I think should be supported.

This PR:
- Makes makes it possible to define properly-typed directive functions without having to immediately call them with `Alpine.directive`
- Fixes incorrect typing on `effect` and `cleanup` which both accept a callback function

e.g. my-directive.ts

```ts
import { DirectiveUtilities, DirectiveParameters} from 'alpinejs'

export default myDirective($el: Node, {modifiers, expression}: DirectiveParameters, {cleanup, evaluate}: DirectiveUtilities) => {
  // The type for this was wrong as well
  effect(() => {
    ...
  })
}
```

then in `index.ts`:

```ts
import Alpine from 'alpinejs'
import myDirective from './my-directive.ts`

Alpine.directive('my-directive, myDirective)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://alpinejs.dev/advanced/extending#method-signature
  - https://alpinejs.dev/globals/alpine-data#using-magic-properties
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~