### PR TITLE
@types/chrome: Add world property for content_scripts

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7307,7 +7307,7 @@ declare namespace chrome.runtime {
             match_about_blank?: boolean | undefined;
             include_globs?: string[] | undefined;
             exclude_globs?: string[] | undefined;
-            world: "ISOLATED" | "MAIN" | undefined
+            world?: "ISOLATED" | "MAIN" | undefined
         }[] | undefined;
         content_security_policy?: {
             extension_pages?: string;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7297,6 +7297,18 @@ declare namespace chrome.runtime {
             type?: 'module'; // If the service worker uses ES modules
         }
         | undefined;
+        content_scripts?: {
+            matches?: string[] | undefined;
+            exclude_matches?: string[] | undefined;
+            css?: string[] | undefined;
+            js?: string[] | undefined;
+            run_at?: string | undefined;
+            all_frames?: boolean | undefined;
+            match_about_blank?: boolean | undefined;
+            include_globs?: string[] | undefined;
+            exclude_globs?: string[] | undefined;
+            world: "ISOLATED" | "MAIN" | undefined
+        }[] | undefined;
         content_security_policy?: {
             extension_pages?: string;
             sandbox?: string;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -568,6 +568,13 @@ function testGetManifest() {
         name: 'manifest version 3',
         version: '3.0.0',
         background: { service_worker: 'bg-sw.js', type: 'module' },
+        content_scripts: [
+            {
+                matches: ["https://github.com/*"],
+                js: ["cs.js"],
+                world: "MAIN"
+            }
+        ],
         content_security_policy: {
             extension_pages: "default-src 'self'",
             sandbox: "default-src 'self'",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chrome docs](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#functionality), [chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1330986)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is my first time here, so I hope I did it right :)
