### PR TITLE
[density-clustering] Add missing distance function param to `OPTICS.run`

### DIFF
--- a/types/density-clustering/density-clustering-tests.ts
+++ b/types/density-clustering/density-clustering-tests.ts
@@ -1,25 +1,68 @@
 import clustering = require('density-clustering');
 
-const dataset = [
-    [1, 1],
-    [0, 1],
-    [1, 0],
-    [10, 10],
-    [10, 13],
-    [13, 13],
-    [54, 54],
-    [55, 55],
-    [89, 89],
-    [57, 55],
-];
+function test1() {
+    const dataset = [
+        [1, 1],
+        [0, 1],
+        [1, 0],
+        [10, 10],
+        [10, 13],
+        [13, 13],
+        [54, 54],
+        [55, 55],
+        [89, 89],
+        [57, 55],
+    ];
 
-const dbscan = new clustering.DBSCAN();
-dbscan.run(dataset, 5, 2);
-dbscan.noise;
+    const dbscan = new clustering.DBSCAN();
+    dbscan.run(dataset, 5, 2);
+    dbscan.noise;
 
-const optics = new clustering.OPTICS();
-optics.run(dataset, 2, 2);
-optics.getReachabilityPlot();
+    const optics = new clustering.OPTICS();
+    optics.run(dataset, 2, 2);
+    optics.getReachabilityPlot();
 
-const kmeans = new clustering.KMEANS();
-kmeans.run(dataset, 3);
+    const kmeans = new clustering.KMEANS();
+    kmeans.run(dataset, 3);
+}
+
+function test2() {
+    // Test DBSCAN with distanceFunction.
+    const dataset = [
+        [1, 1],
+        [0, 1],
+        [1, 0],
+        [10, 10],
+        [10, 13],
+        [13, 13],
+        [54, 54],
+        [55, 55],
+        [89, 89],
+        [57, 55],
+    ];
+
+    const distance = () => 0;
+    const dbscan = new clustering.DBSCAN();
+    dbscan.run(dataset, 5, 2, distance);
+}
+
+function test3() {
+    // Test OPTICS with distanceFunction.
+    const dataset = [
+        [1, 1],
+        [0, 1],
+        [1, 0],
+        [10, 10],
+        [10, 13],
+        [13, 13],
+        [54, 54],
+        [55, 55],
+        [89, 89],
+        [57, 55],
+    ];
+
+    const distance = () => 0;
+    const optics = new clustering.OPTICS();
+    optics.run(dataset, 2, 2, distance);
+    optics.getReachabilityPlot();
+}

--- a/types/density-clustering/index.d.ts
+++ b/types/density-clustering/index.d.ts
@@ -15,7 +15,12 @@ export class DBSCAN {
 }
 
 export class OPTICS {
-    run(dataset: number[][], neighborhoodRadius: number, minPointsPerCluster: number): number[][];
+    run(
+        dataset: number[][],
+        neighborhoodRadius: number,
+        minPointsPerCluster: number,
+        distanceFunction?: (p: number[], q: number[]) => number,
+    ): number[][];
     getReachabilityPlot(): number[][];
 }
 

--- a/types/density-clustering/index.d.ts
+++ b/types/density-clustering/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for density-clustering 1.3
-// Project: https://github.com/LukaszKrawczyk/density-clustering
-// Definitions by: Matt Fedderly <https://github.com/mfedderly>
+// Project: https://github.com/uhho/density-clustering
+// Definitions by:  Matt Fedderly <https://github.com/mfedderly>
+//                  Levi Gruspe <https://github.com/lggruspe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class DBSCAN {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/uhho/density-clustering/blob/6fd080356cb05ae6a9bc980ec49b4731d08cfb5d/lib/OPTICS.js#L59C1-L59C78>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.