### PR TITLE
fix documentation and typing for chroma.scale in chroma-js

### DIFF
--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -215,9 +215,12 @@ declare namespace chroma {
          */
         bezier(colors: string[]): { (t: number): Color; scale(): Scale };
 
-        scale(name: string | Color): Scale;
-
-        scale(colors?: Array<string | Color>): Scale;
+        /**
+         * Return a function that maps a numeric value to a color scale.
+         * Either pass a name of a palette (as in https://colorbrewer2.org/, e.g. "RdYlBu") or an array of colors.
+         * If no argument is passed, uses a scale from white to black.
+         */
+        scale(name_or_colors?: string | Array<string | Color>): Scale;
 
         cubehelix(): Cubehelix;
 


### PR DESCRIPTION
A `chroma.scale` either takes the name of a scale (e.g. `RdYlBu`) or a list of colors.
I currently have code, that puts a  `string | string[]` into a `chroma.scale` and it fails with

```
  Overload 1 of 2, '(name: string | Color): Scale<Color>', gave the following error.
    Argument of type 'string | string[]' is not assignable to parameter of type 'string | Color'.
      Type 'string[]' is not assignable to type 'string | Color'.
  Overload 2 of 2, '(colors?: (string | Color)[] | undefined): Scale<Color>', gave the following error.
    Argument of type 'string | string[]' is not assignable to parameter of type '(string | Color)[] | undefined'.
      Type 'string' is not assignable to type '(string | Color)[]'.
```

I think this can be fixed in two ways:
1. fix the overloads to have a common overload definition
2. provide one signature that captures all use cases, as suggested in https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#use-union-types (which this PR tries to do).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gka.github.io/chroma.js/#color-scales
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  I use chroma 2.4.2, the header says 2.4, so I think that is correct.

