### PR TITLE
[jsonld] Use different name for local type and variable

### DIFF
--- a/types/jsonld/index.d.ts
+++ b/types/jsonld/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
-import { Frame, Url, JsonLdProcessor, RemoteDocument, JsonLdObj, JsonLdArray } from './jsonld-spec';
+import { Frame, Url, JsonLdProcessor as JsonLdProcessorInterface, RemoteDocument, JsonLdObj, JsonLdArray } from './jsonld-spec';
 import {
     JsonLdDocument,
     ContextDefinition,
@@ -143,7 +143,7 @@ export function toRDF(input: JsonLdDocument, callback: Callback<RdfDataSet>): vo
 export function toRDF(input: JsonLdDocument, options: Options.ToRdf, callback: Callback<RdfDataSet>): void;
 export function toRDF(input: JsonLdDocument, options?: Options.ToRdf): Promise<RdfDataSet>;
 
-export let JsonLdProcessor: JsonLdProcessor;
+export let JsonLdProcessor: JsonLdProcessorInterface;
 
 // disable autoexport
 export {};


### PR DESCRIPTION
Fixing errors in preparation of https://github.com/microsoft/TypeScript/pull/54659.