### PR TITLE
[webidl2] Add typedefs for missing functions

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -2,12 +2,14 @@
 // Project: https://github.com/w3c/webidl2.js#readme
 // Definitions by: Kagama Sascha Rosylight <https://github.com/saschanaz>
 //                 ExE Boss <https://github.com/ExE-Boss>
+//                 Vinyl Da.i'gyu-Kazotetsu <https://github.com/queengooborg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace WebIDL2;
 export {};
 
 export function parse(str: string, options?: ParseOptions): IDLRootType[];
+export function write(ast: IDLRootType[] options?: WriteOptions): string;
 
 export type IDLRootType =
     | CallbackType
@@ -40,6 +42,73 @@ export interface ParseOptions {
     concrete?: boolean | undefined;
     /** The source name, typically a filename. Errors and validation objects can indicate their origin if you pass a value. */
     sourceName?: string | undefined;
+}
+
+export interface WriteOptions {
+    templates?: {
+        /**
+         * A function that receives syntax strings plus anything the templates returned.
+         * The items are guaranteed to be ordered.
+         * The returned value may be again passed to any template functions,
+         * or it may also be the final return value of `write()`.
+         * @param {any[]} items
+         */
+        wrap?(items: any[]): any,
+        /**
+         * @param {string} t A trivia string, which includes whitespaces and comments.
+         */
+        trivia?(t: string): string,
+        /**
+         * The identifier for a container type. For example, the `Foo` part of `interface Foo {};`.
+         * @param {string} escaped The escaped raw name of the definition.
+         * @param data The definition with the name
+         * @param parent The parent of the definition, undefined if absent
+         */
+        name?(escaped: string, { data, parent }: {data: any, parent: any}): string,
+        /**
+         * Called for each type referece, e.g. `Window`, `DOMString`, or `unsigned long`.
+         * @param escaped The referenced name. Typically string, but may also be the return
+         *            value of `wrap()` if the name contains whitespace.
+         * @param unescaped Unescaped reference.
+         */
+        reference?(escaped: any, unescaped: any): any,
+        /**
+         * Called for each generic-form syntax, e.g. `sequence`, `Promise`, or `maplike`.
+         * @param {string} name The keyword for syntax
+         */
+        generic?(name: string): string,
+        /**
+         * Called for each nameless members, e.g. `stringifier` for `stringifier;` and `constructor` for `constructor();`
+         * @param {string} keyword The keyword for syntax
+         */
+        nameless?(keyword: string, { data, parent }: {data: any, parent: any}): string,
+        /**
+         * Called only once for each types, e.g. `Document`, `Promise<DOMString>`, or `sequence<long>`.
+         * @param type The `wrap()`ed result of references and syntatic bracket strings.
+         */
+        type?(type: any): any,
+        /**
+         * Receives the return value of `reference()`. String if it's absent.
+         */
+        inheritance?(inh: any): any,
+        /**
+         * Called for each IDL type definition, e.g. an interface, an operation, or a typedef.
+         * @param content The wrapped value of everything the definition contains.
+         * @param data The original definition object
+         * @param parent The parent of the definition, undefined if absent
+         */
+        definition?(content: any, { data, parent }: {data: any, parent: any}): any,
+        /**
+         * Called for each extended attribute annotation.
+         * @param content The wrapped value of everything the annotation contains.
+         */
+        extendedAttribute?(content: any): any,
+        /**
+         * The `Foo` part of `[Foo=Whatever]`.
+         * @param ref The name of the referenced extended attribute name.
+         */
+        extendedAttributeReference?(ref: any): any
+    };
 }
 
 export class WebIDLParseError extends Error {

--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -9,7 +9,7 @@ export as namespace WebIDL2;
 export {};
 
 export function parse(str: string, options?: ParseOptions): IDLRootType[];
-export function write(ast: IDLRootType[] options?: WriteOptions): string;
+export function write(ast: IDLRootType[], options?: WriteOptions): string;
 
 export type IDLRootType =
     | CallbackType

--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -52,63 +52,63 @@ export interface WriteOptions {
          * The items are guaranteed to be ordered.
          * The returned value may be again passed to any template functions,
          * or it may also be the final return value of `write()`.
-         * @param {any[]} items
+         * @param items
          */
-        wrap?(items: any[]): any,
+        wrap?(items: any[]): any;
         /**
-         * @param {string} t A trivia string, which includes whitespaces and comments.
+         * @param t A trivia string, which includes whitespaces and comments.
          */
-        trivia?(t: string): string,
+        trivia?(t: string): string;
         /**
          * The identifier for a container type. For example, the `Foo` part of `interface Foo {};`.
-         * @param {string} escaped The escaped raw name of the definition.
+         * @param escaped The escaped raw name of the definition.
          * @param data The definition with the name
          * @param parent The parent of the definition, undefined if absent
          */
-        name?(escaped: string, { data, parent }: {data: any, parent: any}): string,
+        name?(escaped: string, { data, parent }: { data: any; parent: any }): string;
         /**
          * Called for each type referece, e.g. `Window`, `DOMString`, or `unsigned long`.
          * @param escaped The referenced name. Typically string, but may also be the return
          *            value of `wrap()` if the name contains whitespace.
          * @param unescaped Unescaped reference.
          */
-        reference?(escaped: any, unescaped: any): any,
+        reference?(escaped: any, unescaped: any): any;
         /**
          * Called for each generic-form syntax, e.g. `sequence`, `Promise`, or `maplike`.
-         * @param {string} name The keyword for syntax
+         * @param name The keyword for syntax
          */
-        generic?(name: string): string,
+        generic?(name: string): string;
         /**
          * Called for each nameless members, e.g. `stringifier` for `stringifier;` and `constructor` for `constructor();`
-         * @param {string} keyword The keyword for syntax
+         * @param keyword The keyword for syntax
          */
-        nameless?(keyword: string, { data, parent }: {data: any, parent: any}): string,
+        nameless?(keyword: string, { data, parent }: { data: any; parent: any }): string;
         /**
          * Called only once for each types, e.g. `Document`, `Promise<DOMString>`, or `sequence<long>`.
          * @param type The `wrap()`ed result of references and syntatic bracket strings.
          */
-        type?(type: any): any,
+        type?(type: any): any;
         /**
          * Receives the return value of `reference()`. String if it's absent.
          */
-        inheritance?(inh: any): any,
+        inheritance?(inh: any): any;
         /**
          * Called for each IDL type definition, e.g. an interface, an operation, or a typedef.
          * @param content The wrapped value of everything the definition contains.
          * @param data The original definition object
          * @param parent The parent of the definition, undefined if absent
          */
-        definition?(content: any, { data, parent }: {data: any, parent: any}): any,
+        definition?(content: any, { data, parent }: { data: any; parent: any }): any;
         /**
          * Called for each extended attribute annotation.
          * @param content The wrapped value of everything the annotation contains.
          */
-        extendedAttribute?(content: any): any,
+        extendedAttribute?(content: any): any;
         /**
          * The `Foo` part of `[Foo=Whatever]`.
          * @param ref The name of the referenced extended attribute name.
          */
-        extendedAttributeReference?(ref: any): any
+        extendedAttributeReference?(ref: any): any;
     };
 }
 
@@ -139,12 +139,12 @@ export class WebIDLParseError extends WebIDLError {
         tokens: Token[];
     });
 
-    name: "WebIDLParseError";
+    name: 'WebIDLParseError';
 }
 
 export class WebIDLErrorData extends WebIDLError {
     /** the level of error */
-    level: "error" | "warning";
+    level: 'error' | 'warning';
 
     /** A function to automatically fix the error */
     autofix?(): void;
@@ -188,7 +188,7 @@ export interface AbstractTypeDescription extends AbstractBase {
 
 interface AbstractNonUnionTypeDescription extends AbstractTypeDescription {
     /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
-    generic: IDLTypeDescription["generic"];
+    generic: IDLTypeDescription['generic'];
     /** Boolean indicating whether this is a union type or not. */
     union: false;
 }
@@ -209,32 +209,32 @@ export type GenericTypeDescription =
     | SequenceTypeDescription;
 
 export interface FrozenArrayTypeDescription extends AbstractGenericTypeDescription {
-    generic: "FrozenArray";
+    generic: 'FrozenArray';
     idlType: [IDLTypeDescription];
 }
 
 export interface ObservableArrayTypeDescription extends AbstractGenericTypeDescription {
-    generic: "ObservableArray";
+    generic: 'ObservableArray';
     idlType: [IDLTypeDescription];
 }
 
 export interface PromiseTypeDescription extends AbstractGenericTypeDescription {
-    generic: "Promise";
+    generic: 'Promise';
     idlType: [IDLTypeDescription];
 }
 
 export interface RecordTypeDescription extends AbstractGenericTypeDescription {
-    generic: "record";
+    generic: 'record';
     idlType: [IDLTypeDescription, IDLTypeDescription];
 }
 
 export interface SequenceTypeDescription extends AbstractGenericTypeDescription {
-    generic: "sequence";
+    generic: 'sequence';
     idlType: [IDLTypeDescription];
 }
 
 export interface SingleTypeDescription extends AbstractNonUnionTypeDescription {
-    generic: "";
+    generic: '';
     /**
      * In most cases, this will just be a string with the type name.
      * If the type is a union, then this contains an array of the types it unites.
@@ -246,7 +246,7 @@ export interface SingleTypeDescription extends AbstractNonUnionTypeDescription {
 
 export interface UnionTypeDescription extends AbstractTypeDescription {
     /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
-    generic: "";
+    generic: '';
     /** Boolean indicating whether this is a union type or not. */
     union: true;
     /**
@@ -268,14 +268,14 @@ export interface AbstractContainer extends AbstractBase {
 }
 
 export interface CallbackInterfaceType extends AbstractContainer {
-    type: "callback interface";
+    type: 'callback interface';
     members: IDLCallbackInterfaceMemberType[];
     inheritance: null;
     parent: null;
 }
 
 export interface InterfaceType extends AbstractContainer {
-    type: "interface";
+    type: 'interface';
     members: IDLInterfaceMemberType[];
     /** A string giving the name of an interface this one inherits from, null otherwise. */
     inheritance: string | null;
@@ -283,21 +283,21 @@ export interface InterfaceType extends AbstractContainer {
 }
 
 export interface InterfaceMixinType extends AbstractContainer {
-    type: "interface mixin";
+    type: 'interface mixin';
     members: IDLInterfaceMixinMemberType[];
     inheritance: null;
     parent: null;
 }
 
 export interface NamespaceType extends AbstractContainer {
-    type: "namespace";
+    type: 'namespace';
     members: IDLNamespaceMemberType[];
     inheritance: null;
     parent: null;
 }
 
 export interface CallbackType extends AbstractBase {
-    type: "callback";
+    type: 'callback';
     /** The name of the callback. */
     name: string;
     /** An IDL Type describing what the callback returns. */
@@ -308,7 +308,7 @@ export interface CallbackType extends AbstractBase {
 }
 
 export interface DictionaryType extends AbstractContainer {
-    type: "dictionary";
+    type: 'dictionary';
     members: DictionaryMemberType[];
     /** A string giving the name of a dictionary this one inherits from, null otherwise. */
     inheritance: string | null;
@@ -318,7 +318,7 @@ export interface DictionaryType extends AbstractContainer {
 export type DictionaryMemberType = FieldType;
 
 export interface FieldType extends AbstractBase {
-    type: "field";
+    type: 'field';
     /** The name of the field. */
     name: string;
     /** Boolean indicating whether this is a required field. */
@@ -331,17 +331,17 @@ export interface FieldType extends AbstractBase {
 }
 
 export interface EnumType extends AbstractBase {
-    type: "enum";
+    type: 'enum';
     /** The enum's name. */
     name: string;
     /** An array of values (strings). */
-    values: Array<{ type: "enum-value"; value: string; parent: EnumType }>;
+    values: Array<{ type: 'enum-value'; value: string; parent: EnumType }>;
     /** The container of this type. */
     parent: null;
 }
 
 export interface TypedefType extends AbstractBase {
-    type: "typedef";
+    type: 'typedef';
     /** The typedef's name. */
     name: string;
     /** An IDL Type describing what typedef's type. */
@@ -350,7 +350,7 @@ export interface TypedefType extends AbstractBase {
 }
 
 export interface IncludesType extends AbstractBase {
-    type: "includes";
+    type: 'includes';
     /** The interface that includes an interface mixin. */
     target: string;
     /** The interface mixin that is being included by the target. */
@@ -359,16 +359,16 @@ export interface IncludesType extends AbstractBase {
 }
 
 export interface ConstructorMemberType extends AbstractBase {
-    type: "constructor";
+    type: 'constructor';
     /** An array of arguments for the constructor operation. */
     arguments: Argument[];
     parent: InterfaceType;
 }
 
 export interface OperationMemberType extends AbstractBase {
-    type: "operation";
+    type: 'operation';
     /** Special modifier if exists */
-    special: "getter" | "setter" | "deleter" | "static" | "stringifier" | null;
+    special: 'getter' | 'setter' | 'deleter' | 'static' | 'stringifier' | null;
     /** An IDL Type of what the operation returns. If a stringifier, may be absent. */
     idlType: IDLTypeDescription | null;
     /** The name of the operation. If a stringifier, may be null. */
@@ -379,11 +379,11 @@ export interface OperationMemberType extends AbstractBase {
 }
 
 export interface AttributeMemberType extends AbstractBase {
-    type: "attribute";
+    type: 'attribute';
     /** The attribute's name. */
     name: string;
     /** Special modifier if exists */
-    special: "static" | "stringifier" | null;
+    special: 'static' | 'stringifier' | null;
     /** True if it's an inherit attribute. */
     inherit: boolean;
     /** True if it's a read-only attribute. */
@@ -394,7 +394,7 @@ export interface AttributeMemberType extends AbstractBase {
 }
 
 export interface ConstantMemberType extends AbstractBase {
-    type: "const";
+    type: 'const';
     /** Whether its type is nullable. */
     nullable: boolean;
     /** An IDL Type of the constant that represents a simple type, the type name. */
@@ -407,7 +407,7 @@ export interface ConstantMemberType extends AbstractBase {
 }
 
 interface AbstractDeclarationMemberType extends AbstractBase {
-    type: DeclarationMemberType["type"];
+    type: DeclarationMemberType['type'];
     /** An array with one or more IDL Types representing the declared type arguments. */
     idlType: IDLTypeDescription[];
     /** Whether the iterable is declared as async. */
@@ -425,7 +425,7 @@ export type DeclarationMemberType =
     | SetlikeDeclarationMemberType;
 
 export interface IterableDeclarationMemberType extends AbstractDeclarationMemberType {
-    type: "iterable";
+    type: 'iterable';
     idlType: [IDLTypeDescription] | [IDLTypeDescription, IDLTypeDescription];
     async: boolean;
     readonly: false;
@@ -438,17 +438,17 @@ interface AbstractCollectionLikeMemberType extends AbstractDeclarationMemberType
 }
 
 export interface MaplikeDeclarationMemberType extends AbstractCollectionLikeMemberType {
-    type: "maplike";
+    type: 'maplike';
     idlType: [IDLTypeDescription, IDLTypeDescription];
 }
 
 export interface SetlikeDeclarationMemberType extends AbstractCollectionLikeMemberType {
-    type: "setlike";
+    type: 'setlike';
     idlType: [IDLTypeDescription];
 }
 
 export interface Argument extends AbstractBase {
-    type: "argument";
+    type: 'argument';
     /** A default value, absent if there is none. */
     default: ValueDescription | null;
     /** True if the argument is optional. */
@@ -463,7 +463,7 @@ export interface Argument extends AbstractBase {
 }
 
 export interface ExtendedAttribute extends AbstractBase {
-    type: "extended-attribute";
+    type: 'extended-attribute';
     /** The extended attribute's name. */
     name: string;
     /** If the extended attribute takes arguments or if its right-hand side does they are listed here. */
@@ -491,42 +491,42 @@ export type ExtendedAttributeRightHandSideList =
     | ExtendedAttributeRightHandSideIntegerList;
 
 export interface ExtendedAttributeRightHandSideIdentifier {
-    type: "identifier";
+    type: 'identifier';
     value: string;
 }
 
 export interface ExtendedAttributeRightHandSideIdentifierList {
-    type: "identifier-list";
+    type: 'identifier-list';
     value: ExtendedAttributeRightHandSideIdentifier[];
 }
 
 export interface ExtendedAttributeRightHandSideString {
-    type: "string";
+    type: 'string';
     value: string;
 }
 
 export interface ExtendedAttributeRightHandSideStringList {
-    type: "string-list";
+    type: 'string-list';
     value: ExtendedAttributeRightHandSideString[];
 }
 
 export interface ExtendedAttributeRightHandSideDecimal {
-    type: "decimal";
+    type: 'decimal';
     value: string;
 }
 
 export interface ExtendedAttributeRightHandSideDecimalList {
-    type: "decimal-list";
+    type: 'decimal-list';
     value: ExtendedAttributeRightHandSideDecimal[];
 }
 
 export interface ExtendedAttributeRightHandSideInteger {
-    type: "integer";
+    type: 'integer';
     value: string;
 }
 
 export interface ExtendedAttributeRightHandSideIntegerList {
-    type: "integer-list";
+    type: 'integer-list';
     value: ExtendedAttributeRightHandSideInteger[];
 }
 
@@ -545,38 +545,38 @@ export type ValueDescription =
     | ValueDescriptionDictionary;
 
 export interface ValueDescriptionString extends AbstractValueDescription {
-    type: "string";
+    type: 'string';
     value: string;
 }
 
 export interface ValueDescriptionNumber extends AbstractValueDescription {
-    type: "number";
+    type: 'number';
     value: string;
 }
 
 export interface ValueDescriptionBoolean extends AbstractValueDescription {
-    type: "boolean";
+    type: 'boolean';
     value: boolean;
 }
 
 export interface ValueDescriptionNull extends AbstractValueDescription {
-    type: "null";
+    type: 'null';
 }
 
 export interface ValueDescriptionInfinity extends AbstractValueDescription {
-    type: "Infinity";
+    type: 'Infinity';
     negative: boolean;
 }
 
 export interface ValueDescriptionNaN extends AbstractValueDescription {
-    type: "NaN";
+    type: 'NaN';
 }
 
 export interface ValueDescriptionSequence extends AbstractValueDescription {
-    type: "sequence";
+    type: 'sequence';
     value: [];
 }
 
 export interface ValueDescriptionDictionary extends AbstractValueDescription {
-    type: "dictionary";
+    type: 'dictionary';
 }

--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webidl2 23.13
+// Type definitions for webidl2 24.4
 // Project: https://github.com/w3c/webidl2.js#readme
 // Definitions by: Kagama Sascha Rosylight <https://github.com/saschanaz>
 //                 ExE Boss <https://github.com/ExE-Boss>

--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -112,7 +112,23 @@ export interface WriteOptions {
     };
 }
 
-export class WebIDLParseError extends Error {
+export class WebIDLError extends Error {
+    /** the error message */
+    message: string;
+    bareMessage: string;
+
+    /** the line at which the error occurred. */
+    context: string;
+    line: number;
+    sourceName: string | undefined;
+
+    /** a short peek at the text at the point where the error happened */
+    input: string;
+    /** the five tokens at the point of error, as understood by the tokeniser */
+    tokens: Token[];
+}
+
+export class WebIDLParseError extends WebIDLError {
     constructor(options: {
         message: string;
         bareMessage: string;
@@ -124,31 +140,9 @@ export class WebIDLParseError extends Error {
     });
 
     name: "WebIDLParseError";
-
-    /** the error message */
-    message: string;
-    bareMessage: string;
-
-    context: string;
-    /** the line at which the error occurred. */
-    line: number;
-    sourceName: string | undefined;
-
-    /** a short peek at the text at the point where the error happened */
-    input: string;
-    /** the five tokens at the point of error, as understood by the tokeniser */
-    tokens: Token[];
 }
 
-export class WebIDLErrorData extends Error {
-    /** the error message */
-    message: string;
-    bareMessage: string;
-
-    /** the line at which the error occurred. */
-    line: number;
-    sourceName: string | undefined;
-
+export class WebIDLErrorData extends WebIDLError {
     /** the level of error */
     level: "error" | "warning";
 
@@ -157,11 +151,6 @@ export class WebIDLErrorData extends Error {
 
     /** The name of the rule that threw the error */
     ruleName: string;
-
-    /** a short peek at the text at the point where the error happened */
-    input: string;
-    /** the five tokens at the point of error, as understood by the tokeniser */
-    tokens: Token[];
 }
 
 export interface Token {

--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -10,6 +10,7 @@ export {};
 
 export function parse(str: string, options?: ParseOptions): IDLRootType[];
 export function write(ast: IDLRootType[], options?: WriteOptions): string;
+export function validate(ast: IDLRootType[]): WebIDLErrorData[];
 
 export type IDLRootType =
     | CallbackType
@@ -132,6 +133,30 @@ export class WebIDLParseError extends Error {
     /** the line at which the error occurred. */
     line: number;
     sourceName: string | undefined;
+
+    /** a short peek at the text at the point where the error happened */
+    input: string;
+    /** the five tokens at the point of error, as understood by the tokeniser */
+    tokens: Token[];
+}
+
+export class WebIDLErrorData extends Error {
+    /** the error message */
+    message: string;
+    bareMessage: string;
+
+    /** the line at which the error occurred. */
+    line: number;
+    sourceName: string | undefined;
+
+    /** the level of error */
+    level: "error" | "warning";
+
+    /** A function to automatically fix the error */
+    autofix?(): void;
+
+    /** The name of the rule that threw the error */
+    ruleName: string;
 
     /** a short peek at the text at the point where the error happened */
     input: string;

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -1,48 +1,48 @@
-import * as webidl2 from "webidl2";
+import * as webidl2 from 'webidl2';
 
 // $ExpectType IDLRootType[]
-const parsed = webidl2.parse("");
+const parsed = webidl2.parse('');
 
 for (const rootType of parsed) {
     rootType.parent; // $ExpectType null
 
-    if (rootType.type !== "includes") {
+    if (rootType.type !== 'includes') {
         console.log(rootType.name);
     }
 
     switch (rootType.type) {
-        case "interface mixin":
+        case 'interface mixin':
             rootType; // $ExpectType InterfaceMixinType
             console.log(rootType.partial);
             logInterfaceMixinMembers(rootType.members);
             break;
 
-        case "interface":
+        case 'interface':
             rootType; // $ExpectType InterfaceType
             console.log(rootType.inheritance);
             console.log(rootType.partial);
             logInterfaceMembers(rootType.members);
             break;
 
-        case "namespace":
+        case 'namespace':
             rootType; // $ExpectType NamespaceType
             console.log(rootType.partial);
             logNamespaceMembers(rootType.members);
             break;
 
-        case "callback interface":
+        case 'callback interface':
             rootType; // $ExpectType CallbackInterfaceType
             console.log(rootType.inheritance);
             console.log(rootType.partial);
             logCallbackInterfaceMembers(rootType.members);
             break;
 
-        case "callback":
+        case 'callback':
             rootType; // $ExpectType CallbackType
             logArguments(rootType.arguments);
             break;
 
-        case "dictionary":
+        case 'dictionary':
             rootType; // $ExpectType DictionaryType
             console.log(rootType.inheritance);
             for (const member of rootType.members) {
@@ -55,7 +55,7 @@ for (const rootType of parsed) {
             }
             break;
 
-        case "enum":
+        case 'enum':
             rootType; // $ExpectType EnumType
             for (const v of rootType.values) {
                 console.log(v.type);
@@ -63,12 +63,12 @@ for (const rootType of parsed) {
             }
             break;
 
-        case "typedef":
+        case 'typedef':
             rootType; // $ExpectType TypedefType
             logIdlType(rootType.idlType);
             break;
 
-        case "includes":
+        case 'includes':
             rootType; // $ExpectType IncludesType
             console.log(rootType.target);
             console.log(rootType.includes);
@@ -92,31 +92,31 @@ function logInterfaceMembers(members: webidl2.IDLInterfaceMemberType[]) {
 
 function logInterfaceMember(member: webidl2.IDLInterfaceMemberType) {
     switch (member.type) {
-        case "constructor":
+        case 'constructor':
             member; // $ExpectType ConstructorMemberType
             member.parent; // $ExpectType InterfaceType
             logArguments(member.arguments);
             break;
 
-        case "operation":
+        case 'operation':
             member; // $ExpectType OperationMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
             logInterfaceMixinMember(member);
             break;
 
-        case "attribute":
+        case 'attribute':
             member; // $ExpectType AttributeMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType | NamespaceType
             logInterfaceMixinMember(member);
             break;
 
-        case "const":
+        case 'const':
             member; // $ExpectType ConstantMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType
             logInterfaceMixinMember(member);
             break;
 
-        case "iterable":
+        case 'iterable':
             member; // $ExpectType IterableDeclarationMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType
             member.async; // $ExpectType boolean
@@ -127,7 +127,7 @@ function logInterfaceMember(member: webidl2.IDLInterfaceMemberType) {
             logArguments(member.arguments);
             break;
 
-        case "maplike":
+        case 'maplike':
             member; // $ExpectType MaplikeDeclarationMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType
             member.async; // $ExpectType false
@@ -138,7 +138,7 @@ function logInterfaceMember(member: webidl2.IDLInterfaceMemberType) {
             logArguments(member.arguments);
             break;
 
-        case "setlike":
+        case 'setlike':
             member; // $ExpectType SetlikeDeclarationMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType
             member.async; // $ExpectType false
@@ -164,19 +164,19 @@ function logInterfaceMixinMembers(members: webidl2.IDLInterfaceMixinMemberType[]
 
 function logInterfaceMixinMember(member: webidl2.IDLInterfaceMixinMemberType) {
     switch (member.type) {
-        case "operation":
+        case 'operation':
             member; // $ExpectType OperationMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
             logCallbackInterfaceMember(member);
             break;
 
-        case "attribute":
+        case 'attribute':
             member; // $ExpectType AttributeMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType | NamespaceType
             logNamespaceMember(member);
             break;
 
-        case "const":
+        case 'const':
             member; // $ExpectType ConstantMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType
             logCallbackInterfaceMember(member);
@@ -197,13 +197,13 @@ function logCallbackInterfaceMembers(members: webidl2.IDLCallbackInterfaceMember
 
 function logCallbackInterfaceMember(member: webidl2.IDLCallbackInterfaceMemberType) {
     switch (member.type) {
-        case "operation":
+        case 'operation':
             member; // $ExpectType OperationMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
             logNamespaceMember(member);
             break;
 
-        case "const":
+        case 'const':
             member; // $ExpectType ConstantMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType
             console.log(member.name);
@@ -227,7 +227,7 @@ function logNamespaceMembers(members: webidl2.IDLNamespaceMemberType[]) {
 
 function logNamespaceMember(member: webidl2.IDLNamespaceMemberType) {
     switch (member.type) {
-        case "operation":
+        case 'operation':
             member; // $ExpectType OperationMemberType
             member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
             logArguments(member.arguments);
@@ -235,7 +235,7 @@ function logNamespaceMember(member: webidl2.IDLNamespaceMemberType) {
             console.log(member.special);
             break;
 
-        case "attribute":
+        case 'attribute':
             member; // $ExpectType AttributeMemberType
             member.parent; // $ExpectType InterfaceMixinType | InterfaceType | NamespaceType
             console.log(member.name);
@@ -255,23 +255,23 @@ function logExtAttrs(extAttrs: webidl2.ExtendedAttribute[]) {
 }
 
 function logExtAttr(extAttr: webidl2.ExtendedAttribute) {
-    console.log(extAttr.name, "on", extAttr.parent.type);
+    console.log(extAttr.name, 'on', extAttr.parent.type);
     logArguments(extAttr.arguments);
     const { rhs } = extAttr;
     if (rhs !== null) {
         switch (rhs.type) {
-            case "identifier":
-            case "string":
-            case "decimal":
-            case "integer":
+            case 'identifier':
+            case 'string':
+            case 'decimal':
+            case 'integer':
                 rhs.value; // $ExpectType string
                 logExtAttrRHS(rhs);
                 break;
 
-            case "identifier-list":
-            case "string-list":
-            case "decimal-list":
-            case "integer-list":
+            case 'identifier-list':
+            case 'string-list':
+            case 'decimal-list':
+            case 'integer-list':
                 logExtAttrRHSList(rhs);
                 break;
 
@@ -319,15 +319,15 @@ function logIdlType(idlType: webidl2.IDLTypeDescription) {
         idlType.generic; // $ExpectType "FrozenArray" | "ObservableArray" | "Promise" | "record" | "sequence" || "record" | "sequence" | "FrozenArray" | "ObservableArray" | "Promise"
         console.log(idlType);
         switch (idlType.generic) {
-            case "FrozenArray":
-            case "ObservableArray":
-            case "Promise":
-            case "sequence":
+            case 'FrozenArray':
+            case 'ObservableArray':
+            case 'Promise':
+            case 'sequence':
                 idlType.idlType; // $ExpectType [IDLTypeDescription]
                 idlType.idlType.length; // $ExpectType 1
                 break;
 
-            case "record":
+            case 'record':
                 idlType.idlType.length; // $ExpectType 2
                 break;
 
@@ -346,46 +346,46 @@ function logValueDescription(valueDesc: webidl2.ValueDescription) {
     valueDesc.parent; // $ExpectType FieldType | ConstantMemberType | Argument || ConstantMemberType | Argument | FieldType
     console.log(valueDesc.type);
     switch (valueDesc.type) {
-        case "string":
+        case 'string':
             valueDesc; // $ExpectType ValueDescriptionString
             valueDesc.value; // $ExpectType string
             console.log(valueDesc.value);
             break;
 
-        case "number":
+        case 'number':
             valueDesc; // $ExpectType ValueDescriptionNumber
             valueDesc.value; // $ExpectType string
             console.log(valueDesc.value);
             break;
 
-        case "boolean":
+        case 'boolean':
             valueDesc; // $ExpectType ValueDescriptionBoolean
             valueDesc.value; // $ExpectType boolean
             console.log(valueDesc.value);
             break;
 
-        case "null":
+        case 'null':
             valueDesc; // $ExpectType ValueDescriptionNull
             break;
 
-        case "Infinity":
+        case 'Infinity':
             valueDesc; // $ExpectType ValueDescriptionInfinity
             valueDesc.negative; // $ExpectType boolean
             console.log(valueDesc.negative);
             break;
 
-        case "NaN":
+        case 'NaN':
             valueDesc; // $ExpectType ValueDescriptionNaN
             break;
 
-        case "sequence":
+        case 'sequence':
             valueDesc; // $ExpectType ValueDescriptionSequence
             valueDesc.value; // $ExpectType []
             valueDesc.value.length; // $ExpectType 0
             console.log(valueDesc.value);
             break;
 
-        case "dictionary":
+        case 'dictionary':
             valueDesc; // $ExpectType ValueDescriptionDictionary
             break;
 
@@ -394,3 +394,9 @@ function logValueDescription(valueDesc: webidl2.ValueDescription) {
             break;
     }
 }
+
+// $ExpectType string
+const written = webidl2.write(parsed);
+
+// $ExpectType WebIDLErrorData[]
+const errors = webidl2.validate(parsed);


### PR DESCRIPTION
Hello!  This is my first pull request to DefinitelyTyped -- please let me know how I can improve my pull request!

---

This PR resolves https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63342 by adding the missing typedefs for the `write()` and `validate()` functions, including the `WriteOptions` and `WebIDLErrorData` interfaces/classes.  In turn, this synchronizes the typedefs with version 24.4.0 of the package.

---

Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - write():
    - https://github.com/w3c/webidl2.js/blob/7193ff191558778d3b322fd9ea7aa8ddee24752d/lib/writer.js#L68-L74
    - https://github.com/w3c/webidl2.js#documentation
  - validate():
    - https://github.com/w3c/webidl2.js/blob/7193ff191558778d3b322fd9ea7aa8ddee24752d/lib/validator.js#L88-L94
  - WebIDLErrorData:
    - https://github.com/w3c/webidl2.js/blob/7193ff191558778d3b322fd9ea7aa8ddee24752d/lib/error.js#L33
    - https://github.com/w3c/webidl2.js/blob/7193ff191558778d3b322fd9ea7aa8ddee24752d/lib/error.js#L105-L116
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
