### PR TITLE
Update dom-webcodecs for TS 5.2

### DIFF
--- a/types/dom-mediacapture-transform/index.d.ts
+++ b/types/dom-mediacapture-transform/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/mediacapture-transform/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 5.1
+// Minimum TypeScript Version: 5.2
 
 // In general, these types are only available behind a command line flag or an origin trial in
 // Chrome 90+.

--- a/types/dom-webcodecs/index.d.ts
+++ b/types/dom-webcodecs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/webcodecs/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 5.1
+// Minimum TypeScript Version: 5.2
 
 // Versioning:
 // Until the WebCodecs spec is finalized, the major version number is 0. I have chosen to use minor

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -400,7 +400,7 @@ interface WebCodecsErrorCallback {
     (error: DOMException): void;
 }
 
-type AllowSharedBufferSource = ArrayBuffer | ArrayBufferView;
+// type AllowSharedBufferSource = ArrayBuffer | ArrayBufferView;
 // type BitrateMode = "constant" | "variable";
 type ImageBufferSource = ArrayBuffer | ArrayBufferView | ReadableStream;
 // type AlphaOption = "discard" | "keep";


### PR DESCRIPTION
AllowSharedBufferSource is now part of the DOM, so can't be declared in dom-webcodecs.