### PR TITLE
[react-dom] Support `fetchPriority` for `preload()` and `preinit()`

### DIFF
--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -5,26 +5,26 @@
  *
  * To load the types declared here in an actual project, there are three ways. The easiest one,
  * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
- * is to add `"react-dom/next"` to the `"types"` array.
+ * is to add `"react-dom/canary"` to the `"types"` array.
  *
  * Alternatively, a specific import syntax can to be used from a typescript file.
  * This module does not exist in reality, which is why the {} is important:
  *
  * ```ts
- * import {} from 'react-dom/next'
+ * import {} from 'react-dom/canary'
  * ```
  *
  * It is also possible to include it through a triple-slash reference:
  *
  * ```ts
- * /// <reference types="react-dom/next" />
+ * /// <reference types="react-dom/canary" />
  * ```
  *
  * Either the import or the reference only needs to appear once, anywhere in the project.
  */
 
 // See https://github.com/facebook/react/blob/main/packages/react-dom/index.js to see how the exports are declared,
-// but confirm with published source code (e.g. https://unpkg.com/react-dom@next) that these exports end up in the published code
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@canary) that these exports end up in the published code
 
 import React = require('react');
 import ReactDOM = require('.');

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -36,6 +36,7 @@ declare module '.' {
     interface PreloadOptions {
         as: PreloadAs;
         crossOrigin?: string | undefined;
+        fetchPriority?: 'high' | 'low' | 'auto';
         integrity?: string | undefined;
     }
     function preload(href: string, options?: PreloadOptions): void;
@@ -44,9 +45,10 @@ declare module '.' {
     interface PreinitOptions {
         as: PreinitAs;
         crossOrigin?: string | undefined;
-        precedence?: string | undefined;
+        fetchPriority?: 'high' | 'low' | 'auto';
         integrity?: string | undefined;
         nonce?: string | undefined;
+        precedence?: string | undefined;
     }
     function preinit(href: string, options?: PreinitOptions): void;
 }

--- a/types/react-dom/experimental.d.ts
+++ b/types/react-dom/experimental.d.ts
@@ -28,7 +28,7 @@
 // but confirm with published source code (e.g. https://unpkg.com/react-dom@experimental) that these exports end up in the published code
 
 import React = require('react');
-import ReactDOM = require('./next');
+import ReactDOM = require('./canary');
 
 export {};
 

--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -11,9 +11,9 @@
         "default": "./client.d.ts"
       }
     },
-    "./next": {
+    "./canary": {
       "types": {
-        "default": "./next.d.ts"
+        "default": "./canary.d.ts"
       }
     },
     "./server": {

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -1,4 +1,4 @@
-/// <reference types="../next"/>
+/// <reference types="../canary"/>
 
 function preloadTest() {
     function Component() {

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -14,6 +14,14 @@ function preloadTest() {
             // @ts-expect-error -- Only allowed in preinit
             nonce: '0xeac1',
         });
+        ReactDOM.preload('foo', { as: 'style', fetchPriority: 'auto' });
+        ReactDOM.preload('foo', { as: 'style', fetchPriority: 'high' });
+        ReactDOM.preload('foo', { as: 'style', fetchPriority: 'low' });
+        ReactDOM.preload('foo', {
+            as: 'style',
+            // @ts-expect-error
+            fetchPriority: 'unknown',
+        });
 
         ReactDOM.preinit('foo', {
             as: 'style',
@@ -35,6 +43,14 @@ function preloadTest() {
         ReactDOM.preinit('baz', {
             as: 'script',
             nonce: '0xeac1',
+        });
+        ReactDOM.preinit('foo', { as: 'style', fetchPriority: 'auto' });
+        ReactDOM.preinit('foo', { as: 'style', fetchPriority: 'high' });
+        ReactDOM.preinit('foo', { as: 'style', fetchPriority: 'low' });
+        ReactDOM.preinit('foo', {
+            as: 'style',
+            // @ts-expect-error
+            fetchPriority: 'unknown',
         });
     }
 }

--- a/types/react-dom/tsconfig.json
+++ b/types/react-dom/tsconfig.json
@@ -3,7 +3,7 @@
         "index.d.ts",
         "test/react-dom-tests.tsx",
         "test/experimental-tests.tsx",
-        "test/next-tests.tsx"
+        "test/canary-tests.tsx"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react-is/canary.d.ts
+++ b/types/react-is/canary.d.ts
@@ -5,19 +5,19 @@
  *
  * To load the types declared here in an actual project, there are three ways. The easiest one,
  * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
- * is to add `"react-is/next"` to the `"types"` array.
+ * is to add `"react-is/canary"` to the `"types"` array.
  *
  * Alternatively, a specific import syntax can to be used from a typescript file.
  * This module does not exist in reality, which is why the {} is important:
  *
  * ```ts
- * import {} from 'react-is/next'
+ * import {} from 'react-is/canary'
  * ```
  *
  * It is also possible to include it through a triple-slash reference:
  *
  * ```ts
- * /// <reference types="react-is/next" />
+ * /// <reference types="react-is/canary" />
  * ```
  *
  * Either the import or the reference only needs to appear once, anywhere in the project.

--- a/types/react-is/test/canary-tests.tsx
+++ b/types/react-is/test/canary-tests.tsx
@@ -1,7 +1,7 @@
 /// <reference types="../../react/experimental"/>
 import * as React from 'react';
 import * as ReactIs from 'react-is';
-import 'react-is/next';
+import 'react-is/canary';
 
 // Suspense
 ReactIs.isSuspenseList(<React.SuspenseList children={<div />} />); // true

--- a/types/react-is/tsconfig.json
+++ b/types/react-is/tsconfig.json
@@ -21,6 +21,6 @@
     "files": [
         "index.d.ts",
         "test/react-is-tests.tsx",
-        "test/next-tests.tsx"
+        "test/canary-tests.tsx"
     ]
 }

--- a/types/react/OTHER_FILES.txt
+++ b/types/react/OTHER_FILES.txt
@@ -1,4 +1,4 @@
-next.d.ts
+canary.d.ts
 experimental.d.ts
 jsx-dev-runtime.d.ts
 jsx-runtime.d.ts

--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -1,21 +1,21 @@
 /**
- * These are types for things that are present in the React `next` release channel.
+ * These are types for things that are present in the React `canary` release channel.
  *
  * To load the types declared here in an actual project, there are three ways. The easiest one,
  * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
- * is to add `"react/next"` to the `"types"` array.
+ * is to add `"react/canary"` to the `"types"` array.
  *
  * Alternatively, a specific import syntax can to be used from a typescript file.
  * This module does not exist in reality, which is why the {} is important:
  *
  * ```ts
- * import {} from 'react/next'
+ * import {} from 'react/canary'
  * ```
  *
  * It is also possible to include it through a triple-slash reference:
  *
  * ```ts
- * /// <reference types="react/next" />
+ * /// <reference types="react/canary" />
  * ```
  *
  * Either the import or the reference only needs to appear once, anywhere in the project.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -34,7 +34,7 @@
 //
 // Suspense-related handling can be found in ReactFiberThrow.js.
 
-import React = require('./next');
+import React = require('./canary');
 
 export {};
 

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -13,12 +13,12 @@
         "default": "./index.d.ts"
       }
     },
-    "./next": {
+    "./canary": {
       "types@<=5.0": {
-        "default": "./ts5.0/next.d.ts"
+        "default": "./ts5.0/canary.d.ts"
       },
       "types": {
-        "default": "./next.d.ts"
+        "default": "./canary.d.ts"
       }
     },
     "./experimental": {

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -1,4 +1,4 @@
-/// <reference types="../next"/>
+/// <reference types="../canary"/>
 
 const contextUsers = React.createContext(['HAL']);
 const promisedUsers = Promise.resolve(['Dave']);

--- a/types/react/ts5.0/OTHER_FILES.txt
+++ b/types/react/ts5.0/OTHER_FILES.txt
@@ -1,4 +1,4 @@
-next.d.ts
+canary.d.ts
 experimental.d.ts
 jsx-dev-runtime.d.ts
 jsx-runtime.d.ts

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -1,21 +1,21 @@
 /**
- * These are types for things that are present in the React `next` release channel.
+ * These are types for things that are present in the React `canary` release channel.
  *
  * To load the types declared here in an actual project, there are three ways. The easiest one,
  * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
- * is to add `"react/next"` to the `"types"` array.
+ * is to add `"react/canary"` to the `"types"` array.
  *
  * Alternatively, a specific import syntax can to be used from a typescript file.
  * This module does not exist in reality, which is why the {} is important:
  *
  * ```ts
- * import {} from 'react/next'
+ * import {} from 'react/canary'
  * ```
  *
  * It is also possible to include it through a triple-slash reference:
  *
  * ```ts
- * /// <reference types="react/next" />
+ * /// <reference types="react/canary" />
  * ```
  *
  * Either the import or the reference only needs to appear once, anywhere in the project.

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -34,7 +34,7 @@
 //
 // Suspense-related handling can be found in ReactFiberThrow.js.
 
-import React = require('./next');
+import React = require('./canary');
 
 export {};
 

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -1,4 +1,4 @@
-/// <reference types="../next"/>
+/// <reference types="../canary"/>
 
 const contextUsers = React.createContext(['HAL']);
 const promisedUsers = Promise.resolve(['Dave']);

--- a/types/react/ts5.0/tsconfig.json
+++ b/types/react/ts5.0/tsconfig.json
@@ -8,7 +8,7 @@
         "test/managedAttributes.tsx",
         "test/hooks.tsx",
         "test/experimental.tsx",
-        "test/next.tsx"
+        "test/canary.tsx"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react/tsconfig.json
+++ b/types/react/tsconfig.json
@@ -8,7 +8,7 @@
         "test/managedAttributes.tsx",
         "test/hooks.tsx",
         "test/experimental.tsx",
-        "test/next.tsx"
+        "test/canary.tsx"
     ],
     "compilerOptions": {
         "module": "commonjs",


### PR DESCRIPTION
Stacked on [#65734](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65734) ([Diff against #65734](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/eps1lon:feat/react/canary...eps1lon:feat/react-dom/fetchprio))

Types for https://github.com/facebook/react/pull/26880

/cc @gnoff