### PR TITLE
[@types/react-test-renderer] fix type of react children may be any primitive

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -20,7 +20,7 @@ export {};
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | ReactTestRendererNode[];
+    children: ReactTestRendererNode | ReactTestRendererNode[];
 }
 export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -22,7 +22,7 @@ export interface ReactTestRendererJSON {
     props: { [propName: string]: any };
     children: null | ReactTestRendererNode[];
 }
-export type ReactTestRendererNode = ReactTestRendererJSON | string;
+export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
     nodeType: 'component' | 'host';
     instance: any;

--- a/types/react-test-renderer/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/react-test-renderer-tests.ts
@@ -95,3 +95,23 @@ void (async () => {
     // @ts-expect-error
     await act(async () => null);
 })();
+
+[undefined, null, true, false, 0, 1, "", "test"].forEach((children) => {
+    const renderer = create(React.createElement("div", { children }), {
+        createNodeMock: (el: React.ReactElement) => {
+            return {};
+        }
+    });
+
+    const json = renderer.toJSON();
+
+    if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+
+    const tree = renderer.toTree();
+
+    if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+});

--- a/types/react-test-renderer/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/react-test-renderer-tests.ts
@@ -102,14 +102,12 @@ void (async () => {
             return {};
         }
     });
-
     const json = renderer.toJSON();
+    const tree = renderer.toTree();
 
     if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));
     }
-
-    const tree = renderer.toTree();
 
     if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -15,7 +15,7 @@ export interface ReactTestInstance {
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | Array<string | ReactTestRendererJSON>;
+    children: null | Array<undefined | null | boolean | number | string | ReactTestRendererJSON>;
     $$typeof?: any;
 }
 export interface TestRendererOptions {

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -15,9 +15,10 @@ export interface ReactTestInstance {
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | Array<undefined | null | boolean | number | string | ReactTestRendererJSON>;
+    children: ReactTestRendererNode | Array<ReactTestRendererNode>;
     $$typeof?: any;
 }
+export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface TestRendererOptions {
     createNodeMock(element: ReactElement): any;
 }

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -15,7 +15,7 @@ export interface ReactTestInstance {
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: ReactTestRendererNode | Array<ReactTestRendererNode>;
+    children: ReactTestRendererNode | ReactTestRendererNode[];
     $$typeof?: any;
 }
 export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;

--- a/types/react-test-renderer/v15/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v15/react-test-renderer-tests.ts
@@ -21,3 +21,17 @@ const component = React.createElement(TestComponent);
 const shallowRenderer = createRenderer();
 shallowRenderer.render(component);
 shallowRenderer.getRenderOutput();
+
+[undefined, null, true, false, 0, 1, "", "test"].forEach((children) => {
+    const renderer = create(React.createElement("div", { children }), {
+        createNodeMock: (el: React.ReactElement) => {
+            return {};
+        }
+    });
+
+    const json = renderer.toJSON();
+
+    if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+});

--- a/types/react-test-renderer/v15/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v15/react-test-renderer-tests.ts
@@ -28,7 +28,6 @@ shallowRenderer.getRenderOutput();
             return {};
         }
     });
-
     const json = renderer.toJSON();
 
     if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {

--- a/types/react-test-renderer/v16/index.d.ts
+++ b/types/react-test-renderer/v16/index.d.ts
@@ -19,7 +19,7 @@ export {};
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | ReactTestRendererNode[];
+    children: ReactTestRendererNode | ReactTestRendererNode[];
 }
 export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {

--- a/types/react-test-renderer/v16/index.d.ts
+++ b/types/react-test-renderer/v16/index.d.ts
@@ -21,7 +21,7 @@ export interface ReactTestRendererJSON {
     props: { [propName: string]: any };
     children: null | ReactTestRendererNode[];
 }
-export type ReactTestRendererNode = ReactTestRendererJSON | string;
+export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
     nodeType: 'component' | 'host';
     instance: any;

--- a/types/react-test-renderer/v16/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v16/react-test-renderer-tests.ts
@@ -95,3 +95,23 @@ void (async () => {
     // @ts-expect-error
     await act(async () => null);
 })();
+
+[undefined, null, true, false, 0, 1, "", "test"].forEach((children) => {
+    const renderer = create(React.createElement("div", { children }), {
+        createNodeMock: (el: React.ReactElement) => {
+            return {};
+        }
+    });
+
+    const json = renderer.toJSON();
+
+    if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+
+    const tree = renderer.toTree();
+
+    if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+});

--- a/types/react-test-renderer/v16/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v16/react-test-renderer-tests.ts
@@ -102,14 +102,12 @@ void (async () => {
             return {};
         }
     });
-
     const json = renderer.toJSON();
+    const tree = renderer.toTree();
 
     if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));
     }
-
-    const tree = renderer.toTree();
 
     if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));

--- a/types/react-test-renderer/v17/index.d.ts
+++ b/types/react-test-renderer/v17/index.d.ts
@@ -19,7 +19,7 @@ export {};
 export interface ReactTestRendererJSON {
     type: string;
     props: { [propName: string]: any };
-    children: null | ReactTestRendererNode[];
+    children: ReactTestRendererNode | ReactTestRendererNode[];
 }
 export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {

--- a/types/react-test-renderer/v17/index.d.ts
+++ b/types/react-test-renderer/v17/index.d.ts
@@ -21,7 +21,7 @@ export interface ReactTestRendererJSON {
     props: { [propName: string]: any };
     children: null | ReactTestRendererNode[];
 }
-export type ReactTestRendererNode = ReactTestRendererJSON | string;
+export type ReactTestRendererNode = ReactTestRendererJSON | string | number | boolean | null | undefined;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
     nodeType: 'component' | 'host';
     instance: any;

--- a/types/react-test-renderer/v17/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v17/react-test-renderer-tests.ts
@@ -95,3 +95,23 @@ void (async () => {
     // @ts-expect-error
     await act(async () => null);
 })();
+
+[undefined, null, true, false, 0, 1, "", "test"].forEach((children) => {
+    const renderer = create(React.createElement("div", { children }), {
+        createNodeMock: (el: React.ReactElement) => {
+            return {};
+        }
+    });
+
+    const json = renderer.toJSON();
+
+    if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+
+    const tree = renderer.toTree();
+
+    if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
+        throw(new Error(`Type of children ${children} doesn't match!`));
+    }
+});

--- a/types/react-test-renderer/v17/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/v17/react-test-renderer-tests.ts
@@ -102,14 +102,12 @@ void (async () => {
             return {};
         }
     });
-
     const json = renderer.toJSON();
+    const tree = renderer.toTree();
 
     if (!json || typeof json !== "object" || Array.isArray(json) || json.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));
     }
-
-    const tree = renderer.toTree();
 
     if (!tree || typeof tree !== "object" || Array.isArray(tree) || tree.children !== children) {
         throw(new Error(`Type of children ${children} doesn't match!`));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   `toTree` works on a node of type `Fiber`, with that [`type` prop](https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/packages/react-reconciler/src/ReactInternalTypes.js#L68-L69).
https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/packages/react-test-renderer/src/ReactTestRenderer.js#L172
   - React 17: https://github.com/facebook/react/blob/17.0.2/packages/react-test-renderer/src/ReactTestRenderer.js#L172
   - React 16: https://github.com/facebook/react/blob/16.8.6/packages/react-test-renderer/src/ReactTestRenderer.js#L171
   - React 15: https://github.com/facebook/react/blob/15-stable/src/renderers/testing/ReactTestRenderer.js#L112C39-L112C51
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

[**JSX** children](https://legacy.reactjs.org/docs/introducing-jsx.html#specifying-children-with-jsx) may hold any valid JavaScript expression, from the documentation:

> You can put any valid [JavaScript expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Expressions) inside the curly braces in JSX.
https://legacy.reactjs.org/docs/introducing-jsx.html#embedding-expressions-in-jsx

Improves [#65263](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65263)