### PR TITLE
[UPDATE] Add version range for mongoose-delete in package.json

### DIFF
--- a/types/mongoose-delete/package.json
+++ b/types/mongoose-delete/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "mongoose": "^5.11 || ^6"
+        "mongoose": "^5.11 || ^6 || ^7.x"
     }
 }


### PR DESCRIPTION
This pull request adds a specific version range for the mongoose dependency in the package.json file. The version range has been set as "^5.11 || ^6 || ^7.x". This will allow automatic minor updates within the 5, 6, and 7 versions of mongoose, but it will not allow updates to version 8.

This change has been made to ensure proper compatibility with the current project dependencies and to ensure that updates are done within proven and tested versions of mongoose.