### PR TITLE
AlpineJS: Fix issue when adding types to initial state arguments in Alpine.data

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -471,8 +471,15 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     }));
 
     // $ExpectType void
-    Alpine.data('dropdown', (initialOpenState = false) => ({
+    Alpine.data('dropdown', (initialOpenState: boolean = false) => ({
+        // $ExpectType boolean
         open: initialOpenState
+    }));
+
+    // $ExpectType void
+    Alpine.data('dropdown', (options: { open: boolean }) => ({
+        // $ExpectType boolean
+        open: options.open
     }));
 
     // $ExpectType void

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -269,7 +269,8 @@ export interface Alpine {
      * @param name the id of the x-data context
      * @param callback the initializer of the x-data context
      */
-    data(name: string, callback: (...initialStateArgs: unknown[]) => AlpineComponent): void;
+    // eslint-disable-next-line no-unnecessary-generics
+    data<TInitialStateArgs extends unknown[]>(name: string, callback: (...initialStateArgs: TInitialStateArgs) => AlpineComponent): void;
 }
 
 declare const AlpineInstance: Alpine;


### PR DESCRIPTION
This PR save the argument types for `Alpine.data` functions in a generic and allow TS to infer them rather than just casting them all to `unknown`. Previously, when trying to add types to initial state args TS would complain since the type of these args was defined as `unknown[]`:

<img width="664" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/64985/bfd3bc0a-8969-4b35-8642-666795590739">

<img width="931" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/64985/009fa7ca-90cf-4586-833f-d8ef9301a8dd">

```ts
data(name: string, callback: (...initialStateArgs: unknown[]) => AlpineComponent): void;
```

Changing this to

```ts
data<TInitialStateArgs extends unknown[]>(name: string, callback: (...initialStateArgs: TInitialStateArgs) => AlpineComponent): void;
```

Fixes the issue:

<img width="604" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/64985/46c99326-937c-4800-ab32-f79feb4f3298">

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://alpinejs.dev/essentials/state
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
