### PR TITLE
Wordpress-Editor: Fix get*PostAttribute() type hints

### DIFF
--- a/types/wordpress__editor/store/selectors.d.ts
+++ b/types/wordpress__editor/store/selectors.d.ts
@@ -106,9 +106,9 @@ export function getCurrentPost(): Page | Post;
  *
  * @param attributeName - Post attribute name.
  */
-export function getCurrentPostAttribute<T extends keyof (Page | Post)>(
+export function getCurrentPostAttribute<T extends keyof (Page & Post)>(
     attributeName: T
-): (Page | Post)[T] | undefined;
+): (Page & Post)[T] | undefined;
 
 /**
  * Returns the ID of the post currently being edited.
@@ -137,9 +137,9 @@ export function getCurrentPostType(): string;
  *
  * @param attributeName - Post attribute name.
  */
-export function getEditedPostAttribute<T extends keyof (Page | Post)>(
+export function getEditedPostAttribute<T extends keyof (Page & Post)>(
     attributeName: T
-): (Page | Post)[T] | undefined;
+): (Page & Post)[T] | undefined;
 
 /**
  * Returns the content of the post being edited, preferring raw string edit before falling back to


### PR DESCRIPTION
"keyof a union type" produces the wrong list of attributes, using an intersection type is more appropriate here. See also https://github.com/microsoft/TypeScript/issues/12948

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

