### PR TITLE
[eslint] Adding metadata to Plugin/Processor/ParserModule

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -666,8 +666,22 @@ linter.defineRules({
 
 linter.getRules();
 
-linter.defineParser('custom-parser', { parse: (src, opts) => AST });
 linter.defineParser('custom-parser', {
+    name: 'foo',
+    version: '1.2.3',
+    meta: {
+        name: 'foo',
+        version: '1.2.3'
+    },
+    parse: (src, opts) => AST
+});
+linter.defineParser('custom-parser', {
+    name: 'foo',
+    version: '1.2.3',
+    meta: {
+        name: 'foo',
+        version: '1.2.3'
+    },
     parseForESLint(src, opts) {
         return {
             ast: AST,
@@ -679,6 +693,12 @@ linter.defineParser('custom-parser', {
 });
 
 const _processor: Linter.Processor = {
+    name: 'foo',
+    version: '1.2.3',
+    meta: {
+        name: 'foo',
+        version: '1.2.3'
+    },
     supportsAutofix: true,
     preprocess(text, filename) {
         return [
@@ -775,6 +795,12 @@ eslint = new ESLint({ plugins: { foo: {} } });
 eslint = new ESLint({
     plugins: {
         bar: {
+            name: 'bar',
+            version: '1.0.0',
+            meta: {
+                name: 'bar',
+                version: '1.0.0'
+            },
             configs: {
                 myConfig: {
                     noInlineConfig: true
@@ -789,6 +815,12 @@ eslint = new ESLint({
             },
             processors: {
                 myProcessor: {
+                    name: 'blah',
+                    version: '1.2.3',
+                    meta: {
+                        name: 'blah',
+                        version: '1.2.3'
+                    },
                     supportsAutofix: false
                 }
             },

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -907,13 +907,10 @@ export namespace Linter {
         messages: LintMessage[];
     }
 
-    type ParserModule =
-        | {
-              parse(text: string, options?: any): AST.Program;
-          }
-        | {
-              parseForESLint(text: string, options?: any): ESLintParseResult;
-          };
+    type ParserModule = ESLint.ObjectMetaProperties & (
+          { parse(text: string, options?: any): AST.Program; }
+        | { parseForESLint(text: string, options?: any): ESLintParseResult; }
+        );
 
     interface ESLintParseResult {
         ast: AST.Program;
@@ -928,7 +925,7 @@ export namespace Linter {
     }
 
     // https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
-    interface Processor<T extends string | ProcessorFile = string | ProcessorFile> {
+    interface Processor<T extends string | ProcessorFile = string | ProcessorFile> extends ESLint.ObjectMetaProperties {
         supportsAutofix?: boolean | undefined;
         preprocess?(text: string, filename: string): T[];
         postprocess?(messages: LintMessage[][], filename: string): LintMessage[];
@@ -1055,7 +1052,20 @@ export namespace ESLint {
         parserOptions?: Linter.ParserOptions | undefined;
     }
 
-    interface Plugin {
+    interface ObjectMetaProperties {
+        /** @deprecated Use `meta.name` instead. */
+        name?: string | undefined;
+
+        /** @deprecated Use `meta.version` instead. */
+        version?: string | undefined;
+
+        meta?: {
+            name?: string | undefined;
+            version?: string | undefined;
+        };
+    }
+
+    interface Plugin extends ObjectMetaProperties {
         configs?: Record<string, ConfigData | Linter.FlatConfig | Linter.FlatConfig[]> | undefined;
         environments?: Record<string, Environment> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The [custom plugin documentation](https://eslint.org/docs/latest/extend/plugins#metadata-in-plugins) lists `meta.name` and `meta.version` (and legacy `name`/`version` properties) that can be specified on a plugin. While not necessarily documented, ESLint also accepts/expects the same metadata on processors and parsers in some cases (caching mostly).