### PR TITLE
Add URLSearchParams.size

### DIFF
--- a/types/node/v14/ts4.8/url.d.ts
+++ b/types/node/v14/ts4.8/url.d.ts
@@ -127,6 +127,7 @@ declare module 'url' {
 
     class URLSearchParams implements Iterable<[string, string]> {
         constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        readonly size: number;
         append(name: string, value: string): void;
         delete(name: string): void;
         entries(): IterableIterator<[string, string]>;

--- a/types/node/v14/url.d.ts
+++ b/types/node/v14/url.d.ts
@@ -127,6 +127,7 @@ declare module 'url' {
 
     class URLSearchParams implements Iterable<[string, string]> {
         constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        readonly size: number;
         append(name: string, value: string): void;
         delete(name: string): void;
         entries(): IterableIterator<[string, string]>;

--- a/types/node/v16/ts4.8/url.d.ts
+++ b/types/node/v16/ts4.8/url.d.ts
@@ -712,6 +712,7 @@ declare module 'url' {
      */
     class URLSearchParams implements Iterable<[string, string]> {
         constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        readonly size: number;
         /**
          * Append a new name-value pair to the query string.
          */

--- a/types/node/v16/url.d.ts
+++ b/types/node/v16/url.d.ts
@@ -712,6 +712,7 @@ declare module 'url' {
      */
     class URLSearchParams implements Iterable<[string, string]> {
         constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        readonly size: number;
         /**
          * Append a new name-value pair to the query string.
          */


### PR DESCRIPTION
URLSearchParams.size is required in TS 5.2 beta and above, but missing in node 14 and 16, so I added it.

Edit: Added it for 4.8 and below as well as 4.9 and above.