### PR TITLE
web-app-manifest: inline type of orientation

### DIFF
--- a/types/web-app-manifest/index.d.ts
+++ b/types/web-app-manifest/index.d.ts
@@ -253,7 +253,7 @@ export interface WebAppManifest {
      *
      * @see https://w3c.github.io/manifest/#orientation-member
      */
-    orientation?: OrientationLockType | undefined;
+    orientation?: "any" | "landscape" | "landscape-primary" | "landscape-secondary" | "natural" | "portrait" | "portrait-primary" | "portrait-secondary" | undefined;
 
     /**
      * The manifest's id member is a string that represents the identity for the application.


### PR DESCRIPTION
`OrientationLockType` is no longer in Typescript 5.2 beta, so inline the members of the union into `orientation`'s type.