### PR TITLE
MapboxGeocoder - add missing options/methods

### DIFF
--- a/types/mapbox__mapbox-gl-geocoder/index.d.ts
+++ b/types/mapbox__mapbox-gl-geocoder/index.d.ts
@@ -158,6 +158,30 @@ declare namespace MapboxGeocoder {
          * If `false`, indicates that the `localGeocoder` results should be combined with those from the Mapbox API with the `localGeocoder` results ranked higher. (optional, default false)
          */
         localGeocoderOnly?: boolean | undefined;
+        /**
+         * Specify whether to return autocomplete results or not. When autocomplete is enabled,
+         * results will be included that start with the requested string, rather than just responses
+         * that match it exactly. (optional, default true)
+         */
+        autocomplete?: boolean | undefined;
+        /**
+         *  Specify whether the Geocoding API should attempt approximate, as well as exact, matching
+         *  when performing searches, or whether it should opt out of this behavior and only attempt
+         *  exact matching. (optional, default true)
+         */
+        fuzzyMatch?: boolean | undefined;
+        /**
+         * Specify whether to request additional metadata about the recommended navigation
+         * destination corresponding to the feature or not. Only applicable for address features.
+         * (optional, default false)
+         */
+        routing?: boolean | undefined;
+        /**
+         * Filter results to geographic features whose characteristics are defined differently by
+         * audiences belonging to various regional, cultural, or political groups. (optional,
+         * default "us")
+         */
+        worldview?: string | undefined;
     }
 }
 declare class MapboxGeocoder implements mapboxgl.IControl {
@@ -252,6 +276,14 @@ declare class MapboxGeocoder implements mapboxgl.IControl {
     setFilter(filter: (feature: MapboxGeocoder.Result) => boolean): this;
     setOrigin(origin: string): this;
     getOrigin(): string;
+    setAutocomplete(value: boolean): this;
+    getAutocomplete(): boolean;
+    setFuzzyMatch(value: boolean): this;
+    getFuzzyMatch(): boolean;
+    setRouting(value: boolean): this;
+    getRouting(): boolean;
+    setWorldview(code: string): this;
+    getWorldview(): string;
     /**
      * Subscribe to events that happen within the plugin.
      * type name of event. Available events and the data passed into their respective event objects are:

--- a/types/mapbox__mapbox-gl-geocoder/mapbox__mapbox-gl-geocoder-tests.ts
+++ b/types/mapbox__mapbox-gl-geocoder/mapbox__mapbox-gl-geocoder-tests.ts
@@ -26,3 +26,27 @@ geocoder.clear();
 
 // $ExpectType void
 geocoder.clear(new Event('clear'));
+
+// $ExpectType MapboxGeocoder
+geocoder.setAutocomplete(true);
+
+// $ExpectType boolean
+geocoder.getAutocomplete();
+
+// $ExpectType MapboxGeocoder
+geocoder.setFuzzyMatch(true);
+
+// $ExpectType boolean
+geocoder.getFuzzyMatch();
+
+// $ExpectType MapboxGeocoder
+geocoder.setRouting(true);
+
+// $ExpectType boolean
+geocoder.getRouting();
+
+// $ExpectType MapboxGeocoder
+geocoder.setWorldview('en');
+
+// $ExpectType string
+geocoder.getWorldview();


### PR DESCRIPTION
Noticed that some options and methods were missing while trying to use MapboxGeocoder.
Added new options and methods based on [mapbox-gl-geocoder/API.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/main/API.md)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [mapbox-gl-geocoder/API.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/main/API.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
