### PR TITLE
Align Matchers type with the one from `expect` for @testing-library/jest-dom

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -18,5 +18,5 @@ declare global {
 }
 
 declare module "expect" {
-    interface Matchers<R = void, T = {}> extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+    interface Matchers<R = void, T = unknown> extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/testing-library/jest-dom/issues/426#issuecomment-1623790932
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As per https://github.com/testing-library/jest-dom/issues/426#issuecomment-1623790932, I hope this fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65987#discussioncomment-6371630, ~~but I can't verify because I don't know how to reproduce~~ (edit: someone who could reproduce [has verified it](https://github.com/testing-library/jest-dom/issues/426#issuecomment-1624120507), and so has [someone else](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65987#discussioncomment-6378257)), and I'm not 100% confident about what I'm doing :/ However, potentially this supersedes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65990 and fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65987.