### PR TITLE
[node] add missing serialization property in ClusterSettings

### DIFF
--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -56,6 +56,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -65,6 +66,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/test/cluster.ts
+++ b/types/node/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'json',
     });
 }
 

--- a/types/node/ts4.8/cluster.d.ts
+++ b/types/node/ts4.8/cluster.d.ts
@@ -56,6 +56,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -65,6 +66,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/ts4.8/test/cluster.ts
+++ b/types/node/ts4.8/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'json',
     });
 }
 

--- a/types/node/v14/cluster.d.ts
+++ b/types/node/v14/cluster.d.ts
@@ -4,6 +4,7 @@ declare module 'cluster' {
     import * as net from 'net';
 
     // interfaces
+    type SerializationType = 'json' | 'advanced';
     interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -13,6 +14,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
 
     interface Address {

--- a/types/node/v14/ts4.8/cluster.d.ts
+++ b/types/node/v14/ts4.8/cluster.d.ts
@@ -4,6 +4,7 @@ declare module 'cluster' {
     import * as net from 'net';
 
     // interfaces
+    type SerializationType = 'json' | 'advanced';
     interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -13,6 +14,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
 
     interface Address {

--- a/types/node/v16/cluster.d.ts
+++ b/types/node/v16/cluster.d.ts
@@ -55,6 +55,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -64,6 +65,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v16/test/cluster.ts
+++ b/types/node/v16/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'advanced',
     });
 }
 

--- a/types/node/v16/ts4.8/cluster.d.ts
+++ b/types/node/v16/ts4.8/cluster.d.ts
@@ -55,6 +55,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -64,6 +65,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v16/ts4.8/test/cluster.ts
+++ b/types/node/v16/ts4.8/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'advanced',
     });
 }
 

--- a/types/node/v18/cluster.d.ts
+++ b/types/node/v18/cluster.d.ts
@@ -56,6 +56,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -65,6 +66,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v18/test/cluster.ts
+++ b/types/node/v18/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'advanced',
     });
 }
 

--- a/types/node/v18/ts4.8/cluster.d.ts
+++ b/types/node/v18/ts4.8/cluster.d.ts
@@ -56,6 +56,7 @@ declare module 'cluster' {
     import * as child from 'node:child_process';
     import EventEmitter = require('node:events');
     import * as net from 'node:net';
+    type SerializationType = 'json' | 'advanced';
     export interface ClusterSettings {
         execArgv?: string[] | undefined; // default: process.execArgv
         exec?: string | undefined;
@@ -65,6 +66,7 @@ declare module 'cluster' {
         uid?: number | undefined;
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
+        serialization?: SerializationType | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v18/ts4.8/test/cluster.ts
+++ b/types/node/v18/ts4.8/test/cluster.ts
@@ -16,6 +16,7 @@ cluster.on('setup', (settings: ClusterSettings) => { });
 {
     cluster.setupPrimary({
         args: ['1'],
+        serialization: 'advanced',
     });
 }
 


### PR DESCRIPTION
The `serialization` property is missing in the ClusterSettings definitions so I add that property. (The serialization option is supported from v13.2.0, v12.16.0)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/cluster.html#clustersettings>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
