### PR TITLE
Add VexTab library types

### DIFF
--- a/types/vextab/index.d.ts
+++ b/types/vextab/index.d.ts
@@ -1,0 +1,230 @@
+// Type definitions for vextab 3.0
+// Project: http://www.vexflow.com/vextab/
+// Definitions by: Franco Speziali <https://github.com/WeMakeMachines>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import Vex = require('vexflow');
+
+export { Vex };
+
+type Articulation = 'b' | 's' | 'h' | 'p' | 't' | 'T' | 'v' | 'V';
+
+type Decorator = 'v' | 'V' | 'u' | 'd';
+
+interface ABC {
+    key: any;
+    accidental: null | '' | '#' | '##' | 'b' | 'bb' | 'n' | undefined;
+    accidental_type: null | 'c';
+}
+
+interface StaveOptions {
+    notation?: 'true' | 'false';
+    tablature?: 'true' | 'false';
+    key?: string;
+    clef?: 'treble' | 'bass' | 'tenor' | 'alto' | 'percussion' | 'none';
+    voice?: 'top' | 'bottom' | 'new';
+    time?: string;
+    tuning?: string;
+    strings?: number;
+}
+
+interface ArtistCustomizations {
+    'font-size'?: string;
+    'font-face'?: string;
+    'font-style'?: string;
+    'annotation-position'?: string;
+    scale?: number;
+    width?: number;
+    'stave-distance'?: number;
+    space?: number;
+    player?: string;
+    tempo?: number;
+    instrument?: string;
+    accidentals?: string;
+    'tab-stems'?: string;
+    'tab-stem-direction'?: string;
+    'beam-rests'?: string;
+    'beam-stemlets'?: string;
+    'beam-middle-only'?: string;
+    'connector-space'?: number;
+}
+
+interface ArtistStaveNoteParams {
+    is_rest: boolean;
+    play_note: Vex.Flow.Note;
+    spec: string[];
+    accidentals: Array<null | string>;
+}
+
+interface VexTabNote {
+    command?: 'bar' | 'tuplet' | 'annotations' | 'rest' | 'command';
+    time?: number;
+    dot?: boolean;
+    fret?: string;
+    articulation?: string;
+    decorator?: string;
+    abc?: ABC;
+    octave?: string;
+    string?: string;
+}
+
+export class Artist {
+    customizations: ArtistCustomizations;
+
+    constructor(
+        x: number,
+        y: number,
+        width: number,
+        options?: {
+            font_face?: string;
+            font_size?: number;
+            font_style?: any;
+            bottom_spacing?: number;
+            tab_stave_lower_spacing?: number;
+            note_stave_lower_spacing?: number;
+            scale?: number;
+        },
+    );
+
+    reset(): void;
+
+    attachPlayer(player: any): void;
+
+    setOptions(options: ArtistCustomizations): void;
+
+    getPlayerData(): {
+        voices: [];
+        context: CanvasRenderingContext2D;
+        scale: number;
+    };
+
+    render(renderer: Vex.Flow.Renderer): void;
+
+    isRendered(): boolean;
+
+    draw(renderer: Vex.Flow.Renderer): void;
+
+    getNoteForFret(fret: string, string: string): [string, number, string | null];
+
+    getNoteForABC(abc: ABC, string: string): [any, string, any];
+
+    addStaveNote(note_params: ArtistStaveNoteParams): void;
+
+    addTabNote(spec: Array<{ str: number; fret: number }>, play_note: Vex.Flow.TabNote | null): void;
+
+    setDuration(time: string, dot: boolean): void;
+
+    addBar(type: Vex.Flow.Barline.type): void;
+
+    openBends(
+        first_note: Vex.Flow.TabNote,
+        last_note: Vex.Flow.TabNote,
+        first_indices: number[],
+        last_indices: number[],
+    ): void;
+
+    closeBends(offset: number): void;
+
+    makeTuplets(tuplets: number, notes?: any): void;
+
+    makeFingering(text: string): null | Array<{
+        num: number;
+        modifier: Vex.Flow.FretHandFinger | Vex.Flow.StringNumber | null;
+    }>;
+
+    makeStroke(text: string): Vex.Flow.Stroke | null;
+
+    makeScoreArticulation(text: string): Vex.Flow.Articulation | null;
+
+    makeAnnotation(text: string): Vex.Flow.Annotation | null;
+
+    addAnnotations(annotations: VexTabNote[]): void;
+
+    addTabArticulation(
+        type: Articulation,
+        first_note: Vex.Flow.TabNote,
+        last_note: Vex.Flow.TabNote,
+        first_indices: number[],
+        last_indices: number[],
+    ): void;
+
+    addStaveArticulation(
+        type: Articulation,
+        first_note: Vex.Flow.TabNote,
+        last_note: Vex.Flow.TabNote,
+        first_indices: number[],
+        last_indices: number[],
+    ): void;
+
+    getPreviousNoteIndex(): number;
+
+    addDecorator(decorator?: Decorator): void;
+
+    addArticulations(articulations: Articulation[]): void;
+
+    addRest(params: { position: number }): void;
+
+    addChord(chord: VexTabNote[], chord_articulation?: Articulation, chord_decorator?: Decorator): void;
+
+    addNote(note: VexTabNote): void;
+
+    addTextVoice(): void;
+
+    setTextFont(font: string): void;
+
+    addTextNote(
+        text: string,
+        position: number,
+        justification: 'center' | 'left' | 'right',
+        smooth: boolean,
+        ignore_ticks: boolean,
+    ): void;
+
+    addVoice(options: 'tabstave' | 'stave'): void;
+
+    addStave(element: 'tabstave' | 'stave', options?: StaveOptions): void;
+
+    runCommand(line: string, _l: number, _c: number): void;
+}
+
+export class VexTab {
+    constructor(artist: Artist);
+
+    reset(): void;
+
+    isValid(): boolean;
+
+    getArtist(): Artist;
+
+    parseStaveOptions<T extends {}>(options: T): T;
+
+    parseCommand(note: VexTabNote): void;
+
+    parseChord(note: VexTabNote): void;
+
+    parseFret(note: VexTabNote): void;
+
+    parseABC(note: VexTabNote): void;
+
+    parseStaveElements(notes: VexTabNote[]): void;
+
+    parseStaveText(text_line: string[]): void;
+
+    generate(): void;
+
+    parse(code: string): string[];
+}
+
+export class Div {
+    constructor(selector: string);
+
+    redraw(): Div;
+
+    drawInternal(): Div;
+
+    parseInternal(): Div;
+
+    parse(): Div;
+
+    draw(): Div;
+}

--- a/types/vextab/tsconfig.json
+++ b/types/vextab/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vextab-tests.ts"
+    ]
+}

--- a/types/vextab/tslint.json
+++ b/types/vextab/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/vextab/vextab-tests.ts
+++ b/types/vextab/vextab-tests.ts
@@ -1,0 +1,193 @@
+import { Artist, VexTab, Div, Vex } from 'vextab';
+
+const artist = new Artist(10, 10, 600, { scale: 0.8 });
+const renderer = new Vex.Flow.Renderer(document.createElement('div'), Vex.Flow.Renderer.Backends.SVG);
+
+// $ExpectType void
+artist.reset();
+
+// $ExpectType void
+artist.attachPlayer({});
+
+// $ExpectType void
+artist.setOptions({});
+
+// $ExpectType { voices: []; context: CanvasRenderingContext2D; scale: number; }
+artist.getPlayerData();
+
+// $ExpectType void
+artist.render(renderer);
+
+// $ExpectType boolean
+artist.isRendered();
+
+// $ExpectType void
+artist.draw(renderer);
+
+// $ExpectType [string, number, string | null]
+artist.getNoteForFret('5', '6');
+
+// $ExpectType [any, string, any]
+artist.getNoteForABC({ key: 'C', accidental: '#', accidental_type: 'c' }, '6');
+
+// $ExpectType void
+artist.addStaveNote({
+    is_rest: false,
+    play_note: new Vex.Flow.Note({ type: '', duration: '', dots: 2 }),
+    spec: ['6'],
+    accidentals: ['#'],
+});
+
+// $ExpectType void
+artist.addTabNote([{ str: 6, fret: 3 }], null);
+
+// $ExpectType void
+artist.setDuration('C', true);
+
+// $ExpectType void
+artist.addBar(Vex.Flow.Barline.type.SINGLE);
+
+// $ExpectType void
+artist.openBends(
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    [0],
+    [0],
+);
+
+// $ExpectType void
+artist.closeBends(1);
+
+// $ExpectType void
+artist.makeTuplets(2);
+
+// $ExpectType { num: number; modifier: FretHandFinger | StringNumber | null; }[] | null
+artist.makeFingering('.fingering/a.');
+
+// $ExpectType Stroke | null
+artist.makeStroke('.stroke/bu.');
+
+// $ExpectType Articulation | null
+artist.makeScoreArticulation('.aabc/txyz.');
+
+// $ExpectType Annotation | null
+artist.makeAnnotation('Text');
+
+// $ExpectType void
+artist.addAnnotations([{ command: 'bar' }]);
+
+// $ExpectType void
+artist.addTabArticulation(
+    'v',
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    [0],
+    [0],
+);
+
+// $ExpectType void
+artist.addStaveArticulation(
+    'v',
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    new Vex.Flow.TabNote({ positions: [{ str: 3, fret: 4 }], duration: 'w' }),
+    [0],
+    [0],
+);
+
+// $ExpectType number
+artist.getPreviousNoteIndex();
+
+// $ExpectType void
+artist.addDecorator('v');
+
+// $ExpectType void
+artist.addArticulations(['b']);
+
+// $ExpectType void
+artist.addRest({ position: 3 });
+
+// $ExpectType void
+artist.addChord([{ command: 'bar' }], 'b', 'v');
+
+// $ExpectType void
+artist.addNote({ command: 'bar' });
+
+// $ExpectType void
+artist.addTextVoice();
+
+// $ExpectType void
+artist.setTextFont('arial-12-italic');
+
+// $ExpectType void
+artist.addTextNote('Text', 3, 'center', true, false);
+
+// $ExpectType void
+artist.addVoice('tabstave');
+
+// $ExpectType void
+artist.addStave('tabstave');
+
+// $ExpectType void
+artist.runCommand('octave-shift 2 3', 1, 3);
+
+const vexTab = new VexTab(artist);
+
+// $ExpectType void
+vexTab.reset();
+
+// $ExpectType boolean
+vexTab.isValid();
+
+// $ExpectType Artist
+vexTab.getArtist();
+
+// ExpectType<T>(options: T)
+vexTab.parseStaveOptions({});
+
+// $ExpectType void
+vexTab.parseCommand({ command: 'bar' });
+
+// $ExpectType void
+vexTab.parseChord({ command: 'bar' });
+
+// $ExpectType void
+vexTab.parseABC({ command: 'bar' });
+
+// $ExpectType void
+vexTab.parseStaveElements([{ command: 'bar' }]);
+
+// $ExpectType void
+vexTab.parseStaveText(['q =|: (5/2.5/3.7/4) :8 7-5h6/3 ^3^ 5h6-7/5 ^3^ :q 7V/4 |']);
+
+// $ExpectType void
+vexTab.generate();
+
+// $ExpectType string[]
+vexTab.parse(`width=680 scale=1.0 editor="true"
+    editor-width=680 editor-height=330>
+    options space=20
+    tabstave notation=true key=A time=4/4
+
+    notes :q =|: (5/2.5/3.7/4) :8 7-5h6/3 ^3^ 5h6-7/5 ^3^ :q 7V/4 |
+    notes :8 t12p7/4 s5s3/4 :8 3s:16:5-7/5 :h p5/4
+    text :w, |#segno, ,|, :hd, , #tr
+
+    options space=25`);
+
+// @ts-expect-error
+new Div();
+
+// $ExpectType Div
+const div = new Div('div');
+
+// $ExpectType Div
+div.redraw();
+
+// $ExpectType Div
+div.drawInternal();
+
+// $ExpectType Div
+div.parse();
+
+// $ExpectType Div
+div.draw();


### PR DESCRIPTION
Added Types for VexTab v3

Types created manually since `dts-gen --dt` could not generate them automatically (this is a browser based library)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

