### PR TITLE
Improve types for markdown-it-container

### DIFF
--- a/types/markdown-it-container/index.d.ts
+++ b/types/markdown-it-container/index.d.ts
@@ -8,12 +8,6 @@ import MarkdownIt = require('markdown-it');
 import Renderer = require('markdown-it/lib/renderer');
 import Token = require('markdown-it/lib/token');
 
-declare function MarkdownItContainer(
-    md: MarkdownIt,
-    name: string,
-    opts: ContainerOpts,
-): void;
-
 declare namespace MarkdownItContainer {
     interface ContainerOpts {
         marker?: string | undefined;
@@ -22,5 +16,10 @@ declare namespace MarkdownItContainer {
     }
 }
 
+declare function MarkdownItContainer(
+    md: MarkdownIt,
+    name: string,
+    opts: MarkdownItContainer.ContainerOpts,
+): void;
 
 export = MarkdownItContainer;

--- a/types/markdown-it-container/index.d.ts
+++ b/types/markdown-it-container/index.d.ts
@@ -8,15 +8,16 @@ import MarkdownIt = require('markdown-it');
 import Renderer = require('markdown-it/lib/renderer');
 import Token = require('markdown-it/lib/token');
 
-declare namespace markdownItContainer {
-    interface ContainerOpts {
-        marker?: string | undefined;
-        validate?(params: string): boolean;
-        render?(tokens: Token[], index: number, options: any, env: any, self: Renderer): string;
-    }
-
-    function container_plugin(md: MarkdownIt, name: string, opts: ContainerOpts): void;
+export interface ContainerOpts {
+    marker?: string | undefined;
+    validate?(params: string): boolean;
+    render?: Renderer.RenderRule | undefined;
 }
 
-declare var MarkdownItContainer: typeof markdownItContainer.container_plugin;
+declare function MarkdownItContainer(
+    md: MarkdownIt,
+    name: string,
+    opts: ContainerOpts,
+): void;
+
 export = MarkdownItContainer;

--- a/types/markdown-it-container/index.d.ts
+++ b/types/markdown-it-container/index.d.ts
@@ -8,16 +8,19 @@ import MarkdownIt = require('markdown-it');
 import Renderer = require('markdown-it/lib/renderer');
 import Token = require('markdown-it/lib/token');
 
-export interface ContainerOpts {
-    marker?: string | undefined;
-    validate?(params: string): boolean;
-    render?: Renderer.RenderRule | undefined;
-}
-
 declare function MarkdownItContainer(
     md: MarkdownIt,
     name: string,
     opts: ContainerOpts,
 ): void;
+
+declare namespace MarkdownItContainer {
+    interface ContainerOpts {
+        marker?: string | undefined;
+        validate?(params: string): boolean;
+        render?: Renderer.RenderRule | undefined;
+    }
+}
+
 
 export = MarkdownItContainer;


### PR DESCRIPTION
Removes the unnecessary namespace, makes the ContainerOpts interface visible, and uses the markdown-it type Renderer.RenderRule to type the render method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
