### PR TITLE
protoo-server: fix return type of Room.createPeer

### DIFF
--- a/types/protoo-server/index.d.ts
+++ b/types/protoo-server/index.d.ts
@@ -77,7 +77,7 @@ export class Room {
     peers: Peer[];
     closed: boolean;
     constructor();
-    createPeer(peerId: string, transport: WebSocketTransport): Promise<Peer>;
+    createPeer(peerId: string, transport: WebSocketTransport): Peer;
     hasPeer(peerId: string): boolean;
     getPeer(peerId: string): Peer;
     close(): void;

--- a/types/protoo-server/protoo-server-tests.ts
+++ b/types/protoo-server/protoo-server-tests.ts
@@ -9,7 +9,7 @@ const wss = new WebSocketServer(server);
 wss.on('connectionrequest', async (info, accept, reject) => {
     const transport = accept();
 
-    const peer: Peer = await room.createPeer('foo', transport);
+    const peer: Peer = room.createPeer('foo', transport);
     peer.id; // $ExpectType string
     peer.closed; // $ExpectType boolean
     const res = room.hasPeer('foo'); // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/versatica/protoo/commit/026e133babd904d5362c5eb04b516a0ceb71805a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

