### PR TITLE
[react] Add support for legacy context in class components in JSXElementConstructor

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -83,7 +83,13 @@ declare namespace React {
                */
               deprecatedLegacyContext?: any,
           ) => ReactNode)
-        | (new (props: P) => Component<any, any>);
+        | (new (
+              props: P,
+              /**
+               * @deprecated https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods
+               */
+              deprecatedLegacyContext?: any,
+          ) => Component<any, any>);
 
     interface RefObject<T> {
         readonly current: T | null;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -810,6 +810,11 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
         return null;
     };
     Wrapper = (props, legacyContext: { foo: number }) => null;
+    Wrapper = class Exact extends React.Component<ExactProps> {
+        constructor(props: ExactProps, legacyContext: { foo: number }) {
+            super(props, legacyContext);
+        }
+    };
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -357,6 +357,22 @@ class LegacyContext extends React.Component {
     }
 }
 
+class LegacyContextWithConstructor extends React.Component {
+    static contextTypes = { foo: PropTypes.node.isRequired };
+
+    constructor(props: {}, context: {}) {
+        super(props, context);
+    }
+
+    render() {
+        // $ExpectType unknown
+        this.context;
+        return (this.context as any).foo;
+    }
+}
+
+<LegacyContextWithConstructor />;
+
 class LegacyContextAnnotated extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
     context: { foo: React.ReactNode } = { foo: {} as React.ReactNode };

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -357,22 +357,6 @@ class LegacyContext extends React.Component {
     }
 }
 
-class LegacyContextWithConstructor extends React.Component {
-    static contextTypes = { foo: PropTypes.node.isRequired };
-
-    constructor(props: {}, context: {}) {
-        super(props, context);
-    }
-
-    render() {
-        // $ExpectType unknown
-        this.context;
-        return (this.context as any).foo;
-    }
-}
-
-<LegacyContextWithConstructor />;
-
 class LegacyContextAnnotated extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
     context: { foo: React.ReactNode } = { foo: {} as React.ReactNode };
@@ -720,6 +704,20 @@ function elementTypeTests() {
     };
     const FCWithLegacyContext: React.FC<{ foo: string }> = ReturnWithLegacyContext;
 
+    class RenderWithLegacyContext extends React.Component {
+        static contextTypes = { foo: PropTypes.node.isRequired };
+
+        constructor(props: {}, context: {}) {
+            super(props, context);
+        }
+
+        render() {
+            // $ExpectType unknown
+            this.context;
+            return (this.context as any).foo;
+        }
+    }
+
     // Desired behavior.
     // @ts-expect-error
     <ReturnVoid />;
@@ -792,6 +790,9 @@ function elementTypeTests() {
 
     <ReturnWithLegacyContext foo="one" />;
     React.createElement(ReturnWithLegacyContext, {foo: 'one'});
+
+    <RenderWithLegacyContext />;
+    React.createElement(RenderWithLegacyContext);
 }
 
 function managingRefs() {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -51,7 +51,13 @@ declare namespace React {
                */
               deprecatedLegacyContext?: any,
           ) => ReactElement<any, any> | null)
-        | (new (props: P) => Component<any, any>);
+        | (new (
+              props: P,
+              /**
+               * @deprecated https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods
+               */
+              deprecatedLegacyContext?: any,
+          ) => Component<any, any>);
 
     interface RefObject<T> {
         readonly current: T | null;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -818,6 +818,11 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
         return null;
     };
     Wrapper = (props, legacyContext: { foo: number }) => null;
+    Wrapper = class Exact extends React.Component<ExactProps> {
+        constructor(props: ExactProps, legacyContext: { foo: number }) {
+            super(props, legacyContext);
+        }
+    };
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -357,6 +357,22 @@ class LegacyContext extends React.Component {
     }
 }
 
+class LegacyContextWithConstructor extends React.Component {
+    static contextTypes = { foo: PropTypes.node.isRequired };
+
+    constructor(props: {}, context: {}) {
+        super(props, context);
+    }
+
+    render() {
+        // $ExpectType unknown
+        this.context;
+        return (this.context as any).foo;
+    }
+}
+
+<LegacyContextWithConstructor />;
+
 class LegacyContextAnnotated extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
     context: { foo: React.ReactNode } = { foo: {} as React.ReactNode };

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -357,22 +357,6 @@ class LegacyContext extends React.Component {
     }
 }
 
-class LegacyContextWithConstructor extends React.Component {
-    static contextTypes = { foo: PropTypes.node.isRequired };
-
-    constructor(props: {}, context: {}) {
-        super(props, context);
-    }
-
-    render() {
-        // $ExpectType unknown
-        this.context;
-        return (this.context as any).foo;
-    }
-}
-
-<LegacyContextWithConstructor />;
-
 class LegacyContextAnnotated extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
     context: { foo: React.ReactNode } = { foo: {} as React.ReactNode };
@@ -709,6 +693,20 @@ function elementTypeTests() {
     };
     const FCWithLegacyContext: React.FC<{ foo: string }> = ReturnWithLegacyContext;
 
+    class RenderWithLegacyContext extends React.Component {
+        static contextTypes = { foo: PropTypes.node.isRequired };
+
+        constructor(props: {}, context: {}) {
+            super(props, context);
+        }
+
+        render() {
+            // $ExpectType unknown
+            this.context;
+            return (this.context as any).foo;
+        }
+    }
+
     // Desired behavior.
     // @ts-expect-error
     <ReturnVoid />;
@@ -792,6 +790,9 @@ function elementTypeTests() {
 
     <ReturnWithLegacyContext foo="one" />;
     React.createElement(ReturnWithLegacyContext, {foo: 'one'});
+
+    <RenderWithLegacyContext />;
+    React.createElement(RenderWithLegacyContext);
 }
 
 function managingRefs() {


### PR DESCRIPTION
This is a follow-up to #65566 for class components referencing legacy context in the constructor.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65566
