### PR TITLE
[plotly.js] Add missing data property on PlotlyHTMLElement.

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -310,6 +310,7 @@ export interface PlotlyHTMLElement extends HTMLElement {
         callback: () => void,
     ): void;
     removeAllListeners: (handler: string) => void;
+    data: Data[];
 }
 
 export interface ToImgopts {

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -928,6 +928,8 @@ function rand() {
     });
 
     myPlot.removeAllListeners('plotly_restyle');
+
+    myPlot.data; // $ExpectType Data[]
 })();
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
According to an example from the [`plotly.js/src/plot_api/plot_api.js`](https://github.com/plotly/plotly.js/blob/32b6fec5d271c44440edaddc376c59e9d9d2ad48/src/plot_api/plot_api.js#L113-L117), this [reference](https://github.com/plotly/plotly.js/blob/32b6fec5d271c44440edaddc376c59e9d9d2ad48/src/plot_api/plot_api.js#L561C1-L569C2), and [documentation](https://plotly.com/javascript/plotlyjs-function-reference/#:~:text=After%20plotting%2C%20the%20data%20or%20layout%20can%20always%20be%20retrieved%20from%20the%20%3Cdiv%3E%20element%20in%20which%20the%20plot%20was%20drawn%3A), a `PlotlyHTMLElement` object should be able to access `data` property. Such `data` property is currently not supported. This PR fixes this.

Testing and the rest of checklist are WIP. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

