### PR TITLE
[@types/react] Add suppressHydrationWarning type to SVGAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2591,6 +2591,9 @@ declare namespace React {
     //   - "string"
     //   - union of string literals
     interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // React-specific Attributes
+        suppressHydrationWarning?: boolean | undefined;
+
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
         className?: string | undefined;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -83,7 +83,7 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
 <ComponentWithChildren3 bar="42"></ComponentWithChildren3>;
 
 // svg sanity check
-<svg viewBox="0 0 1000 1000">
+<svg suppressHydrationWarning viewBox="0 0 1000 1000">
     <g>
         <text x="200" y="300" strokeWidth="5" stroke="black" alignmentBaseline="middle">
             Hello, world!

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2560,6 +2560,9 @@ declare namespace React {
     //   - "string"
     //   - union of string literals
     interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // React-specific Attributes
+        suppressHydrationWarning?: boolean | undefined;
+        
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
         className?: string | undefined;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -37,10 +37,10 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ElementType<P = any> =
-        | {
-              [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never;
-          }[keyof JSX.IntrinsicElements]
-        | ComponentType<P>;
+        {
+            [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
+        }[keyof JSX.IntrinsicElements] |
+        ComponentType<P>;
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
@@ -57,7 +57,7 @@ declare namespace React {
         readonly current: T | null;
     }
     // Bivariance hack for consistent unsoundness with RefObject
-    type RefCallback<T> = { bivarianceHack(instance: T | null): void }['bivarianceHack'];
+    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
     type Ref<T> = RefCallback<T> | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
     /**
@@ -82,12 +82,14 @@ declare namespace React {
             | ForwardRefExoticComponent<any>
             | { new (props: any): Component<any> }
             | ((props: any, context?: any) => ReactElement | null)
-            | keyof JSX.IntrinsicElements,
+            | keyof JSX.IntrinsicElements
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
         // otherwise it will infer `{}` instead of `never`
-        'ref' extends keyof ComponentPropsWithRef<C>
-            ? NonNullable<ComponentPropsWithRef<C>['ref']> extends Ref<infer Instance>
+        "ref" extends keyof ComponentPropsWithRef<C>
+            ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
+                infer Instance
+            >
                 ? Instance
                 : never
             : never;
@@ -120,10 +122,7 @@ declare namespace React {
         ref?: LegacyRef<T> | undefined;
     }
 
-    interface ReactElement<
-        P = any,
-        T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>,
-    > {
+    interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
         key: Key | null;
@@ -131,11 +130,11 @@ declare namespace React {
 
     interface ReactComponentElement<
         T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
-        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>,
-    > extends ReactElement<P, Exclude<T, number>> {}
+        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
+    > extends ReactElement<P, Exclude<T, number>> { }
 
     interface FunctionComponentElement<P> extends ReactElement<P, FunctionComponent<P>> {
-        ref?: ('ref' extends keyof P ? (P extends { ref?: infer R | undefined } ? R : never) : never) | undefined;
+        ref?: ('ref' extends keyof P ? P extends { ref?: infer R | undefined } ? R : never : never) | undefined;
     }
 
     type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
@@ -146,13 +145,12 @@ declare namespace React {
     type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
 
     // string fallback for custom web-components
-    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element>
-        extends ReactElement<P, string> {
+    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P, string> {
         ref: LegacyRef<T>;
     }
 
     // ReactHTML for ReactHTMLElement
-    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> {}
+    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> { }
 
     interface DetailedReactHTMLElement<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMElement<P, T> {
         type: keyof ReactHTML;
@@ -179,35 +177,25 @@ declare namespace React {
      */
     type SFCFactory<P> = FunctionComponentFactory<P>;
 
-    type FunctionComponentFactory<P> = (
-        props?: Attributes & P,
-        ...children: ReactNode[]
-    ) => FunctionComponentElement<P>;
+    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
 
-    type ComponentFactory<P, T extends Component<P, ComponentState>> = (
-        props?: ClassAttributes<T> & P,
-        ...children: ReactNode[]
-    ) => CElement<P, T>;
+    type ComponentFactory<P, T extends Component<P, ComponentState>> =
+        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
-    type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
-        props?: (ClassAttributes<T> & P) | null,
-        ...children: ReactNode[]
-    ) => DOMElement<P, T>;
+    type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
 
     interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
 
     interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
-        (props?: (ClassAttributes<T> & P) | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     }
 
     interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
-        (
-            props?: (ClassAttributes<SVGElement> & SVGAttributes<SVGElement>) | null,
-            ...children: ReactNode[]
-        ): ReactSVGElement;
+        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
     }
 
     /**
@@ -251,108 +239,94 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     // DOM Elements
-    function createFactory<T extends HTMLElement>(type: keyof ReactHTML): HTMLFactory<T>;
-    function createFactory(type: keyof ReactSVG): SVGFactory;
-    function createFactory<P extends DOMAttributes<T>, T extends Element>(type: string): DOMFactory<P, T>;
+    function createFactory<T extends HTMLElement>(
+        type: keyof ReactHTML): HTMLFactory<T>;
+    function createFactory(
+        type: keyof ReactSVG): SVGFactory;
+    function createFactory<P extends DOMAttributes<T>, T extends Element>(
+        type: string): DOMFactory<P, T>;
 
     // Custom components
     function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
     function createFactory<P>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-    ): CFactory<P, ClassicComponent<P, ComponentState>>;
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
-        type: ClassType<P, T, C>,
-    ): CFactory<P, T>;
+        type: ClassType<P, T, C>): CFactory<P, T>;
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
     // DOM Elements
     // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
     function createElement(
-        type: 'input',
-        props?: (InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement>) | null,
-        ...children: ReactNode[]
-    ): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+        type: "input",
+        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
     function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         type: keyof ReactHTML,
-        props?: (ClassAttributes<T> & P) | null,
-        ...children: ReactNode[]
-    ): DetailedReactHTMLElement<P, T>;
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
         type: keyof ReactSVG,
-        props?: (ClassAttributes<T> & P) | null,
-        ...children: ReactNode[]
-    ): ReactSVGElement;
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): ReactSVGElement;
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
-        props?: (ClassAttributes<T> & P) | null,
-        ...children: ReactNode[]
-    ): DOMElement<P, T>;
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DOMElement<P, T>;
 
     // Custom components
 
     function createElement<P extends {}>(
         type: FunctionComponent<P>,
-        props?: (Attributes & P) | null,
-        ...children: ReactNode[]
-    ): FunctionComponentElement<P>;
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): FunctionComponentElement<P>;
     function createElement<P extends {}>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: (ClassAttributes<ClassicComponent<P, ComponentState>> & P) | null,
-        ...children: ReactNode[]
-    ): CElement<P, ClassicComponent<P, ComponentState>>;
+        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
+        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
-        props?: (ClassAttributes<T> & P) | null,
-        ...children: ReactNode[]
-    ): CElement<P, T>;
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): CElement<P, T>;
     function createElement<P extends {}>(
         type: FunctionComponent<P> | ComponentClass<P> | string,
-        props?: (Attributes & P) | null,
-        ...children: ReactNode[]
-    ): ReactElement<P>;
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): ReactElement<P>;
 
     // DOM Elements
     // ReactHTMLElement
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: DetailedReactHTMLElement<P, T>,
         props?: P,
-        ...children: ReactNode[]
-    ): DetailedReactHTMLElement<P, T>;
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     // ReactHTMLElement, less specific
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: ReactHTMLElement<T>,
         props?: P,
-        ...children: ReactNode[]
-    ): ReactHTMLElement<T>;
+        ...children: ReactNode[]): ReactHTMLElement<T>;
     // SVGElement
     function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
         element: ReactSVGElement,
         props?: P,
-        ...children: ReactNode[]
-    ): ReactSVGElement;
+        ...children: ReactNode[]): ReactSVGElement;
     // DOM Element (has to be the last, because type checking stops at first overload that fits)
     function cloneElement<P extends DOMAttributes<T>, T extends Element>(
         element: DOMElement<P, T>,
         props?: DOMAttributes<T> & P,
-        ...children: ReactNode[]
-    ): DOMElement<P, T>;
+        ...children: ReactNode[]): DOMElement<P, T>;
 
     // Custom components
     function cloneElement<P>(
         element: FunctionComponentElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]
-    ): FunctionComponentElement<P>;
+        ...children: ReactNode[]): FunctionComponentElement<P>;
     function cloneElement<P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
         props?: Partial<P> & ClassAttributes<T>,
-        ...children: ReactNode[]
-    ): CElement<P, T>;
+        ...children: ReactNode[]): CElement<P, T>;
     function cloneElement<P>(
         element: ReactElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]
-    ): ReactElement<P>;
+        ...children: ReactNode[]): ReactElement<P>;
 
     // Context via RenderProps
     interface ProviderProps<T> {
@@ -378,7 +352,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): ReactElement | null;
+        (props: P): (ReactElement | null);
         readonly $$typeof: symbol;
     }
 
@@ -411,10 +385,8 @@ declare namespace React {
 
     // Sync with `ReactChildren` until `ReactChildren` is removed.
     const Children: {
-        map<T, C>(
-            children: C | ReadonlyArray<C>,
-            fn: (child: C, index: number) => T,
-        ): C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
         forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
         count(children: any): number;
         only<C>(children: C): C extends any[] ? never : C;
@@ -438,7 +410,7 @@ declare namespace React {
      */
     type ProfilerOnRenderCallback = (
         id: string,
-        phase: 'mount' | 'update',
+        phase: "mount" | "update",
         actualDuration: number,
         baseDuration: number,
         startTime: number,
@@ -460,7 +432,7 @@ declare namespace React {
     type ReactInstance = Component<any> | Element;
 
     // Base component for plain JS classes
-    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> {}
+    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
     class Component<P, S> {
         // tslint won't let me format the sample code in a way that vscode likes it :(
         /**
@@ -513,8 +485,8 @@ declare namespace React {
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
         setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: Readonly<P>) => Pick<S, K> | S | null) | (Pick<S, K> | S | null),
-            callback?: () => void,
+            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+            callback?: () => void
         ): void;
 
         forceUpdate(callback?: () => void): void;
@@ -527,11 +499,11 @@ declare namespace React {
          * https://legacy.reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
          */
         refs: {
-            [key: string]: ReactInstance;
+            [key: string]: ReactInstance
         };
     }
 
-    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> {}
+    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
 
     interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;
@@ -610,7 +582,8 @@ declare namespace React {
      * a single argument, which is useful for many top-level API defs.
      * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
      */
-    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> = C &
+    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
+        C &
         (new (props: P, context?: any) => T);
 
     //
@@ -781,11 +754,9 @@ declare namespace React {
 
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>> | undefined;
-        statics?:
-            | {
-                  [key: string]: any;
-              }
-            | undefined;
+        statics?: {
+            [key: string]: any;
+        } | undefined;
 
         displayName?: string | undefined;
         propTypes?: ValidationMap<any> | undefined;
@@ -811,9 +782,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(
-        render: ForwardRefRenderFunction<T, P>,
-    ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =
@@ -842,20 +811,22 @@ declare namespace React {
         T extends JSXElementConstructor<infer P>
             ? P
             : T extends keyof JSX.IntrinsicElements
-            ? JSX.IntrinsicElements[T]
-            : {};
-    type ComponentPropsWithRef<T extends ElementType> = T extends new (props: infer P) => Component<any, any>
-        ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
-        : PropsWithRef<ComponentProps<T>>;
-    type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
+                ? JSX.IntrinsicElements[T]
+                : {};
+    type ComponentPropsWithRef<T extends ElementType> =
+        T extends (new (props: infer P) => Component<any, any>)
+            ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+            : PropsWithRef<ComponentProps<T>>;
+    type ComponentPropsWithoutRef<T extends ElementType> =
+        PropsWithoutRef<ComponentProps<T>>;
 
     type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
         ComponentPropsWithoutRef<T> & RefAttributes<infer Method>
     >
         ? Method
         : ComponentPropsWithRef<T> extends RefAttributes<infer Method>
-        ? Method
-        : never;
+            ? Method
+            : never;
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
     // but can be given its own specific name
@@ -865,18 +836,20 @@ declare namespace React {
 
     function memo<P extends object>(
         Component: FunctionComponent<P>,
-        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean,
+        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
     ): NamedExoticComponent<P>;
     function memo<T extends ComponentType<any>>(
         Component: T,
-        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
     ): MemoExoticComponent<T>;
 
     type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
         readonly _result: T;
     };
 
-    function lazy<T extends ComponentType<any>>(factory: () => Promise<{ default: T }>): LazyExoticComponent<T>;
+    function lazy<T extends ComponentType<any>>(
+        factory: () => Promise<{ default: T }>
+    ): LazyExoticComponent<T>;
 
     //
     // React Hooks
@@ -900,13 +873,12 @@ declare namespace React {
     type ReducerState<R extends Reducer<any, any>> = R extends Reducer<infer S, any> ? S : never;
     type ReducerAction<R extends Reducer<any, any>> = R extends Reducer<any, infer A> ? A : never;
     // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
-    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> = R extends ReducerWithoutAction<infer S>
-        ? S
-        : never;
+    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
+        R extends ReducerWithoutAction<infer S> ? S : never;
     type DependencyList = ReadonlyArray<unknown>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-    type EffectCallback = () => void | Destructor;
+    type EffectCallback = () => (void | Destructor);
 
     interface MutableRefObject<T> {
         current: T;
@@ -920,7 +892,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useContext
      */
-    function useContext<T>(context: Context<T> /*, (not public API) observedBits?: number|boolean */): T;
+    function useContext<T>(context: Context<T>/*, (not public API) observedBits?: number|boolean */): T;
     /**
      * Returns a stateful value, and a function to update it.
      *
@@ -950,7 +922,7 @@ declare namespace React {
     function useReducer<R extends ReducerWithoutAction<any>, I>(
         reducer: R,
         initializerArg: I,
-        initializer: (arg: I) => ReducerStateWithoutAction<R>,
+        initializer: (arg: I) => ReducerStateWithoutAction<R>
     ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
     /**
      * An alternative to `useState`.
@@ -966,7 +938,7 @@ declare namespace React {
     function useReducer<R extends ReducerWithoutAction<any>>(
         reducer: R,
         initializerArg: ReducerStateWithoutAction<R>,
-        initializer?: undefined,
+        initializer?: undefined
     ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
     /**
      * An alternative to `useState`.
@@ -984,7 +956,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>, I>(
         reducer: R,
         initializerArg: I & ReducerState<R>,
-        initializer: (arg: I & ReducerState<R>) => ReducerState<R>,
+        initializer: (arg: I & ReducerState<R>) => ReducerState<R>
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * An alternative to `useState`.
@@ -1000,7 +972,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>, I>(
         reducer: R,
         initializerArg: I,
-        initializer: (arg: I) => ReducerState<R>,
+        initializer: (arg: I) => ReducerState<R>
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * An alternative to `useState`.
@@ -1025,7 +997,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>>(
         reducer: R,
         initialState: ReducerState<R>,
-        initializer?: undefined,
+        initializer?: undefined
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
@@ -1052,7 +1024,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useRef
      */
-    function useRef<T>(initialValue: T | null): RefObject<T>;
+    function useRef<T>(initialValue: T|null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
     /**
@@ -1100,7 +1072,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useImperativeHandle
      */
-    function useImperativeHandle<T, R extends T>(ref: Ref<T> | undefined, init: () => R, deps?: DependencyList): void;
+    function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, deps?: DependencyList): void;
     // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
     // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
     /**
@@ -1195,7 +1167,7 @@ declare namespace React {
      *
      * @see https://github.com/facebook/react/pull/21913
      */
-    export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
+     export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
 
     /**
      * @param subscribe
@@ -1271,7 +1243,8 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
-    interface FormEvent<T = Element> extends SyntheticEvent<T> {}
+    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
         target: EventTarget & T;
@@ -1281,21 +1254,7 @@ declare namespace React {
         target: EventTarget & T;
     }
 
-    export type ModifierKey =
-        | 'Alt'
-        | 'AltGraph'
-        | 'CapsLock'
-        | 'Control'
-        | 'Fn'
-        | 'FnLock'
-        | 'Hyper'
-        | 'Meta'
-        | 'NumLock'
-        | 'ScrollLock'
-        | 'Shift'
-        | 'Super'
-        | 'Symbol'
-        | 'SymbolLock';
+    export type ModifierKey = "Alt" | "AltGraph" | "CapsLock" | "Control" | "Fn" | "FnLock" | "Hyper" | "Meta" | "NumLock" | "ScrollLock" | "Shift" | "Super" | "Symbol" | "SymbolLock";
 
     interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
@@ -1386,7 +1345,7 @@ declare namespace React {
     // Event Handler Types
     // ----------------------------------------------------------------------
 
-    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }['bivarianceHack'];
+    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
 
     type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
@@ -1409,24 +1368,24 @@ declare namespace React {
     // Props / DOM Attributes
     // ----------------------------------------------------------------------
 
-    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {}
+    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
+    }
 
     type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = ClassAttributes<T> & E;
 
-    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {}
+    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {
+    }
 
     interface SVGLineElementAttributes<T> extends SVGProps<T> {}
     interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
-        dangerouslySetInnerHTML?:
-            | {
-                  // Should be InnerHTML['innerHTML'].
-                  // But unfortunately we're mixing renderer-specific type declarations.
-                  __html: string | TrustedHTML;
-              }
-            | undefined;
+        dangerouslySetInnerHTML?: {
+            // Should be InnerHTML['innerHTML'].
+            // But unfortunately we're mixing renderer-specific type declarations.
+            __html: string | TrustedHTML;
+        } | undefined;
 
         // Clipboard Events
         onCopy?: ClipboardEventHandler<T> | undefined;
@@ -1797,18 +1756,7 @@ declare namespace React {
          * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
          * @see aria-atomic.
          */
-        'aria-relevant'?:
-            | 'additions'
-            | 'additions removals'
-            | 'additions text'
-            | 'all'
-            | 'removals'
-            | 'removals additions'
-            | 'removals text'
-            | 'text'
-            | 'text additions'
-            | 'text removals'
-            | undefined;
+        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined;
         /** Indicates that user input is required on the element before a form may be submitted. */
         'aria-required'?: Booleanish | undefined;
         /** Defines a human-readable, author-localized description for the role of an element. */
@@ -1942,7 +1890,7 @@ declare namespace React {
         accessKey?: string | undefined;
         autoFocus?: boolean | undefined;
         className?: string | undefined;
-        contentEditable?: Booleanish | 'inherit' | undefined;
+        contentEditable?: Booleanish | "inherit" | undefined;
         contextMenu?: string | undefined;
         dir?: string | undefined;
         draggable?: Booleanish | undefined;
@@ -2038,7 +1986,7 @@ declare namespace React {
         colSpan?: number | undefined;
         controls?: boolean | undefined;
         coords?: string | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         data?: string | undefined;
         dateTime?: string | undefined;
         default?: boolean | undefined;
@@ -2134,7 +2082,12 @@ declare namespace React {
         | 'strict-origin-when-cross-origin'
         | 'unsafe-url';
 
-    type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
+    type HTMLAttributeAnchorTarget =
+        | '_self'
+        | '_blank'
+        | '_parent'
+        | '_top'
+        | (string & {});
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
         download?: any;
@@ -2215,8 +2168,8 @@ declare namespace React {
     }
 
     interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
-        onCancel?: ReactEventHandler<T> | undefined;
-        onClose?: ReactEventHandler<T> | undefined;
+        onCancel?: ReactEventHandler<T> |  undefined;
+        onClose?: ReactEventHandler<T> |  undefined;
         open?: boolean | undefined;
     }
 
@@ -2258,7 +2211,7 @@ declare namespace React {
         /** @deprecated */
         frameBorder?: number | string | undefined;
         height?: number | string | undefined;
-        loading?: 'eager' | 'lazy' | undefined;
+        loading?: "eager" | "lazy" | undefined;
         /** @deprecated */
         marginHeight?: number | undefined;
         /** @deprecated */
@@ -2276,10 +2229,10 @@ declare namespace React {
 
     interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
-        decoding?: 'async' | 'auto' | 'sync' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        decoding?: "async" | "auto" | "sync" | undefined;
         height?: number | string | undefined;
-        loading?: 'eager' | 'lazy' | undefined;
+        loading?: "eager" | "lazy" | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
         sizes?: string | undefined;
         src?: string | undefined;
@@ -2324,7 +2277,7 @@ declare namespace React {
         autoComplete?: string | undefined;
         capture?: boolean | 'user' | 'environment' | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         disabled?: boolean | undefined;
         enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
         form?: string | undefined;
@@ -2378,8 +2331,8 @@ declare namespace React {
 
     interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
         as?: string | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
-        fetchpriority?: 'high' | 'low' | 'auto';
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        fetchpriority?: "high" | "low" | "auto";
         href?: string | undefined;
         hrefLang?: string | undefined;
         integrity?: string | undefined;
@@ -2404,7 +2357,7 @@ declare namespace React {
         autoPlay?: boolean | undefined;
         controls?: boolean | undefined;
         controlsList?: string | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         loop?: boolean | undefined;
         mediaGroup?: string | undefined;
         muted?: boolean | undefined;
@@ -2488,7 +2441,7 @@ declare namespace React {
         async?: boolean | undefined;
         /** @deprecated */
         charSet?: string | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         defer?: boolean | undefined;
         integrity?: string | undefined;
         noModule?: boolean | undefined;
@@ -2526,13 +2479,13 @@ declare namespace React {
     }
 
     interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: 'left' | 'center' | 'right' | undefined;
+        align?: "left" | "center" | "right" | undefined;
         bgcolor?: string | undefined;
         border?: number | undefined;
         cellPadding?: number | string | undefined;
         cellSpacing?: number | string | undefined;
         frame?: boolean | undefined;
-        rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined;
+        rules?: "none" | "groups" | "rows" | "columns" | "all" | undefined;
         summary?: string | undefined;
         width?: number | string | undefined;
     }
@@ -2557,7 +2510,7 @@ declare namespace React {
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
         colSpan?: number | undefined;
         headers?: string | undefined;
         rowSpan?: number | undefined;
@@ -2565,11 +2518,11 @@ declare namespace React {
         abbr?: string | undefined;
         height?: number | string | undefined;
         width?: number | string | undefined;
-        valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
+        valign?: "top" | "middle" | "bottom" | "baseline" | undefined;
     }
 
     interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
         colSpan?: number | undefined;
         headers?: string | undefined;
         rowSpan?: number | undefined;
@@ -2630,31 +2583,18 @@ declare namespace React {
         // Other HTML properties supported by SVG elements in browsers
         role?: AriaRole | undefined;
         tabIndex?: number | undefined;
-        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
 
         // SVG Specific attributes
         accentHeight?: number | string | undefined;
-        accumulate?: 'none' | 'sum' | undefined;
-        additive?: 'replace' | 'sum' | undefined;
-        alignmentBaseline?:
-            | 'auto'
-            | 'baseline'
-            | 'before-edge'
-            | 'text-before-edge'
-            | 'middle'
-            | 'central'
-            | 'after-edge'
-            | 'text-after-edge'
-            | 'ideographic'
-            | 'alphabetic'
-            | 'hanging'
-            | 'mathematical'
-            | 'inherit'
-            | undefined;
-        allowReorder?: 'no' | 'yes' | undefined;
+        accumulate?: "none" | "sum" | undefined;
+        additive?: "replace" | "sum" | undefined;
+        alignmentBaseline?: "auto" | "baseline" | "before-edge" | "text-before-edge" | "middle" | "central" | "after-edge" |
+        "text-after-edge" | "ideographic" | "alphabetic" | "hanging" | "mathematical" | "inherit" | undefined;
+        allowReorder?: "no" | "yes" | undefined;
         alphabetic?: number | string | undefined;
         amplitude?: number | string | undefined;
-        arabicForm?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined;
+        arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined;
         ascent?: number | string | undefined;
         attributeName?: string | undefined;
         attributeType?: string | undefined;
@@ -2674,7 +2614,7 @@ declare namespace React {
         clipPathUnits?: number | string | undefined;
         clipRule?: number | string | undefined;
         colorInterpolation?: number | string | undefined;
-        colorInterpolationFilters?: 'auto' | 'sRGB' | 'linearRGB' | 'inherit' | undefined;
+        colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit" | undefined;
         colorProfile?: number | string | undefined;
         colorRendering?: number | string | undefined;
         contentScriptType?: number | string | undefined;
@@ -2701,13 +2641,13 @@ declare namespace React {
         externalResourcesRequired?: Booleanish | undefined;
         fill?: string | undefined;
         fillOpacity?: number | string | undefined;
-        fillRule?: 'nonzero' | 'evenodd' | 'inherit' | undefined;
+        fillRule?: "nonzero" | "evenodd" | "inherit" | undefined;
         filter?: string | undefined;
         filterRes?: number | string | undefined;
         filterUnits?: number | string | undefined;
         floodColor?: number | string | undefined;
         floodOpacity?: number | string | undefined;
-        focusable?: Booleanish | 'auto' | undefined;
+        focusable?: Booleanish | "auto" | undefined;
         fontFamily?: string | undefined;
         fontSize?: number | string | undefined;
         fontSizeAdjust?: number | string | undefined;
@@ -2826,8 +2766,8 @@ declare namespace React {
         stroke?: string | undefined;
         strokeDasharray?: string | number | undefined;
         strokeDashoffset?: string | number | undefined;
-        strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit' | undefined;
-        strokeLinejoin?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined;
+        strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined;
+        strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined;
         strokeMiterlimit?: number | string | undefined;
         strokeOpacity?: number | string | undefined;
         strokeWidth?: number | string | undefined;
@@ -3029,7 +2969,7 @@ declare namespace React {
         track: DetailedHTMLFactory<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
         u: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         ul: DetailedHTMLFactory<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
-        var: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        "var": DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         video: DetailedHTMLFactory<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
         wbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
@@ -3093,7 +3033,7 @@ declare namespace React {
         view: SVGFactory;
     }
 
-    interface ReactDOM extends ReactHTML, ReactSVG {}
+    interface ReactDOM extends ReactHTML, ReactSVG { }
 
     //
     // React.PropTypes
@@ -3110,7 +3050,7 @@ declare namespace React {
             ? Validator<T[K] | null | undefined>
             : undefined extends T[K]
             ? Validator<T[K] | null | undefined>
-            : Validator<T[K]>;
+            : Validator<T[K]>
     };
 
     interface ReactPropTypes {
@@ -3141,10 +3081,8 @@ declare namespace React {
      */
     // Sync with type of `const Children`.
     interface ReactChildren {
-        map<T, C>(
-            children: C | ReadonlyArray<C>,
-            fn: (child: C, index: number) => T,
-        ): C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
         forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
         count(children: any): number;
         only<C>(children: C): C extends any[] ? never : C;
@@ -3214,18 +3152,16 @@ type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
 type MergePropTypes<P, T> =
     // Distribute over P in case it is a union type
     P extends any
-        ? // If props is type any, use propTypes definitions
-          IsExactlyAny<P> extends true
-            ? T
-            : // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
-            string extends keyof P
-            ? P
-            : // Prefer declared types which are not exactly any
-              Pick<P, NotExactlyAnyPropertyKeys<P>> &
-                  // For props which are exactly any, use the type inferred from propTypes if present
-                  Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>> &
-                  // Keep leftover props not specified in propTypes
-                  Pick<P, Exclude<keyof P, keyof T>>
+        // If props is type any, use propTypes definitions
+        ? IsExactlyAny<P> extends true ? T :
+            // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+            string extends keyof P ? P :
+                // Prefer declared types which are not exactly any
+                & Pick<P, NotExactlyAnyPropertyKeys<P>>
+                // For props which are exactly any, use the type inferred from propTypes if present
+                & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
+                // Keep leftover props not specified in propTypes
+                & Pick<P, Exclude<keyof P, keyof T>>
         : never;
 
 type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
@@ -3235,49 +3171,42 @@ type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
 // If declared props have indexed properties, ignore default props entirely as keyof gets widened
 // Wrap in an outer-level conditional type to allow distribution over props that are unions
 type Defaultize<P, D> = P extends any
-    ? string extends keyof P
-        ? P
-        : Pick<P, Exclude<keyof P, keyof D>> &
-              InexactPartial<Pick<P, Extract<keyof P, keyof D>>> &
-              InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
+    ? string extends keyof P ? P :
+        & Pick<P, Exclude<keyof P, keyof D>>
+        & InexactPartial<Pick<P, Extract<keyof P, keyof D>>>
+        & InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
     : never;
 
-type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D }
+type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D; }
     ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
-    : C extends { propTypes: infer T }
-    ? MergePropTypes<P, PropTypes.InferProps<T>>
-    : C extends { defaultProps: infer D }
-    ? Defaultize<P, D>
-    : P;
+    : C extends { propTypes: infer T; }
+        ? MergePropTypes<P, PropTypes.InferProps<T>>
+        : C extends { defaultProps: infer D; }
+            ? Defaultize<P, D>
+            : P;
 
 declare global {
     /**
      * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
      */
     namespace JSX {
-        interface Element extends React.ReactElement<any, any> {}
+        interface Element extends React.ReactElement<any, any> { }
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
-        interface ElementAttributesProperty {
-            props: {};
-        }
-        interface ElementChildrenAttribute {
-            children: {};
-        }
+        interface ElementAttributesProperty { props: {}; }
+        interface ElementChildrenAttribute { children: {}; }
 
         // We can't recurse forever because `type` can't be self-referential;
         // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
-        type LibraryManagedAttributes<C, P> = C extends
-            | React.MemoExoticComponent<infer T>
-            | React.LazyExoticComponent<infer T>
+        type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
             ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
                 ? ReactManagedAttributes<U, P>
                 : ReactManagedAttributes<T, P>
             : ReactManagedAttributes<C, P>;
 
-        interface IntrinsicAttributes extends React.Attributes {}
-        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> {}
+        interface IntrinsicAttributes extends React.Attributes { }
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
         interface IntrinsicElements {
             // HTML
@@ -3396,7 +3325,7 @@ declare global {
             track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
             u: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             ul: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
-            var: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            "var": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
             wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -37,10 +37,10 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ElementType<P = any> =
-        {
-            [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
-        }[keyof JSX.IntrinsicElements] |
-        ComponentType<P>;
+        | {
+              [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never;
+          }[keyof JSX.IntrinsicElements]
+        | ComponentType<P>;
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
@@ -57,7 +57,7 @@ declare namespace React {
         readonly current: T | null;
     }
     // Bivariance hack for consistent unsoundness with RefObject
-    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type RefCallback<T> = { bivarianceHack(instance: T | null): void }['bivarianceHack'];
     type Ref<T> = RefCallback<T> | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
     /**
@@ -82,14 +82,12 @@ declare namespace React {
             | ForwardRefExoticComponent<any>
             | { new (props: any): Component<any> }
             | ((props: any, context?: any) => ReactElement | null)
-            | keyof JSX.IntrinsicElements
+            | keyof JSX.IntrinsicElements,
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
         // otherwise it will infer `{}` instead of `never`
-        "ref" extends keyof ComponentPropsWithRef<C>
-            ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
-                infer Instance
-            >
+        'ref' extends keyof ComponentPropsWithRef<C>
+            ? NonNullable<ComponentPropsWithRef<C>['ref']> extends Ref<infer Instance>
                 ? Instance
                 : never
             : never;
@@ -122,7 +120,10 @@ declare namespace React {
         ref?: LegacyRef<T> | undefined;
     }
 
-    interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
+    interface ReactElement<
+        P = any,
+        T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>,
+    > {
         type: T;
         props: P;
         key: Key | null;
@@ -130,11 +131,11 @@ declare namespace React {
 
     interface ReactComponentElement<
         T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
-        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
-    > extends ReactElement<P, Exclude<T, number>> { }
+        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>,
+    > extends ReactElement<P, Exclude<T, number>> {}
 
     interface FunctionComponentElement<P> extends ReactElement<P, FunctionComponent<P>> {
-        ref?: ('ref' extends keyof P ? P extends { ref?: infer R | undefined } ? R : never : never) | undefined;
+        ref?: ('ref' extends keyof P ? (P extends { ref?: infer R | undefined } ? R : never) : never) | undefined;
     }
 
     type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
@@ -145,12 +146,13 @@ declare namespace React {
     type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
 
     // string fallback for custom web-components
-    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P, string> {
+    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element>
+        extends ReactElement<P, string> {
         ref: LegacyRef<T>;
     }
 
     // ReactHTML for ReactHTMLElement
-    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> { }
+    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> {}
 
     interface DetailedReactHTMLElement<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMElement<P, T> {
         type: keyof ReactHTML;
@@ -177,25 +179,35 @@ declare namespace React {
      */
     type SFCFactory<P> = FunctionComponentFactory<P>;
 
-    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
+    type FunctionComponentFactory<P> = (
+        props?: Attributes & P,
+        ...children: ReactNode[]
+    ) => FunctionComponentElement<P>;
 
-    type ComponentFactory<P, T extends Component<P, ComponentState>> =
-        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
+    type ComponentFactory<P, T extends Component<P, ComponentState>> = (
+        props?: ClassAttributes<T> & P,
+        ...children: ReactNode[]
+    ) => CElement<P, T>;
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
-    type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
-        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
+    type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
+        props?: (ClassAttributes<T> & P) | null,
+        ...children: ReactNode[]
+    ) => DOMElement<P, T>;
 
     interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
 
     interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
-        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        (props?: (ClassAttributes<T> & P) | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     }
 
     interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
-        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
+        (
+            props?: (ClassAttributes<SVGElement> & SVGAttributes<SVGElement>) | null,
+            ...children: ReactNode[]
+        ): ReactSVGElement;
     }
 
     /**
@@ -239,94 +251,108 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     // DOM Elements
-    function createFactory<T extends HTMLElement>(
-        type: keyof ReactHTML): HTMLFactory<T>;
-    function createFactory(
-        type: keyof ReactSVG): SVGFactory;
-    function createFactory<P extends DOMAttributes<T>, T extends Element>(
-        type: string): DOMFactory<P, T>;
+    function createFactory<T extends HTMLElement>(type: keyof ReactHTML): HTMLFactory<T>;
+    function createFactory(type: keyof ReactSVG): SVGFactory;
+    function createFactory<P extends DOMAttributes<T>, T extends Element>(type: string): DOMFactory<P, T>;
 
     // Custom components
     function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
     function createFactory<P>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
+    ): CFactory<P, ClassicComponent<P, ComponentState>>;
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
-        type: ClassType<P, T, C>): CFactory<P, T>;
+        type: ClassType<P, T, C>,
+    ): CFactory<P, T>;
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
     // DOM Elements
     // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
     function createElement(
-        type: "input",
-        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
-        ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+        type: 'input',
+        props?: (InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement>) | null,
+        ...children: ReactNode[]
+    ): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
     function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         type: keyof ReactHTML,
-        props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        props?: (ClassAttributes<T> & P) | null,
+        ...children: ReactNode[]
+    ): DetailedReactHTMLElement<P, T>;
     function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
         type: keyof ReactSVG,
-        props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): ReactSVGElement;
+        props?: (ClassAttributes<T> & P) | null,
+        ...children: ReactNode[]
+    ): ReactSVGElement;
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
-        props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        props?: (ClassAttributes<T> & P) | null,
+        ...children: ReactNode[]
+    ): DOMElement<P, T>;
 
     // Custom components
 
     function createElement<P extends {}>(
         type: FunctionComponent<P>,
-        props?: Attributes & P | null,
-        ...children: ReactNode[]): FunctionComponentElement<P>;
+        props?: (Attributes & P) | null,
+        ...children: ReactNode[]
+    ): FunctionComponentElement<P>;
     function createElement<P extends {}>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
-        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
+        props?: (ClassAttributes<ClassicComponent<P, ComponentState>> & P) | null,
+        ...children: ReactNode[]
+    ): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
-        props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): CElement<P, T>;
+        props?: (ClassAttributes<T> & P) | null,
+        ...children: ReactNode[]
+    ): CElement<P, T>;
     function createElement<P extends {}>(
         type: FunctionComponent<P> | ComponentClass<P> | string,
-        props?: Attributes & P | null,
-        ...children: ReactNode[]): ReactElement<P>;
+        props?: (Attributes & P) | null,
+        ...children: ReactNode[]
+    ): ReactElement<P>;
 
     // DOM Elements
     // ReactHTMLElement
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: DetailedReactHTMLElement<P, T>,
         props?: P,
-        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+        ...children: ReactNode[]
+    ): DetailedReactHTMLElement<P, T>;
     // ReactHTMLElement, less specific
     function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         element: ReactHTMLElement<T>,
         props?: P,
-        ...children: ReactNode[]): ReactHTMLElement<T>;
+        ...children: ReactNode[]
+    ): ReactHTMLElement<T>;
     // SVGElement
     function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
         element: ReactSVGElement,
         props?: P,
-        ...children: ReactNode[]): ReactSVGElement;
+        ...children: ReactNode[]
+    ): ReactSVGElement;
     // DOM Element (has to be the last, because type checking stops at first overload that fits)
     function cloneElement<P extends DOMAttributes<T>, T extends Element>(
         element: DOMElement<P, T>,
         props?: DOMAttributes<T> & P,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        ...children: ReactNode[]
+    ): DOMElement<P, T>;
 
     // Custom components
     function cloneElement<P>(
         element: FunctionComponentElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]): FunctionComponentElement<P>;
+        ...children: ReactNode[]
+    ): FunctionComponentElement<P>;
     function cloneElement<P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
         props?: Partial<P> & ClassAttributes<T>,
-        ...children: ReactNode[]): CElement<P, T>;
+        ...children: ReactNode[]
+    ): CElement<P, T>;
     function cloneElement<P>(
         element: ReactElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]): ReactElement<P>;
+        ...children: ReactNode[]
+    ): ReactElement<P>;
 
     // Context via RenderProps
     interface ProviderProps<T> {
@@ -352,7 +378,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement | null);
+        (props: P): ReactElement | null;
         readonly $$typeof: symbol;
     }
 
@@ -385,8 +411,10 @@ declare namespace React {
 
     // Sync with `ReactChildren` until `ReactChildren` is removed.
     const Children: {
-        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
-            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        map<T, C>(
+            children: C | ReadonlyArray<C>,
+            fn: (child: C, index: number) => T,
+        ): C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
         forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
         count(children: any): number;
         only<C>(children: C): C extends any[] ? never : C;
@@ -410,7 +438,7 @@ declare namespace React {
      */
     type ProfilerOnRenderCallback = (
         id: string,
-        phase: "mount" | "update",
+        phase: 'mount' | 'update',
         actualDuration: number,
         baseDuration: number,
         startTime: number,
@@ -432,7 +460,7 @@ declare namespace React {
     type ReactInstance = Component<any> | Element;
 
     // Base component for plain JS classes
-    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
+    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> {}
     class Component<P, S> {
         // tslint won't let me format the sample code in a way that vscode likes it :(
         /**
@@ -485,8 +513,8 @@ declare namespace React {
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
         setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
-            callback?: () => void
+            state: ((prevState: Readonly<S>, props: Readonly<P>) => Pick<S, K> | S | null) | (Pick<S, K> | S | null),
+            callback?: () => void,
         ): void;
 
         forceUpdate(callback?: () => void): void;
@@ -499,11 +527,11 @@ declare namespace React {
          * https://legacy.reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
          */
         refs: {
-            [key: string]: ReactInstance
+            [key: string]: ReactInstance;
         };
     }
 
-    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
+    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> {}
 
     interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;
@@ -582,8 +610,7 @@ declare namespace React {
      * a single argument, which is useful for many top-level API defs.
      * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
      */
-    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
-        C &
+    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> = C &
         (new (props: P, context?: any) => T);
 
     //
@@ -754,9 +781,11 @@ declare namespace React {
 
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>> | undefined;
-        statics?: {
-            [key: string]: any;
-        } | undefined;
+        statics?:
+            | {
+                  [key: string]: any;
+              }
+            | undefined;
 
         displayName?: string | undefined;
         propTypes?: ValidationMap<any> | undefined;
@@ -782,7 +811,9 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(
+        render: ForwardRefRenderFunction<T, P>,
+    ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =
@@ -811,22 +842,20 @@ declare namespace React {
         T extends JSXElementConstructor<infer P>
             ? P
             : T extends keyof JSX.IntrinsicElements
-                ? JSX.IntrinsicElements[T]
-                : {};
-    type ComponentPropsWithRef<T extends ElementType> =
-        T extends (new (props: infer P) => Component<any, any>)
-            ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
-            : PropsWithRef<ComponentProps<T>>;
-    type ComponentPropsWithoutRef<T extends ElementType> =
-        PropsWithoutRef<ComponentProps<T>>;
+            ? JSX.IntrinsicElements[T]
+            : {};
+    type ComponentPropsWithRef<T extends ElementType> = T extends new (props: infer P) => Component<any, any>
+        ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+        : PropsWithRef<ComponentProps<T>>;
+    type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
 
     type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
         ComponentPropsWithoutRef<T> & RefAttributes<infer Method>
     >
         ? Method
         : ComponentPropsWithRef<T> extends RefAttributes<infer Method>
-            ? Method
-            : never;
+        ? Method
+        : never;
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
     // but can be given its own specific name
@@ -836,20 +865,18 @@ declare namespace React {
 
     function memo<P extends object>(
         Component: FunctionComponent<P>,
-        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
+        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean,
     ): NamedExoticComponent<P>;
     function memo<T extends ComponentType<any>>(
         Component: T,
-        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean,
     ): MemoExoticComponent<T>;
 
     type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
         readonly _result: T;
     };
 
-    function lazy<T extends ComponentType<any>>(
-        factory: () => Promise<{ default: T }>
-    ): LazyExoticComponent<T>;
+    function lazy<T extends ComponentType<any>>(factory: () => Promise<{ default: T }>): LazyExoticComponent<T>;
 
     //
     // React Hooks
@@ -873,12 +900,13 @@ declare namespace React {
     type ReducerState<R extends Reducer<any, any>> = R extends Reducer<infer S, any> ? S : never;
     type ReducerAction<R extends Reducer<any, any>> = R extends Reducer<any, infer A> ? A : never;
     // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
-    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
-        R extends ReducerWithoutAction<infer S> ? S : never;
+    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> = R extends ReducerWithoutAction<infer S>
+        ? S
+        : never;
     type DependencyList = ReadonlyArray<unknown>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-    type EffectCallback = () => (void | Destructor);
+    type EffectCallback = () => void | Destructor;
 
     interface MutableRefObject<T> {
         current: T;
@@ -892,7 +920,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useContext
      */
-    function useContext<T>(context: Context<T>/*, (not public API) observedBits?: number|boolean */): T;
+    function useContext<T>(context: Context<T> /*, (not public API) observedBits?: number|boolean */): T;
     /**
      * Returns a stateful value, and a function to update it.
      *
@@ -922,7 +950,7 @@ declare namespace React {
     function useReducer<R extends ReducerWithoutAction<any>, I>(
         reducer: R,
         initializerArg: I,
-        initializer: (arg: I) => ReducerStateWithoutAction<R>
+        initializer: (arg: I) => ReducerStateWithoutAction<R>,
     ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
     /**
      * An alternative to `useState`.
@@ -938,7 +966,7 @@ declare namespace React {
     function useReducer<R extends ReducerWithoutAction<any>>(
         reducer: R,
         initializerArg: ReducerStateWithoutAction<R>,
-        initializer?: undefined
+        initializer?: undefined,
     ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
     /**
      * An alternative to `useState`.
@@ -956,7 +984,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>, I>(
         reducer: R,
         initializerArg: I & ReducerState<R>,
-        initializer: (arg: I & ReducerState<R>) => ReducerState<R>
+        initializer: (arg: I & ReducerState<R>) => ReducerState<R>,
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * An alternative to `useState`.
@@ -972,7 +1000,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>, I>(
         reducer: R,
         initializerArg: I,
-        initializer: (arg: I) => ReducerState<R>
+        initializer: (arg: I) => ReducerState<R>,
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * An alternative to `useState`.
@@ -997,7 +1025,7 @@ declare namespace React {
     function useReducer<R extends Reducer<any, any>>(
         reducer: R,
         initialState: ReducerState<R>,
-        initializer?: undefined
+        initializer?: undefined,
     ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
     /**
      * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
@@ -1024,7 +1052,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useRef
      */
-    function useRef<T>(initialValue: T|null): RefObject<T>;
+    function useRef<T>(initialValue: T | null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
     /**
@@ -1072,7 +1100,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://react.dev/reference/react/useImperativeHandle
      */
-    function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, deps?: DependencyList): void;
+    function useImperativeHandle<T, R extends T>(ref: Ref<T> | undefined, init: () => R, deps?: DependencyList): void;
     // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
     // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
     /**
@@ -1167,7 +1195,7 @@ declare namespace React {
      *
      * @see https://github.com/facebook/react/pull/21913
      */
-     export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
+    export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
 
     /**
      * @param subscribe
@@ -1243,8 +1271,7 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
-    interface FormEvent<T = Element> extends SyntheticEvent<T> {
-    }
+    interface FormEvent<T = Element> extends SyntheticEvent<T> {}
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
         target: EventTarget & T;
@@ -1254,7 +1281,21 @@ declare namespace React {
         target: EventTarget & T;
     }
 
-    export type ModifierKey = "Alt" | "AltGraph" | "CapsLock" | "Control" | "Fn" | "FnLock" | "Hyper" | "Meta" | "NumLock" | "ScrollLock" | "Shift" | "Super" | "Symbol" | "SymbolLock";
+    export type ModifierKey =
+        | 'Alt'
+        | 'AltGraph'
+        | 'CapsLock'
+        | 'Control'
+        | 'Fn'
+        | 'FnLock'
+        | 'Hyper'
+        | 'Meta'
+        | 'NumLock'
+        | 'ScrollLock'
+        | 'Shift'
+        | 'Super'
+        | 'Symbol'
+        | 'SymbolLock';
 
     interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
@@ -1345,7 +1386,7 @@ declare namespace React {
     // Event Handler Types
     // ----------------------------------------------------------------------
 
-    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
+    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }['bivarianceHack'];
 
     type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
@@ -1368,24 +1409,24 @@ declare namespace React {
     // Props / DOM Attributes
     // ----------------------------------------------------------------------
 
-    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
-    }
+    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {}
 
     type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = ClassAttributes<T> & E;
 
-    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {
-    }
+    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {}
 
     interface SVGLineElementAttributes<T> extends SVGProps<T> {}
     interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
-        dangerouslySetInnerHTML?: {
-            // Should be InnerHTML['innerHTML'].
-            // But unfortunately we're mixing renderer-specific type declarations.
-            __html: string | TrustedHTML;
-        } | undefined;
+        dangerouslySetInnerHTML?:
+            | {
+                  // Should be InnerHTML['innerHTML'].
+                  // But unfortunately we're mixing renderer-specific type declarations.
+                  __html: string | TrustedHTML;
+              }
+            | undefined;
 
         // Clipboard Events
         onCopy?: ClipboardEventHandler<T> | undefined;
@@ -1756,7 +1797,18 @@ declare namespace React {
          * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
          * @see aria-atomic.
          */
-        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined;
+        'aria-relevant'?:
+            | 'additions'
+            | 'additions removals'
+            | 'additions text'
+            | 'all'
+            | 'removals'
+            | 'removals additions'
+            | 'removals text'
+            | 'text'
+            | 'text additions'
+            | 'text removals'
+            | undefined;
         /** Indicates that user input is required on the element before a form may be submitted. */
         'aria-required'?: Booleanish | undefined;
         /** Defines a human-readable, author-localized description for the role of an element. */
@@ -1890,7 +1942,7 @@ declare namespace React {
         accessKey?: string | undefined;
         autoFocus?: boolean | undefined;
         className?: string | undefined;
-        contentEditable?: Booleanish | "inherit" | undefined;
+        contentEditable?: Booleanish | 'inherit' | undefined;
         contextMenu?: string | undefined;
         dir?: string | undefined;
         draggable?: Booleanish | undefined;
@@ -1986,7 +2038,7 @@ declare namespace React {
         colSpan?: number | undefined;
         controls?: boolean | undefined;
         coords?: string | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
         data?: string | undefined;
         dateTime?: string | undefined;
         default?: boolean | undefined;
@@ -2082,12 +2134,7 @@ declare namespace React {
         | 'strict-origin-when-cross-origin'
         | 'unsafe-url';
 
-    type HTMLAttributeAnchorTarget =
-        | '_self'
-        | '_blank'
-        | '_parent'
-        | '_top'
-        | (string & {});
+    type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
         download?: any;
@@ -2168,8 +2215,8 @@ declare namespace React {
     }
 
     interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
-        onCancel?: ReactEventHandler<T> |  undefined;
-        onClose?: ReactEventHandler<T> |  undefined;
+        onCancel?: ReactEventHandler<T> | undefined;
+        onClose?: ReactEventHandler<T> | undefined;
         open?: boolean | undefined;
     }
 
@@ -2211,7 +2258,7 @@ declare namespace React {
         /** @deprecated */
         frameBorder?: number | string | undefined;
         height?: number | string | undefined;
-        loading?: "eager" | "lazy" | undefined;
+        loading?: 'eager' | 'lazy' | undefined;
         /** @deprecated */
         marginHeight?: number | undefined;
         /** @deprecated */
@@ -2229,10 +2276,10 @@ declare namespace React {
 
     interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
-        decoding?: "async" | "auto" | "sync" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        decoding?: 'async' | 'auto' | 'sync' | undefined;
         height?: number | string | undefined;
-        loading?: "eager" | "lazy" | undefined;
+        loading?: 'eager' | 'lazy' | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
         sizes?: string | undefined;
         src?: string | undefined;
@@ -2277,7 +2324,7 @@ declare namespace React {
         autoComplete?: string | undefined;
         capture?: boolean | 'user' | 'environment' | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
         disabled?: boolean | undefined;
         enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
         form?: string | undefined;
@@ -2331,8 +2378,8 @@ declare namespace React {
 
     interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
         as?: string | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
-        fetchpriority?: "high" | "low" | "auto";
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+        fetchpriority?: 'high' | 'low' | 'auto';
         href?: string | undefined;
         hrefLang?: string | undefined;
         integrity?: string | undefined;
@@ -2357,7 +2404,7 @@ declare namespace React {
         autoPlay?: boolean | undefined;
         controls?: boolean | undefined;
         controlsList?: string | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
         loop?: boolean | undefined;
         mediaGroup?: string | undefined;
         muted?: boolean | undefined;
@@ -2441,7 +2488,7 @@ declare namespace React {
         async?: boolean | undefined;
         /** @deprecated */
         charSet?: string | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
         defer?: boolean | undefined;
         integrity?: string | undefined;
         noModule?: boolean | undefined;
@@ -2479,13 +2526,13 @@ declare namespace React {
     }
 
     interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: "left" | "center" | "right" | undefined;
+        align?: 'left' | 'center' | 'right' | undefined;
         bgcolor?: string | undefined;
         border?: number | undefined;
         cellPadding?: number | string | undefined;
         cellSpacing?: number | string | undefined;
         frame?: boolean | undefined;
-        rules?: "none" | "groups" | "rows" | "columns" | "all" | undefined;
+        rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined;
         summary?: string | undefined;
         width?: number | string | undefined;
     }
@@ -2510,7 +2557,7 @@ declare namespace React {
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
         colSpan?: number | undefined;
         headers?: string | undefined;
         rowSpan?: number | undefined;
@@ -2518,11 +2565,11 @@ declare namespace React {
         abbr?: string | undefined;
         height?: number | string | undefined;
         width?: number | string | undefined;
-        valign?: "top" | "middle" | "bottom" | "baseline" | undefined;
+        valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
     }
 
     interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
         colSpan?: number | undefined;
         headers?: string | undefined;
         rowSpan?: number | undefined;
@@ -2562,7 +2609,7 @@ declare namespace React {
     interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
         // React-specific Attributes
         suppressHydrationWarning?: boolean | undefined;
-        
+
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
         className?: string | undefined;
@@ -2583,18 +2630,31 @@ declare namespace React {
         // Other HTML properties supported by SVG elements in browsers
         role?: AriaRole | undefined;
         tabIndex?: number | undefined;
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
 
         // SVG Specific attributes
         accentHeight?: number | string | undefined;
-        accumulate?: "none" | "sum" | undefined;
-        additive?: "replace" | "sum" | undefined;
-        alignmentBaseline?: "auto" | "baseline" | "before-edge" | "text-before-edge" | "middle" | "central" | "after-edge" |
-        "text-after-edge" | "ideographic" | "alphabetic" | "hanging" | "mathematical" | "inherit" | undefined;
-        allowReorder?: "no" | "yes" | undefined;
+        accumulate?: 'none' | 'sum' | undefined;
+        additive?: 'replace' | 'sum' | undefined;
+        alignmentBaseline?:
+            | 'auto'
+            | 'baseline'
+            | 'before-edge'
+            | 'text-before-edge'
+            | 'middle'
+            | 'central'
+            | 'after-edge'
+            | 'text-after-edge'
+            | 'ideographic'
+            | 'alphabetic'
+            | 'hanging'
+            | 'mathematical'
+            | 'inherit'
+            | undefined;
+        allowReorder?: 'no' | 'yes' | undefined;
         alphabetic?: number | string | undefined;
         amplitude?: number | string | undefined;
-        arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined;
+        arabicForm?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined;
         ascent?: number | string | undefined;
         attributeName?: string | undefined;
         attributeType?: string | undefined;
@@ -2614,7 +2674,7 @@ declare namespace React {
         clipPathUnits?: number | string | undefined;
         clipRule?: number | string | undefined;
         colorInterpolation?: number | string | undefined;
-        colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit" | undefined;
+        colorInterpolationFilters?: 'auto' | 'sRGB' | 'linearRGB' | 'inherit' | undefined;
         colorProfile?: number | string | undefined;
         colorRendering?: number | string | undefined;
         contentScriptType?: number | string | undefined;
@@ -2641,13 +2701,13 @@ declare namespace React {
         externalResourcesRequired?: Booleanish | undefined;
         fill?: string | undefined;
         fillOpacity?: number | string | undefined;
-        fillRule?: "nonzero" | "evenodd" | "inherit" | undefined;
+        fillRule?: 'nonzero' | 'evenodd' | 'inherit' | undefined;
         filter?: string | undefined;
         filterRes?: number | string | undefined;
         filterUnits?: number | string | undefined;
         floodColor?: number | string | undefined;
         floodOpacity?: number | string | undefined;
-        focusable?: Booleanish | "auto" | undefined;
+        focusable?: Booleanish | 'auto' | undefined;
         fontFamily?: string | undefined;
         fontSize?: number | string | undefined;
         fontSizeAdjust?: number | string | undefined;
@@ -2766,8 +2826,8 @@ declare namespace React {
         stroke?: string | undefined;
         strokeDasharray?: string | number | undefined;
         strokeDashoffset?: string | number | undefined;
-        strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined;
-        strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined;
+        strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit' | undefined;
+        strokeLinejoin?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined;
         strokeMiterlimit?: number | string | undefined;
         strokeOpacity?: number | string | undefined;
         strokeWidth?: number | string | undefined;
@@ -2969,7 +3029,7 @@ declare namespace React {
         track: DetailedHTMLFactory<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
         u: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         ul: DetailedHTMLFactory<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
-        "var": DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        var: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         video: DetailedHTMLFactory<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
         wbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
@@ -3033,7 +3093,7 @@ declare namespace React {
         view: SVGFactory;
     }
 
-    interface ReactDOM extends ReactHTML, ReactSVG { }
+    interface ReactDOM extends ReactHTML, ReactSVG {}
 
     //
     // React.PropTypes
@@ -3050,7 +3110,7 @@ declare namespace React {
             ? Validator<T[K] | null | undefined>
             : undefined extends T[K]
             ? Validator<T[K] | null | undefined>
-            : Validator<T[K]>
+            : Validator<T[K]>;
     };
 
     interface ReactPropTypes {
@@ -3081,8 +3141,10 @@ declare namespace React {
      */
     // Sync with type of `const Children`.
     interface ReactChildren {
-        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
-            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        map<T, C>(
+            children: C | ReadonlyArray<C>,
+            fn: (child: C, index: number) => T,
+        ): C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
         forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
         count(children: any): number;
         only<C>(children: C): C extends any[] ? never : C;
@@ -3152,16 +3214,18 @@ type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
 type MergePropTypes<P, T> =
     // Distribute over P in case it is a union type
     P extends any
-        // If props is type any, use propTypes definitions
-        ? IsExactlyAny<P> extends true ? T :
-            // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
-            string extends keyof P ? P :
-                // Prefer declared types which are not exactly any
-                & Pick<P, NotExactlyAnyPropertyKeys<P>>
-                // For props which are exactly any, use the type inferred from propTypes if present
-                & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
-                // Keep leftover props not specified in propTypes
-                & Pick<P, Exclude<keyof P, keyof T>>
+        ? // If props is type any, use propTypes definitions
+          IsExactlyAny<P> extends true
+            ? T
+            : // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+            string extends keyof P
+            ? P
+            : // Prefer declared types which are not exactly any
+              Pick<P, NotExactlyAnyPropertyKeys<P>> &
+                  // For props which are exactly any, use the type inferred from propTypes if present
+                  Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>> &
+                  // Keep leftover props not specified in propTypes
+                  Pick<P, Exclude<keyof P, keyof T>>
         : never;
 
 type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
@@ -3171,42 +3235,49 @@ type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
 // If declared props have indexed properties, ignore default props entirely as keyof gets widened
 // Wrap in an outer-level conditional type to allow distribution over props that are unions
 type Defaultize<P, D> = P extends any
-    ? string extends keyof P ? P :
-        & Pick<P, Exclude<keyof P, keyof D>>
-        & InexactPartial<Pick<P, Extract<keyof P, keyof D>>>
-        & InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
+    ? string extends keyof P
+        ? P
+        : Pick<P, Exclude<keyof P, keyof D>> &
+              InexactPartial<Pick<P, Extract<keyof P, keyof D>>> &
+              InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
     : never;
 
-type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D; }
+type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D }
     ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
-    : C extends { propTypes: infer T; }
-        ? MergePropTypes<P, PropTypes.InferProps<T>>
-        : C extends { defaultProps: infer D; }
-            ? Defaultize<P, D>
-            : P;
+    : C extends { propTypes: infer T }
+    ? MergePropTypes<P, PropTypes.InferProps<T>>
+    : C extends { defaultProps: infer D }
+    ? Defaultize<P, D>
+    : P;
 
 declare global {
     /**
      * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
      */
     namespace JSX {
-        interface Element extends React.ReactElement<any, any> { }
+        interface Element extends React.ReactElement<any, any> {}
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
-        interface ElementAttributesProperty { props: {}; }
-        interface ElementChildrenAttribute { children: {}; }
+        interface ElementAttributesProperty {
+            props: {};
+        }
+        interface ElementChildrenAttribute {
+            children: {};
+        }
 
         // We can't recurse forever because `type` can't be self-referential;
         // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
-        type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
+        type LibraryManagedAttributes<C, P> = C extends
+            | React.MemoExoticComponent<infer T>
+            | React.LazyExoticComponent<infer T>
             ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
                 ? ReactManagedAttributes<U, P>
                 : ReactManagedAttributes<T, P>
             : ReactManagedAttributes<C, P>;
 
-        interface IntrinsicAttributes extends React.Attributes { }
-        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
+        interface IntrinsicAttributes extends React.Attributes {}
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> {}
 
         interface IntrinsicElements {
             // HTML
@@ -3325,7 +3396,7 @@ declare global {
             track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
             u: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             ul: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
-            "var": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            var: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
             wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -83,7 +83,7 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
 <ComponentWithChildren3 bar="42"></ComponentWithChildren3>;
 
 // svg sanity check
-<svg viewBox="0 0 1000 1000">
+<svg suppressHydrationWarning viewBox="0 0 1000 1000">
     <g>
         <text x="200" y="300" strokeWidth="5" stroke="black" alignmentBaseline="middle">
             Hello, world!


### PR DESCRIPTION
Added `suppressHydrationWarning` property to SVGAttributes, confirmed by my local code that it works in runtime the same way as for HTMLAttributes.

Found 1 discussion about it https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64548

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/components/common#common-props
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
