### PR TITLE
`humps` - fix distributed conditional type

### DIFF
--- a/types/humps/index.d.ts
+++ b/types/humps/index.d.ts
@@ -10,56 +10,72 @@ export type SnakeToCamelCase<S extends string> = S extends `${infer P1}_${infer 
     ? `${P1}${Uppercase<P2>}${SnakeToCamelCase<P3>}`
     : S;
 
-export type Camelized<T> = {
-    [K in keyof T as SnakeToCamelCase<string & K>]: T[K] extends Array<(infer U)>
+export type CamelizedProperty<T> = T extends any
+    ? T extends Array<infer U>
         ? U extends {}
             ? Array<Camelized<U>>
-            : T[K]
-        : T[K] extends {}
-            ? Camelized<T[K]>
-            : T[K];
+            : T
+        : T extends {}
+        ? Camelized<T>
+        : T
+    : never;
+
+export type Camelized<T> = {
+    [K in keyof T as SnakeToCamelCase<string & K>]: CamelizedProperty<T[K]>;
 };
 
 export type SnakeToPascalCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
     ? `${Capitalize<P1>}${Uppercase<P2>}${SnakeToPascalCase<P3>}`
     : S;
 
-export type Pascalized<T> = {
-    [K in keyof T as SnakeToPascalCase<string & K>]: T[K] extends Array<(infer U)>
+export type PascalizedProperty<T> = T extends any
+    ? T extends Array<infer U>
         ? U extends {}
             ? Array<Pascalized<U>>
-            : T[K]
-        : T[K] extends {}
-            ? Pascalized<T[K]>
-            : T[K];
+            : T
+        : T extends {}
+        ? Pascalized<T>
+        : T
+    : never;
+
+export type Pascalized<T> = {
+    [K in keyof T as SnakeToPascalCase<string & K>]: PascalizedProperty<T[K]>;
 };
 
 export type CamelToSnakeCase<S extends string> = S extends `${infer T}${infer U}`
     ? `${T extends Capitalize<T> ? '_' : ''}${Lowercase<T>}${CamelToSnakeCase<U>}`
     : S;
 
-export type Decamelized<T> = {
-    [K in keyof T as CamelToSnakeCase<string & K>]: T[K] extends Array<(infer U)>
+export type DecamelizedProperty<T> = T extends any
+    ? T extends Array<infer U>
         ? U extends {}
             ? Array<Decamelized<U>>
-            : T[K]
-        : T[K] extends {}
-            ? Decamelized<T[K]>
-            : T[K];
+            : T
+        : T extends {}
+        ? Decamelized<T>
+        : T
+    : never;
+
+export type Decamelized<T> = {
+    [K in keyof T as CamelToSnakeCase<string & K>]: DecamelizedProperty<T[K]>;
 };
 
 export type PascalToSnakeCase<S extends string> = S extends `${infer T1}${infer T2}${infer U}`
     ? `${T2 extends Capitalize<T2> ? '_' : ''}${Lowercase<T1>}${Lowercase<T2>}${CamelToSnakeCase<U>}`
     : S;
 
-export type Depascalized<T> = {
-    [K in keyof T as CamelToSnakeCase<string & K>]: T[K] extends Array<(infer U)>
+export type DepascalizedProperty<T> = T extends any
+    ? T extends Array<infer U>
         ? U extends {}
             ? Array<Decamelized<U>>
-            : T[K]
-        : T[K] extends {}
-            ? Decamelized<T[K]>
-            : T[K];
+            : T
+        : T extends {}
+        ? Decamelized<T>
+        : T
+    : never;
+
+export type Depascalized<T> = {
+    [K in keyof T as CamelToSnakeCase<string & K>]: DepascalizedProperty<T[K]>;
 };
 
 export function camelize<T extends string>(value: T): SnakeToCamelCase<T>;

--- a/types/humps/test/humps-tests.cjs.ts
+++ b/types/humps/test/humps-tests.cjs.ts
@@ -79,3 +79,8 @@ humps.depascalizeKeys<{ AttrOne: string, AttrTwo: string }>(somePascalObject); /
 [...humps.pascalizeKeys(someSnakeArray)];
 [...humps.decamelizeKeys(someCamelArray)];
 [...humps.depascalizeKeys(somePascalArray)];
+
+const snakeObjectWithUnion = { a_o: 'foo', a_tw: [{ a_th: 'bar' }] };
+
+humps.camelizeKeys<{ a_o: string; a_tw: Array<{ a_th: string }> | null }>(snakeObjectWithUnion); // $ExpectType Camelized<{ a_o: string; a_tw: { a_th: string; }[] | null; }>
+humps.pascalizeKeys<{ a_o: string; a_tw: Array<{ a_th: string }> | null }>(snakeObjectWithUnion); // $ExpectType Pascalized<{ a_o: string; a_tw: { a_th: string; }[] | null; }>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Changes

When using some deep property with union type with array like `SomeType[] | null` or `SomeType[] | number`, properties inside array are not affected. 

I prepared demo in this TS playground: https://tsplay.dev/weaXVw

Explanation why this change solves the problem: https://twitter.com/jasek_dominik/status/1672243934855036931?s=20