### PR TITLE
[can-autoplay] Allow error property of CheckResponse to be null

### DIFF
--- a/types/can-autoplay/can-autoplay-tests.ts
+++ b/types/can-autoplay/can-autoplay-tests.ts
@@ -1,21 +1,25 @@
 import canAutoPlay = require('can-autoplay');
 
-canAutoPlay
-    .video({ timeout: 100, muted: true })
-    .then(({ result, error }) => {
-        if (result) {
-            // Can autoplay
-        } else {
-            // Can not autoplay
-        }
-    });
+function logNull(error: null): void {}
 
-canAutoPlay
-    .video()
-    .then(({ result, error }) => {
-        if (result) {
-            // Can autoplay
-        } else {
-            // Can not autoplay
-        }
-    });
+function logError(error: Error): void {}
+
+canAutoPlay.video({ timeout: 100, muted: true }).then(({ result, error }) => {
+    if (result) {
+        // Can autoplay
+        logNull(error);
+    } else {
+        // Can not autoplay
+        logError(error);
+    }
+});
+
+canAutoPlay.video().then(({ result, error }) => {
+    if (result) {
+        // Can autoplay
+        logNull(error);
+    } else {
+        // Can not autoplay
+        logError(error);
+    }
+});

--- a/types/can-autoplay/index.d.ts
+++ b/types/can-autoplay/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/video-dev/can-autoplay
 // Definitions by: Viacheslav Borodulin <https://github.com/vborodulin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.6
 
 export interface Options {
     inline?: boolean | undefined;
@@ -9,10 +10,17 @@ export interface Options {
     timeout?: number | undefined;
 }
 
-export interface CheckResponse {
-    result: boolean;
+export interface CheckResponseTrue {
+    result: true;
+    error: null;
+}
+
+export interface CheckResponseFalse {
+    result: false;
     error: Error;
 }
+
+export type CheckResponse = CheckResponseTrue | CheckResponseFalse;
 
 export function audio(options?: Options): Promise<CheckResponse>;
 export function video(options?: Options): Promise<CheckResponse>;


### PR DESCRIPTION
Error is null when the autoplay detection is successful (result is true). This can be observed in the code:

https://github.com/video-dev/can-autoplay/blob/7a039b436a852a4b76e3beafabe2ab2939e9c6b8/lib/index.js#L49

Notice that sendOutput() is call without an error, so it defaults to null.

https://github.com/video-dev/can-autoplay/blob/7a039b436a852a4b76e3beafabe2ab2939e9c6b8/lib/index.js#L35

The error property will still be set when result is false.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/video-dev/can-autoplay/blob/7a039b436a852a4b76e3beafabe2ab2939e9c6b8/lib/index.js#L49)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

