### PR TITLE
types/unist: Change unist types

### DIFF
--- a/types/hast/hast-tests.ts
+++ b/types/hast/hast-tests.ts
@@ -1,85 +1,37 @@
-import { Data, Point, Position } from 'unist';
-import { Parent, Properties, Literal, Root, Element, DocType, Comment, Text } from 'hast';
+import { Comment, Data, Doctype, Element, Literal, Node, Parent, Properties, Root, Text } from 'hast';
 
-// Augmentations
+const data: Data = {};
 
-declare module 'hast' {
-    interface RootContentMap {
-        raw: Raw;
-    }
-}
-
-interface Raw extends Literal {
-    type: 'raw';
-}
-
-// Tests
-
-declare var raw: Raw;
-
-const data: Data = {
-    string: 'string',
-    number: 1,
-    object: {
-        key: 'value',
-    },
-    array: [],
-    boolean: true,
-    null: null,
-};
-
-const point: Point = {
-    line: 1,
-    column: 1,
-    offset: 0,
-};
-
-const position: Position = {
-    start: point,
-    end: point,
-    indent: [1],
+const position = {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 },
 };
 
 const literal: Literal = {
-    type: 'text',
-    data,
-    position,
+    type: 'whatever',
     value: 'value',
+    position,
+    data,
 };
 
 const comment: Comment = {
     type: 'comment',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const text: Text = {
     type: 'text',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
-const docType: DocType = {
+const doctype: Doctype = {
     type: 'doctype',
-    name: 'name',
-};
-
-const element: Element = getElement();
-
-const parent: Parent = {
-    type: 'parent',
-    data,
     position,
-    children: [getElement(), docType, comment, text],
-};
-
-const root: Root = {
-    type: 'root',
     data,
-    position,
-    children: [getElement(), docType, comment, text, raw],
 };
 
 const properties: Properties = {
@@ -92,12 +44,127 @@ const properties: Properties = {
     propertyName7: undefined,
 };
 
-function getElement(): Element {
-    return {
-        type: 'element',
-        tagName: 'tagName',
-        properties,
-        content: root,
-        children: [element, comment, text],
-    };
+const element: Element = {
+    type: 'element',
+    tagName: 'x',
+    properties,
+    children: [{ type: 'element', tagName: 'y', properties: {}, children: [] }, comment, text],
+};
+
+const elementWithWrongChild: Element = {
+    type: 'element',
+    name: 'z',
+    attributes: {},
+    children: [
+        // @ts-expect-error: doctypes are not valid in elements.
+        doctype,
+    ],
+};
+
+const parent: Parent = {
+    type: 'whatever',
+    data,
+    position,
+    children: [element, doctype, comment, text],
+};
+
+const root: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [element, doctype, comment, text],
+};
+
+// Test custom hast node registration.
+interface Custom extends Node {
+    type: 'custom';
 }
+
+declare module 'hast' {
+    interface RootContentMap {
+        custom: Custom;
+    }
+
+    interface ElementContentMap {
+        custom: Custom;
+    }
+}
+
+const rootOther: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+const elementOther: Element = {
+    type: 'element',
+    tagName: 'foo',
+    properties: { key: 'value' },
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+const rootAnother: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [
+        // @ts-expect-error: node not registered in `RootContentMap`.
+        { type: 'invalid' },
+    ],
+};
+
+const elementAnother: Element = {
+    type: 'element',
+    name: 'foo',
+    data,
+    position,
+    children: [
+        // @ts-expect-error: node not registered in `ElementContentMap`.
+        { type: 'invalid' },
+    ],
+};
+
+// Register a field on `Data`, which will be available on all nodes.
+declare module 'hast' {
+    interface Data {
+        someField?: string | undefined;
+    }
+
+    interface CommentData {
+        someOtherField?: number | undefined;
+    }
+}
+
+const textWithData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: registered on comments, not on texts.
+        someOtherField: 1,
+    },
+};
+
+const textWithOtherData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
+};
+
+const commentWithData: Comment = {
+    type: 'comment',
+    value: 'value',
+    data: {
+        someField: 'a',
+        someOtherField: 1,
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
+};

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -5,7 +5,6 @@
 //                 Christian Murphy <https://github.com/ChristianMurphy>
 //                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
 import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
 

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -1,50 +1,58 @@
-// Type definitions for non-npm package Hast 2.3
+// Type definitions for non-npm package hast 3.0
 // Project: https://github.com/syntax-tree/hast
 // Definitions by: lukeggchapman <https://github.com/lukeggchapman>
 //                 Junyoung Choi <https://github.com/rokt33r>
 //                 Christian Murphy <https://github.com/ChristianMurphy>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
 
-export { UnistNode as Node };
+// ## Interfaces
 
 /**
- * This map registers all node types that may be used as top-level content in the document.
+ * Info associated with hast nodes by the ecosystem.
  *
- * These types are accepted inside `root` nodes.
+ * This space is guaranteed to never be specified by unist or hast.
+ * But you can use it in utilities and plugins to store data.
  *
- * This interface can be augmented to register custom node types.
+ * This type can be augmented to register custom data.
+ * For example:
  *
- * @example
+ * ```ts
  * declare module 'hast' {
- *   interface RootContentMap {
- *     // Allow using raw nodes defined by `rehype-raw`.
- *     raw: Raw;
+ *   interface Data {
+ *     // `someNode.data.myId` is typed as `number | undefined`
+ *     myId?: number | undefined
  *   }
  * }
+ * ```
  */
-export interface RootContentMap {
-    comment: Comment;
-    doctype: DocType;
-    element: Element;
-    text: Text;
+// tslint:disable-next-line
+export interface Data extends UnistData {}
+
+/**
+ * Info associated with an element.
+ */
+export interface Properties {
+    [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
 }
 
+// ## Content maps
+
 /**
- * This map registers all node types that may be used as content in an element.
+ * Union of registered hast nodes that can occur in {@link Element}.
  *
- * These types are accepted inside `element` nodes.
+ * To register mote custom hast nodes, add them to {@link ElementContentMap}.
+ * They will be automatically added here.
+ */
+export type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+/**
+ * Registry of all hast nodes that can occur as children of {@link Element}.
  *
- * This interface can be augmented to register custom node types.
- *
- * @example
- * declare module 'hast' {
- *   interface RootContentMap {
- *     custom: Custom;
- *   }
- * }
+ * For a union of all {@link Element} children, see {@link ElementContent}.
  */
 export interface ElementContentMap {
     comment: Comment;
@@ -52,111 +60,238 @@ export interface ElementContentMap {
     text: Text;
 }
 
-export type Content = RootContent | ElementContent;
-
+/**
+ * Union of registered hast nodes that can occur in {@link Root}.
+ *
+ * To register custom hast nodes, add them to {@link RootContentMap}.
+ * They will be automatically added here.
+ */
 export type RootContent = RootContentMap[keyof RootContentMap];
 
-export type ElementContent = ElementContentMap[keyof ElementContentMap];
+/**
+ * Registry of all hast nodes that can occur as children of {@link Root}.
+ *
+ * > 👉 **Note**: {@link Root} does not need to be an entire document.
+ * > it can also be a fragment.
+ *
+ * For a union of all {@link Root} children, see {@link RootContent}.
+ */
+export interface RootContentMap {
+    comment: Comment;
+    doctype: Doctype;
+    element: Element;
+    text: Text;
+}
+
+// ### Special content types
 
 /**
- * Node in hast containing other nodes.
+ * Union of registered hast nodes that can occur in {@link Root}.
+ *
+ * @deprecated Use {@link RootContent} instead.
  */
-export interface Parent extends UnistParent {
+export type Content = RootContent;
+
+/**
+ * Union of registered hast literals.
+ *
+ * To register custom hast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Literals = Extract<Nodes, UnistLiteral>;
+
+/**
+ * Union of registered hast nodes.
+ *
+ * To register custom hast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Nodes = Root | RootContent;
+
+/**
+ * Union of registered hast parents.
+ *
+ * To register custom hast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Parents = Extract<Nodes, UnistParent>;
+
+// ## Abstract nodes
+
+/**
+ * Abstract hast node.
+ *
+ * This interface is supposed to be extended.
+ * If you can use {@link Literal} or {@link Parent}, you should.
+ * But for example in HTML, a `Doctype` is neither literal nor parent, but
+ * still a node.
+ *
+ * To register custom hast nodes, add them to {@link RootContentMap} and other
+ * places where relevant (such as {@link ElementContentMap}).
+ *
+ * For a union of all registered hast nodes, see {@link Nodes}.
+ */
+export interface Node extends UnistNode {
     /**
-     * List representing the children of a node.
+     * Info from the ecosystem.
      */
-    children: Content[];
+    data?: Data | undefined;
 }
 
 /**
- * Nodes in hast containing a value.
+ * Abstract hast node that contains the smallest possible value.
+ *
+ * This interface is supposed to be extended if you make custom hast nodes.
+ *
+ * For a union of all registered hast literals, see {@link Literals}.
  */
-export interface Literal extends UnistLiteral {
+export interface Literal extends Node {
+    /**
+     * Plain-text value.
+     */
     value: string;
 }
 
 /**
- * Root represents a document.
- * Can be used as the rood of a tree, or as a value of the
- * content field on a 'template' Element, never as a child.
+ * Abstract hast node that contains other hast nodes (*children*).
+ *
+ * This interface is supposed to be extended if you make custom hast nodes.
+ *
+ * For a union of all registered hast parents, see {@link Parents}.
  */
-export interface Root extends Parent {
+export interface Parent extends Node {
     /**
-     * Represents this variant of a Node.
-     */
-    type: 'root';
-
-    /**
-     * List representing the children of a node.
+     * List of children.
      */
     children: RootContent[];
 }
 
-/**
- * Element represents an HTML Element.
- */
-export interface Element extends Parent {
-    /**
-     * Represents this variant of a Node.
-     */
-    type: 'element';
-
-    /**
-     * Represents the element’s local name.
-     */
-    tagName: string;
-
-    /**
-     * Represents information associated with the element.
-     */
-    properties?: Properties | undefined;
-
-    /**
-     * If the tagName field is 'template', a content field can be present.
-     */
-    content?: Root | undefined;
-
-    /**
-     * List representing the children of a node.
-     */
-    children: ElementContent[];
-}
+// ## Concrete nodes
 
 /**
- * Represents information associated with an element.
- */
-export interface Properties {
-    [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
-}
-
-/**
- * Represents an HTML DocumentType.
- */
-export interface DocType extends UnistNode {
-    /**
-     * Represents this variant of a Node.
-     */
-    type: 'doctype';
-
-    name: string;
-}
-
-/**
- * Represents an HTML Comment.
+ * HTML comment.
  */
 export interface Comment extends Literal {
     /**
-     * Represents this variant of a Literal.
+     * Node type of HTML comments in hast.
      */
     type: 'comment';
+    /**
+     * Data associated with the comment.
+     */
+    data?: CommentData | undefined;
 }
 
 /**
- * Represents an HTML Text.
+ * Info associated with hast comments by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface CommentData extends Data {}
+
+/**
+ * HTML document type.
+ */
+export interface Doctype extends UnistNode {
+    /**
+     * Node type of HTML document types in hast.
+     */
+    type: 'doctype';
+    /**
+     * Data associated with the doctype.
+     */
+    data?: DoctypeData | undefined;
+}
+
+/**
+ * Info associated with hast doctypes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface DoctypeData extends Data {}
+
+/**
+ * HTML element.
+ */
+export interface Element extends Parent {
+    /**
+     * Node type of elements.
+     */
+    type: 'element';
+    /**
+     * Tag name (such as `'body'`) of the element.
+     */
+    tagName: string;
+    /**
+     * Info associated with the element.
+     */
+    properties: Properties;
+    /**
+     * Children of element.
+     */
+    children: ElementContent[];
+    /**
+     * When the `tagName` field is `'template'`, a `content` field can be
+     * present.
+     */
+    content?: Root | undefined;
+    /**
+     * Data associated with the element.
+     */
+    data?: ElementData | undefined;
+}
+
+/**
+ * Info associated with hast elements by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ElementData extends Data {}
+
+/**
+ * Document fragment or a whole document.
+ *
+ * Should be used as the root of a tree and must not be used as a child.
+ *
+ * Can also be used as the value for the content field on a `'template'` element.
+ */
+export interface Root extends Parent {
+    /**
+     * Node type of hast root.
+     */
+    type: 'root';
+    /**
+     * Children of root.
+     */
+    children: RootContent[];
+    /**
+     * Data associated with the hast root.
+     */
+    data?: RootData | undefined;
+}
+
+/**
+ * Info associated with hast root nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface RootData extends Data {}
+
+/**
+ * HTML character data (plain text).
  */
 export interface Text extends Literal {
     /**
-     * Represents this variant of a Literal.
+     * Node type of HTML character data (plain text) in hast.
      */
     type: 'text';
+    /**
+     * Data associated with the text.
+     */
+    data?: TextData | undefined;
 }
+
+/**
+ * Info associated with hast texts by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TextData extends Data {}

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -28,7 +28,6 @@ import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Par
  * }
  * ```
  */
-// tslint:disable-next-line
 export interface Data extends UnistData {}
 
 /**
@@ -187,7 +186,6 @@ export interface Comment extends Literal {
 /**
  * Info associated with hast comments by the ecosystem.
  */
-// tslint:disable-next-line
 export interface CommentData extends Data {}
 
 /**
@@ -207,7 +205,6 @@ export interface Doctype extends UnistNode {
 /**
  * Info associated with hast doctypes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface DoctypeData extends Data {}
 
 /**
@@ -244,7 +241,6 @@ export interface Element extends Parent {
 /**
  * Info associated with hast elements by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ElementData extends Data {}
 
 /**
@@ -272,7 +268,6 @@ export interface Root extends Parent {
 /**
  * Info associated with hast root nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface RootData extends Data {}
 
 /**
@@ -292,5 +287,4 @@ export interface Text extends Literal {
 /**
  * Info associated with hast texts by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TextData extends Data {}

--- a/types/hast/tslint.json
+++ b/types/hast/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/mapbox__hast-util-table-cell-style/mapbox__hast-util-table-cell-style-tests.ts
+++ b/types/mapbox__hast-util-table-cell-style/mapbox__hast-util-table-cell-style-tests.ts
@@ -4,4 +4,4 @@ import tableCellStyle = require('@mapbox/hast-util-table-cell-style');
 tableCellStyle({ type: 'root', children: [] });
 
 // $ExpectType Element
-tableCellStyle({ type: 'element', tagName: 'div', children: [] });
+tableCellStyle({ type: 'element', tagName: 'div', properties: {}, children: [] });

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -4,69 +4,205 @@
 //                 Jun Lu <https://github.com/lujun2>
 //                 Remco Haszing <https://github.com/remcohaszing>
 //                 Titus Wormer <https://github.com/wooorm>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import { Parent as UnistParent, Literal as UnistLiteral, Node } from 'unist';
+import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
 
-export type AlignType = 'left' | 'right' | 'center' | null;
+// ## Enumeration
 
+/**
+ * How phrasing content is aligned
+ * ({@link https://drafts.csswg.org/css-text/ | [CSSTEXT]}).
+ *
+ * * `'left'`: See the
+ *   {@link https://drafts.csswg.org/css-text/#valdef-text-align-left | left}
+ *   value of the `text-align` CSS property
+ * * `'right'`: See the
+ *   {@link https://drafts.csswg.org/css-text/#valdef-text-align-right | right}
+ *   value of the `text-align` CSS property
+ * * `'center'`: See the
+ *   {@link https://drafts.csswg.org/css-text/#valdef-text-align-center | center}
+ *   value of the `text-align` CSS property
+ * * `null`: phrasing content is aligned as defined by the host environment
+ *
+ * Used in GFM tables.
+ */
+export type AlignType = 'center' | 'left' | 'right' | null;
+
+/**
+ * Explicitness of a reference.
+ *
+ * `'shortcut'`: the reference is implicit, its identifier inferred from its
+ *   content
+ * `'collapsed'`: the reference is explicit, its identifier inferred from its
+ *   content
+ * `'full'`: the reference is explicit, its identifier explicitly set
+ */
 export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
 
+// ## Mixin
+
 /**
- * This map registers all node types that may be used where markdown block content is accepted.
+ * Node with a fallback.
+ */
+export interface Alternative {
+    /**
+     * Equivalent content for environments that cannot represent the node as
+     * intended.
+     */
+    alt?: string | null | undefined;
+}
+
+/**
+ * Internal relation from one node to another.
  *
- * These types are accepted inside block quotes, list items, footnotes, and roots.
+ * Whether the value of `identifier` is expected to be a unique identifier or
+ * not depends on the type of node including the Association.
+ * An example of this is that they should be unique on {@link Definition},
+ * whereas multiple {@link LinkReference}s can be non-unique to be associated
+ * with one definition.
+ */
+export interface Association {
+    /**
+     * Relation of association.
+     *
+     * `identifier` is a source value: character escapes and character
+     * references are not parsed.
+     *
+     * It can match another node.
+     *
+     * Its value must be normalized.
+     * To normalize a value, collapse markdown whitespace (`[\t\n\r ]+`) to a space,
+     * trim the optional initial and/or final space, and perform Unicode-aware
+     * case-folding.
+     */
+    identifier: string;
+
+    /**
+     * Relation of association, in parsed form.
+     *
+     * `label` is a `string` value: it works just like `title` on {@link Link}
+     * or a `lang` on {@link Code}: character escapes and character references
+     * are parsed.
+     *
+     * It can match another node.
+     */
+    label?: string | null | undefined;
+}
+
+/**
+ * Marker that is associated to another node.
+ */
+export interface Reference extends Association {
+    /**
+     * Explicitness of the reference.
+     */
+    referenceType: ReferenceType;
+}
+
+/**
+ * Reference to resource.
+ */
+export interface Resource {
+    /**
+     * URL to the referenced resource.
+     */
+    url: string;
+    /**
+     * Advisory information for the resource, such as would be appropriate for
+     * a tooltip.
+     */
+    title?: string | null | undefined;
+}
+
+// ## Interfaces
+
+/**
+ * Info associated with mdast nodes by the ecosystem.
  *
- * This interface can be augmented to register custom node types.
+ * This space is guaranteed to never be specified by unist or mdast.
+ * But you can use it in utilities and plugins to store data.
  *
- * @example
+ * This type can be augmented to register custom data.
+ * For example:
+ *
+ * ```ts
+ * declare module 'mdast' {
+ *   interface Data {
+ *     // `someNode.data.myId` is typed as `number | undefined`
+ *     myId?: number | undefined
+ *   }
+ * }
+ * ```
+ */
+// tslint:disable-next-line
+export interface Data extends UnistData {}
+
+// ## Content maps
+
+/**
+ * Union of registered mdast nodes that can occur where block content is
+ * expected.
+ *
+ * To register custom mdast nodes, add them to {@link BlockContentMap}.
+ * They will be automatically added here.
+ */
+export type BlockContent = BlockContentMap[keyof BlockContentMap];
+
+/**
+ * Registry of all mdast nodes that can occur where {@link BlockContent} is
+ * expected.
+ *
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
  * declare module 'mdast' {
  *   interface BlockContentMap {
- *     // Allow using math nodes defined by `remark-math`.
- *     math: Math;
+ *     // Allow using MDX ESM nodes defined by `remark-mdx`.
+ *     mdxjsEsm: MdxjsEsm;
  *   }
  * }
+ * ```
+ *
+ * For a union of all block content, see {@link RootContent}.
  */
 export interface BlockContentMap {
-    paragraph: Paragraph;
-    heading: Heading;
-    thematicBreak: ThematicBreak;
     blockquote: Blockquote;
-    list: List;
-    table: Table;
-    html: HTML;
     code: Code;
+    heading: Heading;
+    html: Html;
+    list: List;
+    paragraph: Paragraph;
+    table: Table;
+    thematicBreak: ThematicBreak;
 }
 
 /**
- * This map registers all frontmatter node types.
+ * Union of registered mdast nodes that can occur where definition content is
+ * expected.
  *
- * This interface can be augmented to register custom node types.
- *
- * @example
- * declare module 'mdast' {
- *   interface FrontmatterContentMap {
- *     // Allow using toml nodes defined by `remark-frontmatter`.
- *     toml: TOML;
- *   }
- * }
+ * To register custom mdast nodes, add them to {@link DefinitionContentMap}.
+ * They will be automatically added here.
  */
-export interface FrontmatterContentMap {
-    yaml: YAML;
-}
+export type DefinitionContent = DefinitionContentMap[keyof DefinitionContentMap];
 
 /**
- * This map registers all node definition types.
+ * Registry of all mdast nodes that can occur where {@link DefinitionContent}
+ * is expected.
  *
- * This interface can be augmented to register custom node types.
+ * This interface can be augmented to register custom node types:
  *
- * @example
+ * ```ts
  * declare module 'mdast' {
  *   interface DefinitionContentMap {
  *     custom: Custom;
  *   }
  * }
+ * ```
+ *
+ * For a union of all definition content, see {@link RootContent}.
  */
 export interface DefinitionContentMap {
     definition: Definition;
@@ -74,273 +210,951 @@ export interface DefinitionContentMap {
 }
 
 /**
- * This map registers all node types that are acceptable in a static phrasing context.
+ * Union of registered mdast nodes that can occur where frontmatter content is
+ * expected.
  *
- * This interface can be augmented to register custom node types in a phrasing context, including links and link
- * references.
+ * To register custom mdast nodes, add them to {@link FrontmatterContentMap}.
+ * They will be automatically added here.
+ */
+export type FrontmatterContent = FrontmatterContentMap[keyof FrontmatterContentMap];
+
+/**
+ * Registry of all mdast nodes that can occur where {@link FrontmatterContent}
+ * is expected.
  *
- * @example
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
  * declare module 'mdast' {
- *   interface StaticPhrasingContentMap {
- *     mdxJsxTextElement: MDXJSXTextElement;
+ *   interface FrontmatterContentMap {
+ *     // Allow using toml nodes defined by `remark-frontmatter`.
+ *     toml: TOML;
  *   }
  * }
+ * ```
+ *
+ * For a union of all frontmatter content, see {@link RootContent}.
  */
-export interface StaticPhrasingContentMap {
-    text: Text;
-    emphasis: Emphasis;
-    strong: Strong;
-    delete: Delete;
-    html: HTML;
-    inlineCode: InlineCode;
-    break: Break;
-    image: Image;
-    imageReference: ImageReference;
-    footnote: Footnote;
-    footnoteReference: FootnoteReference;
+export interface FrontmatterContentMap {
+    yaml: Yaml;
 }
 
 /**
- * This map registers all node types that are acceptable in a (interactive) phrasing context (so not in links).
+ * Union of registered mdast nodes that can occur where list content is
+ * expected.
  *
- * This interface can be augmented to register custom node types in a phrasing context, excluding links and link
- * references.
- *
- * @example
- * declare module 'mdast' {
- *   interface PhrasingContentMap {
- *     custom: Custom;
- *   }
- * }
+ * To register custom mdast nodes, add them to {@link ListContentMap}.
+ * They will be automatically added here.
  */
-export interface PhrasingContentMap extends StaticPhrasingContentMap {
-    link: Link;
-    linkReference: LinkReference;
-}
+export type ListContent = ListContentMap[keyof ListContentMap];
 
 /**
- * This map registers all node types that are acceptable inside lists.
+ * Registry of all mdast nodes that can occur where {@link ListContent}
+ * is expected.
  *
- * This interface can be augmented to register custom node types that are acceptable inside lists.
+ * This interface can be augmented to register custom node types:
  *
- * @example
+ * ```ts
  * declare module 'mdast' {
  *   interface ListContentMap {
  *     custom: Custom;
  *   }
  * }
+ * ```
+ *
+ * For a union of all list content, see {@link RootContent}.
  */
 export interface ListContentMap {
     listItem: ListItem;
 }
 
 /**
- * This map registers all node types that are acceptable inside tables (not table cells).
+ * Union of registered mdast nodes that can occur where phrasing content is
+ * expected.
  *
- * This interface can be augmented to register custom node types that are acceptable inside tables.
+ * To register custom mdast nodes, add them to {@link PhrasingContentMap}.
+ * They will be automatically added here.
+ */
+export type PhrasingContent = PhrasingContentMap[keyof PhrasingContentMap];
+
+/**
+ * Registry of all mdast nodes that can occur where {@link PhrasingContent}
+ * is expected.
  *
- * @example
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
  * declare module 'mdast' {
- *   interface TableContentMap {
- *     custom: Custom;
+ *   interface PhrasingContentMap {
+ *     // Allow using MDX JSX (text) nodes defined by `remark-mdx`.
+ *     mdxJsxTextElement: MDXJSXTextElement;
  *   }
  * }
+ * ```
+ *
+ * For a union of all phrasing content, see {@link RootContent}.
  */
-export interface TableContentMap {
-    tableRow: TableRow;
+export interface PhrasingContentMap {
+    break: Break;
+    delete: Delete;
+    emphasis: Emphasis;
+    footnoteReference: FootnoteReference;
+    html: Html;
+    image: Image;
+    imageReference: ImageReference;
+    inlineCode: InlineCode;
+    link: Link;
+    linkReference: LinkReference;
+    strong: Strong;
+    text: Text;
 }
 
 /**
- * This map registers all node types that are acceptable inside tables rows (not table cells).
+ * Union of registered mdast nodes that can occur in {@link Root}.
  *
- * This interface can be augmented to register custom node types that are acceptable inside table rows.
+ * To register custom mdast nodes, add them to {@link RootContentMap}.
+ * They will be automatically added here.
+ */
+export type RootContent = RootContentMap[keyof RootContentMap];
+
+/**
+ * Registry of all mdast nodes that can occur as children of {@link Root}.
  *
- * @example
+ * > 👉 **Note**: {@link Root} does not need to be an entire document.
+ * > it can also be a fragment.
+ *
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
+ * declare module 'mdast' {
+ *   interface RootContentMap {
+ *     // Allow using toml nodes defined by `remark-frontmatter`.
+ *     toml: TOML;
+ *   }
+ * }
+ * ```
+ *
+ * For a union of all {@link Root} children, see {@link RootContent}.
+ */
+export interface RootContentMap {
+    blockquote: Blockquote;
+    break: Break;
+    code: Code;
+    definition: Definition;
+    delete: Delete;
+    emphasis: Emphasis;
+    footnoteDefinition: FootnoteDefinition;
+    footnoteReference: FootnoteReference;
+    heading: Heading;
+    html: Html;
+    image: Image;
+    imageReference: ImageReference;
+    inlineCode: InlineCode;
+    link: Link;
+    linkReference: LinkReference;
+    list: List;
+    listItem: ListItem;
+    paragraph: Paragraph;
+    strong: Strong;
+    table: Table;
+    tableCell: TableCell;
+    tableRow: TableRow;
+    text: Text;
+    thematicBreak: ThematicBreak;
+    yaml: Yaml;
+}
+
+/**
+ * Union of registered mdast nodes that can occur where row content is
+ * expected.
+ *
+ * To register custom mdast nodes, add them to {@link RowContentMap}.
+ * They will be automatically added here.
+ */
+export type RowContent = RowContentMap[keyof RowContentMap];
+
+/**
+ * Registry of all mdast nodes that can occur where {@link RowContent}
+ * is expected.
+ *
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
  * declare module 'mdast' {
  *   interface RowContentMap {
  *     custom: Custom;
  *   }
  * }
+ * ```
+ *
+ * For a union of all row content, see {@link RootContent}.
  */
 export interface RowContentMap {
     tableCell: TableCell;
 }
 
-export type Content = TopLevelContent | ListContent | TableContent | RowContent | PhrasingContent;
-
-export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionContent;
-
-export type BlockContent = BlockContentMap[keyof BlockContentMap];
-
-export type FrontmatterContent = FrontmatterContentMap[keyof FrontmatterContentMap];
-
-export type DefinitionContent = DefinitionContentMap[keyof DefinitionContentMap];
-
-export type ListContent = ListContentMap[keyof ListContentMap];
-
+/**
+ * Union of registered mdast nodes that can occur where table content is
+ * expected.
+ *
+ * To register custom mdast nodes, add them to {@link TableContentMap}.
+ * They will be automatically added here.
+ */
 export type TableContent = TableContentMap[keyof TableContentMap];
 
-export type RowContent = RowContentMap[keyof RowContentMap];
-
-export type PhrasingContent = PhrasingContentMap[keyof PhrasingContentMap];
-
-export type StaticPhrasingContent = StaticPhrasingContentMap[keyof StaticPhrasingContentMap];
-
-export interface Parent extends UnistParent {
-    children: Content[];
+/**
+ * Registry of all mdast nodes that can occur where {@link TableContent}
+ * is expected.
+ *
+ * This interface can be augmented to register custom node types:
+ *
+ * ```ts
+ * declare module 'mdast' {
+ *   interface TableContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ * ```
+ *
+ * For a union of all table content, see {@link RootContent}.
+ */
+export interface TableContentMap {
+    tableRow: TableRow;
 }
 
-export interface Literal extends UnistLiteral {
+// ### Special content types
+
+/**
+ * Union of registered mdast nodes that can occur in {@link Root}.
+ *
+ * @deprecated Use {@link RootContent} instead.
+ */
+export type Content = RootContent;
+
+/**
+ * Union of registered mdast literals.
+ *
+ * To register custom mdast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Literals = Extract<Nodes, UnistLiteral>;
+
+/**
+ * Union of registered mdast nodes.
+ *
+ * To register custom mdast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Nodes = Root | RootContent;
+
+/**
+ * Union of registered mdast parents.
+ *
+ * To register custom mdast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Parents = Extract<Nodes, UnistParent>;
+
+/**
+ * Union of registered mdast nodes that can occur at the top of the document.
+ *
+ * To register custom mdast nodes, add them to {@link BlockContent},
+ * {@link FrontmatterContent}, or {@link DefinitionContent}.
+ * They will be automatically added here.
+ */
+export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionContent;
+
+// ## Abstract nodes
+
+/**
+ * Abstract mdast node that contains the smallest possible value.
+ *
+ * This interface is supposed to be extended if you make custom mdast nodes.
+ *
+ * For a union of all registered mdast literals, see {@link Literals}.
+ */
+export interface Literal extends Node {
+    /**
+     * Plain-text value.
+     */
     value: string;
 }
 
-export interface Root extends Parent {
-    type: 'root';
+/**
+ * Abstract mdast node.
+ *
+ * This interface is supposed to be extended.
+ * If you can use {@link Literal} or {@link Parent}, you should.
+ * But for example in markdown, a thematic break (`***`) is neither literal nor
+ * parent, but still a node.
+ *
+ * To register custom mdast nodes, add them to {@link RootContentMap} and other
+ * places where relevant (such as {@link ElementContentMap}).
+ *
+ * For a union of all registered mdast nodes, see {@link Nodes}.
+ */
+export interface Node extends UnistNode {
+    /**
+     * Info from the ecosystem.
+     */
+    data?: Data | undefined;
 }
 
-export interface Paragraph extends Parent {
-    type: 'paragraph';
-    children: PhrasingContent[];
+/**
+ * Abstract mdast node that contains other mdast nodes (*children*).
+ *
+ * This interface is supposed to be extended if you make custom mdast nodes.
+ *
+ * For a union of all registered mdast parents, see {@link Parents}.
+ */
+export interface Parent extends Node {
+    /**
+     * List of children.
+     */
+    children: RootContent[];
 }
 
-export interface Heading extends Parent {
-    type: 'heading';
-    depth: 1 | 2 | 3 | 4 | 5 | 6;
-    children: PhrasingContent[];
-}
+// ## Concrete nodes
 
-export interface ThematicBreak extends Node {
-    type: 'thematicBreak';
-}
-
+/**
+ * Markdown block quote.
+ */
 export interface Blockquote extends Parent {
+    /**
+     * Node type of mdast block quote.
+     */
     type: 'blockquote';
+    /**
+     * Children of block quote.
+     */
     children: Array<BlockContent | DefinitionContent>;
+    /**
+     * Data associated with the mdast block quote.
+     */
+    data?: BlockquoteData | undefined;
 }
 
-export interface List extends Parent {
-    type: 'list';
-    ordered?: boolean | null | undefined;
-    start?: number | null | undefined;
-    spread?: boolean | null | undefined;
-    children: ListContent[];
-}
+/**
+ * Info associated with mdast block quote nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface BlockquoteData extends Data {}
 
-export interface ListItem extends Parent {
-    type: 'listItem';
-    checked?: boolean | null | undefined;
-    spread?: boolean | null | undefined;
-    children: Array<BlockContent | DefinitionContent>;
-}
-
-export interface Table extends Parent {
-    type: 'table';
-    align?: AlignType[] | null | undefined;
-    children: TableContent[];
-}
-
-export interface TableRow extends Parent {
-    type: 'tableRow';
-    children: RowContent[];
-}
-
-export interface TableCell extends Parent {
-    type: 'tableCell';
-    children: PhrasingContent[];
-}
-
-export interface HTML extends Literal {
-    type: 'html';
-}
-
-export interface Code extends Literal {
-    type: 'code';
-    lang?: string | null | undefined;
-    meta?: string | null | undefined;
-}
-
-export interface YAML extends Literal {
-    type: 'yaml';
-}
-
-export interface Definition extends Node, Association, Resource {
-    type: 'definition';
-}
-
-export interface FootnoteDefinition extends Parent, Association {
-    type: 'footnoteDefinition';
-    children: Array<BlockContent | DefinitionContent>;
-}
-
-export interface Text extends Literal {
-    type: 'text';
-}
-
-export interface Emphasis extends Parent {
-    type: 'emphasis';
-    children: PhrasingContent[];
-}
-
-export interface Strong extends Parent {
-    type: 'strong';
-    children: PhrasingContent[];
-}
-
-export interface Delete extends Parent {
-    type: 'delete';
-    children: PhrasingContent[];
-}
-
-export interface InlineCode extends Literal {
-    type: 'inlineCode';
-}
-
+/**
+ * Markdown break.
+ */
 export interface Break extends Node {
+    /**
+     * Node type of mdast break.
+     */
     type: 'break';
+    /**
+     * Data associated with the mdast break.
+     */
+    data?: BreakData | undefined;
 }
 
-export interface Link extends Parent, Resource {
-    type: 'link';
-    children: StaticPhrasingContent[];
+/**
+ * Info associated with mdast break nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface BreakData extends Data {}
+
+/**
+ * Markdown code (flow) (block).
+ */
+export interface Code extends Literal {
+    /**
+     * Node type of mdast code (flow).
+     */
+    type: 'code';
+    /**
+     * Language of computer code being marked up.
+     */
+    lang?: string | null | undefined;
+    /**
+     * Custom information relating to the node.
+     *
+     * If the lang field is present, a meta field can be present.
+     */
+    meta?: string | null | undefined;
+    /**
+     * Data associated with the mdast code (flow).
+     */
+    data?: CodeData | undefined;
 }
 
-export interface Image extends Node, Resource, Alternative {
-    type: 'image';
+/**
+ * Info associated with mdast code (flow) (block) nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface CodeData extends Data {}
+
+/**
+ * Markdown definition.
+ */
+export interface Definition extends Node, Association, Resource {
+    /**
+     * Node type of mdast definition.
+     */
+    type: 'definition';
+    /**
+     * Data associated with the mdast definition.
+     */
+    data?: DefinitionData | undefined;
 }
 
-export interface LinkReference extends Parent, Reference {
-    type: 'linkReference';
-    children: StaticPhrasingContent[];
-}
+/**
+ * Info associated with mdast definition nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface DefinitionData extends Data {}
 
-export interface ImageReference extends Node, Reference, Alternative {
-    type: 'imageReference';
-}
-
-export interface Footnote extends Parent {
-    type: 'footnote';
+/**
+ * Markdown GFM delete (strikethrough).
+ */
+export interface Delete extends Parent {
+    /**
+     * Node type of mdast GFM delete.
+     */
+    type: 'delete';
+    /**
+     * Children of GFM delete.
+     */
     children: PhrasingContent[];
+    /**
+     * Data associated with the mdast GFM delete.
+     */
+    data?: DeleteData | undefined;
 }
 
-export interface FootnoteReference extends Node, Association {
+/**
+ * Info associated with mdast GFM delete nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface DeleteData extends Data {}
+
+/**
+ * Markdown emphasis.
+ */
+export interface Emphasis extends Parent {
+    /**
+     * Node type of mdast emphasis.
+     */
+    type: 'emphasis';
+    /**
+     * Children of emphasis.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast emphasis.
+     */
+    data?: EmphasisData | undefined;
+}
+
+/**
+ * Info associated with mdast emphasis nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface EmphasisData extends Data {}
+
+/**
+ * Markdown GFM footnote definition.
+ */
+export interface FootnoteDefinition extends Parent, Association {
+    /**
+     * Node type of mdast GFM footnote definition.
+     */
+    type: 'footnoteDefinition';
+    /**
+     * Children of GFM footnote definition.
+     */
+    children: Array<BlockContent | DefinitionContent>;
+    /**
+     * Data associated with the mdast GFM footnote definition.
+     */
+    data?: FootnoteDefinitionData | undefined;
+}
+
+/**
+ * Info associated with mdast GFM footnote definition nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface FootnoteDefinitionData extends Data {}
+
+/**
+ * Markdown GFM footnote reference.
+ */
+export interface FootnoteReference extends Association, Node {
+    /**
+     * Node type of mdast GFM footnote reference.
+     */
     type: 'footnoteReference';
+    /**
+     * Data associated with the mdast GFM footnote reference.
+     */
+    data?: FootnoteReferenceData | undefined;
 }
 
-// Mixin
-export interface Resource {
-    url: string;
-    title?: string | null | undefined;
+/**
+ * Info associated with mdast GFM footnote reference nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface FootnoteReferenceData extends Data {}
+
+/**
+ * Markdown heading.
+ */
+export interface Heading extends Parent {
+    /**
+     * Node type of mdast heading.
+     */
+    type: 'heading';
+    /**
+     * Heading rank.
+     *
+     * A value of `1` is said to be the highest rank and `6` the lowest.
+     */
+    depth: 1 | 2 | 3 | 4 | 5 | 6;
+    /**
+     * Children of heading.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast heading.
+     */
+    data?: HeadingData | undefined;
 }
 
-export interface Association {
-    identifier: string;
-    label?: string | null | undefined;
+/**
+ * Info associated with mdast heading nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface HeadingData extends Data {}
+
+/**
+ * Markdown HTML.
+ */
+export interface Html extends Literal {
+    /**
+     * Node type of mdast HTML.
+     */
+    type: 'html';
+    /**
+     * Data associated with the mdast HTML.
+     */
+    data?: HtmlData | undefined;
 }
 
-export interface Reference extends Association {
-    referenceType: ReferenceType;
+/**
+ * Info associated with mdast HTML nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface HtmlData extends Data {}
+
+/**
+ * Old name of `Html` node.
+ *
+ * @deprecated
+ *   Please use `Html` instead.
+ */
+export type HTML = Html;
+
+/**
+ * Markdown image.
+ */
+export interface Image extends Alternative, Node, Resource {
+    /**
+     * Node type of mdast image.
+     */
+    type: 'image';
+    /**
+     * Data associated with the mdast image.
+     */
+    data?: ImageData | undefined;
 }
 
-export interface Alternative {
-    alt?: string | null | undefined;
+/**
+ * Info associated with mdast image nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ImageData extends Data {}
+
+/**
+ * Markdown image reference.
+ */
+export interface ImageReference extends Alternative, Node, Reference {
+    /**
+     * Node type of mdast image reference.
+     */
+    type: 'imageReference';
+    /**
+     * Data associated with the mdast image reference.
+     */
+    data?: ImageReferenceData | undefined;
 }
+
+/**
+ * Info associated with mdast image reference nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ImageReferenceData extends Data {}
+
+/**
+ * Markdown code (text) (inline).
+ */
+export interface InlineCode extends Literal {
+    /**
+     * Node type of mdast code (text).
+     */
+    type: 'inlineCode';
+    /**
+     * Data associated with the mdast code (text).
+     */
+    data?: InlineCodeData | undefined;
+}
+
+/**
+ * Info associated with mdast code (text) (inline) nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface InlineCodeData extends Data {}
+
+/**
+ * Markdown link.
+ */
+export interface Link extends Parent, Resource {
+    /**
+     * Node type of mdast link.
+     */
+    type: 'link';
+    /**
+     * Children of link.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast link.
+     */
+    data?: LinkData | undefined;
+}
+
+/**
+ * Info associated with mdast link nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface LinkData extends Data {}
+
+/**
+ * Markdown link reference.
+ */
+export interface LinkReference extends Parent, Reference {
+    /**
+     * Node type of mdast link reference.
+     */
+    type: 'linkReference';
+    /**
+     * Children of link reference.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast link reference.
+     */
+    data?: LinkReferenceData | undefined;
+}
+
+/**
+ * Info associated with mdast link reference nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface LinkReferenceData extends Data {}
+
+/**
+ * Markdown list.
+ */
+export interface List extends Parent {
+    /**
+     * Node type of mdast list.
+     */
+    type: 'list';
+    /**
+     * Whether the items have been intentionally ordered (when `true`), or that
+     * the order of items is not important (when `false` or not present).
+     */
+    ordered?: boolean | null | undefined;
+    /**
+     * The starting number of the list, when the `ordered` field is `true`.
+     */
+    start?: number | null | undefined;
+    /**
+     * Whether one or more of the children are separated with a blank line from
+     * its siblings (when `true`), or not (when `false` or not present).
+     */
+    spread?: boolean | null | undefined;
+    /**
+     * Children of list.
+     */
+    children: ListContent[];
+    /**
+     * Data associated with the mdast list.
+     */
+    data?: ListData | undefined;
+}
+
+/**
+ * Info associated with mdast list nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ListData extends Data {}
+
+/**
+ * Markdown list item.
+ */
+export interface ListItem extends Parent {
+    /**
+     * Node type of mdast list item.
+     */
+    type: 'listItem';
+    /**
+     * Whether the item is a tasklist item (when `boolean`).
+     *
+     * When `true`, the item is complete.
+     * When `false`, the item is incomplete.
+     */
+    checked?: boolean | null | undefined;
+    /**
+     * Whether one or more of the children are separated with a blank line from
+     * its siblings (when `true`), or not (when `false` or not present).
+     */
+    spread?: boolean | null | undefined;
+    /**
+     * Children of list item.
+     */
+    children: Array<BlockContent | DefinitionContent>;
+    /**
+     * Data associated with the mdast list item.
+     */
+    data?: ListItemData | undefined;
+}
+
+/**
+ * Info associated with mdast list item nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ListItemData extends Data {}
+
+/**
+ * Markdown paragraph.
+ */
+export interface Paragraph extends Parent {
+    /**
+     * Node type of mdast paragraph.
+     */
+    type: 'paragraph';
+    /**
+     * Children of paragraph.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast paragraph.
+     */
+    data?: ParagraphData | undefined;
+}
+
+/**
+ * Info associated with mdast paragraph nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ParagraphData extends Data {}
+
+/**
+ * Document fragment or a whole document.
+ *
+ * Should be used as the root of a tree and must not be used as a child.
+ */
+export interface Root extends Parent {
+    /**
+     * Node type of mdast root.
+     */
+    type: 'root';
+    /**
+     * Data associated with the mdast root.
+     */
+    data?: RootData | undefined;
+}
+
+/**
+ * Info associated with mdast root nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface RootData extends Data {}
+
+/**
+ * Markdown strong.
+ */
+export interface Strong extends Parent {
+    /**
+     * Node type of mdast strong.
+     */
+    type: 'strong';
+    /**
+     * Children of strong.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast strong.
+     */
+    data?: StrongData | undefined;
+}
+
+/**
+ * Info associated with mdast strong nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface StrongData extends Data {}
+
+/**
+ * Markdown GFM table.
+ */
+export interface Table extends Parent {
+    /**
+     * Node type of mdast GFM table.
+     */
+    type: 'table';
+    /**
+     * How cells in columns are aligned.
+     */
+    align?: AlignType[] | null | undefined;
+    /**
+     * Children of GFM table.
+     */
+    children: TableContent[];
+    /**
+     * Data associated with the mdast GFM table.
+     */
+    data?: TableData | undefined;
+}
+
+/**
+ * Info associated with mdast GFM table nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TableData extends Data {}
+
+/**
+ * Markdown GFM table row.
+ */
+export interface TableRow extends Parent {
+    /**
+     * Node type of mdast GFM table row.
+     */
+    type: 'tableRow';
+    /**
+     * Children of GFM table row.
+     */
+    children: RowContent[];
+    /**
+     * Data associated with the mdast GFM table row.
+     */
+    data?: TableRowData | undefined;
+}
+
+/**
+ * Info associated with mdast GFM table row nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TableRowData extends Data {}
+
+/**
+ * Markdown GFM table cell.
+ */
+export interface TableCell extends Parent {
+    /**
+     * Node type of mdast GFM table cell.
+     */
+    type: 'tableCell';
+    /**
+     * Children of GFM table cell.
+     */
+    children: PhrasingContent[];
+    /**
+     * Data associated with the mdast GFM table cell.
+     */
+    data?: TableCellData | undefined;
+}
+
+/**
+ * Info associated with mdast GFM table cell nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TableCellData extends Data {}
+
+/**
+ * Markdown text.
+ */
+export interface Text extends Literal {
+    /**
+     * Node type of mdast text.
+     */
+    type: 'text';
+    /**
+     * Data associated with the mdast text.
+     */
+    data?: TextData | undefined;
+}
+
+/**
+ * Info associated with mdast text nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TextData extends Data {}
+
+/**
+ * Markdown thematic break (horizontal rule).
+ */
+export interface ThematicBreak extends Node {
+    /**
+     * Node type of mdast thematic break.
+     */
+    type: 'thematicBreak';
+    /**
+     * Data associated with the mdast thematic break.
+     */
+    data?: ThematicBreakData | undefined;
+}
+
+/**
+ * Info associated with mdast thematic break nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ThematicBreakData extends Data {}
+
+/**
+ * Markdown YAML.
+ */
+export interface Yaml extends Literal {
+    /**
+     * Node type of mdast YAML.
+     */
+    type: 'yaml';
+    /**
+     * Data associated with the mdast YAML.
+     */
+    data?: YamlData | undefined;
+}
+
+/**
+ * Info associated with mdast YAML nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface YamlData extends Data {}
+
+/**
+ * Old name of `Yaml` node.
+ *
+ * @deprecated
+ *   Please use `Yaml` instead.
+ */
+export type YAML = Yaml;

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -136,7 +136,6 @@ export interface Resource {
  * }
  * ```
  */
-// tslint:disable-next-line
 export interface Data extends UnistData {}
 
 // ## Content maps
@@ -539,7 +538,6 @@ export interface Blockquote extends Parent {
 /**
  * Info associated with mdast block quote nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface BlockquoteData extends Data {}
 
 /**
@@ -559,7 +557,6 @@ export interface Break extends Node {
 /**
  * Info associated with mdast break nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface BreakData extends Data {}
 
 /**
@@ -589,7 +586,6 @@ export interface Code extends Literal {
 /**
  * Info associated with mdast code (flow) (block) nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface CodeData extends Data {}
 
 /**
@@ -609,7 +605,6 @@ export interface Definition extends Node, Association, Resource {
 /**
  * Info associated with mdast definition nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface DefinitionData extends Data {}
 
 /**
@@ -633,7 +628,6 @@ export interface Delete extends Parent {
 /**
  * Info associated with mdast GFM delete nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface DeleteData extends Data {}
 
 /**
@@ -657,7 +651,6 @@ export interface Emphasis extends Parent {
 /**
  * Info associated with mdast emphasis nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface EmphasisData extends Data {}
 
 /**
@@ -681,7 +674,6 @@ export interface FootnoteDefinition extends Parent, Association {
 /**
  * Info associated with mdast GFM footnote definition nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface FootnoteDefinitionData extends Data {}
 
 /**
@@ -701,7 +693,6 @@ export interface FootnoteReference extends Association, Node {
 /**
  * Info associated with mdast GFM footnote reference nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface FootnoteReferenceData extends Data {}
 
 /**
@@ -731,7 +722,6 @@ export interface Heading extends Parent {
 /**
  * Info associated with mdast heading nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface HeadingData extends Data {}
 
 /**
@@ -751,7 +741,6 @@ export interface Html extends Literal {
 /**
  * Info associated with mdast HTML nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface HtmlData extends Data {}
 
 /**
@@ -779,7 +768,6 @@ export interface Image extends Alternative, Node, Resource {
 /**
  * Info associated with mdast image nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ImageData extends Data {}
 
 /**
@@ -799,7 +787,6 @@ export interface ImageReference extends Alternative, Node, Reference {
 /**
  * Info associated with mdast image reference nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ImageReferenceData extends Data {}
 
 /**
@@ -819,7 +806,6 @@ export interface InlineCode extends Literal {
 /**
  * Info associated with mdast code (text) (inline) nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface InlineCodeData extends Data {}
 
 /**
@@ -843,7 +829,6 @@ export interface Link extends Parent, Resource {
 /**
  * Info associated with mdast link nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface LinkData extends Data {}
 
 /**
@@ -867,7 +852,6 @@ export interface LinkReference extends Parent, Reference {
 /**
  * Info associated with mdast link reference nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface LinkReferenceData extends Data {}
 
 /**
@@ -905,7 +889,6 @@ export interface List extends Parent {
 /**
  * Info associated with mdast list nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ListData extends Data {}
 
 /**
@@ -941,7 +924,6 @@ export interface ListItem extends Parent {
 /**
  * Info associated with mdast list item nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ListItemData extends Data {}
 
 /**
@@ -965,7 +947,6 @@ export interface Paragraph extends Parent {
 /**
  * Info associated with mdast paragraph nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ParagraphData extends Data {}
 
 /**
@@ -987,7 +968,6 @@ export interface Root extends Parent {
 /**
  * Info associated with mdast root nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface RootData extends Data {}
 
 /**
@@ -1011,7 +991,6 @@ export interface Strong extends Parent {
 /**
  * Info associated with mdast strong nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface StrongData extends Data {}
 
 /**
@@ -1039,7 +1018,6 @@ export interface Table extends Parent {
 /**
  * Info associated with mdast GFM table nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TableData extends Data {}
 
 /**
@@ -1063,7 +1041,6 @@ export interface TableRow extends Parent {
 /**
  * Info associated with mdast GFM table row nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TableRowData extends Data {}
 
 /**
@@ -1087,7 +1064,6 @@ export interface TableCell extends Parent {
 /**
  * Info associated with mdast GFM table cell nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TableCellData extends Data {}
 
 /**
@@ -1107,7 +1083,6 @@ export interface Text extends Literal {
 /**
  * Info associated with mdast text nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TextData extends Data {}
 
 /**
@@ -1127,7 +1102,6 @@ export interface ThematicBreak extends Node {
 /**
  * Info associated with mdast thematic break nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ThematicBreakData extends Data {}
 
 /**
@@ -1147,7 +1121,6 @@ export interface Yaml extends Literal {
 /**
  * Info associated with mdast YAML nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface YamlData extends Data {}
 
 /**

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mdast 3.0
+// Type definitions for Mdast 4.0
 // Project: https://github.com/syntax-tree/mdast, https://github.com/wooorm/mdast
 // Definitions by: Christian Murphy <https://github.com/ChristianMurphy>
 //                 Jun Lu <https://github.com/lujun2>

--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -6,7 +6,6 @@
 //                 Titus Wormer <https://github.com/wooorm>
 //                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
 import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
 

--- a/types/mdast/mdast-tests.ts
+++ b/types/mdast/mdast-tests.ts
@@ -1,123 +1,459 @@
-import * as Mdast from 'mdast';
+import type {
+    Blockquote,
+    BlockContentMap,
+    Break,
+    Code,
+    Data,
+    Definition,
+    DefinitionContentMap,
+    Delete,
+    Emphasis,
+    FootnoteDefinition,
+    FootnoteReference,
+    FrontmatterContentMap,
+    Heading,
+    Html,
+    Image,
+    ImageReference,
+    InlineCode,
+    Link,
+    LinkReference,
+    List,
+    ListContentMap,
+    ListItem,
+    Literal,
+    Paragraph,
+    Parent,
+    PhrasingContentMap,
+    Root,
+    RootContentMap,
+    RowContentMap,
+    Strong,
+    Table,
+    TableCell,
+    TableContentMap,
+    TableRow,
+    Text,
+    ThematicBreak,
+    Yaml,
+} from 'mdast';
 
-// Augmentations
+const data: Data = {};
 
-declare module 'mdast' {
-    interface FrontmatterContentMap {
-        toml: TOML;
-    }
-
-    interface StaticPhrasingContentMap {
-        mdxJsxTextElement: MDXJSXTextElement;
-    }
-}
-
-interface TOML extends Mdast.Literal {
-    type: 'toml';
-}
-
-interface MDXJSXTextElement extends Mdast.Literal {
-    type: 'mdxJsxTextElement';
-}
-
-// Tests
-
-declare var toml: TOML;
-declare var mdxJsxTextElement: MDXJSXTextElement;
-
-const text: Mdast.Text = {
-    type: 'text',
-    value: 'text',
+const position = {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 },
 };
 
-const cell: Mdast.TableCell = {
-    type: 'tableCell',
-    children: [text],
+// ## CommonMark voids
+
+const break_: Break = {
+    type: 'break',
+    position,
+    data,
 };
 
-const row: Mdast.TableRow = {
-    type: 'tableRow',
-    children: [cell],
+const definition: Definition = {
+    type: 'definition',
+    identifier: 'mdast',
+    url: 'https://github.com/syntax-tree/mdast',
+    position,
+    data,
 };
 
-const table: Mdast.Table = {
-    type: 'table',
-    align: ['left', 'center', 'right'],
-    children: [row],
+// @ts-expect-error: `identifier` is required.
+const definitionWithoutIdentifier: Definition = {
+    type: 'definition',
+    url: '',
 };
 
-const header: Mdast.Heading = {
-    type: 'heading',
-    depth: 1,
-    children: [text],
+// @ts-expect-error: `url` is required.
+const definitionWithoutIdentifier: Definition = {
+    type: 'definition',
+    identifier: '',
 };
 
-const code: Mdast.Code = {
-    type: 'code',
-    lang: 'javascript',
-    value: 'let n = 42;',
+const definitionWithTitle: Definition = {
+    type: 'definition',
+    identifier: '',
+    url: '',
+    title: '',
 };
 
-const paragraph: Mdast.Paragraph = {
-    type: 'paragraph',
-    children: [text, mdxJsxTextElement],
+const definitionWithLabel: Definition = {
+    type: 'definition',
+    identifier: '',
+    label: '',
+    url: '',
 };
 
-const item: Mdast.ListItem = {
-    type: 'listItem',
-    children: [paragraph],
-};
-
-const list: Mdast.List = {
-    type: 'list',
-    children: [item],
-};
-
-const footNote: Mdast.FootnoteReference = {
-    type: 'footnoteReference',
-    identifier: 'ref1',
-    label: 'Referfence 1',
-};
-
-const image: Mdast.Image = {
+const image: Image = {
     type: 'image',
     url: 'https://github.com/syntax-tree/mdast',
     alt: 'image alternative',
+    position,
+    data,
 };
 
-const root: Mdast.Root = {
-    type: 'root',
-    children: [header, table, code, image, toml],
+// @ts-expect-error: `url` is required.
+const imageWithoutUrl: Image = {
+    type: 'image',
 };
 
-const link: Mdast.Link = {
+const imageWithTitle: Image = {
+    type: 'image',
+    url: '',
+    title: '',
+};
+
+const imageReference: ImageReference = {
+    type: 'imageReference',
+    identifier: 'x',
+    referenceType: 'full',
+    alt: 'image alternative',
+    position,
+    data,
+};
+
+const thematicBreak: ThematicBreak = {
+    type: 'thematicBreak',
+    position,
+    data,
+};
+
+// ## CommonMark literals
+
+const literal: Literal = {
+    type: 'whatever',
+    value: 'value',
+    position,
+    data,
+};
+
+const code: Code = {
+    type: 'code',
+    value: '',
+    position,
+    data,
+};
+
+const codeWithLang: Code = {
+    type: 'code',
+    lang: 'js',
+    value: '',
+    position,
+    data,
+};
+
+const codeWithLangAndMeta: Code = {
+    type: 'code',
+    lang: 'js',
+    meta: 'eval',
+    value: '',
+    position,
+    data,
+};
+
+const html: Html = {
+    type: 'html',
+    value: '',
+    position,
+    data,
+};
+
+const inlineCode: InlineCode = {
+    type: 'inlineCode',
+    value: '',
+    position,
+    data,
+};
+
+const text: Text = {
+    type: 'text',
+    value: '',
+    position,
+    data,
+};
+
+// ## CommonMark parents
+
+const parent: Parent = {
+    type: 'whatever',
+    children: [text],
+    position,
+    data,
+};
+
+const paragraph: Paragraph = {
+    type: 'paragraph',
+    children: [text],
+    position,
+    data,
+};
+
+const blockquote: Blockquote = {
+    type: 'blockquote',
+    children: [paragraph],
+    position,
+    data,
+};
+
+const emphasis: Emphasis = {
+    type: 'emphasis',
+    children: [text],
+    position,
+    data,
+};
+
+const heading: Heading = {
+    type: 'heading',
+    depth: 1,
+    children: [text],
+    position,
+    data,
+};
+
+// @ts-expect-error: `depth` is required.
+const headingWithoutDepth: Heading = {
+    type: 'heading',
+    children: [],
+};
+
+const link: Link = {
     type: 'link',
     children: [text],
     url: 'https://example.com',
-    title: null,
+    position,
+    data,
 };
 
-// Combination of all the declared ContentMap interfaces.
-interface ContentMap
-    extends Mdast.BlockContentMap,
-        Mdast.DefinitionContentMap,
-        Mdast.FrontmatterContentMap,
-        Mdast.ListContentMap,
-        Mdast.PhrasingContentMap,
-        Mdast.RowContentMap,
-        Mdast.StaticPhrasingContentMap,
-        Mdast.TableContentMap {}
+const linkReference: LinkReference = {
+    type: 'linkReference',
+    identifier: 'x',
+    referenceType: 'full',
+    children: [text],
+    position,
+    data,
+};
 
-// Type with all …ContentMap keys corresponding to something whose `{type: "…"}` field does not match the key.
-// This should be empty. A previous version of these type definitions named a few entries like
-// "inlinecode" referring to a type keyed as "inlineCode", and so on.
+// @ts-expect-error: `url` is required.
+const linkWithoutUrl: Link = {
+    type: 'link',
+    children: [],
+};
+
+const linkWithTitle: Link = {
+    type: 'link',
+    children: [],
+    url: 'https://example.com',
+    title: '',
+};
+
+const listItem: ListItem = {
+    type: 'listItem',
+    children: [paragraph],
+    position,
+    data,
+};
+
+const listItemWithChecked: ListItem = {
+    type: 'listItem',
+    children: [],
+    checked: true,
+};
+
+const listItemWithSpread: ListItem = {
+    type: 'listItem',
+    children: [],
+    spread: true,
+};
+
+const list: List = {
+    type: 'list',
+    children: [listItem],
+    position,
+    data,
+};
+
+const listWithOrdered: List = {
+    type: 'list',
+    children: [],
+    ordered: true,
+};
+
+const root: Root = {
+    type: 'root',
+    children: [],
+    position,
+    data,
+};
+
+const strong: Strong = {
+    type: 'strong',
+    children: [text],
+    position,
+    data,
+};
+
+// ## GFM
+const delete_: Delete = {
+    type: 'delete',
+    children: [text],
+    position,
+    data,
+};
+
+const footnoteDefinition: FootnoteDefinition = {
+    type: 'footnoteDefinition',
+    identifier: 'mdast',
+    children: [paragraph],
+    position,
+    data,
+};
+
+const footnoteReference: FootnoteReference = {
+    type: 'footnoteReference',
+    identifier: 'mdast',
+    position,
+    data,
+};
+
+const tableCell: TableCell = {
+    type: 'tableCell',
+    children: [text],
+    position,
+    data,
+};
+
+const tableRow: TableRow = {
+    type: 'tableRow',
+    children: [tableCell],
+    position,
+    data,
+};
+
+const table: Table = {
+    type: 'table',
+    children: [tableRow],
+    position,
+    data,
+};
+
+const tableWithAlign: Table = {
+    type: 'table',
+    align: ['left', 'center', 'right'],
+    children: [tableRow],
+    position,
+    data,
+};
+
+// ## Frontmatter
+const yaml: Yaml = {
+    type: 'yaml',
+    value: '',
+    position,
+    data,
+};
+
+// Test custom mdast node registration.
+interface Toml extends Literal {
+    type: 'toml';
+}
+
+declare module 'mdast' {
+    interface RootContentMap {
+        toml: Toml;
+    }
+
+    interface FrontmatterContentMap {
+        toml: Toml;
+    }
+}
+
+const rootOther: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [{ type: 'toml', value: '' }],
+};
+
+const rootAnother: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [
+        // @ts-expect-error: node not registered in `RootContentMap`.
+        { type: 'invalid' },
+    ],
+};
+
+// Register a field on `Data`, which will be available on all nodes.
+declare module 'mdast' {
+    interface Data {
+        someField?: string | undefined;
+    }
+
+    interface InlineCodeData {
+        someOtherField?: number | undefined;
+    }
+}
+
+const textWithData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: registered on inline codes, not on texts.
+        someOtherField: 1,
+    },
+};
+
+const textWithOtherData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
+};
+
+const inlineCodeWithData: InlineCode = {
+    type: 'inlineCode',
+    value: 'value',
+    data: {
+        someField: 'a',
+        someOtherField: 1,
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
+};
+
+// ## Content map checks
+
+// Tests
+
+// Check that all keys of a map are assignable to their corresponding node’s
+// `type` field.
 //
-// The ContentMap interfaces themselves aren't used at runtime: they're just groupings of types.
-// However that inconsistency prevented them from being used for things like defining rendering/handling
-// functions keyed on the node type names.
+// A previous version of the types used a few cases such as `inlinecode` for
+// `inlineCode` and so on.
+//
+// The content maps themselves are not used at runtime: they’re just groupings
+// of types.
+// However that inconsistency prevented them from being used for things like
+// defining rendering/handling functions keyed on the node type names.
 type TypeMapIssues<M extends {}> = {
     [K in keyof M as M[K] extends { type: K } ? never : K]: [K, M[K]];
 };
 
-// Assert that there are no incorrect keys. If there are, this is not assignable.
-const typeMapIssues: TypeMapIssues<ContentMap> = {};
+// Assert that there are no incorrect keys.
+// If there are, these is not assignable.
+const blockContent: TypeMapIssues<BlockContentMap> = {};
+const definitionContent: TypeMapIssues<DefinitionContentMap> = {};
+const frontmatterContent: TypeMapIssues<FrontmatterContentMap> = {};
+const listContent: TypeMapIssues<ListContentMap> = {};
+const phrasingContent: TypeMapIssues<PhrasingContentMap> = {};
+const rootContent: TypeMapIssues<RootContentMap> = {};
+const rowContent: TypeMapIssues<RowContentMap> = {};
+const tableContent: TypeMapIssues<TableContentMap> = {};

--- a/types/mdast/tslint.json
+++ b/types/mdast/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/mdast/tslint.json
+++ b/types/mdast/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
 }

--- a/types/nlcst/index.d.ts
+++ b/types/nlcst/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package nlcst 1.0
+// Type definitions for non-npm package nlcst 2.0
 // Project: https://github.com/syntax-tree/nlcst
 // Definitions by: Titus Wormer <https://github.com/wooorm>
 //                 Christian Murphy <https://github.com/ChristianMurphy>

--- a/types/nlcst/index.d.ts
+++ b/types/nlcst/index.d.ts
@@ -27,7 +27,6 @@ import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Par
  * }
  * ```
  */
-// tslint:disable-next-line
 export interface Data extends UnistData {}
 
 // ## Content maps
@@ -230,7 +229,6 @@ export interface Paragraph extends Parent {
 /**
  * Info associated with nlcst paragraph nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ParagraphData extends Data {}
 
 /**
@@ -253,7 +251,6 @@ export interface Punctuation extends Literal {
 /**
  * Info associated with nlcst punctuation nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface PunctuationData extends Data {}
 
 /**
@@ -277,7 +274,6 @@ export interface Root extends Parent {
 /**
  * Info associated with nlcst root nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface RootData extends Data {}
 
 /**
@@ -306,7 +302,6 @@ export interface Sentence extends Parent {
 /**
  * Info associated with nlcst sentence nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface SentenceData extends Data {}
 
 /**
@@ -329,7 +324,6 @@ export interface Source extends Literal {
 /**
  * Info associated with nlcst source nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface SourceData extends Data {}
 
 /**
@@ -352,7 +346,6 @@ export interface Symbol extends Literal {
 /**
  * Info associated with nlcst symbol nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface SymbolData extends Data {}
 
 /**
@@ -374,7 +367,6 @@ export interface Text extends Literal {
 /**
  * Info associated with nlcst text nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TextData extends Data {}
 
 /**
@@ -396,7 +388,6 @@ export interface WhiteSpace extends Literal {
 /**
  * Info associated with nlcst white space nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface WhiteSpaceData extends Data {}
 
 /**
@@ -424,5 +415,4 @@ export interface Word extends Parent {
 /**
  * Info associated with nlcst word nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface WordData extends Data {}

--- a/types/nlcst/index.d.ts
+++ b/types/nlcst/index.d.ts
@@ -5,18 +5,45 @@
 //                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Parent as UnistParent, Literal as UnistLiteral } from 'unist';
+import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
+
+// ## Interfaces
 
 /**
- * This map registers all node types that are acceptable inside paragraphs.
- * This interface can be augmented to register custom node types.
+ * Info associated with nlcst nodes by the ecosystem.
  *
- * @example
+ * This space is guaranteed to never be specified by unist or nlcst.
+ * But you can use it in utilities and plugins to store data.
+ *
+ * This type can be augmented to register custom data.
+ * For example:
+ *
+ * ```ts
  * declare module 'nlcst' {
- *   interface ParagraphContentMap {
- *     custom: Custom;
+ *   interface Data {
+ *     // `someNode.data.myId` is typed as `number | undefined`
+ *     myId?: number | undefined
  *   }
  * }
+ * ```
+ */
+// tslint:disable-next-line
+export interface Data extends UnistData {}
+
+// ## Content maps
+
+/**
+ * Union of registered nlcst nodes that can occur in {@link Paragraph}.
+ *
+ * To register more custom nlcst nodes, add them to {@link ParagraphContentMap}.
+ * They will be automatically added here.
+ */
+export type ParagraphContent = ParagraphContentMap[keyof ParagraphContentMap];
+
+/**
+ * Registry of all nlcst nodes that can occur as children of {@link Paragraph}.
+ *
+ * For a union of all {@link Paragraph} children, see {@link ParagraphContent}.
  */
 export interface ParagraphContentMap {
     sentence: Sentence;
@@ -25,15 +52,44 @@ export interface ParagraphContentMap {
 }
 
 /**
- * This map registers all node types that are acceptable inside sentences.
- * This interface can be augmented to register custom node types.
+ * Union of registered nlcst nodes that can occur in {@link Root}.
  *
- * @example
- * declare module 'nlcst' {
- *   interface SentenceContentMap {
- *     custom: Custom;
- *   }
- * }
+ * To register custom nlcst nodes, add them to {@link RootContentMap}.
+ * They will be automatically added here.
+ */
+export type RootContent = RootContentMap[keyof RootContentMap];
+
+/**
+ * Registry of all nlcst nodes that can occur as children of {@link Root}.
+ *
+ * > 👉 **Note**: {@link Root} does not need to be an entire document.
+ * > it can also be a fragment.
+ *
+ * For a union of all {@link Root} children, see {@link RootContent}.
+ */
+export interface RootContentMap {
+    paragraph: Paragraph;
+    punctuation: Punctuation;
+    sentence: Sentence;
+    source: Source;
+    symbol: Symbol;
+    text: Text;
+    whiteSpace: WhiteSpace;
+    word: Word;
+}
+
+/**
+ * Union of registered nlcst nodes that can occur in {@link Sentence}.
+ *
+ * To register more custom nlcst nodes, add them to {@link SentenceContentMap}.
+ * They will be automatically added here.
+ */
+export type SentenceContent = SentenceContentMap[keyof SentenceContentMap];
+
+/**
+ * Registry of all nlcst nodes that can occur as children of {@link Sentence}.
+ *
+ * For a union of all {@link Sentence} children, see {@link SentenceContent}.
  */
 export interface SentenceContentMap {
     punctuation: Punctuation;
@@ -44,15 +100,17 @@ export interface SentenceContentMap {
 }
 
 /**
- * This map registers all node types that are acceptable inside words.
- * This interface can be augmented to register custom node types.
+ * Union of registered nlcst nodes that can occur in {@link Word}.
  *
- * @example
- * declare module 'nlcst' {
- *   interface WordContentMap {
- *     custom: Custom;
- *   }
- * }
+ * To register more custom nlcst nodes, add them to {@link WordContentMap}.
+ * They will be automatically added here.
+ */
+export type WordContent = WordContentMap[keyof WordContentMap];
+
+/**
+ * Registry of all nlcst nodes that can occur as children of {@link Word}.
+ *
+ * For a union of all {@link Word} children, see {@link WordContent}.
  */
 export interface WordContentMap {
     punctuation: Punctuation;
@@ -61,120 +119,310 @@ export interface WordContentMap {
     text: Text;
 }
 
-export type Content = Paragraph | ParagraphContent | SentenceContent | WordContent;
-
-export type ParagraphContent = ParagraphContentMap[keyof ParagraphContentMap];
-
-export type SentenceContent = SentenceContentMap[keyof SentenceContentMap];
-
-export type WordContent = WordContentMap[keyof WordContentMap];
+// ### Special content types
 
 /**
- * Node in nlcst containing other nodes
+ * Union of registered nlcst nodes that can occur in {@link Root}.
+ *
+ * @deprecated Use {@link RootContent} instead.
  */
-export interface Parent extends UnistParent {
-    children: Content[];
-}
+export type Content = RootContent;
 
 /**
- * Node in nlcst containing a value.
+ * Union of registered nlcst literals.
+ *
+ * To register custom nlcst nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
  */
-export interface Literal extends UnistLiteral {
+export type Literals = Extract<Nodes, UnistLiteral>;
+
+/**
+ * Union of registered nlcst nodes.
+ *
+ * To register custom nlcst nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Nodes = Root | RootContent;
+
+/**
+ * Union of registered nlcst parents.
+ *
+ * To register custom nlcst nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Parents = Extract<Nodes, UnistParent>;
+
+// ## Abstract nodes
+
+/**
+ * Abstract nlcst node that contains the smallest possible value.
+ *
+ * This interface is supposed to be extended if you make custom nlcst nodes.
+ *
+ * For a union of all registered nlcst literals, see {@link Literals}.
+ */
+export interface Literal extends Node {
+    /**
+     * Plain-text value.
+     */
     value: string;
 }
 
 /**
- * Node representing a document.
+ * Abstract nlcst node.
  *
- * Root can be used as the root of a tree, never as a child.
+ * This interface is supposed to be extended.
+ * If you can use {@link Literal} or {@link Parent}, you should.
+ * But for example in markdown, a `thematicBreak` (`***`) is neither literal
+ * nor parent, but still a node.
+ *
+ * To register custom nlcst nodes, add them to {@link RootContentMap} and other
+ * places where relevant (such as {@link SentenceContentMap}).
+ *
+ * For a union of all registered nlcst nodes, see {@link Nodes}.
+ */
+export interface Node extends UnistNode {
+    /**
+     * Info from the ecosystem.
+     */
+    data?: Data | undefined;
+}
+
+/**
+ * Abstract nlcst node that contains other nlcst nodes (*children*).
+ *
+ * This interface is supposed to be extended if you make custom nlcst nodes.
+ *
+ * For a union of all registered nlcst parents, see {@link Parents}.
+ */
+export interface Parent extends Node {
+    /**
+     * List of children.
+     */
+    children: RootContent[];
+}
+
+// ## Concrete nodes
+
+/**
+ * Unit of discourse dealing with a particular point or idea.
+ *
+ * Can contain sentence, whitespace, and source nodes.
+ */
+export interface Paragraph extends Parent {
+    /**
+     * Node type of nlcst paragraph.
+     */
+    type: 'ParagraphNode';
+    /**
+     * Children of paragraph.
+     */
+    children: ParagraphContent[];
+    /**
+     * Data associated with the nlcst paragraph.
+     */
+    data?: ParagraphData | undefined;
+}
+
+/**
+ * Info associated with nlcst paragraph nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ParagraphData extends Data {}
+
+/**
+ * Typographical devices which aid understanding and correct reading of other
+ * grammatical units.
+ *
+ * Can be used in sentence or word nodes.
+ */
+export interface Punctuation extends Literal {
+    /**
+     * Node type of nlcst punctuations.
+     */
+    type: 'PunctuationNode';
+    /**
+     * Data associated with the nlcst punctuation.
+     */
+    data?: PunctuationData | undefined;
+}
+
+/**
+ * Info associated with nlcst punctuation nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface PunctuationData extends Data {}
+
+/**
+ * Document fragment or a whole document.
+ *
+ * Should be used as the root of a tree and must not be used as a child.
  * Its content model is not limited, it can contain any nlcst content, with the
  * restriction that all content must be of the same category.
  */
 export interface Root extends Parent {
+    /**
+     * Node type of nlcst root.
+     */
     type: 'RootNode';
-    children: Content[];
+    /**
+     * Data associated with the nlcst root.
+     */
+    data?: RootData | undefined;
 }
 
 /**
- * Node representing a unit of discourse dealing with a particular point or idea.
- *
- * It can contain sentence, whitespace, and source nodes.
+ * Info associated with nlcst root nodes by the ecosystem.
  */
-export interface Paragraph extends Parent {
-    type: 'ParagraphNode';
-    children: ParagraphContent[];
-}
+// tslint:disable-next-line
+export interface RootData extends Data {}
 
 /**
- * Node representing a grouping of grammatically linked words, that in principle
- * tells a complete thought, although it may make little sense taken in
- * isolation out of context.
+ * Grouping of grammatically linked words, that in principle tells a complete
+ * thought, although it may make little sense taken in isolation out of
+ * context.
  *
- * It can be used in a paragraph node.
- * It can contain word, symbol, punctuation, whitespace, and source nodes.
+ * Can be used in a paragraph node.
+ * Can contain word, symbol, punctuation, whitespace, and source nodes.
  */
 export interface Sentence extends Parent {
+    /**
+     * Node type of nlcst sentence.
+     */
     type: 'SentenceNode';
+    /**
+     * Children of sentence.
+     */
     children: SentenceContent[];
+    /**
+     * Data associated with the nlcst sentence.
+     */
+    data?: SentenceData | undefined;
 }
 
 /**
- * Node representing the smallest element that may be uttered in isolation with
- * semantic or pragmatic content.
- *
- * It can be used in a sentence node.
- * It can contain text, symbol, punctuation, and source nodes.
+ * Info associated with nlcst sentence nodes by the ecosystem.
  */
-export interface Word extends Parent {
-    type: 'WordNode';
-    children: WordContent[];
-}
+// tslint:disable-next-line
+export interface SentenceData extends Data {}
 
 /**
- * Node representing typographical devices different from characters which
- * represent sounds (like letters and numerals), white space, or punctuation.
+ * External (ungrammatical) value embedded into a grammatical unit: a hyperlink,
+ * code, and such.
  *
- * It can be used in sentence or word nodes.
- */
-export interface Symbol extends Literal {
-    type: 'SymbolNode';
-}
-
-/**
- * Node representing typographical devices devoid of content, separating other
- * units.
- *
- * It can be used in root, paragraph, or sentence nodes.
- */
-export interface WhiteSpace extends Literal {
-    type: 'WhiteSpaceNode';
-}
-
-/**
- * Node representing typographical devices which aid understanding and correct
- * reading of other grammatical units.
- *
- * It can be used in sentence or word nodes.
- */
-export interface Punctuation extends Literal {
-    type: 'PunctuationNode';
-}
-
-/**
- * Node representing an external (ungrammatical) value embedded into a
- * grammatical unit: a hyperlink, code, and such.
- *
- * It can be used in root, paragraph, sentence, or word nodes.
+ * Can be used in root, paragraph, sentence, or word nodes.
  */
 export interface Source extends Literal {
+    /**
+     * Node type of nlcst sources.
+     */
     type: 'SourceNode';
+    /**
+     * Data associated with the nlcst source.
+     */
+    data?: SourceData | undefined;
 }
 
 /**
- * Node representing actual content in nlcst documents: one or more characters.
+ * Info associated with nlcst source nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface SourceData extends Data {}
+
+/**
+ * Typographical devices different from characters which represent sounds (like
+ * letters and numerals), white space, or punctuation.
  *
- * It can be used in word nodes.
+ * Can be used in sentence or word nodes.
+ */
+export interface Symbol extends Literal {
+    /**
+     * Node type of nlcst symbols.
+     */
+    type: 'SymbolNode';
+    /**
+     * Data associated with the nlcst symbol.
+     */
+    data?: SymbolData | undefined;
+}
+
+/**
+ * Info associated with nlcst symbol nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface SymbolData extends Data {}
+
+/**
+ * Actual content in nlcst documents: one or more characters.
+ *
+ * Can be used in word nodes.
  */
 export interface Text extends Literal {
+    /**
+     * Node type of nlcst texts.
+     */
     type: 'TextNode';
+    /**
+     * Data associated with the nlcst text.
+     */
+    data?: TextData | undefined;
 }
+
+/**
+ * Info associated with nlcst text nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TextData extends Data {}
+
+/**
+ * Typographical devices devoid of content, separating other units.
+ *
+ * Can be used in root, paragraph, or sentence nodes.
+ */
+export interface WhiteSpace extends Literal {
+    /**
+     * Node type of nlcst white space.
+     */
+    type: 'WhiteSpaceNode';
+    /**
+     * Data associated with the nlcst white space.
+     */
+    data?: WhiteSpaceData | undefined;
+}
+
+/**
+ * Info associated with nlcst white space nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface WhiteSpaceData extends Data {}
+
+/**
+ * Smallest element that may be uttered in isolation with semantic or pragmatic
+ * content.
+ *
+ * Can be used in a sentence node.
+ * Can contain text, symbol, punctuation, and source nodes.
+ */
+export interface Word extends Parent {
+    /**
+     * Node type of nlcst word.
+     */
+    type: 'WordNode';
+    /**
+     * Children of word.
+     */
+    children: WordContent[];
+    /**
+     * Data associated with the nlcst word.
+     */
+    data?: WordData | undefined;
+}
+
+/**
+ * Info associated with nlcst word nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface WordData extends Data {}

--- a/types/nlcst/nlcst-tests.ts
+++ b/types/nlcst/nlcst-tests.ts
@@ -1,145 +1,195 @@
-import { Data, Node, Point, Position } from 'unist';
-import {
-    Parent,
+import type {
+    Data,
+    Node,
     Literal,
-    Root,
     Paragraph,
-    Sentence,
-    Word,
-    Symbol,
-    WhiteSpace,
+    Parent,
     Punctuation,
+    Root,
+    Sentence,
     Source,
+    Symbol,
     Text,
+    WhiteSpace,
+    Word,
 } from 'nlcst';
 
-const data: Data = {
-    string: 'string',
-    number: 1,
-    object: {
-        key: 'value',
-    },
-    array: [],
-    boolean: true,
-    null: null,
-};
+const data: Data = {};
 
-const point: Point = {
-    line: 1,
-    column: 1,
-    offset: 0,
-};
-
-const position: Position = {
-    start: point,
-    end: point,
-};
-
-const literal: Literal = {
-    type: 'TextNode',
-    data,
-    position,
-    value: 'value',
+const position = {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 },
 };
 
 const symbol: Symbol = {
     type: 'SymbolNode',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const punctuation: Punctuation = {
     type: 'PunctuationNode',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const text: Text = {
     type: 'TextNode',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const source: Source = {
     type: 'SourceNode',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const whiteSpace: WhiteSpace = {
     type: 'WhiteSpaceNode',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
-let paragraph: Paragraph = getParagraph();
+const word: Word = {
+    type: 'WordNode',
+    children: [punctuation, source, symbol, text],
+};
 
-const sentence: Sentence = getSentence();
+const sentence: Sentence = {
+    type: 'SentenceNode',
+    children: [punctuation, source, symbol, whiteSpace, word],
+};
 
-const word: Word = getWord();
-
-const parent: Parent = {
-    type: 'parent',
-    data,
-    position,
-    children: [getParagraph(), getSentence(), getWord(), punctuation, source, symbol, text, whiteSpace],
+const paragraph: Paragraph = {
+    type: 'ParagraphNode',
+    children: [sentence, source, whiteSpace],
 };
 
 const root: Root = {
     type: 'RootNode',
-    data,
+    children: [paragraph, punctuation, sentence, source, symbol, text, whiteSpace, word],
     position,
-    children: [getParagraph(), getSentence(), getWord(), punctuation, source, symbol, text, whiteSpace],
+    data,
 };
 
-function getParagraph(): Paragraph {
-    return {
-        type: 'ParagraphNode',
-        children: [getSentence(), source, whiteSpace],
-    };
-}
+const parent: Parent = {
+    type: 'ParentNode',
+    children: [paragraph, punctuation, sentence, source, symbol, text, whiteSpace, word],
+    position,
+    data,
+};
 
-function getSentence(): Sentence {
-    return {
-        type: 'SentenceNode',
-        children: [punctuation, source, symbol, whiteSpace, getWord()],
-    };
-}
+const wordWithWrongChild: Word = {
+    type: 'WordNode',
+    children: [
+        // @ts-expect-error: paragraphs are not valid in words.
+        paragraph,
+    ],
+};
 
-function getWord(): Word {
-    return {
-        type: 'WordNode',
-        children: [punctuation, source, symbol, text],
-    };
-}
+const sentenceWithWrongChild: Sentence = {
+    type: 'SentenceNode',
+    children: [
+        // @ts-expect-error: paragraphs are not valid in sentences.
+        paragraph,
+    ],
+};
 
-// Test custom nlcst node registration
+const paragraphWithWrongChild: Paragraph = {
+    type: 'ParagraphNode',
+    children: [
+        // @ts-expect-error: words are not valid in sentences.
+        word,
+    ],
+};
+
+// Test custom nlcst node registration.
 interface Custom extends Node {
     type: 'CustomNode';
 }
 
 declare module 'nlcst' {
-    interface ParagraphContentMap {
+    interface RootContentMap {
+        custom: Custom;
+    }
+
+    interface SentenceContentMap {
         custom: Custom;
     }
 }
 
-paragraph = {
-    type: 'ParagraphNode',
-    data,
-    position,
+const rootOther: Root = {
+    type: 'RootNode',
     children: [{ type: 'CustomNode' }],
 };
 
-paragraph = {
-    type: 'ParagraphNode',
+const sentenceOther: Sentence = {
+    type: 'SentenceNode',
+    children: [{ type: 'CustomNode' }],
+};
+
+const rootAnother: Root = {
+    type: 'RootNode',
     data,
     position,
-    // @ts-expect-error
-    children: [{ type: 'invalid' }],
+    children: [
+        // @ts-expect-error: node not registered in `RootContentMap`.
+        { type: 'InvalidNode' },
+    ],
+};
+
+const sentenceAnother: Sentence = {
+    type: 'SentenceNode',
+    children: [
+        // @ts-expect-error: node not registered in `SentenceContentMap`.
+        { type: 'InvalidNode' },
+    ],
+};
+
+// Register a field on `Data`, which will be available on all nodes.
+declare module 'nlcst' {
+    interface Data {
+        someField?: string | undefined;
+    }
+
+    interface SymbolData {
+        someOtherField?: number | undefined;
+    }
+}
+
+const textWithData: Text = {
+    type: 'TextNode',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered on all nlcst nodes.
+        someOtherField: 1,
+    },
+};
+
+const textWithOtherData: Text = {
+    type: 'TextNode',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered on text nodes.
+        someUnknownField: true,
+    },
+};
+
+const symbolWithData: Symbol = {
+    type: 'SymbolNode',
+    value: 'value',
+    data: {
+        someField: 'a',
+        someOtherField: 1,
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
 };

--- a/types/nlcst/tslint.json
+++ b/types/nlcst/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "ban-types": false
+        "ban-types": false,
+        "npm-naming": false
     }
 }

--- a/types/nlcst/tslint.json
+++ b/types/nlcst/tslint.json
@@ -2,6 +2,7 @@
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
         "ban-types": false,
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Unist 2.0
+// Type definitions for non-npm package unist 3.0
 // Project: https://github.com/syntax-tree/unist
 // Definitions by: bizen241 <https://github.com/bizen241>
 //                 Jun Lu <https://github.com/lujun2>
@@ -7,61 +7,32 @@
 //                 Junyoung Choi <https://github.com/rokt33r>
 //                 Ben Moon <https://github.com/GuiltyDolphin>
 //                 JounQin <https://github.com/JounQin>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+
+// ## Interfaces
 
 /**
- * Syntactic units in unist syntax trees are called nodes.
+ * Info associated with nodes by the ecosystem.
  *
- * @typeParam TData Information from the ecosystem. Useful for more specific {@link Node.data}.
- */
-export interface Node<TData extends object = Data> {
-    /**
-     * The variant of a node.
-     */
-    type: string;
-
-    /**
-     * Information from the ecosystem.
-     */
-    data?: TData | undefined;
-
-    /**
-     * Location of a node in a source document.
-     * Must not be present if a node is generated.
-     */
-    position?: Position | undefined;
-}
-
-/**
- * Information associated by the ecosystem with the node.
- * Space is guaranteed to never be specified by unist or specifications
+ * This space is guaranteed to never be specified by unist or specifications
  * implementing unist.
+ * But you can use it in utilities and plugins to store data.
+ *
+ * This type can be augmented to register custom data.
+ * For example:
+ *
+ * ```ts
+ * declare module 'unist' {
+ *   interface Data {
+ *     // `someNode.data.myId` is typed as `number | undefined`
+ *     myId?: number | undefined
+ *   }
+ * }
+ * ```
  */
-export interface Data {
-    [key: string]: unknown;
-}
-
-/**
- * Location of a node in a source file.
- */
-export interface Position {
-    /**
-     * Place of the first character of the parsed source region.
-     */
-    start: Point;
-
-    /**
-     * Place of the first character after the parsed source region.
-     */
-    end: Point;
-
-    /**
-     * Start column at each index (plus start line) in the source region,
-     * for elements that span multiple lines.
-     */
-    indent?: number[] | undefined;
-}
+// tslint:disable-next-line
+export interface Data {}
 
 /**
  * One place in a source file.
@@ -83,32 +54,79 @@ export interface Point {
 }
 
 /**
- * Util for extracting type of {@link Node.data}
+ * Position of a node in a source document.
  *
- * @typeParam TNode Specific node type such as {@link Node} with {@link Data}, {@link Literal}, etc.
- *
- * @example `NodeData<Node<{ key: string }>>` -> `{ key: string }`
+ * A position is a range between two points.
  */
-export type NodeData<TNode extends Node<object>> = TNode extends Node<infer TData> ? TData : never;
+export interface Position {
+    /**
+     * Place of the first character of the parsed source region.
+     */
+    start: Point;
+
+    /**
+     * Place of the first character after the parsed source region.
+     */
+    end: Point;
+}
+
+// ## Abstract nodes
 
 /**
- * Nodes containing other nodes.
+ * Abstract unist node that contains the smallest possible value.
  *
- * @typeParam ChildNode Node item of {@link Parent.children}
+ * This interface is supposed to be extended.
+ *
+ * For example, in HTML, a `text` node is a leaf that contains text.
  */
-export interface Parent<ChildNode extends Node<object> = Node, TData extends object = NodeData<ChildNode>>
-    extends Node<TData> {
+export interface Literal extends Node {
     /**
-     * List representing the children of a node.
+     * Plain value.
      */
-    children: ChildNode[];
+    value: unknown;
 }
 
 /**
- * Nodes containing a value.
+ * Abstract unist node.
  *
- * @typeParam Value Specific value type of {@link Literal.value} such as `string` for `Text` node
+ * The syntactic unit in unist syntax trees are called nodes.
+ *
+ * This interface is supposed to be extended.
+ * If you can use {@link Literal} or {@link Parent}, you should.
+ * But for example in markdown, a `thematicBreak` (`***`), is neither literal
+ * nor parent, but still a node.
  */
-export interface Literal<Value = unknown, TData extends object = Data> extends Node<TData> {
-    value: Value;
+export interface Node {
+    /**
+     * Node type.
+     */
+    type: string;
+
+    /**
+     * Info from the ecosystem.
+     */
+    data?: Data | undefined;
+
+    /**
+     * Position of a node in a source document.
+     *
+     * Nodes that are generated (not in the original source document) must not
+     * have a position.
+     */
+    position?: Position | undefined;
+}
+
+/**
+ * Abstract unist node that contains other nodes (*children*).
+ *
+ * This interface is supposed to be extended.
+ *
+ * For example, in XML, an element is a parent of different things, such as
+ * comments, text, and further elements.
+ */
+export interface Parent extends Node {
+    /**
+     * List of children.
+     */
+    children: Node[];
 }

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -31,7 +31,6 @@
  * }
  * ```
  */
-// tslint:disable-next-line
 export interface Data {}
 
 /**

--- a/types/unist/tslint.json
+++ b/types/unist/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/unist/unist-tests.ts
+++ b/types/unist/unist-tests.ts
@@ -1,15 +1,4 @@
-import { Data, Point, Position, Node, Literal, Parent, NodeData } from 'unist';
-
-const data: Data = {
-    string: 'string',
-    number: 1,
-    object: {
-        key: 'value',
-    },
-    array: [],
-    boolean: true,
-    null: null,
-};
+import { Literal, Node, Parent, Point, Position } from 'unist';
 
 const point: Point = {
     line: 1,
@@ -20,129 +9,83 @@ const point: Point = {
 const position: Position = {
     start: point,
     end: point,
-    indent: [1],
 };
 
 const node: Node = {
     type: 'node',
-    data,
     position,
 };
 
 const text: Literal = {
     type: 'text',
-    data,
     position,
     value: 'value',
 };
 
 const parent: Parent = {
     type: 'parent',
-    data,
     position,
     children: [node, text],
 };
 
 const noExtraKeysInNode: Node = {
     type: 'noExtraKeysInNode',
-    // @ts-expect-error
+    // @ts-expect-error: `extra` does not exist on the abstract `Node` type: extend `Node` to add it.
     extra: 'extra',
 };
 
 const noChildrenInNode: Node = {
     type: 'noChildrenInNode',
-    // @ts-expect-error
+    // @ts-expect-error: `children` does not exist on the abstract `Node` type: use `Parent` to get it.
     children: [],
 };
 
-const stringLiteral: Literal<string> = {
+const stringLiteral: Literal = {
     type: 'text',
-    data,
     position,
     value: 'value',
 };
 
-const literalParent: Parent<Literal<string>> = {
+const literalParent: Parent = {
     type: 'literalParent',
-    data,
     position,
     children: [stringLiteral],
 };
 
-const nodeData: Node<{ key: string }> = {
+// Register a field on `Data`, which will be available on all nodes.
+declare module 'unist' {
+    interface Data {
+        someField?: string | undefined;
+    }
+}
+
+const nodeDataKeyOk: Node = {
+    type: 'nodeData',
+    data: { someField: 'value' },
+};
+
+const nodeDataKeyNok: Node = {
     type: 'nodeData',
     data: {
-        key: 'value',
+        // @ts-expect-error: `someField` is supposed to be `string | undefined`.
+        someField: 123,
     },
-};
-
-const nodeData2: Node<{ key: string }> = {
-    type: 'nodeData',
-    // @ts-expect-error
-    data: {},
-};
-
-// @ts-expect-error
-type DataType = NodeData<Node<string>>;
-
-const literalData: Literal<string, { key: string }> = {
-    type: 'literalData',
-    data: {
-        key: 'value',
-    },
-    value: 'value',
-};
-
-const literalParentData: Parent<Literal<string>, Data> = {
-    type: 'literalParent',
-    data,
-    position,
-    children: [stringLiteral],
-};
-
-const data1 = {
-    key1: 'value1',
-};
-
-const data2 = {
-    key2: 'value2',
-};
-
-const nestedliteralParentData: Parent<Literal<string, typeof data1>, typeof data2> = {
-    type: 'literalParent',
-    data: data2,
-    position,
-    children: [
-        {
-            ...stringLiteral,
-            data: data1,
-        },
-    ],
 };
 
 function exampleNodeUtil(node: Node) {}
 
-const inferredNode = { type: 'example' };
-const inferredNotNode = { notType: 'whoops' };
-
-exampleNodeUtil(inferredNode);
-// @ts-expect-error
-exampleNodeUtil(inferredNotNode);
+exampleNodeUtil({ type: 'example' });
+// @ts-expect-error: `type` is needed by the abstract `Node` interface.
+exampleNodeUtil({ notType: 'whoops' });
 
 function exampleLiteralUtil(node: Literal) {}
 
-const inferredLiteral = { type: 'example', value: 'value' };
-const inferredNotLiteral = { type: 'example' };
-
-exampleLiteralUtil(inferredLiteral);
-// @ts-expect-error
-exampleLiteralUtil(inferredNotLiteral);
+exampleLiteralUtil({ type: 'example', value: 'value' });
+// @ts-expect-error: `value` is needed by the abstract `Literal` interface.
+exampleLiteralUtil({ type: 'example' });
 
 function exampleParentUtil(node: Parent) {}
 
-const inferredParent = { type: 'example', children: [inferredNode] };
-const inferredNotParent = { type: 'example', children1: [] };
-
-exampleParentUtil(inferredParent);
-// @ts-expect-error
-exampleParentUtil(inferredNotParent);
+exampleParentUtil({ type: 'example', children: [{ type: 'example' }] });
+// @ts-expect-error: `children` is needed by the abstract `Parent` interface.
+exampleParentUtil({ type: 'example' });

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -1,42 +1,84 @@
-// Type definitions for non-npm package xast 1.0
+// Type definitions for non-npm package xast 2.0
 // Project: https://github.com/syntax-tree/xast
 // Definitions by: stefanprobst <https://github.com/stefanprobst>
 //                 Titus Wormer <https://github.com/wooorm>
 //                 Christian Murphy <https://github.com/ChristianMurphy>
 //                 Junyoung Choi <https://github.com/rokt33r>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
-import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
 
-export { UnistNode as Node };
-export { UnistParent as Parent };
+// ## Interfaces
 
 /**
- * Node in xast containing a value.
+ * Info associated with an element.
  */
-export interface Literal extends UnistLiteral {
-    value: string;
+export interface Attributes {
+    [name: string]: string | null | undefined;
 }
 
 /**
- * This map registers valid children for a xast root node.
+ * Info associated with xast nodes by the ecosystem.
  *
- * For example to register a custom node type as a valid xast rppt child:
+ * This space is guaranteed to never be specified by unist or xast.
+ * But you can use it in utilities and plugins to store data.
+ *
+ * This type can be augmented to register custom data.
+ * For example:
  *
  * ```ts
- * interface Custom extends Node {
- *   type: 'custom';
- * }
- *
  * declare module 'xast' {
- *   interface RootChildMap {
- *     custom: Custom;
+ *   interface Data {
+ *     // `someNode.data.myId` is typed as `number | undefined`
+ *     myId?: number | undefined
  *   }
  * }
  * ```
  */
-export interface RootChildMap {
+// tslint:disable-next-line
+export interface Data extends UnistData {}
+
+// ## Content maps
+
+/**
+ * Union of registered xast nodes that can occur in {@link Element}.
+ *
+ * To register more custom xast nodes, add them to {@link ElementContentMap}.
+ * They will be automatically added here.
+ */
+export type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+/**
+ * Registry of all xast nodes that can occur as children of {@link Element}.
+ *
+ * For a union of all {@link Element} children, see {@link ElementContent}.
+ */
+export interface ElementContentMap {
+    cdata: Cdata;
+    comment: Comment;
+    element: Element;
+    instruction: Instruction;
+    text: Text;
+}
+
+/**
+ * Union of registered xast nodes that can occur in {@link Root}.
+ *
+ * To register custom xast nodes, add them to {@link RootContentMap}.
+ * They will be automatically added here.
+ */
+export type RootContent = RootContentMap[keyof RootContentMap];
+
+/**
+ * Registry of all xast nodes that can occur as children of {@link Root}.
+ *
+ * > 👉 **Note**: {@link Root} does not need to be an entire document.
+ * > it can also be a fragment.
+ *
+ * For a union of all {@link Root} children, see {@link RootContent}.
+ */
+export interface RootContentMap {
     cdata: Cdata;
     comment: Comment;
     doctype: Doctype;
@@ -45,108 +87,261 @@ export interface RootChildMap {
     text: Text;
 }
 
+// ### Special content types
+
 /**
- * Document fragment or a whole document.
- * Should be used as the root of a tree and must not be used as a child.
+ * Union of registered xast literals.
  *
- * XML specifies that documents should have exactly one element child,
- * therefore a root should have exactly one element child when representing a
- * whole document.
+ * To register custom xast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
  */
-export interface Root extends UnistParent {
-    type: 'root';
-    children: Array<RootChildMap[keyof RootChildMap]>;
-}
+export type Literals = Extract<Nodes, UnistLiteral>;
 
 /**
- * This map registers valid children for a xast element node.
+ * Union of registered xast nodes.
  *
- * For example to register a custom node type as a valid xast element child:
+ * To register custom xast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Nodes = Root | RootContent;
+
+/**
+ * Union of registered xast parents.
  *
- * ```ts
- * interface Custom extends Node {
- *   type: 'custom';
- * }
+ * To register custom xast nodes, add them to {@link RootContentMap} and other
+ * places where relevant.
+ * They will be automatically added here.
+ */
+export type Parents = Extract<Nodes, UnistParent>;
+
+// ## Abstract nodes
+
+/**
+ * Abstract xast node that contains the smallest possible value.
  *
- * declare module 'xast' {
- *   interface ElementChildMap {
- *     custom: Custom;
- *   }
- * }
- * ```
+ * This interface is supposed to be extended if you make custom xast nodes.
+ *
+ * For a union of all registered xast literals, see {@link Literals}.
  */
-export interface ElementChildMap {
-    element: Element;
-    text: Text;
-    comment: Comment;
-    instruction: Instruction;
-    cdata: Cdata;
-}
-
-/**
- * An XML element.
- */
-export interface Element extends UnistParent {
-    type: 'element';
+export interface Literal extends Node {
     /**
-     * The element's qualified name.
+     * Plain-text value.
      */
-    name: string;
+    value: string;
+}
+
+/**
+ * Abstract xast node.
+ *
+ * This interface is supposed to be extended.
+ * If you can use {@link Literal} or {@link Parent}, you should.
+ * But for example in XML, a `Doctype` is neither literal nor parent, but
+ * still a node.
+ *
+ * To register custom xast nodes, add them to {@link RootContentMap} and other
+ * places where relevant (such as {@link ElementContentMap}).
+ *
+ * For a union of all registered xast nodes, see {@link Nodes}.
+ */
+export interface Node extends UnistNode {
     /**
-     * Information associated with the element.
+     * Info from the ecosystem.
      */
-    attributes?: Attributes | undefined;
-    children: Array<ElementChildMap[keyof ElementChildMap]>;
+    data?: Data | undefined;
 }
 
 /**
- * Information associated with an element.
+ * Abstract xast node that contains other xast nodes (*children*).
+ *
+ * This interface is supposed to be extended if you make custom xast nodes.
+ *
+ * For a union of all registered xast parents, see {@link Parents}.
  */
-export interface Attributes {
-    [name: string]: string | null | undefined;
-}
-
-/**
- * XML character data.
- */
-export interface Text extends Literal {
-    type: 'text';
-}
-
-/**
- * XML comment.
- */
-export interface Comment extends Literal {
-    type: 'comment';
-}
-
-/**
- * XML doctype.
- */
-export interface Doctype extends UnistNode {
-    type: 'doctype';
-    name: string;
+export interface Parent extends Node {
     /**
-     * The document’s public identifier.
+     * List of children.
      */
-    public?: string | undefined;
-    /**
-     * The document’s system identifier.
-     */
-    system?: string | undefined;
+    children: RootContent[];
 }
 
-/**
- * XML processing instruction.
- */
-export interface Instruction extends Literal {
-    type: 'instruction';
-    name: string;
-}
+// ## Concrete nodes
 
 /**
  * XML CDATA section.
  */
 export interface Cdata extends Literal {
+    /**
+     * Node type of XML CDATA sections in xast.
+     */
     type: 'cdata';
+    /**
+     * Data associated with the cdata.
+     */
+    data?: CdataData | undefined;
 }
+
+/**
+ * Info associated with xast instructions by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface CdataData extends Data {}
+
+/**
+ * XML comment.
+ */
+export interface Comment extends Literal {
+    /**
+     * Node type of XML comments in xast.
+     */
+    type: 'comment';
+    /**
+     * Data associated with the comment.
+     */
+    data?: CommentData | undefined;
+}
+
+/**
+ * Info associated with xast comments by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface CommentData extends Data {}
+
+/**
+ * XML document type.
+ */
+export interface Doctype extends Node {
+    /**
+     * Node type of XML document types in xast.
+     */
+    type: 'doctype';
+    /**
+     * Name of the root element.
+     *
+     * To illustrate, for `<!DOCTYPE html>`, `name` is `'html'`.
+     */
+    name: string;
+    /**
+     * Public identifier of the document.
+     */
+    public?: string | undefined;
+    /**
+     * System identifier of the document.
+     */
+    system?: string | undefined;
+    /**
+     * Data associated with the doctype.
+     */
+    data?: DoctypeData | undefined;
+}
+
+/**
+ * Info associated with xast doctypes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface DoctypeData extends Data {}
+
+/**
+ * XML processing instruction.
+ */
+export interface Instruction extends Literal {
+    /**
+     * Node type of XML processing instructions in xast.
+     */
+    type: 'instruction';
+    /**
+     * Name of the instruction.
+     *
+     * To illustrate, for `<?php?>`, `name` is `'php'`.
+     */
+    name: string;
+    /**
+     * Data associated with the instruction.
+     */
+    data?: InstructionData | undefined;
+}
+
+/**
+ * Info associated with xast instructions by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface InstructionData extends Data {}
+
+/**
+ * XML element.
+ */
+export interface Element extends Parent {
+    /**
+     * Node type of elements.
+     */
+    type: 'element';
+    /**
+     * Qualified name (such as `'artist'` or `'svg:rect'`) of the element.
+     */
+    name: string;
+    /**
+     * Info associated with the element.
+     */
+    attributes: Attributes;
+    /**
+     * Children of element.
+     */
+    children: ElementContent[];
+    /**
+     * Data associated with the element.
+     */
+    data?: ElementData | undefined;
+}
+
+/**
+ * Info associated with xast elements by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface ElementData extends Data {}
+
+/**
+ * Document fragment or a whole document.
+ *
+ * Should be used as the root of a tree and must not be used as a child.
+ *
+ * XML specifies that documents should have exactly one element child, so a
+ * root should have exactly one element child when representing a whole
+ * document.
+ */
+export interface Root extends Parent {
+    /**
+     * Node type of xast root.
+     */
+    type: 'root';
+    /**
+     * Data associated with the xast root.
+     */
+    data?: RootData | undefined;
+}
+
+/**
+ * Info associated with xast root nodes by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface RootData extends Data {}
+
+/**
+ * XML character data (plain text).
+ */
+export interface Text extends Literal {
+    /**
+     * Node type of XML character data (plain text) in xast.
+     */
+    type: 'text';
+    /**
+     * Data associated with the text.
+     */
+    data?: TextData | undefined;
+}
+
+/**
+ * Info associated with xast texts by the ecosystem.
+ */
+// tslint:disable-next-line
+export interface TextData extends Data {}

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -36,7 +36,6 @@ export interface Attributes {
  * }
  * ```
  */
-// tslint:disable-next-line
 export interface Data extends UnistData {}
 
 // ## Content maps
@@ -185,7 +184,6 @@ export interface Cdata extends Literal {
 /**
  * Info associated with xast instructions by the ecosystem.
  */
-// tslint:disable-next-line
 export interface CdataData extends Data {}
 
 /**
@@ -205,7 +203,6 @@ export interface Comment extends Literal {
 /**
  * Info associated with xast comments by the ecosystem.
  */
-// tslint:disable-next-line
 export interface CommentData extends Data {}
 
 /**
@@ -239,7 +236,6 @@ export interface Doctype extends Node {
 /**
  * Info associated with xast doctypes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface DoctypeData extends Data {}
 
 /**
@@ -265,7 +261,6 @@ export interface Instruction extends Literal {
 /**
  * Info associated with xast instructions by the ecosystem.
  */
-// tslint:disable-next-line
 export interface InstructionData extends Data {}
 
 /**
@@ -297,7 +292,6 @@ export interface Element extends Parent {
 /**
  * Info associated with xast elements by the ecosystem.
  */
-// tslint:disable-next-line
 export interface ElementData extends Data {}
 
 /**
@@ -323,7 +317,6 @@ export interface Root extends Parent {
 /**
  * Info associated with xast root nodes by the ecosystem.
  */
-// tslint:disable-next-line
 export interface RootData extends Data {}
 
 /**
@@ -343,5 +336,4 @@ export interface Text extends Literal {
 /**
  * Info associated with xast texts by the ecosystem.
  */
-// tslint:disable-next-line
 export interface TextData extends Data {}

--- a/types/xast/tslint.json
+++ b/types/xast/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-empty-interface": false,
         "npm-naming": false
     }
 }

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -1,148 +1,199 @@
-import { Data, Node, Point, Position } from 'unist';
-import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
+import {
+    Attributes,
+    Cdata,
+    Comment,
+    Data,
+    Doctype,
+    Element,
+    Instruction,
+    Literal,
+    Node,
+    Parent,
+    Root,
+    Text,
+} from 'xast';
 
-const data: Data = {
-    string: 'string',
-    number: 1,
-    object: {
-        key: 'value',
-    },
-    array: [],
-    boolean: true,
-    null: null,
-};
+const data: Data = {};
 
-const point: Point = {
-    line: 1,
-    column: 1,
-    offset: 0,
-};
-
-const position: Position = {
-    start: point,
-    end: point,
-    indent: [1],
+const position = {
+    start: { line: 1, column: 1, offset: 0 },
+    end: { line: 1, column: 2, offset: 1 },
 };
 
 const literal: Literal = {
-    type: 'text',
-    data,
-    position,
+    type: 'whatever',
     value: 'value',
+    position,
+    data,
 };
 
 const comment: Comment = {
     type: 'comment',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const text: Text = {
     type: 'text',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
-const docType: Doctype = {
+const doctype: Doctype = {
     type: 'doctype',
-    data,
-    position,
     name: 'name',
     public: 'public',
     system: 'system',
+    position,
+    data,
 };
 
 const cdata: Cdata = {
     type: 'cdata',
-    data,
-    position,
     value: 'value',
+    position,
+    data,
 };
 
 const instruction: Instruction = {
     type: 'instruction',
-    data,
-    position,
     name: 'name',
     value: 'value',
-};
-
-let element: Element = getElement();
-
-const parent: Parent = {
-    type: 'parent',
-    data,
     position,
-    children: [getElement(), docType, comment, text, instruction, cdata],
-};
-
-let root: Root = {
-    type: 'root',
     data,
-    position,
-    children: [getElement(), docType, comment, text, instruction, cdata],
 };
 
 const attributes: Attributes = {
     attributeName1: 'attributeValue',
     attributeName2: null,
     attributeName3: undefined,
+    // @ts-expect-error: only nullish strings are allowed.
+    attributeName4: 1,
 };
 
-function getElement(): Element {
-    return {
-        type: 'element',
-        name: 'name',
-        attributes,
-        children: [element, comment, text, cdata, instruction],
-    };
-}
+const element: Element = {
+    type: 'element',
+    name: 'x',
+    attributes,
+    children: [{ type: 'element', name: 'y', attributes: {}, children: [] }, comment, text, cdata, instruction],
+};
 
-// Test custom xast node registration
+const elementWithWrongChild: Element = {
+    type: 'element',
+    name: 'z',
+    attributes: {},
+    children: [
+        // @ts-expect-error: doctypes are not valid in elements.
+        doctype,
+    ],
+};
+
+const parent: Parent = {
+    type: 'whatever',
+    data,
+    position,
+    children: [element, doctype, comment, text, instruction, cdata],
+};
+
+const root: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [element, doctype, comment, text, instruction, cdata],
+};
+
+// Test custom xast node registration.
 interface Custom extends Node {
     type: 'custom';
 }
 
 declare module 'xast' {
-    interface RootChildMap {
+    interface RootContentMap {
         custom: Custom;
     }
 
-    interface ElementChildMap {
+    interface ElementContentMap {
         custom: Custom;
     }
 }
 
-root = {
+const rootOther: Root = {
     type: 'root',
     data,
     position,
     children: [{ type: 'custom' }],
 };
 
-element = {
+const elementOther: Element = {
     type: 'element',
     name: 'foo',
+    attributes: { key: 'value' },
     data,
     position,
     children: [{ type: 'custom' }],
 };
 
-root = {
+const rootAnother: Root = {
     type: 'root',
     data,
     position,
-    // @ts-expect-error
-    children: [{ type: 'invalid' }],
+    children: [
+        // @ts-expect-error: node not registered in `RootContentMap`.
+        { type: 'invalid' },
+    ],
 };
 
-element = {
+const elementAnother: Element = {
     type: 'element',
     name: 'foo',
     data,
     position,
-    // @ts-expect-error
-    children: [{ type: 'invalid' }],
+    children: [
+        // @ts-expect-error: node not registered in `ElementContentMap`.
+        { type: 'invalid' },
+    ],
+};
+
+// Register a field on `Data`, which will be available on all nodes.
+declare module 'xast' {
+    interface Data {
+        someField?: string | undefined;
+    }
+
+    interface CommentData {
+        someOtherField?: number | undefined;
+    }
+}
+
+const textWithData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered on all xast nodes.
+        someOtherField: 1,
+    },
+};
+
+const textWithOtherData: Text = {
+    type: 'text',
+    value: 'value',
+    data: {
+        someField: 'a',
+        // @ts-expect-error: not registered on text nodes.
+        someUnknownField: true,
+    },
+};
+
+const commentWithData: Comment = {
+    type: 'comment',
+    value: 'value',
+    data: {
+        someField: 'a',
+        someOtherField: 1,
+        // @ts-expect-error: not registered.
+        someUnknownField: true,
+    },
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/syntax-tree/unist/pull/98
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Update for [unist 3](https://github.com/syntax-tree/unist/releases/tag/3.0.0) (removal of `indent` field) and remove generics

##### Change

*   Remove generic type parameter of `unist` `Node`, `Literal`, `Parent`
*   Remove `indent` of `unist` `Position`
    (see https://github.com/syntax-tree/unist/releases/tag/3.0.0)
*   Change to make `hast` `Element` `properties` required
*   Remove `name` field on `hast` `DocType`, which must always be `'html'`
    (see https://github.com/syntax-tree/hast/releases/tag/2.4.0)
*   Rename `hast` `DocType` to `Doctype`.
*   Remove `mdast` `Footnote` node, which is not used by GFM
    (see https://github.com/syntax-tree/mdast/releases/tag/5.0.0)
*   Rename `mdast` `HTML` to `Html` and `YAML` to `Yaml`
    (see https://github.com/syntax-tree/mdast/releases/tag/5.0.0)
*   Change to make `xast` `Element` `attributes` required

##### Add

*   Add data registries to all nodes
*   Add types for different concrete node unions (such as `Literals` from
    for all literal xast nodes, `Nodes` for all nodes, etc.)

##### Refactor

*   Add lots of doc comments explaining everything


#### Note: generics

Generics were added in GH-54413. This commit undoes generics.

I was neutral on generics 2 years ago, but now that our entire ecosystem is typed, I am against.

There were three generics:

*   `children` and `value`:
    unist is supposed to be an abstract interface that has to be extended before being used.
    *Those* types are supposed to choose a `type` field, specify which other fields exist, and specify particular children or value.
*   `data`:
    I don’t think generic data is a good idea. `Data` is a *shared* space that *several* plugins/utilities can access to store whatever they want. A generic makes it possible to hide conflicts.
    Generics also hide what is actually supported.

    We’ve been adding an alternative in other places (micromark, vfile, mdast/hast/etc for content types of nodes), and I think we should do the same for data: use an interface that can be registered onto.

    While data is not useful on `unist`, I plan to do the same to `mdast` and `hast`, where it gets very useful: `mdast-util-to-hast` for example sets a [`meta` field on `hast`s `element.data`](https://github.com/syntax-tree/mdast-util-to-hast/blob/c87cd606731c88a27dbce4bfeaab913a9589bf83/lib/handlers/code.js#L41), and it adds support for `hProperties`/`hChildren`/`hName` on all mdast nodes. If that utility registers with `hast` `Element.Data` and `mdast` `Node.data`, all other utilities and plugins can get typed data.

Lastly, I searched GH for `unist` and `Node<` and did not see much use, expect for  ugly generated types, such as: https://github.com/nachoaldamav/hardlinks-test/blob/f40b5caf13a53dd063fa5cd0aa7731e73b12631d/data/unist-util-map/index.d.ts#L33.