### PR TITLE
Add types for express-multipart-file-parser 0.1.x

### DIFF
--- a/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
+++ b/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
@@ -13,4 +13,10 @@ fileParser({ rawBodyOptions: { limit: '10mb' } });
 fileParser({ busboyOptions: { limits: { fields: 2 } } });
 
 // @ts-expect-error
-app.use(fileParser({ otherOptions: { foo: 'bar' } }));
+fileParser({ otherOptions: { foo: 'bar' } });
+
+// @ts-expect-error
+fileParser('string');
+
+// @ts-expect-error
+fileParser(123);

--- a/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
+++ b/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
@@ -1,19 +1,16 @@
 import fileParserDefault = require('express-multipart-file-parser');
 const fileParser = fileParserDefault.fileParser;
-import express from 'express';
-
-const app = express();
 
 // $ExpectType FileParser
 fileParserDefault;
 
-// $ExpectType RequestHandler<ParamsDictionary, any, any, ParsedQs, Record<string, any>>
+// $ExpectType RequestHandler
 fileParser();
 
-app.use(fileParserDefault);
-app.use(fileParser());
-app.use(fileParser({ rawBodyOptions: { limit: '10mb' } }));
-app.use(fileParser({ busboyOptions: { limits: { fields: 2 } } }));
+fileParserDefault;
+fileParser();
+fileParser({ rawBodyOptions: { limit: '10mb' } });
+fileParser({ busboyOptions: { limits: { fields: 2 } } });
 
 // @ts-expect-error
 app.use(fileParser({ otherOptions: { foo: 'bar' } }));

--- a/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
+++ b/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
@@ -1,0 +1,19 @@
+import fileParserDefault = require('express-multipart-file-parser');
+const fileParser = fileParserDefault.fileParser;
+import express from 'express';
+
+const app = express();
+
+// $ExpectType FileParser
+fileParserDefault;
+
+// $ExpectType RequestHandler<ParamsDictionary, any, any, ParsedQs, Record<string, any>>
+fileParser();
+
+app.use(fileParserDefault);
+app.use(fileParser());
+app.use(fileParser({ rawBodyOptions: { limit: '10mb' } }));
+app.use(fileParser({ busboyOptions: { limits: { fields: 2 } } }));
+
+// @ts-expect-error
+app.use(fileParser({ otherOptions: { foo: 'bar' } }));

--- a/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
+++ b/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
@@ -4,7 +4,7 @@ const fileParser = fileParserDefault.fileParser;
 // $ExpectType FileParser
 fileParserDefault;
 
-// $ExpectType RequestHandler
+// $ExpectType RequestHandler[]
 fileParser();
 
 fileParserDefault;

--- a/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
+++ b/types/express-multipart-file-parser/express-multipart-file-parser-tests.ts
@@ -1,22 +1,42 @@
 import fileParserDefault = require('express-multipart-file-parser');
 const fileParser = fileParserDefault.fileParser;
 
+// mock of express request handler
+type RequestHandler = (_req: any, _res: any, _next: any) => void;
+
+// mock of express app
+declare const app: {
+    // IRouterMatcher
+    use(path: string, ..._handlers: RequestHandler[]): void;
+    use(path: string, _handlers: RequestHandler | RequestHandler[]): void;
+
+    // IRouterHandler
+    use(_handlers: RequestHandler | RequestHandler[]): void;
+    use(..._handlers: RequestHandler[]): void;
+};
+
 // $ExpectType FileParser
 fileParserDefault;
+
+// $ExpectType FileParserFactory
+fileParser;
 
 // $ExpectType RequestHandler[]
 fileParser();
 
-fileParserDefault;
-fileParser();
-fileParser({ rawBodyOptions: { limit: '10mb' } });
-fileParser({ busboyOptions: { limits: { fields: 2 } } });
+fileParserDefault.push((_req, _res, _next) => {});
+fileParserDefault.pop();
+
+app.use(fileParserDefault);
+app.use(fileParser());
+app.use(fileParser({ rawBodyOptions: { limit: '10mb' } }));
+app.use(fileParser({ busboyOptions: { limits: { fields: 2 } } }));
 
 // @ts-expect-error
-fileParser({ otherOptions: { foo: 'bar' } });
+app.use(fileParser({ otherOptions: { foo: 'bar' } }));
 
 // @ts-expect-error
-fileParser('string');
+app.use(fileParser('string'));
 
 // @ts-expect-error
-fileParser(123);
+app.use(fileParser(123));

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for express-multipart-file-parser 0.1
 // Project: https://github.com/cristovao-trevisan/express-multipart-file-parser#readme
 // Definitions by: Chen Asraf <https://github.com/chenasraf>
+//                 Cristóvão Trevisan <https://github.com/cristovao-trevisan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -26,7 +26,15 @@ interface UploadedFile {
 }
 
 interface FileParserOptions {
+    /**
+     * Options passed to the raw-body library
+     * @see https://www.npmjs.com/package/raw-body#user-content-api
+     */
     rawBodyOptions?: RawBodyOptions;
+    /**
+     * Options passed to the busboy library
+     * @see https://github.com/mscdex/busboy/tree/v1.5.0#readme
+     */
     busboyOptions?: BusboyOptions;
 }
 

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -38,7 +38,7 @@ declare module 'express-serve-static-core' {
 
 type RequestHandler = (req: any, res: any, next: any) => void;
 
-type FileParserFactory = (options?: FileParserOptions) => RequestHandler;
+type FileParserFactory = (options?: FileParserOptions) => RequestHandler[];
 
 type FileParser = RequestHandler & { fileParser: FileParserFactory };
 

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for express-multipart-file-parser 0.1.2
+// Project: https://github.com/cristovao-trevisan/express-multipart-file-parser#readme
+// Definitions by: Chen Asraf <https://github.com/chenasraf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import type { RequestHandler } from 'express';
+import type { BusboyConfig as BusboyOptions } from 'busboy';
+import type { Options as RawBodyOptions } from 'raw-body';
+
+interface UploadedFile {
+    /** Field name specified in the form */
+    fieldname: string;
+    /** Name of the file on the user's computer */
+    originalname: string;
+    /** Encoding type of the file */
+    encoding: string;
+    /** Mime type of the file */
+    mimetype: string;
+    /** Contents of the file */
+    buffer: Buffer;
+}
+
+interface FileParserOptions {
+    rawBodyOptions?: RawBodyOptions;
+    busboyOptions?: BusboyOptions;
+}
+
+declare module 'express-serve-static-core' {
+    interface Request {
+        files?: UploadedFile[];
+    }
+}
+
+type FileParserFactory = (options?: FileParserOptions) => RequestHandler;
+
+type FileParser = RequestHandler & { fileParser: FileParserFactory };
+
+declare const fileParser: FileParser;
+
+export = fileParser;

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for express-multipart-file-parser 0.1.2
+// Type definitions for express-multipart-file-parser 0.1
 // Project: https://github.com/cristovao-trevisan/express-multipart-file-parser#readme
 // Definitions by: Chen Asraf <https://github.com/chenasraf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import type { RequestHandler } from 'express';
+/// <reference types="node" />
+
 import type { BusboyConfig as BusboyOptions } from 'busboy';
 import type { Options as RawBodyOptions } from 'raw-body';
 
@@ -30,6 +31,8 @@ declare module 'express-serve-static-core' {
         files?: UploadedFile[];
     }
 }
+
+type RequestHandler = (req: any, res: any, next: any) => void;
 
 type FileParserFactory = (options?: FileParserOptions) => RequestHandler;
 

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -48,7 +48,7 @@ type RequestHandler = (req: any, res: any, next: any) => void;
 
 type FileParserFactory = (options?: FileParserOptions) => RequestHandler[];
 
-type FileParser = RequestHandler & { fileParser: FileParserFactory };
+type FileParser = RequestHandler[] & { fileParser: FileParserFactory };
 
 declare const fileParser: FileParser;
 

--- a/types/express-multipart-file-parser/index.d.ts
+++ b/types/express-multipart-file-parser/index.d.ts
@@ -11,12 +11,16 @@ import type { Options as RawBodyOptions } from 'raw-body';
 interface UploadedFile {
     /** Field name specified in the form */
     fieldname: string;
+
     /** Name of the file on the user's computer */
     originalname: string;
+
     /** Encoding type of the file */
     encoding: string;
+
     /** Mime type of the file */
     mimetype: string;
+
     /** Contents of the file */
     buffer: Buffer;
 }

--- a/types/express-multipart-file-parser/package.json
+++ b/types/express-multipart-file-parser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/busboy": "^1.5.0",
+        "@types/busboy": "^0.2.3",
         "raw-body": "^2.3.2"
     }
 }

--- a/types/express-multipart-file-parser/package.json
+++ b/types/express-multipart-file-parser/package.json
@@ -2,8 +2,6 @@
     "private": true,
     "dependencies": {
         "@types/busboy": "^1.5.0",
-        "@types/express": "^4.17.17",
-        "@types/node": "^20.3.2",
-        "raw-body": "^2.5.2"
+        "raw-body": "^2.3.2"
     }
 }

--- a/types/express-multipart-file-parser/package.json
+++ b/types/express-multipart-file-parser/package.json
@@ -1,0 +1,9 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/busboy": "^1.5.0",
+        "@types/express": "^4.17.17",
+        "@types/node": "^20.3.2",
+        "raw-body": "^2.5.2"
+    }
+}

--- a/types/express-multipart-file-parser/tsconfig.json
+++ b/types/express-multipart-file-parser/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/express-multipart-file-parser/tsconfig.json
+++ b/types/express-multipart-file-parser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-multipart-file-parser-tests.ts"
+    ]
+}

--- a/types/express-multipart-file-parser/tslint.json
+++ b/types/express-multipart-file-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Types for [express-multipart-file-parser](https://www.npmjs.com/package/express-multipart-file-parser)

This is a relatively old package but it is still useful in some cases.

~I needed to use `esModuleInterop: true` in `tsconfig.json`, not sure if it was avoidable.~

Not sure about how dependencies should work - I only need `@types/busboy` and `raw-body` for the types they contain, as this package accepts their options, and passes them to the respective package.  

Therefore they needed to be contained in the type. I hope I defined the version numbers correctly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test express-multipart-file-parser`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
