### PR TITLE
Use literal types instead of constant value for three.js constants

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -409,7 +409,7 @@ export const RGIntegerFormat: 1031;
  */
 export const RGBAIntegerFormat: 1033;
 
-export const _SRGBAFormat = 1035; // fallback for WebGL 1
+export const _SRGBAFormat: 1035; // fallback for WebGL 1
 
 /**
  * Texture Pixel Formats Modes. Compatible only with {@link WebGLRenderingContext | WebGL 1 Rendering Context}.

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -709,7 +709,7 @@ export type NormalMapTypes = typeof TangentSpaceNormalMap | typeof ObjectSpaceNo
 export const NoColorSpace: '';
 export const SRGBColorSpace: 'srgb';
 export const LinearSRGBColorSpace: 'srgb-linear';
-export const DisplayP3ColorSpace = 'display-p3';
+export const DisplayP3ColorSpace: 'display-p3';
 export type ColorSpace =
     | typeof NoColorSpace
     | typeof SRGBColorSpace


### PR DESCRIPTION
All other constant values use literal types, only `_SRGBAFormat` and `DisplayP3ColorSpace` use constant values, most likely by mistake.
