### PR TITLE
fix(passport-jwt): fix `audience` to also accept array

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -24,7 +24,7 @@ export interface StrategyOptions {
     secretOrKeyProvider?: SecretOrKeyProvider | undefined;
     jwtFromRequest: JwtFromRequestFunction;
     issuer?: string | string[] | undefined;
-    audience?: string | undefined;
+    audience?: string | string[] | undefined;
     algorithms?: string[] | undefined;
     ignoreExpiration?: boolean | undefined;
     passReqToCallback?: boolean | undefined;

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -44,6 +44,7 @@ opts.jwtFromRequest = (req: Request) => {
 };
 opts.secretOrKey = new Buffer('secret');
 opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer('secret'));
+opts.audience = ['example1.org', 'example2.org']
 
 class UserModel {}
 


### PR DESCRIPTION
As we can see in https://github.com/auth0/node-jsonwebtoken/blob/84539b29e17fd40ed25c53fc28db8ae41a34aff8/verify.js#L195, it's possible to pass an array of strings as the value of `audience`.