### PR TITLE
[react] Deprecate `React.ReactFragment` (not to be confused with `React.Fragment`)

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -243,6 +243,9 @@ declare namespace React {
      * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
     type ReactFragment = Iterable<ReactNode>;
 
     /**
@@ -255,7 +258,7 @@ declare namespace React {
         | ReactElement
         | string
         | number
-        | ReactFragment
+        | Iterable<ReactNode>
         | ReactPortal
         | boolean
         | null

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -211,6 +211,10 @@ declare namespace React {
      * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+    /**
+     * WARNING: Not related to `React.Fragment`.
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
     type ReactFragment = Iterable<ReactNode>;
 
     /**
@@ -223,7 +227,7 @@ declare namespace React {
         | ReactElement
         | string
         | number
-        | ReactFragment
+        | Iterable<ReactNode>
         | ReactPortal
         | boolean
         | null


### PR DESCRIPTION
Was intended as the return type for `createFragment` from `react-addons-create-fragment` but with the introduction of `React.Fragment` it's now just confusing.