### PR TITLE
@types/ssh2 fix wrong type for exit event

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -253,7 +253,7 @@ export interface ClientChannel extends Channel {
      * finishes. If the process finished normally, the process's return value is passed to
      * the `exit` callback.
      */
-    on(event: 'exit', listener: (code: string) => void): this;
+    on(event: 'exit', listener: (code: number) => void): this;
     on(event: 'exit', listener: (code: null, signal: string, dump: string, desc: string) => void): this;
     on(event: string | symbol, listener: Function): this;
 }


### PR DESCRIPTION
the argument type should be number instead of string

Reference: https://github.com/mscdex/ssh2/blob/7410a11c282fd0f21e8e989906c699c84ca711ed/README.md?plain=1#L362

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ssh2 documentation](https://github.com/mscdex/ssh2/blob/7410a11c282fd0f21e8e989906c699c84ca711ed/README.md?plain=1#L362)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
