### PR TITLE
[@types/aws-lambda] Added optional marker for Subject to solve #54379

### DIFF
--- a/types/aws-lambda/test/sns-tests.ts
+++ b/types/aws-lambda/test/sns-tests.ts
@@ -1,4 +1,4 @@
-import { SNSEventRecord, SNSHandler, SNSMessage, SNSMessageAttribute, SNSMessageAttributes } from "aws-lambda";
+import { SNSEventRecord, SNSHandler, SNSMessage, SNSMessageAttribute, SNSMessageAttributes } from 'aws-lambda';
 
 const handler: SNSHandler = async (event, context, callback) => {
     const record: SNSEventRecord = event.Records[num];
@@ -18,7 +18,7 @@ const handler: SNSHandler = async (event, context, callback) => {
     str = message.Type;
     str = message.UnsubscribeUrl;
     str = message.TopicArn;
-    str = message.Subject;
+    strOrUndefined = message.Subject;
     strOrUndefined = message.Token;
 
     const attribute: SNSMessageAttribute = attributes[str];

--- a/types/aws-lambda/trigger/sns.d.ts
+++ b/types/aws-lambda/trigger/sns.d.ts
@@ -1,4 +1,4 @@
-import { Handler } from "../handler";
+import { Handler } from '../handler';
 
 export type SNSHandler = Handler<SNSEvent, void>;
 
@@ -23,7 +23,7 @@ export interface SNSMessage {
     Type: string;
     UnsubscribeUrl: string;
     TopicArn: string;
-    Subject: string;
+    Subject?: string;
     Token?: string;
 }
 


### PR DESCRIPTION
This PR closes the issue raised in #54379 by adding the optional marker to the Subject field in the SNSMessage type. This was split off from #65607.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). - I will tick this and run `prettier `once #65607 is merged in since it also includes a full `prettier` run
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
