### PR TITLE
express-mysql-session: Update to 3.0

### DIFF
--- a/types/express-mysql-session/express-mysql-session-tests.ts
+++ b/types/express-mysql-session/express-mysql-session-tests.ts
@@ -1,29 +1,67 @@
 import * as mysqlSession from 'express-mysql-session';
 import * as session from 'express-session';
 
+// $ExpectType typeof MySQLStoreClass
 const MySQLStore = mysqlSession(session);
 
-const options = {
-    host: 'localhost',
+const sessionStore = new MySQLStore({
+    host: 'host',
     port: 3306,
-    user: 'root',
-    password: '',
-    database: 'session_test',
+    user: 'user',
+    password: 'password',
+    database: 'database',
+    clearExpired: true,
+    checkExpirationInterval: 60000,
+    expiration: 60000,
+    createDatabaseTable: true,
+    endConnectionOnClose: true,
+    disableTouch: true,
+    charset: 'charset',
     schema: {
+        tableName: 'table',
         columnNames: {
-            data: 'content',
+            session_id: 'session_id',
+            expires: 'expires',
+            data: 'data',
         },
     },
-};
+    waitForConnections: true,
+    connectionLimit: 10,
+    maxIdle: 10,
+    idleTimeout: 60000,
+    queueLimit: 10,
+});
 
-const sessionStore = new MySQLStore(options);
-
-sessionStore.close();
-sessionStore.get('my-session-id', (error, session) => {});
-sessionStore.all();
-sessionStore.load('my-session-id', (error, session) => {});
-sessionStore.on('connect', () => {});
 session({
-    secret: 'secret',
+    secret: 'session-secret',
     store: sessionStore,
 });
+
+// @ts-expect-error
+sessionStore._expirationInterval;
+
+// $ExpectType Promise<void>
+sessionStore.onReady();
+
+// $ExpectType Promise<void>
+sessionStore.createDatabaseTable();
+
+// $ExpectType Promise<any>
+sessionStore.get('session-id');
+sessionStore.get('session-id', (error, session) => {});
+
+// $ExpectType Promise<void>
+sessionStore.set('session-id', { key: 'value' });
+sessionStore.set('session-id', { key: 'value' }, error => {});
+
+// $ExpectType Promise<void>
+sessionStore.close();
+sessionStore.close(() => {});
+
+// $ExpectType Promise<number>
+sessionStore.length();
+sessionStore.length((error, length) => length.toFixed());
+
+sessionStore.load('session-id', (error, session) => {});
+
+sessionStore.on('connect', () => {});

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-mysql-session 2.1
+// Type definitions for express-mysql-session 3.0
 // Project: https://github.com/chill117/express-mysql-session#readme
 // Definitions by: Akim95 <https://github.com/Akim95>
 //                 Sebastian Krüger <https://github.com/mathe42>
@@ -6,22 +6,74 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as expressSession from 'express-session';
+import { Connection, Pool, PoolOptions } from 'mysql2';
 
 export = MySQLStore;
 
 declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass;
 
 declare namespace MySQLStore {
-    interface Options {
+    interface Options
+        extends Pick<PoolOptions, 'waitForConnections' | 'connectionLimit' | 'maxIdle' | 'idleTimeout' | 'queueLimit'> {
+        /**
+         * Host name for database connection
+         */
         host?: string | undefined;
+
+        /**
+         * Port number for database connection
+         */
         port?: number | undefined;
+
+        /**
+         * Database user
+         */
         user?: string | undefined;
+
+        /**
+         * Password for the above database user
+         */
         password?: string | undefined;
+
+        /**
+         * Database name
+         */
         database?: string | undefined;
+
+        /**
+         * Whether or not to automatically check for and clear expired sessions
+         */
+        clearExpired?: boolean | undefined;
+
+        /**
+         * How frequently expired sessions will be cleared; milliseconds
+         */
         checkExpirationInterval?: number | undefined;
+
+        /**
+         * The maximum age of a valid session; milliseconds
+         */
         expiration?: number | undefined;
+
+        /**
+         * Whether or not to create the sessions database table, if one does not already exist
+         */
         createDatabaseTable?: boolean | undefined;
-        connectionLimit?: number | undefined;
+
+        /**
+         * Whether or not to end the database connection when the store is closed.
+         * The default value of this option depends on whether or not a connection was passed to the constructor.
+         * If a connection object is passed to the constructor, the default value for this option is false.
+         */
+        endConnectionOnClose?: boolean | undefined;
+
+        /**
+         * Whether or not to disable touch
+         */
+        disableTouch?: boolean | undefined;
+
+        charset?: string | undefined;
+
         schema?: Partial<Schema> | undefined;
     }
     interface Schema {
@@ -38,37 +90,82 @@ declare namespace MySQLStore {
 }
 
 declare class MySQLStoreClass extends expressSession.Store {
-    constructor(options: MySQLStore.Options, connection?: any, callback?: (error: any) => void);
+    constructor(options?: MySQLStore.Options, connection?: Connection | Pool);
 
-    setDefaultOptions(): void;
+    state: 'UNINITIALIZED' | 'INITIALIZING' | 'INITIALIZED' | 'CLOSING' | 'CLOSED';
 
-    setOptions(options: MySQLStore.Options): void;
+    defaultOptions: MySQLStore.Options;
+
+    connection: Connection | Pool;
+
+    onReadyPromises: Array<{
+        resolve: () => void;
+        reject: (reason?: any) => void;
+    }>;
+
+    options: MySQLStore.Options;
+
+    private _expirationInterval?: NodeJS.Timer | null;
+
+    onReady(): Promise<void>;
+
+    resolveReadyPromises(): void;
+
+    rejectReadyPromises(error: Error): void;
+
+    prepareOptionsForMySQL2(
+        options: MySQLStore.Options,
+    ): Pick<
+        MySQLStore.Options,
+        | 'host'
+        | 'port'
+        | 'user'
+        | 'password'
+        | 'database'
+        | 'waitForConnections'
+        | 'connectionLimit'
+        | 'maxIdle'
+        | 'idleTimeout'
+        | 'queueLimit'
+    >;
+
+    createPool(options: MySQLStore.Options): Pool;
+
+    setOptions(options?: MySQLStore.Options): void;
 
     validateOptions(options: MySQLStore.Options): void;
 
-    createDatabaseTable(callback?: (error: any) => void): void;
+    createDatabaseTable(): Promise<void>;
 
-    get(sessionId: string, callback?: (error: any, session: any) => void): void;
+    get(sessionId: string, callback: (error: any, session: any) => void): void;
+    get(sessionId: string): Promise<any>;
 
-    set(sessionId: string, data: any, callback?: (error: any) => void): void;
+    set(sessionId: string, data: any, callback: (error: any) => void): void;
+    set(sessionId: string, data: any): Promise<void>;
 
-    touch(sessionId: string, data: any, callback?: (error: any) => void): void;
+    touch(sessionId: string, data: any, callback: (error: any) => void): void;
+    touch(sessionId: string, data: any): Promise<void>;
 
-    destroy(sessionId: string, callback?: (error: any) => void): void;
+    destroy(sessionId: string, callback: (error: any) => void): void;
+    destroy(sessionId: string): Promise<void>;
 
-    length(callback?: (error: any, count: any) => void): void;
+    length(callback: (error: any, count: number) => void): void;
+    length(): Promise<number>;
 
-    all(callback?: (error: any, sessions: any) => void): void;
+    all(callback: (error: any, sessions: Record<string, any>) => void): void;
+    all(): Promise<Record<string, any>>;
 
-    clear(callback?: (error: any) => void): void;
+    clear(callback: (error: any) => void): void;
+    clear(): Promise<void>;
 
-    clearExpiredSessions(callback?: (error: any) => void): void;
+    clearExpiredSessions(): Promise<void>;
 
-    query(sql: string, params: any, callback?: (error: any, rows: any, fields: any) => void): void;
+    query(sql: string, params: any): Promise<any>;
 
     setExpirationInterval(interval: number): void;
 
     clearExpirationInterval(): void;
 
-    close(callback?: () => void): void;
+    close(callback: () => void): void;
+    close(): Promise<void>;
 }

--- a/types/express-mysql-session/package.json
+++ b/types/express-mysql-session/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "mysql2": "3.2.0"
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/chill117/express-mysql-session/releases/tag/v3.0.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `Options` docs are from [the readme](https://github.com/chill117/express-mysql-session/blob/78f5d2f2d45efe140e5d6c88516414c77681bab4/readme.md#options)

The return type for methods with optional callback support is technically a promise of the callback's return type, but I've kept them as `void` to avoid confusion.