### PR TITLE
react-native-snackbar-component positioning props

### DIFF
--- a/types/react-native-snackbar-component/index.d.ts
+++ b/types/react-native-snackbar-component/index.d.ts
@@ -1,10 +1,12 @@
-// Type definitions for react-native-snackbar-components 1.1
+// Type definitions for react-native-snackbar-component 1.1
 // Project: https://github.com/sidevesh/react-native-snackbar
 // Definitions by: Haseeb Majid <https://github.com/hmajid2301>
+//                 Enrico Balsamo <https://github.com/balsick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from 'react';
+import { Animated } from 'react-native';
 
 export interface SnackbarComponentProps {
     accentColor?: string | undefined;
@@ -13,9 +15,10 @@ export interface SnackbarComponentProps {
     backgroundColor?: string | undefined;
     distanceCallback?: (() => void) | undefined;
     actionHandler?: (() => void) | undefined;
-    left?: number | undefined;
-    right?: number | undefined;
-    bottom?: number | undefined;
+    left?: number | Animated.Value | undefined;
+    right?: number | Animated.Value | undefined;
+    top?: number | Animated.Value | undefined;
+    bottom?: number | Animated.Value | undefined;
     position?: string | undefined;
     textMessage?: string | JSX.Element | undefined;
     autoHidingTime?: number | undefined;

--- a/types/react-native-snackbar-component/react-native-snackbar-component-tests.tsx
+++ b/types/react-native-snackbar-component/react-native-snackbar-component-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Text, View } from "react-native";
+import { Animated, Text, View } from "react-native";
 import SnackbarComponent from "react-native-snackbar-component";
 
 const SnackbarComponentTest = () => (
@@ -20,6 +20,23 @@ const WithRendererTextMessage = () => (
             actionText={"OPEN"}
             textMessage={<Text>{'Hello'}</Text>}
             visible={true}
+            bottom={8}
         />
     </View>
     );
+
+const WithAnimatedValues = () => {
+    const bottom = React.useRef(new Animated.Value(8)).current;
+    const left = React.useRef(new Animated.Value(8)).current;
+    const right = React.useRef(new Animated.Value(8)).current;
+    return (
+        <SnackbarComponent
+            autoHidingTime={2000}
+            actionText={"OPEN"}
+            textMessage={'Hello'}
+            bottom={bottom}
+            left={left}
+            right={right}
+            visible={true}
+        />);
+};


### PR DESCRIPTION
In this PR the types of the props related to snackbar's position are fixed to include `Animated.Value`.

Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/sidevesh/react-native-snackbar-component/blob/db0d37a18cf3912a3e4b5193779b6a24a5730a83/index.js#L184)
