### PR TITLE
feat(lodash-es): Export supporting type PropertyPath

### DIFF
--- a/types/lodash-es/index.d.ts
+++ b/types/lodash-es/index.d.ts
@@ -200,7 +200,7 @@ export { default as partialRight } from './partialRight.js';
 export { default as partition } from './partition.js';
 export { default as pick } from './pick.js';
 export { default as pickBy } from './pickBy.js';
-export { default as property } from './property.js';
+export { default as property, PropertyPath } from './property.js';
 export { default as propertyOf } from './propertyOf.js';
 export { default as pull } from './pull.js';
 export { default as pullAll } from './pullAll.js';

--- a/types/lodash-es/lodash-es-tests.ts
+++ b/types/lodash-es/lodash-es-tests.ts
@@ -194,7 +194,7 @@ import partialRight from "lodash-es/partialRight";
 import partition from "lodash-es/partition";
 import pick from "lodash-es/pick";
 import pickBy from "lodash-es/pickBy";
-import property from "lodash-es/property";
+import property, { PropertyPath } from "lodash-es/property";
 import propertyOf from "lodash-es/propertyOf";
 import pull from "lodash-es/pull";
 import pullAll from "lodash-es/pullAll";
@@ -500,6 +500,7 @@ import {
   pick as pick1,
   pickBy as pickBy1,
   property as property1,
+  PropertyPath as PropertyPath1,
   propertyOf as propertyOf1,
   pull as pull1,
   pullAll as pullAll1,

--- a/types/lodash-es/property.d.ts
+++ b/types/lodash-es/property.d.ts
@@ -1,2 +1,4 @@
-import { property } from "lodash";
+import { property, PropertyPath } from "lodash";
+
+export { PropertyPath };
 export default property;


### PR DESCRIPTION
Re-export the supporting type `PropertyPath`.

There has already been two issues (#50200, #51384) and one PR (#49984) opened for this type of problem. Maybe it would be worth going through the `lodash` codebase and re-exporting all the parameter types at once instead of people submitting them one by one. :thinking: If you think that this would be beneficial, I can try to write a script to do this.
