### PR TITLE
[react-native-auth0] add types for var `user` returned by `useAuth0`

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -9,6 +9,7 @@
 //                 Mathias Djärv <https://github.com/mdjarv>
 //                 Greg Friedman <https://github.com/gfriedm4>
 //                 Poovamraj T T <https://github.com/poovamraj>
+//                 TAKAGI Kensuke <https://github.com/januswel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -323,24 +324,72 @@ export default class Auth0 {
     users(token: string): Users;
 }
 
+// https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+export interface OpenIdClaims {
+    sub: string;
+    // Claims other than "sub" are not included in the user profile on Auth0
+}
+export interface ProfileClaims {
+    name: string;
+    given_name: string;
+    family_name: string;
+    middle_name: string;
+    nickname: string;
+    preferred_username: string;
+    profile: string;
+    picture: string;
+    website: string;
+    gender: string;
+    birthdate: string;
+    zoneinfo: string;
+    locale: string;
+    updated_at: string;
+}
+export interface EmailClaims {
+    email: string;
+    email_verified: boolean;
+}
+export interface AddressClaims {
+    address: string;
+}
+export interface PhoneClaims {
+    phone_number: string;
+    phone_number_verified: boolean;
+}
+export interface Identity {
+    user_id: string;
+    provider: string;
+    connection: string;
+    isSocial: boolean;
+}
+export interface Auth0UserProfile {
+    identities: Identity[];
+}
+export type User = {
+    // for custom claim
+    [key: string]: unknown;
+} & OpenIdClaims &
+    Auth0UserProfile &
+    Partial<ProfileClaims & EmailClaims & AddressClaims & PhoneClaims>;
+
 export class Auth0ContextInterface {
-    user: any;
+    user: User | null;
     error: BaseError | null;
     isLoading: boolean;
-    authorize(parameters?: AuthorizeParams, options?: AuthorizeOptions): Promise<void>;
-    clearSession(parameters?: ClearSessionParams, options?: ClearSessionOptions): Promise<void>;
-    getCredentials(scope?: string, minTtl?: number, parameters?: any): Promise<Credentials>;
-    clearCredentials(): Promise<void>;
-    requireLocalAuthentication(
+    authorize: (parameters?: AuthorizeParams, options?: AuthorizeOptions) => Promise<void>;
+    clearSession: (parameters?: ClearSessionParams, options?: ClearSessionOptions) => Promise<void>;
+    getCredentials: (scope?: string, minTtl?: number, parameters?: any) => Promise<Credentials>;
+    clearCredentials: () => Promise<void>;
+    requireLocalAuthentication: (
         title?: string,
         description?: string,
         cancelTitle?: string,
         fallbackTitle?: string,
         strategy?: LocalAuthenticationStrategy,
-    ): Promise<void>;
+    ) => Promise<void>;
 }
 
-export class Auth0Props {
+export interface Auth0Props {
     domain: string;
     clientId: string;
     children?: any;

--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -356,20 +356,10 @@ export interface PhoneClaims {
     phone_number: string;
     phone_number_verified: boolean;
 }
-export interface Identity {
-    user_id: string;
-    provider: string;
-    connection: string;
-    isSocial: boolean;
-}
-export interface Auth0UserProfile {
-    identities: Identity[];
-}
 export type User = {
     // for custom claim
     [key: string]: unknown;
 } & OpenIdClaims &
-    Auth0UserProfile &
     Partial<ProfileClaims & EmailClaims & AddressClaims & PhoneClaims>;
 
 export class Auth0ContextInterface {

--- a/types/react-native-auth0/react-native-auth0-tests.tsx
+++ b/types/react-native-auth0/react-native-auth0-tests.tsx
@@ -285,8 +285,16 @@ auth0.credentialsManager.hasValidCredentials();
 auth0.credentialsManager.hasValidCredentials(123);
 
 function Test() {
-    const { isLoading, error, authorize, clearSession, getCredentials, clearCredentials, requireLocalAuthentication } =
-        useAuth0();
+    const {
+        user,
+        isLoading,
+        error,
+        authorize,
+        clearSession,
+        getCredentials,
+        clearCredentials,
+        requireLocalAuthentication,
+    } = useAuth0();
 
     // can be used without args
     authorize();
@@ -297,6 +305,7 @@ function Test() {
 
     return (
         <Auth0Provider domain={'type'} clientId={'type'}>
+            {!!user && user.sub}
             {!!isLoading && 'Loading'}
             {!!error && error.message}
         </Auth0Provider>


### PR DESCRIPTION
Type definitions are based on OpenID Connect scope claims

https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

And rewrite the types for function property of `useAuth0` return obj with arrow function style to fix errors from the ESLint rule @typescript-eslint/unbound-method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66020
