### PR TITLE
[react-dom] Add reason argument to abort function in react-dom/server

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -39,7 +39,7 @@ export interface RenderToPipeableStreamOptions {
 }
 
 export interface PipeableStream {
-    abort: () => void;
+    abort: (reason?: unknown) => void;
     pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
 }
 

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -383,7 +383,7 @@ function pipeableStreamDocumentedExample() {
 
     let didError = false;
     const response: Response = {} as any;
-    const { pipe } = ReactDOMServer.renderToPipeableStream(<App />, {
+    const { pipe, abort } = ReactDOMServer.renderToPipeableStream(<App />, {
         bootstrapScripts: ['/main.js'],
         onShellReady() {
             response.statusCode = didError ? 500 : 200;
@@ -401,6 +401,14 @@ function pipeableStreamDocumentedExample() {
             console.error(err);
         },
     });
+
+    setTimeout(() => {
+        abort();
+    }, 1000);
+
+    setTimeout(() => {
+        abort("timeout");
+    }, 1000);
 }
 
 /**

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -403,10 +403,12 @@ function pipeableStreamDocumentedExample() {
     });
 
     setTimeout(() => {
+        // $ExpectType void
         abort();
     }, 1000);
 
     setTimeout(() => {
+        // $ExpectType void
         abort("timeout");
     }, 1000);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ReactDOMFizzServerNode](https://github.com/facebook/react/blob/e91142dd69b0454e0d4e934c55dd541344fe32ca/packages/react-dom/src/server/ReactDOMFizzServerNode.js#L58)

The PipeableStream object returned by React DOM's renderToPipeableStream takes a `reason` argument which is logged and also sent to the client.

In flow it's typed as `mixed` -- https://flow.org/en/docs/types/mixed/ -- but the docs -- https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering -- use `abort` without any arguments, so I typed it as an optional `unknown`.

