### PR TITLE
@ember/modifier: cover missing Ember 3.x/4.x APIs

### DIFF
--- a/types/ember__modifier/ember__modifier-tests.ts
+++ b/types/ember__modifier/ember__modifier-tests.ts
@@ -1,8 +1,24 @@
-import { setModifierManager, capabilities, on } from '@ember/modifier';
-import Owner from '@ember/owner';
-
-declare let owner: Owner;
+import {
+    setModifierManager,
+    capabilities,
+    on,
+    ModifierCapabilities,
+    OnModifier,
+    ModifierCapabilitiesVersions,
+} from '@ember/modifier';
 
 on; // $ExpectType OnModifier
-setModifierManager((owner) => {}, {}); // $ExpectType {}
-capabilities('3.24'); // $ExpectType unknown
+setModifierManager(owner => {}, {}); // $ExpectType {}
+const capabilitiesFor3_22 = capabilities('3.22'); // $ExpectType ModifierCapabilities
+capabilitiesFor3_22.disableAutoTracking; // $ExpectType boolean
+
+declare let x: ModifierCapabilitiesVersions;
+x['3.22'].disableAutoTracking;
+// @ts-expect-error
+x['1.23'];
+
+// We can name the type of `OnModifier`.
+declare function takesOn(on: OnModifier): void;
+
+// We can name the type of capabilities:
+declare function takesCapabilities(caps: ModifierCapabilities): void;

--- a/types/ember__modifier/index.d.ts
+++ b/types/ember__modifier/index.d.ts
@@ -31,13 +31,25 @@ export const on: OnModifier;
  *   manager](https://emberjs.github.io/rfcs/0373-Element-Modifier-Managers.html).
  * @param modifier The modifier definition to associate with the manager.
  */
-export function setModifierManager<T>(
-  factory: (owner: Owner) => unknown,
-  modifier: T
-): T;
+export function setModifierManager<T>(factory: (owner: Owner) => unknown, modifier: T): T;
+
+export interface ModifierCapabilitiesVersions {
+    // passes factoryFor(...).class to `.createModifier`
+    // uses args proxy, does not provide a way to opt-out
+    '3.22': {
+        disableAutoTracking?: boolean;
+    };
+}
+
+export interface ModifierCapabilities {
+    disableAutoTracking: boolean;
+}
 
 /**
  * Given a target version of Ember, return an opaque token which Ember can use
  * to determine what a given modifier manager supports.
  */
-export function capabilities(version: string): unknown;
+export function capabilities<Version extends keyof ModifierCapabilitiesVersions>(
+    managerAPI: Version,
+    optionalFeatures?: ModifierCapabilitiesVersions[Version],
+): ModifierCapabilities;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/emberjs/ember.js/blob/v4.0.0/packages/%40ember/modifier/index.ts> – note that this did not have the full set of *types* we are including here in the public API because, well, Ember wasn't shipping types! Compare <https://github.com/emberjs/ember.js/blob/v5.1.0-beta.1/packages/%40ember/modifier/index.ts>, from the first version where Ember will ship types compiled from its source, and <https://github.com/emberjs/ember.js/blob/v4.8.6/types/preview/%40ember/modifier/index.d.ts>, from the version where Ember first shipped hand-authored types. This back-port to DT makes this work for consumers on versions of Ember prior to 4.8.
