### PR TITLE
fix(custom-functions-runtime): mark `CancelableInvocation.onCanceled` as potentially undefined

### DIFF
--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -104,7 +104,7 @@ declare namespace CustomFunctions {
          *
          * @eventproperty
          */
-        onCanceled: (() => void) | undefined;
+        onCanceled?: () => void;
     }
 
     /**

--- a/types/custom-functions-runtime/index.d.ts
+++ b/types/custom-functions-runtime/index.d.ts
@@ -104,7 +104,7 @@ declare namespace CustomFunctions {
          *
          * @eventproperty
          */
-        onCanceled: () => void;
+        onCanceled: (() => void) | undefined;
     }
 
     /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - This requires an Excel runtime, but I have provided screenshots showing that `onCanceled` is undefined before being set.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
  - This package provides bindings to internal Microsoft Office APIs, which are closed-source
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Extras
Below is evidence that `onCanceled` can be `undefined` using Microsoft's Script Lab addin for Excel:
<img width="1119" alt="Screenshot 2023-07-10 at 10 26 13 AM" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/4527949/72ddf9fe-6ba1-4b30-a389-c3978202985e">
<img width="1119" alt="Screenshot 2023-07-10 at 10 26 07 AM" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/4527949/edacf0ba-1462-40a5-abf8-526be0512263">
