### PR TITLE
Add matchers to @jest/globals for @testing-library/jest-dom

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -16,3 +16,7 @@ declare global {
         interface Matchers<R = void, T = {}> extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
     }
 }
+
+declare module "expect" {
+    interface Matchers<R = void, T = {}> extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The types augment Jest's global types to add its custom matchers, but for those who prefer explicit imports, they can also import from `@jest/globals`. Those will also be augmented by `@testing-library/jest-dom`, but that was not reflected in the types.

Unfortunately I couldn't add tests for this, since the types for `@jest/globals` do not come from DefinitelyTyped. Happy to take suggestions on how to add them after all.

The trail which leads to the need to augment the `expect` package:

- [`expect` from `@jest/globals` is a `JestExpect`](https://github.com/jestjs/jest/blob/596422e7f0eefc2a8970ba2febc0f32b69d4b564/packages/jest-globals/src/index.ts#L28)
- [`JestExpect` returns a `JestMatchers`](https://github.com/jestjs/jest/blob/596422e7f0eefc2a8970ba2febc0f32b69d4b564/packages/jest-expect/src/types.ts#L15-L23)
- [`JestMatchers` extends `Matchers`](https://github.com/jestjs/jest/blob/596422e7f0eefc2a8970ba2febc0f32b69d4b564/packages/jest-expect/src/types.ts#L32), which [come from the `expect` package](https://github.com/jestjs/jest/blob/596422e7f0eefc2a8970ba2febc0f32b69d4b564/packages/jest-expect/src/types.ts#L8)