### PR TITLE
[node] add missing cwd, windowsHide property in ClusterSettings

### DIFF
--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -67,6 +67,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/test/cluster.ts
+++ b/types/node/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'json',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 

--- a/types/node/ts4.8/cluster.d.ts
+++ b/types/node/ts4.8/cluster.d.ts
@@ -67,6 +67,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/ts4.8/test/cluster.ts
+++ b/types/node/ts4.8/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'json',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 

--- a/types/node/v14/cluster.d.ts
+++ b/types/node/v14/cluster.d.ts
@@ -15,6 +15,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
 
     interface Address {

--- a/types/node/v14/ts4.8/cluster.d.ts
+++ b/types/node/v14/ts4.8/cluster.d.ts
@@ -15,6 +15,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
 
     interface Address {

--- a/types/node/v16/cluster.d.ts
+++ b/types/node/v16/cluster.d.ts
@@ -66,6 +66,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v16/test/cluster.ts
+++ b/types/node/v16/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'advanced',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 

--- a/types/node/v16/ts4.8/cluster.d.ts
+++ b/types/node/v16/ts4.8/cluster.d.ts
@@ -66,6 +66,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v16/ts4.8/test/cluster.ts
+++ b/types/node/v16/ts4.8/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'advanced',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 

--- a/types/node/v18/cluster.d.ts
+++ b/types/node/v18/cluster.d.ts
@@ -67,6 +67,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v18/test/cluster.ts
+++ b/types/node/v18/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'advanced',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 

--- a/types/node/v18/ts4.8/cluster.d.ts
+++ b/types/node/v18/ts4.8/cluster.d.ts
@@ -67,6 +67,8 @@ declare module 'cluster' {
         gid?: number | undefined;
         inspectPort?: number | (() => number) | undefined;
         serialization?: SerializationType | undefined;
+        cwd?: string | undefined;
+        windowsHide?: boolean | undefined;
     }
     export interface Address {
         address: string;

--- a/types/node/v18/ts4.8/test/cluster.ts
+++ b/types/node/v18/ts4.8/test/cluster.ts
@@ -17,6 +17,8 @@ cluster.on('setup', (settings: ClusterSettings) => { });
     cluster.setupPrimary({
         args: ['1'],
         serialization: 'advanced',
+        cwd: '/path/to/project',
+        windowsHide: true,
     });
 }
 


### PR DESCRIPTION
The  cwd, windowsHide property are missing in the ClusterSettings definitions so I add those properties. 

v9.5.0 | The cwd option is supported now.
v9.4.0 | The windowsHide option is supported now.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/cluster.html#clustersettings>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
