### PR TITLE
katex: fix export default class

### DIFF
--- a/types/katex/index.d.ts
+++ b/types/katex/index.d.ts
@@ -140,24 +140,26 @@ export class ParseError implements Error {
     position: number;
 }
 
-export default class katex {
+declare const katex: {
     /**
      * Renders a TeX expression into the specified DOM element
      * @param tex A TeX expression
      * @param element The DOM element to render into
      * @param options KaTeX options
      */
-    static render(tex: string, element: HTMLElement, options?: KatexOptions): void;
+    render: (tex: string, element: HTMLElement, options?: KatexOptions) => void,
 
     /**
      * Renders a TeX expression into an HTML string
      * @param tex A TeX expression
      * @param options KaTeX options
      */
-    static renderToString(tex: string, options?: KatexOptions): string;
+    renderToString: (tex: string, options?: KatexOptions) => string,
 
     /**
      * KaTeX error, usually during parsing.
      */
-    static ParseError: typeof ParseError;
+    ParseError: typeof ParseError,
 }
+
+export default katex;


### PR DESCRIPTION
The default export isn't a class and never was. This was just an error in the type definition file here. The following leads to runtime errors:

    import katex from 'katex';
    new katex; // or
    class Foo extends katex {}