### PR TITLE
nunjucks: fix ILoader.getSource

### DIFF
--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -69,7 +69,7 @@ export class Environment {
         autoescape: boolean;
     };
 
-    constructor(loader?: ILoader | ILoader[] | null, opts?: ConfigureOptions);
+    constructor(loader?: ILoaderAny | ILoaderAny[] | null, opts?: ConfigureOptions);
     render(name: string, context?: object): string;
     render(name: string, context?: object, callback?: TemplateCallback<string>): void;
 
@@ -106,10 +106,23 @@ export interface Extension {
 
 export function installJinjaCompat(): void;
 
+/** A synchronous or an asynchronous loader. */
+export type ILoaderAny = ILoader | ILoaderAsync | WebLoader;
+// WebLoader is part of the union because it can be both sync or async depending
+// on its constructor arguments, which possibly could only be known on runtime.
+
+/** A synchronous loader. */
 export interface ILoader {
-    async?: boolean | undefined;
-    getSource(name: string): LoaderSource;
-    getSource(name: string, callback: Callback<Error, LoaderSource>): void;
+    async?: false | undefined;
+
+    getSource: (name: string) => LoaderSource;
+}
+
+/** An asynchronous loader. */
+export interface ILoaderAsync {
+    async: true;
+
+    getSource: (name: string, callback: Callback<Error, LoaderSource>) => void;
 }
 
 // Needs both Loader and ILoader since nunjucks uses a custom object system
@@ -119,7 +132,7 @@ export class Loader {
     emit(name: string, ...args: any[]): void;
     resolve(from: string, to: string): string;
     isRelative(filename: string): boolean;
-    static extend<LoaderClass extends typeof Loader>(this: LoaderClass, toExtend: ILoader): LoaderClass;
+    static extend<LoaderClass extends typeof Loader>(this: LoaderClass, toExtend: ILoaderAny): LoaderClass;
 }
 
 export interface LoaderSource {
@@ -154,9 +167,11 @@ export interface WebLoaderOptions {
     async?: boolean;
 }
 
-export class WebLoader extends Loader implements ILoader {
+export class WebLoader extends Loader {
     constructor(baseUrl?: string, opts?: WebLoaderOptions);
-    getSource(name: string): LoaderSource;
+    async: boolean;
+
+    getSource: (name: string, callback: Callback<Error, LoaderSource>) => LoaderSource;
 }
 
 export class PrecompiledLoader extends Loader implements ILoader {

--- a/types/nunjucks/nunjucks-tests.ts
+++ b/types/nunjucks/nunjucks-tests.ts
@@ -81,3 +81,23 @@ const MyOtherLoader = nunjucks.FileSystemLoader.extend({
 env = new nunjucks.Environment(new MyOtherLoader());
 
 new nunjucks.runtime.SafeString('an unsafe string');
+
+nunjucks.Loader.extend({
+    async: true,
+    getSource(name, callback) {},
+});
+
+// @ts-expect-error
+nunjucks.Loader.extend({
+    getSource(name: any, callback: any) {},
+});
+
+// @ts-expect-error
+nunjucks.Loader.extend({
+    async: false,
+    getSource(name: any, callback: any) {},
+});
+
+function foo(async: boolean) {
+    nunjucks.Loader.extend(new nunjucks.WebLoader(undefined, { async }));
+}


### PR DESCRIPTION
Attempting to implement an async ILoader previously failed with the following type error:

    Type '(name: string, callback: Callback<Error, LoaderSource>) => void'
    is not assignable to
    type '{ (name: string): LoaderSource; (name: string, callback: Callback<Error, LoaderSource>): void; }'.
    Target signature provides too few arguments. Expected 2 or more, but got 1.