### PR TITLE
types for "locate-chrome" npm package

### DIFF
--- a/types/locate-chrome/index.d.ts
+++ b/types/locate-chrome/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Ben Houston <https://github.com/bhouston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// locate-chrome.d.ts
 declare function locateChrome(cb?: (path: string) => void): Promise<string>;
 
 export = locateChrome;

--- a/types/locate-chrome/index.d.ts
+++ b/types/locate-chrome/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for locate-chrome
+// Project: https://github.com/davidtheclark/locate-chrome
+// Definitions by: Ben Houston <https://github.com/bhouston>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// locate-chrome.d.ts
+declare module "locate-chrome" {
+    
+    function locateChrome(cb?: (path: string) => void): Promise<string>;
+   
+    export = locateChrome;
+}

--- a/types/locate-chrome/index.d.ts
+++ b/types/locate-chrome/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Ben Houston <https://github.com/bhouston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function locateChrome(cb?: (path: string) => void): Promise<string>;
+declare function locateChrome(cb?: (path: string | null) => void): Promise<string | null>;
 
 export = locateChrome;

--- a/types/locate-chrome/index.d.ts
+++ b/types/locate-chrome/index.d.ts
@@ -1,12 +1,9 @@
-// Type definitions for locate-chrome
+// Type definitions for locate-chrome 0.1
 // Project: https://github.com/davidtheclark/locate-chrome
 // Definitions by: Ben Houston <https://github.com/bhouston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // locate-chrome.d.ts
-declare module "locate-chrome" {
-    
-    function locateChrome(cb?: (path: string) => void): Promise<string>;
-   
-    export = locateChrome;
-}
+declare function locateChrome(cb?: (path: string) => void): Promise<string>;
+
+export = locateChrome;

--- a/types/locate-chrome/locate-chrome-tests.ts
+++ b/types/locate-chrome/locate-chrome-tests.ts
@@ -2,6 +2,6 @@ import locateChrome = require('locate-chrome');
 
 const result = locateChrome(); // $ExpectType Promise<string>
 
-locateChrome( ( path ) => {
+locateChrome(path => {
     path; // $ExpectType string
 });

--- a/types/locate-chrome/locate-chrome-tests.ts
+++ b/types/locate-chrome/locate-chrome-tests.ts
@@ -1,0 +1,7 @@
+import locateChrome = require('locate-chrome');
+
+const result = locateChrome(); // $ExpectType Promise<string>
+
+locateChrome( ( path ) => {
+    path; // $ExpectType string
+});

--- a/types/locate-chrome/locate-chrome-tests.ts
+++ b/types/locate-chrome/locate-chrome-tests.ts
@@ -1,7 +1,7 @@
 import locateChrome = require('locate-chrome');
 
-const result = locateChrome(); // $ExpectType Promise<string>
+const result = locateChrome(); // $ExpectType Promise<string | null>
 
 locateChrome(path => {
-    path; // $ExpectType string
+    path; // $ExpectType string | null
 });

--- a/types/locate-chrome/tsconfig.json
+++ b/types/locate-chrome/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "locate-chrome-tests.ts"
+    ]
+}

--- a/types/locate-chrome/tslint.json
+++ b/types/locate-chrome/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.