### PR TITLE
Add types for `@hapi/pez`

### DIFF
--- a/types/hapi__pez/hapi__pez-tests.ts
+++ b/types/hapi__pez/hapi__pez-tests.ts
@@ -1,0 +1,18 @@
+import Content from "@hapi/content";
+import Pez from '@hapi/pez';
+
+let contentType = Content.type("application/json; charset=utf-8");
+
+const minDispenser = new Pez.Dispenser({ boundary: 'AaB03x' });
+const maxBytesDispenser = new Pez.Dispenser({
+  boundary: 'AaB03x',
+  maxBytes: 4096 - 1,
+  maxParts: 1,
+});
+
+// Example with Node Stream Options type
+const nodeOptionDispenser = new Pez.Dispenser({
+  boundary: 'AaB03x',
+  maxBytes: 50e6,
+  ...contentType,
+});

--- a/types/hapi__pez/hapi__pez-tests.ts
+++ b/types/hapi__pez/hapi__pez-tests.ts
@@ -1,7 +1,7 @@
 import Content from "@hapi/content";
 import Pez from '@hapi/pez';
 
-let contentType = Content.type("application/json; charset=utf-8");
+const contentType = Content.type("application/json; charset=utf-8");
 
 const minDispenser = new Pez.Dispenser({ boundary: 'AaB03x' });
 const maxBytesDispenser = new Pez.Dispenser({

--- a/types/hapi__pez/index.d.ts
+++ b/types/hapi__pez/index.d.ts
@@ -1,18 +1,17 @@
-// Type definitions for @hapi/pez 6.1.0
+// Type definitions for @hapi/pez 6.1
 // Project: https://github.com/hapijs/pez
 // Definitions by: Grant Timmerman <https://github.com/grant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
+import * as stream from 'stream';
 
-import Stream from 'stream';
-
-export interface PezOptions extends Stream.WritableOptions {
+export interface PezOptions extends stream.WritableOptions {
   boundary: string;
   maxBytes?: number;
   maxParts?: number;
 }
 
-export class Dispenser extends Stream.Writable {
+export class Dispenser extends stream.Writable {
   constructor(options?: PezOptions);
 }

--- a/types/hapi__pez/index.d.ts
+++ b/types/hapi__pez/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for @hapi/pez 6.1.0
+// Project: https://github.com/hapijs/pez
+// Definitions by: Grant Timmerman <https://github.com/grant>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import Stream from 'stream';
+
+export interface PezOptions extends Stream.WritableOptions {
+  boundary: string;
+  maxBytes?: number;
+  maxParts?: number;
+}
+
+export class Dispenser extends Stream.Writable {
+  constructor(options?: PezOptions);
+}

--- a/types/hapi__pez/package.json
+++ b/types/hapi__pez/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/content": "^4.1.0",
-    "@hapi/pez": "^6.1.0"
+    "@hapi/content": "^4.1.0"
   }
 }

--- a/types/hapi__pez/package.json
+++ b/types/hapi__pez/package.json
@@ -1,6 +1,3 @@
 {
-  "private": true,
-  "dependencies": {
-    "@hapi/content": "^4.1.0"
-  }
+  "private": true
 }

--- a/types/hapi__pez/package.json
+++ b/types/hapi__pez/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "@hapi/content": "^4.1.0",
+    "@hapi/pez": "^6.1.0"
+  }
+}

--- a/types/hapi__pez/tsconfig.json
+++ b/types/hapi__pez/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictFunctionTypes": true,
+      "strictNullChecks": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "paths": {
+          "@hapi/*": [
+              "hapi__*"
+          ]
+      },
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true,
+      "esModuleInterop": true
+  },
+  "files": [
+      "index.d.ts",
+      "hapi__pez-tests.ts"
+  ]
+}

--- a/types/hapi__pez/tslint.json
+++ b/types/hapi__pez/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) `npx ts-node hapi__pez-tests.ts .`
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). npm test hapi__pez

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

- Related: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60588
- Module: https://github.com/hapijs/pez