### PR TITLE
Json fixer/add dt

### DIFF
--- a/types/json-fixer/index.d.ts
+++ b/types/json-fixer/index.d.ts
@@ -1,23 +1,21 @@
-// Type definitions for json-fixer
+// Type definitions for json-fixer 1.6
 // Project: https://github.com/Berkmann18/json-fixer
 // Definitions by: zbone3 <https://github.com/zbone3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.5
 
-declare module "json-fixer" {
+type JsonFixerDataReturnValue = string | { [k: string]: any };
 
-    type JsonFixerDataReturnValue = string | { [k: string]: any }
-
-    interface FixJsonOptions {
-        verbose?: boolean;
-        parse?: boolean;
-    }
-
-    interface CheckJsonResult {
-        data: JsonFixerDataReturnValue;
-        changed: boolean;
-    }
-
-    function checkJson(data: string, options?: FixJsonOptions | boolean): CheckJsonResult;
-
-    export = checkJson;
+interface FixJsonOptions {
+    verbose?: boolean;
+    parse?: boolean;
 }
+
+interface CheckJsonResult {
+    data: JsonFixerDataReturnValue;
+    changed: boolean;
+}
+
+declare function checkJson(data: string, options?: FixJsonOptions | boolean): CheckJsonResult;
+
+export = checkJson;

--- a/types/json-fixer/index.d.ts
+++ b/types/json-fixer/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for json-fixer
+// Project: https://github.com/Berkmann18/json-fixer
+// Definitions by: zbone3 <https://github.com/zbone3>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "json-fixer" {
+
+    type JsonFixerDataReturnValue = string | { [k: string]: any }
+
+    interface FixJsonOptions {
+        verbose?: boolean;
+        parse?: boolean;
+    }
+
+    interface CheckJsonResult {
+        data: JsonFixerDataReturnValue;
+        changed: boolean;
+    }
+
+    function checkJson(data: string, options?: FixJsonOptions | boolean): CheckJsonResult;
+
+    export = checkJson;
+}

--- a/types/json-fixer/json-fixer-tests.ts
+++ b/types/json-fixer/json-fixer-tests.ts
@@ -1,17 +1,15 @@
-import * as jsonFixer from 'json-fixer'
+import jsonFixer from 'json-fixer';
 
-
-const brokenJson = '{ missingQuotesAroundKey: "someValue" }'
+const brokenJson = '{ missingQuotesAroundKey: "someValue" }';
 
 // No options
-const res = jsonFixer(brokenJson)
-res.data
-res.changed
-
+const res = jsonFixer(brokenJson);
+res.data;
+res.changed;
 
 // All options
-jsonFixer(brokenJson, {parse: true, verbose: false})
+jsonFixer(brokenJson, {parse: true, verbose: false});
 
 // Partial options
-jsonFixer(brokenJson, {verbose: false})
-jsonFixer(brokenJson, {parse: true})
+jsonFixer(brokenJson, {verbose: false});
+jsonFixer(brokenJson, {parse: true});

--- a/types/json-fixer/json-fixer-tests.ts
+++ b/types/json-fixer/json-fixer-tests.ts
@@ -1,4 +1,4 @@
-import jsonFixer from 'json-fixer';
+import jsonFixer = require('json-fixer');
 
 const brokenJson = '{ missingQuotesAroundKey: "someValue" }';
 

--- a/types/json-fixer/json-fixer-tests.ts
+++ b/types/json-fixer/json-fixer-tests.ts
@@ -1,0 +1,17 @@
+import * as jsonFixer from 'json-fixer'
+
+
+const brokenJson = '{ missingQuotesAroundKey: "someValue" }'
+
+// No options
+const res = jsonFixer(brokenJson)
+res.data
+res.changed
+
+
+// All options
+jsonFixer(brokenJson, {parse: true, verbose: false})
+
+// Partial options
+jsonFixer(brokenJson, {verbose: false})
+jsonFixer(brokenJson, {parse: true})

--- a/types/json-fixer/tsconfig.json
+++ b/types/json-fixer/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/json-fixer/tsconfig.json
+++ b/types/json-fixer/tsconfig.json
@@ -4,7 +4,6 @@
         "lib": [
             "es6"
         ],
-        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/json-fixer/tsconfig.json
+++ b/types/json-fixer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json-fixer-tests.ts"
+    ]
+}

--- a/types/json-fixer/tslint.json
+++ b/types/json-fixer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
