### PR TITLE
Jasmine - Make createSpyObj work when toString is overridden

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -230,7 +230,11 @@ declare namespace jasmine {
           };
     type SpyObjMethodNames<T = undefined> = T extends undefined
         ? ReadonlyArray<string> | { [methodName: string]: any }
-        : ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any };
+        : (ReadonlyArray<keyof T> |
+            { [P in keyof T]?:
+                // Value should be the return type (unless this is a method on Object.prototype, since all object literals contain those methods)
+                T[P] extends Func ? (ReturnType<T[P]> | (P extends keyof Object ? Object[P] : never)) : any
+            });
 
     type SpyObjPropertyNames<T = undefined> = T extends undefined
         ? ReadonlyArray<string> | { [propertyName: string]: any }

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -2072,6 +2072,26 @@ describe("better typed spys", () => {
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
         });
+        it("works for classes that override Object prototype methods", () => {
+            // All objects (even object literals) have OBject prototype methods like toString().
+            // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
+            class TestOverride {
+                method(): number {
+                    return 0;
+                }
+                toString(): string {
+                    return '';
+                }
+                toLocaleString(): string {
+                    return '';
+                }
+                // Also make sure we don't throw type errors when using a more specific return type.
+                valueOf(): string {
+                    return '';
+                }
+            }
+            jasmine.createSpyObj<TestOverride>("TestOverride", {method: 1});
+        });
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -2072,25 +2072,29 @@ describe("better typed spys", () => {
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
         });
-        it("works for classes that override Object prototype methods", () => {
-            // All objects (even object literals) have OBject prototype methods like toString().
-            // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
-            class TestOverride {
-                method(): number {
-                    return 0;
-                }
-                toString(): string {
-                    return '';
-                }
-                toLocaleString(): string {
-                    return '';
-                }
-                // Also make sure we don't throw type errors when using a more specific return type.
-                valueOf(): string {
-                    return '';
-                }
+
+        // All objects (even object literals) have Object prototype methods like toString().
+        // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
+        class TestOverride {
+            method(): number {
+                return 0;
             }
+            toString(): string {
+                return '';
+            }
+            toLocaleString(): string {
+                return '';
+            }
+            // Also make sure we don't throw type errors when using a more specific return type.
+            valueOf(): boolean {
+                return true;
+            }
+        }
+        it("works for classes that override Object prototype methods", () => {
             jasmine.createSpyObj<TestOverride>("TestOverride", {method: 1});
+        });
+        it("allows spying on Object prototype methods", () => {
+            jasmine.createSpyObj<TestOverride>("TestOverride", {toString: '', toLocaleString: '', valueOf: false});
         });
     });
 });

--- a/types/jasmine/v3/index.d.ts
+++ b/types/jasmine/v3/index.d.ts
@@ -230,7 +230,11 @@ declare namespace jasmine {
           };
     type SpyObjMethodNames<T = undefined> = T extends undefined
         ? ReadonlyArray<string> | { [methodName: string]: any }
-        : ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any };
+        : (ReadonlyArray<keyof T> |
+            { [P in keyof T]?:
+                // Value should be the return type (unless this is a method on Object.prototype, since all object literals contain those methods)
+                T[P] extends Func ? (ReturnType<T[P]> | (P extends keyof Object ? Object[P] : never)) : any
+            });
 
     type SpyObjPropertyNames<T = undefined> = T extends undefined
         ? ReadonlyArray<string> | { [propertyName: string]: any }

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -2067,25 +2067,29 @@ describe("better typed spys", () => {
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
         });
-        it("works for classes that override Object prototype methods", () => {
-            // All objects (even object literals) have OBject prototype methods like toString().
-            // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
-            class TestOverride {
-                method(): number {
-                    return 0;
-                }
-                toString(): string {
-                    return '';
-                }
-                toLocaleString(): string {
-                    return '';
-                }
-                // Also make sure we don't throw type errors when using a more specific return type.
-                valueOf(): string {
-                    return '';
-                }
+
+        // All objects (even object literals) have Object prototype methods like toString().
+        // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
+        class TestOverride {
+            method(): number {
+                return 0;
             }
+            toString(): string {
+                return '';
+            }
+            toLocaleString(): string {
+                return '';
+            }
+            // Also make sure we don't throw type errors when using a more specific return type.
+            valueOf(): boolean {
+                return true;
+            }
+        }
+        it("works for classes that override Object prototype methods", () => {
             jasmine.createSpyObj<TestOverride>("TestOverride", {method: 1});
+        });
+        it("allows spying on Object prototype methods", () => {
+            jasmine.createSpyObj<TestOverride>("TestOverride", {toString: '', toLocaleString: '', valueOf: false});
         });
     });
 });

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -2067,6 +2067,26 @@ describe("better typed spys", () => {
             // $ExpectType (val: string) => Spy<() => string>
             spyObj.method.and.returnValue;
         });
+        it("works for classes that override Object prototype methods", () => {
+            // All objects (even object literals) have OBject prototype methods like toString().
+            // If a class overrides those methods, createSpyObj shouldn't throw any type errors.
+            class TestOverride {
+                method(): number {
+                    return 0;
+                }
+                toString(): string {
+                    return '';
+                }
+                toLocaleString(): string {
+                    return '';
+                }
+                // Also make sure we don't throw type errors when using a more specific return type.
+                valueOf(): string {
+                    return '';
+                }
+            }
+            jasmine.createSpyObj<TestOverride>("TestOverride", {method: 1});
+        });
     });
 });
 


### PR DESCRIPTION
This fixes a bug that happens when a class overrides `toString` (or any Object prototype method), causing TS to throw an error:

```ts
class Foo {
   bar(): number {
       return 0;
   }
   toString(): string {
       return '';
    }
}
jasmine.createSpyObj<Foo>({bar: 1});
//                        ^^^^^^^^
```

```
        Types of property 'toString' are incompatible.
          Type '() => string' is not assignable to type 'string'.
```

This PR fixes that and adds a couple of tests - the first test would trigger this error, but is fixed by this PR. The second test verifies that no spies are broken as a result of this PR.

----------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/edge/jasmine.html#.createSpyObj
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
