### PR TITLE
feat(google-libphonenumber): add typings for `ShortNumberInfo`

### DIFF
--- a/types/google-libphonenumber/google-libphonenumber-tests.ts
+++ b/types/google-libphonenumber/google-libphonenumber-tests.ts
@@ -1,6 +1,11 @@
-
 import libphonenumber = require('google-libphonenumber');
-import { PhoneNumberFormat, PhoneNumberUtil, AsYouTypeFormatter } from 'google-libphonenumber';
+import {
+    PhoneNumberFormat,
+    PhoneNumberUtil,
+    AsYouTypeFormatter,
+    ShortNumberInfo,
+    RegionCode,
+} from 'google-libphonenumber';
 
 () => {
     // Require `PhoneNumberFormat`.
@@ -23,7 +28,7 @@ import { PhoneNumberFormat, PhoneNumberUtil, AsYouTypeFormatter } from 'google-l
     // Print number in the original format with specified region.
     console.log(phoneUtil.formatInOriginalFormat(phoneNumber, 'US'));
     // => (202) 456-1414
-}
+};
 
 () => {
     // Require `AsYouTypeFormatter`.
@@ -40,7 +45,7 @@ import { PhoneNumberFormat, PhoneNumberUtil, AsYouTypeFormatter } from 'google-l
     console.log(formatter.inputDigit('2')); // => (650) 253-22
 
     formatter.clear();
-}
+};
 
 // Get instance of `PhoneNumberUtil`
 var phoneNumberUtil = PhoneNumberUtil.getInstance();
@@ -50,3 +55,20 @@ phoneNumberUtil.getCountryCodeForRegion('IT'); // $ExpectType number
 
 const aNumber = phoneNumberUtil.parse('+39 02-12345678', 'IT');
 phoneNumberUtil.getNationalSignificantNumber(aNumber); // $ExpectType string
+
+// Get instance of `ShortNumberInfo`
+const shortInfo = ShortNumberInfo.getInstance();
+const phoneNumber = phoneNumberUtil.parse('123456', 'FR');
+const regionCode: RegionCode = 'FR';
+
+shortInfo.isPossibleShortNumberForRegion(phoneNumber, regionCode); // $ExpectType boolean
+shortInfo.isPossibleShortNumber(phoneNumber); // $ExpectType boolean
+shortInfo.isValidShortNumberForRegion(phoneNumber, regionCode); // $ExpectType boolean
+shortInfo.isValidShortNumber(phoneNumber); // $ExpectType boolean
+shortInfo.getExpectedCostForRegion(phoneNumber, regionCode); // $ExpectType ShortNumberCost
+shortInfo.getExpectedCost(phoneNumber); // $ExpectType ShortNumberCost
+shortInfo.connectsToEmergencyNumber('911', 'US'); // $ExpectType boolean
+shortInfo.isEmergencyNumber('911', 'US'); // $ExpectType boolean
+shortInfo.isCarrierSpecific(phoneNumber); // $ExpectType boolean
+shortInfo.isCarrierSpecificForRegion(phoneNumber, regionCode); // $ExpectType boolean
+shortInfo.isSmsServiceForRegion(phoneNumber, regionCode); // $ExpectType boolean

--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -148,9 +148,9 @@ declare namespace libphonenumber {
         getCountryCodeForRegion(supportedRegion: string): number;
         getExampleNumber(regionCode: string): PhoneNumber;
         getExampleNumberForType(regionCode: string, type: PhoneNumberType): PhoneNumber;
-        getRegionCodeForCountryCode(countryCallingCode: number): string;
-        getRegionCodeForNumber(phoneNumber: PhoneNumber): string | undefined;
-        getSupportedRegions(): string[];
+        getRegionCodeForCountryCode(countryCallingCode: number): RegionCode;
+        getRegionCodeForNumber(phoneNumber: PhoneNumber): RegionCode | undefined;
+        getSupportedRegions(): RegionCode[];
         isAlphaNumber(number: string): boolean;
         isLeadingZeroPossible(countryCallingCode: number): boolean;
         isNANPACountry(regionCode?: string): boolean;
@@ -176,6 +176,435 @@ declare namespace libphonenumber {
         inputDigit(digit: string): string;
         clear(): void;
     }
+
+    export module ShortNumberInfo {
+        /** Cost categories of short numbers. */
+        export enum ShortNumberCost {
+            TOLL_FREE = 0,
+            STANDARD_RATE = 1,
+            PREMIUM_RATE = 2,
+            UNKNOWN_COST = 3,
+        }
+    }
+
+    export class ShortNumberInfo {
+        /** Returns the singleton instance of the ShortNumberInfo. */
+        static getInstance(): ShortNumberInfo;
+
+        /**
+         * Check whether a short number is a possible number when dialed from the given region. This
+         * provides a more lenient check than {@link ShortNumberInfo.isValidShortNumberForRegion}.
+         *
+         * @param number the short number to check
+         * @param regionDialingFrom the region from which the number is dialed
+         * @return whether the number is a possible short number
+         */
+        isPossibleShortNumberForRegion(number: PhoneNumber, regionDialingFrom: RegionCode): boolean;
+
+        /**
+         * Check whether a short number is a possible number. If a country calling code is shared by
+         * multiple regions, this returns true if it's possible in any of them. This provides a more
+         * lenient check than {@link ShortNumberInfo.isValidShortNumber}.
+         * See {@link ShortNumberInfo.isPossibleShortNumberForRegion} for details.
+         *
+         * @param number the short number to check
+         * @return whether the number is a possible short number
+         */
+        isPossibleShortNumber(number: PhoneNumber): boolean;
+
+        /**
+         * Tests whether a short number matches a valid pattern in a region. Note that this doesn't verify
+         * the number is actually in use, which is impossible to tell by just looking at the number
+         * itself.
+         *
+         * @param number the short number for which we want to test the validity
+         * @param regionDialingFrom the region from which the number is dialed
+         * @return whether the short number matches a valid pattern
+         */
+        isValidShortNumberForRegion(number: PhoneNumber, regionDialingFrom: RegionCode): boolean;
+
+        /**
+         * Tests whether a short number matches a valid pattern. If a country calling code is shared by
+         * multiple regions, this returns true if it's valid in any of them. Note that this doesn't verify
+         * the number is actually in use, which is impossible to tell by just looking at the number
+         * itself. See {@link ShortNumberInfo.isValidShortNumberForRegion} for details.
+         *
+         * @param number the short number for which we want to test the validity
+         * @return whether the short number matches a valid pattern
+         */
+        isValidShortNumber(number: PhoneNumber): boolean;
+
+        /**
+         * Gets the expected cost category of a short number when dialed from a region (however, nothing
+         * is implied about its validity). If it is important that the number is valid, then its validity
+         * must first be checked using {@link ShortNumberInfo.isValidShortNumberForRegion}. Note that emergency numbers
+         * are always considered toll-free.
+         *
+         * @example Usage:
+         * ```
+         * // The region for which the number was parsed and the region we subsequently check against
+         * // need not be the same. Here we parse the number in the US and check it for Canada.
+         * const phoneNumber = phoneUtil.parse("110", "US");
+         * const regionCode: RegionCode = '"CA"';
+         * const shortInfo = ShortNumberInfo.getInstance();
+         * if (shortInfo.isValidShortNumberForRegion(phoneNumber, regionCode)) {
+         *   const cost = shortInfo.getExpectedCostForRegion(phoneNumber, regionCode);
+         *   // Do something with the cost information here.
+         * }
+         * ```
+         *
+         * @param number the short number for which we want to know the expected cost category
+         * @param regionDialingFrom the region from which the number is dialed
+         * @return the expected cost category for that region of the short number. Returns UNKNOWN_COST
+         * the number does not match a cost category. Note that an invalid number may match any cost
+         * category.
+         */
+        getExpectedCostForRegion(number: PhoneNumber, regionDialingFrom: RegionCode): ShortNumberInfo.ShortNumberCost;
+
+        /**
+         * Gets the expected cost category of a short number (however, nothing is implied about its
+         * validity). If the country calling code is unique to a region, this method behaves exactly the
+         * same as {@link ShortNumberInfo.getExpectedCostForRegion}. However, if the country
+         * calling code is shared by multiple regions, then it returns the highest cost in the sequence
+         * PREMIUM_RATE, UNKNOWN_COST, STANDARD_RATE, TOLL_FREE. The reason for the position of
+         * UNKNOWN_COST in this order is that if a number is UNKNOWN_COST in one region but STANDARD_RATE
+         * or TOLL_FREE in another, its expected cost cannot be estimated as one of the latter since it
+         * might be a PREMIUM_RATE number.
+         *
+         * For example, if a number is STANDARD_RATE in the US, but TOLL_FREE in Canada, the expected
+         * cost returned by this method will be STANDARD_RATE, since the NANPA countries share the same
+         * country calling code.
+         *
+         * Note: If the region from which the number is dialed is known, it is highly preferable to call
+         * {@link ShortNumberInfo.getExpectedCostForRegion} instead.
+         *
+         * @param number the short number for which we want to know the expected cost category
+         * @return the highest expected cost category of the short number in the region(s) with the given
+         * country calling code
+         */
+        getExpectedCost(number: PhoneNumber): ShortNumberInfo.ShortNumberCost;
+
+        /**
+         * Returns true if the given number, exactly as dialed, might be used to connect to an emergency
+         * service in the given region.
+         *
+         * This method accepts a string, rather than a PhoneNumber, because it needs to distinguish
+         * cases such as "+1 911" and "911", where the former may not connect to an emergency service in
+         * all cases but the latter would. This method takes into account cases where the number might
+         * contain formatting, or might have additional digits appended (when it is okay to do that in
+         * the specified region).
+         *
+         * @param number the phone number to test
+         * @param regionCode the region where the phone number is being dialed
+         * @return whether the number might be used to connect to an emergency service in the given region
+         */
+        connectsToEmergencyNumber(number: string, regionDialing: RegionCode): boolean;
+
+        /**
+         * Returns true if the given number exactly matches an emergency service number in the given
+         * region.
+         *
+         * This method takes into account cases where the number might contain formatting, but doesn't
+         * allow additional digits to be appended. Note that `isEmergencyNumber(number, region)`
+         * implies `connectsToEmergencyNumber(number, region)`.
+         *
+         * @param number the phone number to test
+         * @param regionCode the region where the phone number is being dialed
+         * @return whether the number exactly matches an emergency services number in the given region
+         */
+        isEmergencyNumber(number: string, regionCode: RegionCode): boolean;
+
+        /**
+         * Given a valid short number, determines whether it is carrier-specific (however, nothing is
+         * implied about its validity). Carrier-specific numbers may connect to a different end-point, or
+         * not connect at all, depending on the user's carrier. If it is important that the number is
+         * valid, then its validity must first be checked using {@link ShortNumberInfo.isValidShortNumber} or
+         * {@link ShortNumberInfo.isValidShortNumberForRegion}.
+         *
+         * @param number  the valid short number to check
+         * @return whether the short number is carrier-specific, assuming the input was a valid short
+         * number
+         */
+        isCarrierSpecific(number: PhoneNumber): boolean;
+
+        /**
+         * Given a valid short number, determines whether it is carrier-specific when dialed from the
+         * given region (however, nothing is implied about its validity). Carrier-specific numbers may
+         * connect to a different end-point, or not connect at all, depending on the user's carrier. If
+         * it is important that the number is valid, then its validity must first be checked using
+         * {@link ShortNumberInfo.isValidShortNumber} or {@link ShortNumberInfo.isValidShortNumberForRegion}.
+         * Returns false if the number doesn't match the region provided.
+         *
+         * @param number  the valid short number to check
+         * @param regionDialingFrom  the region from which the number is dialed
+         * @return  whether the short number is carrier-specific in the provided region, assuming the
+         * input was a valid short number
+         */
+        isCarrierSpecificForRegion(number: PhoneNumber, regionDialingFrom: RegionCode): boolean;
+
+        /**
+         * Given a valid short number, determines whether it is an SMS service (however, nothing is
+         * implied about its validity). An SMS service is where the primary or only intended usage is to
+         * receive and/or send text messages (SMSs). This includes MMS as MMS numbers downgrade to SMS if
+         * the other party isn't MMS-capable. If it is important that the number is valid, then its
+         * validity must first be checked using {@link ShortNumberInfo.isValidShortNumber} or
+         * {@link ShortNumberInfo.isValidShortNumberForRegion}.
+         * Returns false if the number doesn't match the region provided.
+         *
+         * @param number  the valid short number to check
+         * @param regionDialingFrom  the region from which the number is dialed
+         * @return  whether the short number is an SMS service in the provided region, assuming the input
+         * was a valid short number
+         */
+        isSmsServiceForRegion(number: PhoneNumber, regionDialingFrom: string): boolean;
+    }
+
+    export type RegionCode =
+        | 'AC'
+        | 'AD'
+        | 'AE'
+        | 'AF'
+        | 'AG'
+        | 'AI'
+        | 'AL'
+        | 'AM'
+        | 'AO'
+        | 'AR'
+        | 'AS'
+        | 'AT'
+        | 'AU'
+        | 'AW'
+        | 'AX'
+        | 'AZ'
+        | 'BA'
+        | 'BB'
+        | 'BD'
+        | 'BE'
+        | 'BF'
+        | 'BG'
+        | 'BH'
+        | 'BI'
+        | 'BJ'
+        | 'BL'
+        | 'BM'
+        | 'BN'
+        | 'BO'
+        | 'BQ'
+        | 'BR'
+        | 'BS'
+        | 'BT'
+        | 'BW'
+        | 'BY'
+        | 'BZ'
+        | 'CA'
+        | 'CC'
+        | 'CD'
+        | 'CF'
+        | 'CG'
+        | 'CH'
+        | 'CI'
+        | 'CK'
+        | 'CL'
+        | 'CM'
+        | 'CN'
+        | 'CO'
+        | 'CR'
+        | 'CU'
+        | 'CV'
+        | 'CW'
+        | 'CX'
+        | 'CY'
+        | 'CZ'
+        | 'DE'
+        | 'DJ'
+        | 'DK'
+        | 'DM'
+        | 'DO'
+        | 'DZ'
+        | 'EC'
+        | 'EE'
+        | 'EG'
+        | 'EH'
+        | 'ER'
+        | 'ES'
+        | 'ET'
+        | 'FI'
+        | 'FJ'
+        | 'FK'
+        | 'FM'
+        | 'FO'
+        | 'FR'
+        | 'GA'
+        | 'GB'
+        | 'GD'
+        | 'GE'
+        | 'GF'
+        | 'GG'
+        | 'GH'
+        | 'GI'
+        | 'GL'
+        | 'GM'
+        | 'GN'
+        | 'GP'
+        | 'GQ'
+        | 'GR'
+        | 'GT'
+        | 'GU'
+        | 'GW'
+        | 'GY'
+        | 'HK'
+        | 'HN'
+        | 'HR'
+        | 'HT'
+        | 'HU'
+        | 'ID'
+        | 'IE'
+        | 'IL'
+        | 'IM'
+        | 'IN'
+        | 'IO'
+        | 'IQ'
+        | 'IR'
+        | 'IS'
+        | 'IT'
+        | 'JE'
+        | 'JM'
+        | 'JO'
+        | 'JP'
+        | 'KE'
+        | 'KG'
+        | 'KH'
+        | 'KI'
+        | 'KM'
+        | 'KN'
+        | 'KP'
+        | 'KR'
+        | 'KW'
+        | 'KY'
+        | 'KZ'
+        | 'LA'
+        | 'LB'
+        | 'LC'
+        | 'LI'
+        | 'LK'
+        | 'LR'
+        | 'LS'
+        | 'LT'
+        | 'LU'
+        | 'LV'
+        | 'LY'
+        | 'MA'
+        | 'MC'
+        | 'MD'
+        | 'ME'
+        | 'MF'
+        | 'MG'
+        | 'MH'
+        | 'MK'
+        | 'ML'
+        | 'MM'
+        | 'MN'
+        | 'MO'
+        | 'MP'
+        | 'MQ'
+        | 'MR'
+        | 'MS'
+        | 'MT'
+        | 'MU'
+        | 'MV'
+        | 'MW'
+        | 'MX'
+        | 'MY'
+        | 'MZ'
+        | 'NA'
+        | 'NC'
+        | 'NE'
+        | 'NF'
+        | 'NG'
+        | 'NI'
+        | 'NL'
+        | 'NO'
+        | 'NP'
+        | 'NR'
+        | 'NU'
+        | 'NZ'
+        | 'OM'
+        | 'PA'
+        | 'PE'
+        | 'PF'
+        | 'PG'
+        | 'PH'
+        | 'PK'
+        | 'PL'
+        | 'PM'
+        | 'PR'
+        | 'PS'
+        | 'PT'
+        | 'PW'
+        | 'PY'
+        | 'QA'
+        | 'RE'
+        | 'RO'
+        | 'RS'
+        | 'RU'
+        | 'RW'
+        | 'SA'
+        | 'SB'
+        | 'SC'
+        | 'SD'
+        | 'SE'
+        | 'SG'
+        | 'SH'
+        | 'SI'
+        | 'SJ'
+        | 'SK'
+        | 'SL'
+        | 'SM'
+        | 'SN'
+        | 'SO'
+        | 'SR'
+        | 'SS'
+        | 'ST'
+        | 'SV'
+        | 'SX'
+        | 'SY'
+        | 'SZ'
+        | 'TA'
+        | 'TC'
+        | 'TD'
+        | 'TG'
+        | 'TH'
+        | 'TJ'
+        | 'TK'
+        | 'TL'
+        | 'TM'
+        | 'TN'
+        | 'TO'
+        | 'TR'
+        | 'TT'
+        | 'TV'
+        | 'TW'
+        | 'TZ'
+        | 'UA'
+        | 'UG'
+        | 'US'
+        | 'UY'
+        | 'UZ'
+        | 'VA'
+        | 'VC'
+        | 'VE'
+        | 'VG'
+        | 'VI'
+        | 'VN'
+        | 'VU'
+        | 'WF'
+        | 'WS'
+        | 'XK'
+        | 'YE'
+        | 'YT'
+        | 'ZA'
+        | 'ZM'
+        | 'ZW';
 }
 
 declare module 'google-libphonenumber' {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ruimarinho/google-libphonenumber#i18nphonenumbersshortnumberinfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header

> **Warning**
> These type definitions match two different libraries, I based my changes on `google-libphonenumber` which has a lower version than these typings
