### PR TITLE
[serve-static] Missing `err` parameter added to `next` handler

### DIFF
--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -8,6 +8,7 @@
 /// <reference types="node" />
 import * as m from "mime";
 import * as http from "http";
+import { HttpError } from "http-errors";
 
 /**
  * Create a new middleware function to serve files from within a given root directory.
@@ -101,7 +102,7 @@ declare namespace serveStatic {
     }
 
     interface RequestHandler<R extends http.ServerResponse> {
-        (request: http.IncomingMessage, response: R, next: () => void): any;
+        (request: http.IncomingMessage, response: R, next: (err?: HttpError) => void): any;
     }
 
     interface RequestHandlerConstructor<R extends http.ServerResponse> {

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -1,6 +1,7 @@
 import express = require('express');
 import serveStatic = require('serve-static');
 import http = require('http');
+import { HttpError } from 'http-errors';
 var app = express();
 
 app.use(serveStatic('/1'));
@@ -41,7 +42,7 @@ serveStatic('/does-not-assume-express', {
 });
 
 http.createServer((req, res) => {
-    serveStatic('/works-with-node-server')(req, res, () => {});
+    serveStatic('/works-with-node-server')(req, res, (err?: HttpError) => {});
 });
 
 app.use(serveStatic('/infers-express-response-when-passed-to-express-use', {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Only `next(err)` call in `serve-static`: https://github.com/expressjs/serve-static/blob/master/index.js#L117
  - The `send` package returns `HttpError` objects via the `error` emitter
    - https://github.com/pillarjs/send/blob/master/index.js#L270
    - https://github.com/pillarjs/send/blob/master/index.js#L977-L985
    - https://github.com/pillarjs/send/blob/master/index.js#L15