### PR TITLE
[eslint] Add `ecmaVersion` 2024

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -556,6 +556,8 @@ linter.verify(SOURCE, {}, { postprocess: problemList => problemList[0] });
 
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2021 } }, 'test.js');
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2022 } }, 'test.js');
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2023 } }, 'test.js');
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2024 } }, 'test.js');
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 'latest' } }, 'test.js');
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }, 'test.js');
 linter.verify(
@@ -711,6 +713,8 @@ linterWithFlatConfig.verify(SOURCE, [{}], { postprocess: problemList => problemL
 
 linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 2021 } }], 'test.js');
 linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 2022 } }], 'test.js');
+linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 2023 } }], 'test.js');
+linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 2024 } }], 'test.js');
 linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 'latest' } }], 'test.js');
 linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 6 } }], 'test.js');
 linterWithFlatConfig.verify(

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 8.40
+// Type definitions for eslint 8.44
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>
@@ -843,7 +843,7 @@ export namespace Linter {
     }
 
     interface ParserOptions {
-        ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021 | 2022 | "latest" | undefined;
+        ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021 | 2022 | 2023 | 2024 | "latest" | undefined;
         sourceType?: "script" | "module" | undefined;
         ecmaFeatures?: {
             globalReturn?: boolean | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eslint/eslint/commit/4c5040022639ae804c15b366afc6e64982bd8ae3
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR adds support for `ecmaVersion` 2024 and other values accepted by [ESLint v8.44](https://github.com/eslint/eslint/releases/tag/v8.44.0). 