### PR TITLE
Add standard-version types from 7.1.0 for bumpFiles

### DIFF
--- a/types/standard-version/index.d.ts
+++ b/types/standard-version/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for standard-version 7.0
+// Type definitions for standard-version 7.1
 // Project: https://github.com/conventional-changelog/standard-version#readme
 // Definitions by: Jason Kwok <https://github.com/JasonHK>
+//                 David Goitia <https://github.com/davidgoitia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -21,7 +22,7 @@ declare namespace standardVersion {
          *   'composer.json'
          * ]
          */
-        packageFiles?: string[] | undefined;
+        packageFiles?: Array<string | Options.VersionFile> | undefined;
 
         /**
          * @default
@@ -31,7 +32,7 @@ declare namespace standardVersion {
          *   'composer.lock'
          * ]
          */
-        bumpFiles?: string[] | undefined;
+        bumpFiles?: Array<string | Options.VersionFile> | undefined;
 
         /**
          * Specify the release type manually (like npm version <major|minor|patch>).
@@ -164,6 +165,49 @@ declare namespace standardVersion {
     }
 
     namespace Options {
+        interface Updater {
+            /**
+             * This method is used to read the version from the provided file contents.
+             *
+             * @param contents provided file content
+             * @return semantic version string
+             */
+            readVersion(contents: string): string;
+
+            /**
+             * This method is used to write the version to the provided contents.
+             *
+             * @param contents provided file content
+             * @param version new semantic version string to write
+             * @return value that will be written directly (overwrite) to the provided file
+             */
+            writeVersion(contents: string, version: string): string;
+        }
+
+        interface VersionFile {
+            /**
+             * path to the file you want to "bump"
+             *
+             * If no type or updater provided, type will be inferred from file extension
+             */
+            filename: string;
+
+            /**
+             * Built-in file types
+             *
+             * The `plain-text` updater assumes the file contents represents the version.
+             *
+             * The `json` updater assumes the version is available under a `version` key in the provided JSON document.
+             */
+            type?: 'plain-text' | 'json';
+
+            /**
+             * An updater is expected to be a Javascript module with atleast two methods exposed: readVersion and writeVersion
+             * or the path to require it.
+             */
+            updater?: string | Updater;
+        }
+
         interface Scripts {
             /**
              * Executed before anything happens. If the `prerelease` script returns a

--- a/types/standard-version/standard-version-tests.ts
+++ b/types/standard-version/standard-version-tests.ts
@@ -6,9 +6,79 @@ import standardVersion from "standard-version";
 namespace Module {
     declare const options: standardVersion.Options;
 
+    declare const updater: standardVersion.Options.Updater;
+
+    const files: Array<string | standardVersion.Options.VersionFile> = [
+        'SINGLE_VERSION.txt',
+        {
+            filename: 'MY_VERSION_TRACKER.txt',
+            // The `plain-text` updater assumes the file contents represents the version.
+            type: 'plain-text',
+        },
+        {
+            filename: 'a/deep/package/dot/json/file/package.json',
+            // The `json` updater assumes the version is available under a `version` key in the provided JSON document.
+            type: 'json',
+        },
+        {
+            filename: 'VERSION_TRACKER.json',
+            //  See "Custom `updater`s" for more details.
+            updater: 'standard-version-updater.js',
+        },
+        {
+            filename: 'VERSION_REQUIRED.json',
+            updater: require('./path/to/custom-version-updater'),
+        },
+        {
+            filename: 'VERSION_UPDATER.json',
+            updater,
+        },
+    ];
+
+    const filesOptions: standardVersion.Options = {
+        bumpFiles: files,
+        packageFiles: files,
+    };
+
     // $ExpectType Promise<void>
     standardVersion(options);
 
     // @ts-expect-error
     standardVersion();
+
+    // Handle pacakgeFiles and bumpFiles  with custom updaters
+    // $ExpectType Promise<void>
+    standardVersion(filesOptions);
+
+    // Error when filename is missing
+    standardVersion({
+        packageFiles: [
+            // @ts-expect-error
+            {
+                type: 'json',
+            },
+        ],
+    });
+
+    // Error when invalid type
+    standardVersion({
+        packageFiles: [
+            {
+                filename: 'package.json',
+                // @ts-expect-error
+                type: null,
+            },
+        ],
+    });
+
+    // Error when invalid updater
+    standardVersion({
+        packageFiles: [
+            {
+                filename: 'package.json',
+                // @ts-expect-error
+                updater: {},
+            },
+        ],
+    });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/conventional-changelog/standard-version#can-i-use-standard-version-for-additional-metadata-files-languages-or-version-files
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
