### PR TITLE
[react-native-incall-manager] Updated types for v4.0

### DIFF
--- a/types/react-native-incall-manager/index.d.ts
+++ b/types/react-native-incall-manager/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for react-native-incall-manager 3.2
+// Type definitions for react-native-incall-manager 4.0
 // Project: https://github.com/zxcpoiu/react-native-incall-manager#readme
 // Definitions by: Carlos Quiroga <https://github.com/KarlosQ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 export interface StartSetup {
-    media?: string | undefined;
+    media?: 'video' | 'audio' | undefined;
     auto?: boolean | undefined;
     ringback?: string | undefined;
 }
@@ -23,9 +23,9 @@ declare class InCallManager {
 
     turnScreenOn(): void;
 
-    getIsWiredHeadsetPluggedIn(): Promise<any>;
+    getIsWiredHeadsetPluggedIn(): Promise<{ isWiredHeadsetPluggedIn: boolean }>;
 
-    setFlashOn(enable?: boolean, brightness?: number): number;
+    setFlashOn(enable?: boolean, brightness?: number): void;
 
     setKeepScreenOn(enable?: boolean): void;
 
@@ -37,30 +37,35 @@ declare class InCallManager {
 
     startRingtone(
         ringtone?: string,
-        vibrate_pattern?: any[],
-        ios_category?: string,
-        seconds?: number
+        vibrate_pattern?: number[],
+        ios_category?: "playback" | "default",
+        seconds?: number,
     ): void;
 
     stopRingtone(): void;
+
+    startProximitySensor(): void;
+
+    stopProximitySensor(): void;
 
     startRingback(ringback?: string): void;
 
     stopRingback(): void;
 
-    checkRecordPermission(): Promise<string>;
-
-    requestRecordPermission(): Promise<string>;
-
-    checkCameraPermission(): Promise<string>;
-
-    requestCameraPermission(): Promise<string>;
-
     pokeScreen(_timeout?: number): void;
 
-    getAudioUri(audioType: string, fileType: string): any;
+    getAudioUri(
+        audioType: "ringtone" | "ringback" | "busytone",
+        fileType: string,
+    ): Promise<string | null>;
 
-    chooseAudioRoute(route: any): any;
+    chooseAudioRoute(
+        route: "EARPIECE" | "SPEAKER_PHONE" | "WIRED_HEADSET" | "BLUETOOTH",
+    ): Promise<{ availableAudioDeviceList: string, selectedAudioDevice: string }>;
+
+    requestAudioFocus(): Promise<string | undefined>;
+
+    abandonAudioFocus(): Promise<string | undefined>;
 }
 
 declare const _default: InCallManager;

--- a/types/react-native-incall-manager/react-native-incall-manager-tests.ts
+++ b/types/react-native-incall-manager/react-native-incall-manager-tests.ts
@@ -24,15 +24,11 @@ InCallManager.setMicrophoneMute();
 
 InCallManager.setMicrophoneMute(false);
 
-InCallManager.checkRecordPermission();
-
-InCallManager.requestRecordPermission();
-
-InCallManager.getAudioUri("", "");
+InCallManager.getAudioUri("ringtone", "_DEFAULT_");
 
 InCallManager.startRingtone();
 
-InCallManager.startRingtone("", [], "", 0);
+InCallManager.startRingtone("", [], "playback", 0);
 
 InCallManager.stopRingtone();
 
@@ -41,3 +37,13 @@ InCallManager.setFlashOn();
 InCallManager.setFlashOn(true, 1);
 
 InCallManager.getIsWiredHeadsetPluggedIn();
+
+InCallManager.startProximitySensor();
+
+InCallManager.stopProximitySensor();
+
+InCallManager.chooseAudioRoute("EARPIECE");
+
+InCallManager.requestAudioFocus();
+
+InCallManager.abandonAudioFocus();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

**Changes**

* [StartSetup is expected only be two values, not string](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/index.js#L21)
* [getIsWiredHeadsetPluggedIn returns an object with one value, be more descriptive than any](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/index.js#L40)
* [getFlashOn no longer returns a number](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/index.js#L45C11-L45C11)
* [startRingtone arguments:](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/index.js#L76)
  * specify that vibrate_pattern is expected to be a number array (via react native Vibration.vibrate)
  * specify that ios_category can only be two values, not string
* [two new methods, startProximitySensor and stopProximitySensor](https://github.com/react-native-webrtc/react-native-incall-manager/commit/5f05bbd4167bf3b2288a76030b44bf44c4309f7e)
* [all permission-related functions were removed](https://github.com/react-native-webrtc/react-native-incall-manager/pull/173)
* [getAudioUri arguments:](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/index.js#L127)
  * specify that audioType must be one of the keys of private object `audioUriMap`, namely ringtone, ringback, or busytone
  * specify return type is a string or null, not any
* [chooseAudioRoute arguments based on Android chooseAudioRoute](https://github.com/react-native-webrtc/react-native-incall-manager/blob/a9a767971ad21008fecb3fdd3eb3abf30ad14582/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java#L1530)
* [two new methods for audio focus](https://github.com/react-native-webrtc/react-native-incall-manager/commit/82778ca9d8dfb620b173e71fcc2e1435cbbcdaa9)