### PR TITLE
Expand ESLint.Plugin for new-style configs

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1035,4 +1035,31 @@ ruleTester.run('simple-valid-test', rule, {
 // (): Linter.FlatConfig => ({ files: undefined });
 // (): Linter.FlatConfig => ({ ignores: undefined });
 
+(): ESLint.Plugin => ({
+    configs: {
+        'old-style': {
+            parser: "foo-parser"
+        },
+
+        // @ts-expect-error
+        'old-style-array': [{ parser: "foo-parser" }],
+
+        'new-style': {
+            languageOptions: {
+                parser: {
+                    parseForESLint: () => ({ ast: AST })
+                }
+            }
+        },
+
+        'new-style-array': [{
+            languageOptions: {
+                parser: {
+                    parseForESLint: () => ({ ast: AST })
+                }
+            }
+        }]
+    }
+});
+
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1056,7 +1056,7 @@ export namespace ESLint {
     }
 
     interface Plugin {
-        configs?: Record<string, ConfigData> | undefined;
+        configs?: Record<string, ConfigData | Linter.FlatConfig | Linter.FlatConfig[]> | undefined;
         environments?: Record<string, Environment> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;
         rules?: Record<string, Rule.OldStyleRule | Rule.RuleModule> | undefined;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

While the transition to flat configs is under way, plugins might now expose old or new style configs, depending on whether they've been updated. The flat configuration needs to be able to accept plugin objects with either old or new style configs attached - it doesn't affect runtime as they aren't processed by ESLint, but it does affect type checking (as currently the flat config will only accept plugins with old style configs).

Updated `ESLint.Plugin['configs']` to also allow `Linter.FlatConfig` or `Linter.FlatConfig[]`.