### PR TITLE
[serverless] Add serviceDir and configurationFilename properties

### DIFF
--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -30,7 +30,8 @@ declare namespace Serverless {
     }
 
     interface Config {
-        servicePath: string;
+        servicePath?: string;
+        serviceDir: string;
     }
 
     interface FunctionDefinition {
@@ -100,7 +101,9 @@ declare class Serverless {
     pluginManager: PluginManager;
 
     config: Serverless.Config;
+    configurationFilename: string;
     serverlessDirPath: string;
+    serviceDir: string;
 
     service: Service;
     version: string;

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -30,7 +30,7 @@ declare namespace Serverless {
     }
 
     interface Config {
-        servicePath?: string;
+        servicePath: string;
         serviceDir: string;
     }
 


### PR DESCRIPTION
Serverless Framework introduced `serviceDir` and `configurationFilename` properties in [release 2.36.0](https://github.com/serverless/serverless/releases/tag/v2.36.0).

`config.servicePath` is now an accessor property backed by the `serviceDir` property.

I'm not sure which (if any) tests would be necessary to add for this change.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/serverless/serverless/releases/tag/v2.36.0

