### PR TITLE
[convert-units] Add missing unit 'yd', fix typo 'min/km' => 'min/mi'

### DIFF
--- a/types/convert-units/index.d.ts
+++ b/types/convert-units/index.d.ts
@@ -7,7 +7,7 @@
 // TypeScript Version: 2.7
 
 declare namespace convert {
-    type Distance = "mm" | "cm" | "m" | "km" | "in" | "ft-us" | "ft" | "mi"; // Distance
+    type Distance = "mm" | "cm" | "m" | "km" | "in" | "ft-us" | "ft" | "yd" | "mi"; // Distance
     type Area = "mm2" | "cm2" | "m2" | "ha" | "km2" | "in2" | "ft2" | "ac" | "mi2"; // Area
     type Mass = "mcg" | "mg" | "g" | "kg" | "oz" | "lb" | "mt" | "t"; // Mass
     type Volume = "mm3" | "cm3" | "ml" | "l" | "kl" | "m3" | "km3" | "tsp" | "Tbs" | "in3" | "fl-oz" | "cup" | "pnt" | "qt" | "gal" | "ft3" | "yd3"; // Volume
@@ -53,7 +53,7 @@ declare namespace convert {
     type Time = "ns" | "mu" | "ms" | "s" | "min" | "h" | "d" | "week" | "month" | "year"; // Time
     type Frequency = "Hz" | "mHz" | "kHz" | "MHz" | "GHz" | "THz" | "rpm" | "deg/s" | "rad/s"; // Frequency
     type Speed = "m/s" | "km/h" | "m/h" | "knot" | "ft/s"; // Speed
-    type Pace = "s/m" | "min/km" | "s/ft" | "min/km"; // Pace
+    type Pace = "s/m" | "min/km" | "s/ft" | "min/mi"; // Pace
     type Pressure = "Pa" | "hPa" | "kPa" | "MPa" | "bar" | "torr" | "psi" | "ksi"; // Pressure
     type Ditgital = "b" | "Kb" | "Mb" | "Gb" | "Tb" | "B" | "KB" | "MB" | "GB" | "TB"; // Digital
     type Illuminance = "lx" | "ft-cd"; // Illumunance


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Reason for adding 'yd': https://github.com/convert-units/convert-units/blob/v2.3.3/lib/definitions/length.js#L43

Reason for adding 'min/mi' (replacing the duplicate 'min/km'): https://github.com/convert-units/convert-units/blob/main/src/definitions/pace.ts#L26