### PR TITLE
Add clientMeta to aws-lambda triggers

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -118,6 +118,8 @@ const defineAuthChallenge: DefineAuthChallengeTriggerHandler = async (event, _, 
 
     // @ts-expect-error
     nullOrUndefined = request.userAttributes;
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const createAuthChallenge: CreateAuthChallengeTriggerHandler = async (event, _, callback) => {
@@ -140,6 +142,8 @@ const createAuthChallenge: CreateAuthChallengeTriggerHandler = async (event, _, 
 
     triggerSource === 'CreateAuthChallenge_Authentication';
 
+    objectOrUndefined = request.clientMetadata;
+
     // @ts-expect-error
     nullOrUndefined = request.userAttributes;
 };
@@ -157,6 +161,8 @@ const validateAuthChallengeResponse: VerifyAuthChallengeResponseTriggerHandler =
     bool = response.answerCorrect;
 
     triggerSource === 'VerifyAuthChallengeResponse_Authentication';
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const preAuthentication: PreAuthenticationTriggerHandler = async (event, _, callback) => {
@@ -181,6 +187,8 @@ const postAuthentication: PostAuthenticationTriggerHandler = async (event, _, ca
     objectOrUndefined = response;
 
     triggerSource === 'PostAuthentication_Authentication';
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const preTokenGeneration: PreTokenGenerationTriggerHandler = async (event, _, callback) => {
@@ -207,6 +215,8 @@ const preTokenGeneration: PreTokenGenerationTriggerHandler = async (event, _, ca
     triggerSource === 'TokenGeneration_HostedAuth';
     triggerSource === 'TokenGeneration_NewPasswordChallenge';
     triggerSource === 'TokenGeneration_RefreshTokens';
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const userMigration: UserMigrationTriggerHandler = async (event, _, callback) => {
@@ -234,6 +244,8 @@ const userMigration: UserMigrationTriggerHandler = async (event, _, callback) =>
 
     triggerSource === 'UserMigration_Authentication';
     triggerSource === 'UserMigration_ForgotPassword';
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const customMessage: CustomMessageTriggerHandler = async (event, _, callback) => {
@@ -256,6 +268,8 @@ const customMessage: CustomMessageTriggerHandler = async (event, _, callback) =>
     triggerSource === 'CustomMessage_SignUp';
     triggerSource === 'CustomMessage_UpdateUserAttribute';
     triggerSource === 'CustomMessage_VerifyUserAttribute';
+
+    objectOrUndefined = request.clientMetadata;
 };
 
 const customEmailSender: CustomEmailSenderTriggerHandler = async (event, _, callback) => {

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/create-auth-challenge.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/create-auth-challenge.d.ts
@@ -10,6 +10,7 @@ export interface CreateAuthChallengeTriggerEvent extends BaseTriggerEvent<'Creat
       challengeName: string;
       session: Array<ChallengeResult | CustomChallengeResult>;
       userNotFound?: boolean | undefined;
+      clientMetadata?: StringMap | undefined;
   };
   response: {
       publicChallengeParameters: StringMap;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
@@ -9,6 +9,7 @@ export interface DefineAuthChallengeTriggerEvent extends BaseTriggerEvent<'Defin
       userAttributes: StringMap;
       session: Array<ChallengeResult | CustomChallengeResult>;
       userNotFound?: boolean | undefined;
+      clientMetadata?: StringMap | undefined;
   };
   response: {
       challengeName: string;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/post-authentication.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/post-authentication.d.ts
@@ -8,6 +8,7 @@ export interface PostAuthenticationTriggerEvent extends BaseTriggerEvent<'PostAu
   request: {
       userAttributes: StringMap;
       newDeviceUsed: boolean;
+      clientMetadata?: StringMap | undefined;
   };
 }
 

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/pre-token-generation.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/pre-token-generation.d.ts
@@ -11,6 +11,7 @@ export interface BasePreTokenGenerationTriggerEvent<T extends string> extends Ba
   request: {
       userAttributes: StringMap;
       groupConfiguration: GroupOverrideDetails;
+      clientMetadata?: StringMap | undefined;
   };
   response: {
       claimsOverrideDetails: {

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/verify-auth-challenge-response.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/verify-auth-challenge-response.d.ts
@@ -10,6 +10,7 @@ export interface VerifyAuthChallengeResponseTriggerEvent extends BaseTriggerEven
       privateChallengeParameters: StringMap;
       challengeAnswer: string;
       userNotFound?: boolean | undefined;
+      clientMetadata?: StringMap | undefined;
   };
   response: {
       answerCorrect: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test aws-lambda`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [See below]
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Context

A recent [issue](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65605) and [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65606) removed `clientMetadata` from certain aws-lambda cognito triggers, however I believe this was an error. The [AWS doc](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html) referenced in the issue is misleading: it implies that `clientMetadata` is not added in certain triggers; however I know from usage that is is present on "Create auth challenge" and "Verify auth challenge" events. 

The documentation for each event is more accurate, and explains that `clientMetadata` is present in certain situations:
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-authentication.html
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html

(Note, these docs are all linked in the source code, e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/trigger/cognito-user-pool-trigger/create-auth-challenge.d.ts#L5)