### PR TITLE
[facebook-pixel] Add eventID option

### DIFF
--- a/types/facebook-pixel/facebook-pixel-tests.ts
+++ b/types/facebook-pixel/facebook-pixel-tests.ts
@@ -66,3 +66,18 @@ fbq('track', 'Purchase',
     content_type: 'product'
   }
 );
+
+// Any event can contain an eventID parameter to deduplicate events sent
+// https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events
+fbq('track', 'PageView', {}, {eventID: 'my-event-id'});
+
+fbq('track', 'ViewContent', {
+    content_name: 'The Avengers Trailer',
+    content_category: 'Entertainment',
+    value: 1.50,
+    currency: 'USD',
+}, {eventID: 'my-event-id'});
+
+fbq('trackSingle', '<FB_PIXEL_ID>', 'ViewContent', viewContentParam, {eventID: 'my-event-id'});
+
+fbq('trackCustom', 'MyCustomEvent', custom_params, {eventID: 'my-event-id'});

--- a/types/facebook-pixel/index.d.ts
+++ b/types/facebook-pixel/index.d.ts
@@ -11,34 +11,36 @@ declare module facebook.Pixel {
     interface Event {
         (eventType:string, InitialAppId:string):void;
         (eventType:string, InitialAppId:string, eventName:string,
-            parameters:
-            facebook.Pixel.ViewContentParameters |
-            ViewContentParameters |
-            SearchParameters |
-            AddToCartParameters |
-            AddToWishlistParameters |
-            InitiateCheckoutParameters |
-            AddPaymentInfoParameters |
-            PurchaseParameters |
-            LeadParameters |
-            CompleteRegistrationParameters
-            ):void;
-        (eventType:string, eventName:string):void;
-        (eventType:string, eventName:string, parameters:facebook.Pixel.ViewContentParameters):void;
-        (eventType:string, eventName:string, parameters:ViewContentParameters):void;
-        (eventType:string, eventName:string, parameters:SearchParameters):void;
-        (eventType:string, eventName:string, parameters:AddToCartParameters):void;
-        (eventType:string, eventName:string, parameters:AddToWishlistParameters):void;
-        (eventType:string, eventName:string, parameters:InitiateCheckoutParameters):void;
-        (eventType:string, eventName:string, parameters:AddPaymentInfoParameters):void;
-        (eventType:string, eventName:string, parameters:PurchaseParameters):void;
-        (eventType:string, eventName:string, parameters:LeadParameters):void;
-        (eventType:string, eventName:string, parameters:CompleteRegistrationParameters):void;
-        (eventType:string, eventName:string, parameters:CustomParameters):void;
+         parameters:
+             facebook.Pixel.ViewContentParameters |
+             ViewContentParameters |
+             SearchParameters |
+             AddToCartParameters |
+             AddToWishlistParameters |
+             InitiateCheckoutParameters |
+             AddPaymentInfoParameters |
+             PurchaseParameters |
+             LeadParameters |
+             CompleteRegistrationParameters |
+             CustomParameters,
+         option?: EventIDOptions):void;
 
-        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.AddToCartParameters):void;
-        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.PurchaseParameters):void;
-        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.ViewContentParameters):void;
+        (eventType:string, eventName:string):void;
+        (eventType:string, eventName:string, parameters:facebook.Pixel.ViewContentParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:ViewContentParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:SearchParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:AddToCartParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:AddToWishlistParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:InitiateCheckoutParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:AddPaymentInfoParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:PurchaseParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:LeadParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:CompleteRegistrationParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:CustomParameters, option?: EventIDOptions):void;
+
+        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.AddToCartParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.PurchaseParameters, option?: EventIDOptions):void;
+        (eventType:string, eventName:string, parameters:facebook.Pixel.DPA.ViewContentParameters, option?: EventIDOptions):void;
     }
 
 
@@ -120,6 +122,10 @@ declare module facebook.Pixel {
     }
 
     type CustomParameters = Record<string,any>;
+
+    interface EventIDOptions {
+        eventID:string;
+    }
 }
 
 // For Facebook Tag API using Dynamic Product Ads


### PR DESCRIPTION
To deduplication in the context of the Conversion API, an additional object with an eventID key can be passed for all event triggers.

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/
