### PR TITLE
Update index.d.ts

### DIFF
--- a/types/wpapi/index.d.ts
+++ b/types/wpapi/index.d.ts
@@ -249,7 +249,7 @@ declare namespace WPAPI {
          * Browser) to attach to the request
          * @param name An (optional) filename to use for the file
          */
-        file(file: string | File, name?: string): WPRequest;
+        file(file: string | File | Buffer, name?: string): WPRequest;
 
         /**
          * Get the headers for the specified resource


### PR DESCRIPTION
I added the "buffer" type to the file method because the description states one thing, but the types do not quite match.
According to my local tests, the media() method works fine with a buffer. This fix is needed to address the issue of the types not being displayed correctly.

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WP-API/node-wpapi/blob/2cfe3ecff3b2f492224d67e0b25f5854fd5a81b8/lib/constructors/wp-request.js#L657
