### PR TITLE
[unist] Fix dependency ranges for previous major version

### DIFF
--- a/types/hast/v2/hast-tests.ts
+++ b/types/hast/v2/hast-tests.ts
@@ -1,0 +1,103 @@
+import { Data, Point, Position } from 'unist';
+import { Parent, Properties, Literal, Root, Element, DocType, Comment, Text } from 'hast';
+
+// Augmentations
+
+declare module 'hast' {
+    interface RootContentMap {
+        raw: Raw;
+    }
+}
+
+interface Raw extends Literal {
+    type: 'raw';
+}
+
+// Tests
+
+declare var raw: Raw;
+
+const data: Data = {
+    string: 'string',
+    number: 1,
+    object: {
+        key: 'value',
+    },
+    array: [],
+    boolean: true,
+    null: null,
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0,
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+    indent: [1],
+};
+
+const literal: Literal = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const comment: Comment = {
+    type: 'comment',
+    data,
+    position,
+    value: 'value',
+};
+
+const text: Text = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const docType: DocType = {
+    type: 'doctype',
+    name: 'name',
+};
+
+const element: Element = getElement();
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [getElement(), docType, comment, text],
+};
+
+const root: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, raw],
+};
+
+const properties: Properties = {
+    propertyName1: 'propertyValue1',
+    propertyName2: ['propertyValue2', 'propertyValue3'],
+    propertyName3: true,
+    propertyName4: 47,
+    propertyName5: [4, '4'],
+    propertyName6: null,
+    propertyName7: undefined,
+};
+
+function getElement(): Element {
+    return {
+        type: 'element',
+        tagName: 'tagName',
+        properties,
+        content: root,
+        children: [element, comment, text],
+    };
+}

--- a/types/hast/v2/index.d.ts
+++ b/types/hast/v2/index.d.ts
@@ -1,0 +1,162 @@
+// Type definitions for non-npm package Hast 2.3
+// Project: https://github.com/syntax-tree/hast
+// Definitions by: lukeggchapman <https://github.com/lukeggchapman>
+//                 Junyoung Choi <https://github.com/rokt33r>
+//                 Christian Murphy <https://github.com/ChristianMurphy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+
+export { UnistNode as Node };
+
+/**
+ * This map registers all node types that may be used as top-level content in the document.
+ *
+ * These types are accepted inside `root` nodes.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'hast' {
+ *   interface RootContentMap {
+ *     // Allow using raw nodes defined by `rehype-raw`.
+ *     raw: Raw;
+ *   }
+ * }
+ */
+export interface RootContentMap {
+    comment: Comment;
+    doctype: DocType;
+    element: Element;
+    text: Text;
+}
+
+/**
+ * This map registers all node types that may be used as content in an element.
+ *
+ * These types are accepted inside `element` nodes.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'hast' {
+ *   interface RootContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface ElementContentMap {
+    comment: Comment;
+    element: Element;
+    text: Text;
+}
+
+export type Content = RootContent | ElementContent;
+
+export type RootContent = RootContentMap[keyof RootContentMap];
+
+export type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+/**
+ * Node in hast containing other nodes.
+ */
+export interface Parent extends UnistParent {
+    /**
+     * List representing the children of a node.
+     */
+    children: Content[];
+}
+
+/**
+ * Nodes in hast containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * Root represents a document.
+ * Can be used as the rood of a tree, or as a value of the
+ * content field on a 'template' Element, never as a child.
+ */
+export interface Root extends Parent {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: 'root';
+
+    /**
+     * List representing the children of a node.
+     */
+    children: RootContent[];
+}
+
+/**
+ * Element represents an HTML Element.
+ */
+export interface Element extends Parent {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: 'element';
+
+    /**
+     * Represents the element’s local name.
+     */
+    tagName: string;
+
+    /**
+     * Represents information associated with the element.
+     */
+    properties?: Properties | undefined;
+
+    /**
+     * If the tagName field is 'template', a content field can be present.
+     */
+    content?: Root | undefined;
+
+    /**
+     * List representing the children of a node.
+     */
+    children: ElementContent[];
+}
+
+/**
+ * Represents information associated with an element.
+ */
+export interface Properties {
+    [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
+}
+
+/**
+ * Represents an HTML DocumentType.
+ */
+export interface DocType extends UnistNode {
+    /**
+     * Represents this variant of a Node.
+     */
+    type: 'doctype';
+
+    name: string;
+}
+
+/**
+ * Represents an HTML Comment.
+ */
+export interface Comment extends Literal {
+    /**
+     * Represents this variant of a Literal.
+     */
+    type: 'comment';
+}
+
+/**
+ * Represents an HTML Text.
+ */
+export interface Text extends Literal {
+    /**
+     * Represents this variant of a Literal.
+     */
+    type: 'text';
+}

--- a/types/hast/v2/tsconfig.json
+++ b/types/hast/v2/tsconfig.json
@@ -9,6 +9,7 @@
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
+            "hast": ["hast/v2"],
             "unist": ["unist/v2"]
         },
         "types": [],

--- a/types/hast/v2/tsconfig.json
+++ b/types/hast/v2/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "unist": ["unist/v2"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "hast-tests.ts"]
+}

--- a/types/hast/v2/tslint.json
+++ b/types/hast/v2/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/mdast/v3/index.d.ts
+++ b/types/mdast/v3/index.d.ts
@@ -1,0 +1,346 @@
+// Type definitions for Mdast 3.0
+// Project: https://github.com/syntax-tree/mdast, https://github.com/wooorm/mdast
+// Definitions by: Christian Murphy <https://github.com/ChristianMurphy>
+//                 Jun Lu <https://github.com/lujun2>
+//                 Remco Haszing <https://github.com/remcohaszing>
+//                 Titus Wormer <https://github.com/wooorm>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Parent as UnistParent, Literal as UnistLiteral, Node } from 'unist';
+
+export type AlignType = 'left' | 'right' | 'center' | null;
+
+export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
+
+/**
+ * This map registers all node types that may be used where markdown block content is accepted.
+ *
+ * These types are accepted inside block quotes, list items, footnotes, and roots.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface BlockContentMap {
+ *     // Allow using math nodes defined by `remark-math`.
+ *     math: Math;
+ *   }
+ * }
+ */
+export interface BlockContentMap {
+    paragraph: Paragraph;
+    heading: Heading;
+    thematicBreak: ThematicBreak;
+    blockquote: Blockquote;
+    list: List;
+    table: Table;
+    html: HTML;
+    code: Code;
+}
+
+/**
+ * This map registers all frontmatter node types.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface FrontmatterContentMap {
+ *     // Allow using toml nodes defined by `remark-frontmatter`.
+ *     toml: TOML;
+ *   }
+ * }
+ */
+export interface FrontmatterContentMap {
+    yaml: YAML;
+}
+
+/**
+ * This map registers all node definition types.
+ *
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface DefinitionContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface DefinitionContentMap {
+    definition: Definition;
+    footnoteDefinition: FootnoteDefinition;
+}
+
+/**
+ * This map registers all node types that are acceptable in a static phrasing context.
+ *
+ * This interface can be augmented to register custom node types in a phrasing context, including links and link
+ * references.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface StaticPhrasingContentMap {
+ *     mdxJsxTextElement: MDXJSXTextElement;
+ *   }
+ * }
+ */
+export interface StaticPhrasingContentMap {
+    text: Text;
+    emphasis: Emphasis;
+    strong: Strong;
+    delete: Delete;
+    html: HTML;
+    inlineCode: InlineCode;
+    break: Break;
+    image: Image;
+    imageReference: ImageReference;
+    footnote: Footnote;
+    footnoteReference: FootnoteReference;
+}
+
+/**
+ * This map registers all node types that are acceptable in a (interactive) phrasing context (so not in links).
+ *
+ * This interface can be augmented to register custom node types in a phrasing context, excluding links and link
+ * references.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface PhrasingContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface PhrasingContentMap extends StaticPhrasingContentMap {
+    link: Link;
+    linkReference: LinkReference;
+}
+
+/**
+ * This map registers all node types that are acceptable inside lists.
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside lists.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface ListContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface ListContentMap {
+    listItem: ListItem;
+}
+
+/**
+ * This map registers all node types that are acceptable inside tables (not table cells).
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside tables.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface TableContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface TableContentMap {
+    tableRow: TableRow;
+}
+
+/**
+ * This map registers all node types that are acceptable inside tables rows (not table cells).
+ *
+ * This interface can be augmented to register custom node types that are acceptable inside table rows.
+ *
+ * @example
+ * declare module 'mdast' {
+ *   interface RowContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface RowContentMap {
+    tableCell: TableCell;
+}
+
+export type Content = TopLevelContent | ListContent | TableContent | RowContent | PhrasingContent;
+
+export type TopLevelContent = BlockContent | FrontmatterContent | DefinitionContent;
+
+export type BlockContent = BlockContentMap[keyof BlockContentMap];
+
+export type FrontmatterContent = FrontmatterContentMap[keyof FrontmatterContentMap];
+
+export type DefinitionContent = DefinitionContentMap[keyof DefinitionContentMap];
+
+export type ListContent = ListContentMap[keyof ListContentMap];
+
+export type TableContent = TableContentMap[keyof TableContentMap];
+
+export type RowContent = RowContentMap[keyof RowContentMap];
+
+export type PhrasingContent = PhrasingContentMap[keyof PhrasingContentMap];
+
+export type StaticPhrasingContent = StaticPhrasingContentMap[keyof StaticPhrasingContentMap];
+
+export interface Parent extends UnistParent {
+    children: Content[];
+}
+
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+export interface Root extends Parent {
+    type: 'root';
+}
+
+export interface Paragraph extends Parent {
+    type: 'paragraph';
+    children: PhrasingContent[];
+}
+
+export interface Heading extends Parent {
+    type: 'heading';
+    depth: 1 | 2 | 3 | 4 | 5 | 6;
+    children: PhrasingContent[];
+}
+
+export interface ThematicBreak extends Node {
+    type: 'thematicBreak';
+}
+
+export interface Blockquote extends Parent {
+    type: 'blockquote';
+    children: Array<BlockContent | DefinitionContent>;
+}
+
+export interface List extends Parent {
+    type: 'list';
+    ordered?: boolean | null | undefined;
+    start?: number | null | undefined;
+    spread?: boolean | null | undefined;
+    children: ListContent[];
+}
+
+export interface ListItem extends Parent {
+    type: 'listItem';
+    checked?: boolean | null | undefined;
+    spread?: boolean | null | undefined;
+    children: Array<BlockContent | DefinitionContent>;
+}
+
+export interface Table extends Parent {
+    type: 'table';
+    align?: AlignType[] | null | undefined;
+    children: TableContent[];
+}
+
+export interface TableRow extends Parent {
+    type: 'tableRow';
+    children: RowContent[];
+}
+
+export interface TableCell extends Parent {
+    type: 'tableCell';
+    children: PhrasingContent[];
+}
+
+export interface HTML extends Literal {
+    type: 'html';
+}
+
+export interface Code extends Literal {
+    type: 'code';
+    lang?: string | null | undefined;
+    meta?: string | null | undefined;
+}
+
+export interface YAML extends Literal {
+    type: 'yaml';
+}
+
+export interface Definition extends Node, Association, Resource {
+    type: 'definition';
+}
+
+export interface FootnoteDefinition extends Parent, Association {
+    type: 'footnoteDefinition';
+    children: Array<BlockContent | DefinitionContent>;
+}
+
+export interface Text extends Literal {
+    type: 'text';
+}
+
+export interface Emphasis extends Parent {
+    type: 'emphasis';
+    children: PhrasingContent[];
+}
+
+export interface Strong extends Parent {
+    type: 'strong';
+    children: PhrasingContent[];
+}
+
+export interface Delete extends Parent {
+    type: 'delete';
+    children: PhrasingContent[];
+}
+
+export interface InlineCode extends Literal {
+    type: 'inlineCode';
+}
+
+export interface Break extends Node {
+    type: 'break';
+}
+
+export interface Link extends Parent, Resource {
+    type: 'link';
+    children: StaticPhrasingContent[];
+}
+
+export interface Image extends Node, Resource, Alternative {
+    type: 'image';
+}
+
+export interface LinkReference extends Parent, Reference {
+    type: 'linkReference';
+    children: StaticPhrasingContent[];
+}
+
+export interface ImageReference extends Node, Reference, Alternative {
+    type: 'imageReference';
+}
+
+export interface Footnote extends Parent {
+    type: 'footnote';
+    children: PhrasingContent[];
+}
+
+export interface FootnoteReference extends Node, Association {
+    type: 'footnoteReference';
+}
+
+// Mixin
+export interface Resource {
+    url: string;
+    title?: string | null | undefined;
+}
+
+export interface Association {
+    identifier: string;
+    label?: string | null | undefined;
+}
+
+export interface Reference extends Association {
+    referenceType: ReferenceType;
+}
+
+export interface Alternative {
+    alt?: string | null | undefined;
+}

--- a/types/mdast/v3/mdast-tests.ts
+++ b/types/mdast/v3/mdast-tests.ts
@@ -1,0 +1,123 @@
+import * as Mdast from 'mdast';
+
+// Augmentations
+
+declare module 'mdast' {
+    interface FrontmatterContentMap {
+        toml: TOML;
+    }
+
+    interface StaticPhrasingContentMap {
+        mdxJsxTextElement: MDXJSXTextElement;
+    }
+}
+
+interface TOML extends Mdast.Literal {
+    type: 'toml';
+}
+
+interface MDXJSXTextElement extends Mdast.Literal {
+    type: 'mdxJsxTextElement';
+}
+
+// Tests
+
+declare var toml: TOML;
+declare var mdxJsxTextElement: MDXJSXTextElement;
+
+const text: Mdast.Text = {
+    type: 'text',
+    value: 'text',
+};
+
+const cell: Mdast.TableCell = {
+    type: 'tableCell',
+    children: [text],
+};
+
+const row: Mdast.TableRow = {
+    type: 'tableRow',
+    children: [cell],
+};
+
+const table: Mdast.Table = {
+    type: 'table',
+    align: ['left', 'center', 'right'],
+    children: [row],
+};
+
+const header: Mdast.Heading = {
+    type: 'heading',
+    depth: 1,
+    children: [text],
+};
+
+const code: Mdast.Code = {
+    type: 'code',
+    lang: 'javascript',
+    value: 'let n = 42;',
+};
+
+const paragraph: Mdast.Paragraph = {
+    type: 'paragraph',
+    children: [text, mdxJsxTextElement],
+};
+
+const item: Mdast.ListItem = {
+    type: 'listItem',
+    children: [paragraph],
+};
+
+const list: Mdast.List = {
+    type: 'list',
+    children: [item],
+};
+
+const footNote: Mdast.FootnoteReference = {
+    type: 'footnoteReference',
+    identifier: 'ref1',
+    label: 'Referfence 1',
+};
+
+const image: Mdast.Image = {
+    type: 'image',
+    url: 'https://github.com/syntax-tree/mdast',
+    alt: 'image alternative',
+};
+
+const root: Mdast.Root = {
+    type: 'root',
+    children: [header, table, code, image, toml],
+};
+
+const link: Mdast.Link = {
+    type: 'link',
+    children: [text],
+    url: 'https://example.com',
+    title: null,
+};
+
+// Combination of all the declared ContentMap interfaces.
+interface ContentMap
+    extends Mdast.BlockContentMap,
+        Mdast.DefinitionContentMap,
+        Mdast.FrontmatterContentMap,
+        Mdast.ListContentMap,
+        Mdast.PhrasingContentMap,
+        Mdast.RowContentMap,
+        Mdast.StaticPhrasingContentMap,
+        Mdast.TableContentMap {}
+
+// Type with all …ContentMap keys corresponding to something whose `{type: "…"}` field does not match the key.
+// This should be empty. A previous version of these type definitions named a few entries like
+// "inlinecode" referring to a type keyed as "inlineCode", and so on.
+//
+// The ContentMap interfaces themselves aren't used at runtime: they're just groupings of types.
+// However that inconsistency prevented them from being used for things like defining rendering/handling
+// functions keyed on the node type names.
+type TypeMapIssues<M extends {}> = {
+    [K in keyof M as M[K] extends { type: K } ? never : K]: [K, M[K]];
+};
+
+// Assert that there are no incorrect keys. If there are, this is not assignable.
+const typeMapIssues: TypeMapIssues<ContentMap> = {};

--- a/types/mdast/v3/tsconfig.json
+++ b/types/mdast/v3/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "unist": ["unist/v2"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "mdast-tests.ts"]
+}

--- a/types/mdast/v3/tsconfig.json
+++ b/types/mdast/v3/tsconfig.json
@@ -9,6 +9,7 @@
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
+            "mdast": ["mdast/v3"],
             "unist": ["unist/v2"]
         },
         "types": [],

--- a/types/mdast/v3/tslint.json
+++ b/types/mdast/v3/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json"
+}

--- a/types/nlcst/v1/index.d.ts
+++ b/types/nlcst/v1/index.d.ts
@@ -1,0 +1,180 @@
+// Type definitions for non-npm package nlcst 1.0
+// Project: https://github.com/syntax-tree/nlcst
+// Definitions by: Titus Wormer <https://github.com/wooorm>
+//                 Christian Murphy <https://github.com/ChristianMurphy>
+//                 Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Parent as UnistParent, Literal as UnistLiteral } from 'unist';
+
+/**
+ * This map registers all node types that are acceptable inside paragraphs.
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'nlcst' {
+ *   interface ParagraphContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface ParagraphContentMap {
+    sentence: Sentence;
+    source: Source;
+    whiteSpace: WhiteSpace;
+}
+
+/**
+ * This map registers all node types that are acceptable inside sentences.
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'nlcst' {
+ *   interface SentenceContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface SentenceContentMap {
+    punctuation: Punctuation;
+    source: Source;
+    symbol: Symbol;
+    whiteSpace: WhiteSpace;
+    word: Word;
+}
+
+/**
+ * This map registers all node types that are acceptable inside words.
+ * This interface can be augmented to register custom node types.
+ *
+ * @example
+ * declare module 'nlcst' {
+ *   interface WordContentMap {
+ *     custom: Custom;
+ *   }
+ * }
+ */
+export interface WordContentMap {
+    punctuation: Punctuation;
+    source: Source;
+    symbol: Symbol;
+    text: Text;
+}
+
+export type Content = Paragraph | ParagraphContent | SentenceContent | WordContent;
+
+export type ParagraphContent = ParagraphContentMap[keyof ParagraphContentMap];
+
+export type SentenceContent = SentenceContentMap[keyof SentenceContentMap];
+
+export type WordContent = WordContentMap[keyof WordContentMap];
+
+/**
+ * Node in nlcst containing other nodes
+ */
+export interface Parent extends UnistParent {
+    children: Content[];
+}
+
+/**
+ * Node in nlcst containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * Node representing a document.
+ *
+ * Root can be used as the root of a tree, never as a child.
+ * Its content model is not limited, it can contain any nlcst content, with the
+ * restriction that all content must be of the same category.
+ */
+export interface Root extends Parent {
+    type: 'RootNode';
+    children: Content[];
+}
+
+/**
+ * Node representing a unit of discourse dealing with a particular point or idea.
+ *
+ * It can contain sentence, whitespace, and source nodes.
+ */
+export interface Paragraph extends Parent {
+    type: 'ParagraphNode';
+    children: ParagraphContent[];
+}
+
+/**
+ * Node representing a grouping of grammatically linked words, that in principle
+ * tells a complete thought, although it may make little sense taken in
+ * isolation out of context.
+ *
+ * It can be used in a paragraph node.
+ * It can contain word, symbol, punctuation, whitespace, and source nodes.
+ */
+export interface Sentence extends Parent {
+    type: 'SentenceNode';
+    children: SentenceContent[];
+}
+
+/**
+ * Node representing the smallest element that may be uttered in isolation with
+ * semantic or pragmatic content.
+ *
+ * It can be used in a sentence node.
+ * It can contain text, symbol, punctuation, and source nodes.
+ */
+export interface Word extends Parent {
+    type: 'WordNode';
+    children: WordContent[];
+}
+
+/**
+ * Node representing typographical devices different from characters which
+ * represent sounds (like letters and numerals), white space, or punctuation.
+ *
+ * It can be used in sentence or word nodes.
+ */
+export interface Symbol extends Literal {
+    type: 'SymbolNode';
+}
+
+/**
+ * Node representing typographical devices devoid of content, separating other
+ * units.
+ *
+ * It can be used in root, paragraph, or sentence nodes.
+ */
+export interface WhiteSpace extends Literal {
+    type: 'WhiteSpaceNode';
+}
+
+/**
+ * Node representing typographical devices which aid understanding and correct
+ * reading of other grammatical units.
+ *
+ * It can be used in sentence or word nodes.
+ */
+export interface Punctuation extends Literal {
+    type: 'PunctuationNode';
+}
+
+/**
+ * Node representing an external (ungrammatical) value embedded into a
+ * grammatical unit: a hyperlink, code, and such.
+ *
+ * It can be used in root, paragraph, sentence, or word nodes.
+ */
+export interface Source extends Literal {
+    type: 'SourceNode';
+}
+
+/**
+ * Node representing actual content in nlcst documents: one or more characters.
+ *
+ * It can be used in word nodes.
+ */
+export interface Text extends Literal {
+    type: 'TextNode';
+}

--- a/types/nlcst/v1/nlcst-tests.ts
+++ b/types/nlcst/v1/nlcst-tests.ts
@@ -1,0 +1,145 @@
+import { Data, Node, Point, Position } from 'unist';
+import {
+    Parent,
+    Literal,
+    Root,
+    Paragraph,
+    Sentence,
+    Word,
+    Symbol,
+    WhiteSpace,
+    Punctuation,
+    Source,
+    Text,
+} from 'nlcst';
+
+const data: Data = {
+    string: 'string',
+    number: 1,
+    object: {
+        key: 'value',
+    },
+    array: [],
+    boolean: true,
+    null: null,
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0,
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+};
+
+const literal: Literal = {
+    type: 'TextNode',
+    data,
+    position,
+    value: 'value',
+};
+
+const symbol: Symbol = {
+    type: 'SymbolNode',
+    data,
+    position,
+    value: 'value',
+};
+
+const punctuation: Punctuation = {
+    type: 'PunctuationNode',
+    data,
+    position,
+    value: 'value',
+};
+
+const text: Text = {
+    type: 'TextNode',
+    data,
+    position,
+    value: 'value',
+};
+
+const source: Source = {
+    type: 'SourceNode',
+    data,
+    position,
+    value: 'value',
+};
+
+const whiteSpace: WhiteSpace = {
+    type: 'WhiteSpaceNode',
+    data,
+    position,
+    value: 'value',
+};
+
+let paragraph: Paragraph = getParagraph();
+
+const sentence: Sentence = getSentence();
+
+const word: Word = getWord();
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [getParagraph(), getSentence(), getWord(), punctuation, source, symbol, text, whiteSpace],
+};
+
+const root: Root = {
+    type: 'RootNode',
+    data,
+    position,
+    children: [getParagraph(), getSentence(), getWord(), punctuation, source, symbol, text, whiteSpace],
+};
+
+function getParagraph(): Paragraph {
+    return {
+        type: 'ParagraphNode',
+        children: [getSentence(), source, whiteSpace],
+    };
+}
+
+function getSentence(): Sentence {
+    return {
+        type: 'SentenceNode',
+        children: [punctuation, source, symbol, whiteSpace, getWord()],
+    };
+}
+
+function getWord(): Word {
+    return {
+        type: 'WordNode',
+        children: [punctuation, source, symbol, text],
+    };
+}
+
+// Test custom nlcst node registration
+interface Custom extends Node {
+    type: 'CustomNode';
+}
+
+declare module 'nlcst' {
+    interface ParagraphContentMap {
+        custom: Custom;
+    }
+}
+
+paragraph = {
+    type: 'ParagraphNode',
+    data,
+    position,
+    children: [{ type: 'CustomNode' }],
+};
+
+paragraph = {
+    type: 'ParagraphNode',
+    data,
+    position,
+    // @ts-expect-error
+    children: [{ type: 'invalid' }],
+};

--- a/types/nlcst/v1/tsconfig.json
+++ b/types/nlcst/v1/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "unist": ["unist/v2"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "nlcst-tests.ts"]
+}

--- a/types/nlcst/v1/tsconfig.json
+++ b/types/nlcst/v1/tsconfig.json
@@ -9,6 +9,7 @@
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
+            "nlcst": ["nlcst/v1"],
             "unist": ["unist/v2"]
         },
         "types": [],

--- a/types/nlcst/v1/tslint.json
+++ b/types/nlcst/v1/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "ban-types": false
+    }
+}

--- a/types/unist/v2/index.d.ts
+++ b/types/unist/v2/index.d.ts
@@ -1,0 +1,114 @@
+// Type definitions for non-npm package Unist 2.0
+// Project: https://github.com/syntax-tree/unist
+// Definitions by: bizen241 <https://github.com/bizen241>
+//                 Jun Lu <https://github.com/lujun2>
+//                 Hernan Rajchert <https://github.com/hrajchert>
+//                 Titus Wormer <https://github.com/wooorm>
+//                 Junyoung Choi <https://github.com/rokt33r>
+//                 Ben Moon <https://github.com/GuiltyDolphin>
+//                 JounQin <https://github.com/JounQin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/**
+ * Syntactic units in unist syntax trees are called nodes.
+ *
+ * @typeParam TData Information from the ecosystem. Useful for more specific {@link Node.data}.
+ */
+export interface Node<TData extends object = Data> {
+    /**
+     * The variant of a node.
+     */
+    type: string;
+
+    /**
+     * Information from the ecosystem.
+     */
+    data?: TData | undefined;
+
+    /**
+     * Location of a node in a source document.
+     * Must not be present if a node is generated.
+     */
+    position?: Position | undefined;
+}
+
+/**
+ * Information associated by the ecosystem with the node.
+ * Space is guaranteed to never be specified by unist or specifications
+ * implementing unist.
+ */
+export interface Data {
+    [key: string]: unknown;
+}
+
+/**
+ * Location of a node in a source file.
+ */
+export interface Position {
+    /**
+     * Place of the first character of the parsed source region.
+     */
+    start: Point;
+
+    /**
+     * Place of the first character after the parsed source region.
+     */
+    end: Point;
+
+    /**
+     * Start column at each index (plus start line) in the source region,
+     * for elements that span multiple lines.
+     */
+    indent?: number[] | undefined;
+}
+
+/**
+ * One place in a source file.
+ */
+export interface Point {
+    /**
+     * Line in a source file (1-indexed integer).
+     */
+    line: number;
+
+    /**
+     * Column in a source file (1-indexed integer).
+     */
+    column: number;
+    /**
+     * Character in a source file (0-indexed integer).
+     */
+    offset?: number | undefined;
+}
+
+/**
+ * Util for extracting type of {@link Node.data}
+ *
+ * @typeParam TNode Specific node type such as {@link Node} with {@link Data}, {@link Literal}, etc.
+ *
+ * @example `NodeData<Node<{ key: string }>>` -> `{ key: string }`
+ */
+export type NodeData<TNode extends Node<object>> = TNode extends Node<infer TData> ? TData : never;
+
+/**
+ * Nodes containing other nodes.
+ *
+ * @typeParam ChildNode Node item of {@link Parent.children}
+ */
+export interface Parent<ChildNode extends Node<object> = Node, TData extends object = NodeData<ChildNode>>
+    extends Node<TData> {
+    /**
+     * List representing the children of a node.
+     */
+    children: ChildNode[];
+}
+
+/**
+ * Nodes containing a value.
+ *
+ * @typeParam Value Specific value type of {@link Literal.value} such as `string` for `Text` node
+ */
+export interface Literal<Value = unknown, TData extends object = Data> extends Node<TData> {
+    value: Value;
+}

--- a/types/unist/v2/tsconfig.json
+++ b/types/unist/v2/tsconfig.json
@@ -8,6 +8,9 @@
         "strictFunctionTypes": true,
         "baseUrl": "../../",
         "typeRoots": ["../../"],
+        "paths": {
+            "unist": ["unist/v2"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/unist/v2/tsconfig.json
+++ b/types/unist/v2/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "unist-tests.ts"]
+}

--- a/types/unist/v2/tslint.json
+++ b/types/unist/v2/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/unist/v2/unist-tests.ts
+++ b/types/unist/v2/unist-tests.ts
@@ -1,0 +1,148 @@
+import { Data, Point, Position, Node, Literal, Parent, NodeData } from 'unist';
+
+const data: Data = {
+    string: 'string',
+    number: 1,
+    object: {
+        key: 'value',
+    },
+    array: [],
+    boolean: true,
+    null: null,
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0,
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+    indent: [1],
+};
+
+const node: Node = {
+    type: 'node',
+    data,
+    position,
+};
+
+const text: Literal = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [node, text],
+};
+
+const noExtraKeysInNode: Node = {
+    type: 'noExtraKeysInNode',
+    // @ts-expect-error
+    extra: 'extra',
+};
+
+const noChildrenInNode: Node = {
+    type: 'noChildrenInNode',
+    // @ts-expect-error
+    children: [],
+};
+
+const stringLiteral: Literal<string> = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const literalParent: Parent<Literal<string>> = {
+    type: 'literalParent',
+    data,
+    position,
+    children: [stringLiteral],
+};
+
+const nodeData: Node<{ key: string }> = {
+    type: 'nodeData',
+    data: {
+        key: 'value',
+    },
+};
+
+const nodeData2: Node<{ key: string }> = {
+    type: 'nodeData',
+    // @ts-expect-error
+    data: {},
+};
+
+// @ts-expect-error
+type DataType = NodeData<Node<string>>;
+
+const literalData: Literal<string, { key: string }> = {
+    type: 'literalData',
+    data: {
+        key: 'value',
+    },
+    value: 'value',
+};
+
+const literalParentData: Parent<Literal<string>, Data> = {
+    type: 'literalParent',
+    data,
+    position,
+    children: [stringLiteral],
+};
+
+const data1 = {
+    key1: 'value1',
+};
+
+const data2 = {
+    key2: 'value2',
+};
+
+const nestedliteralParentData: Parent<Literal<string, typeof data1>, typeof data2> = {
+    type: 'literalParent',
+    data: data2,
+    position,
+    children: [
+        {
+            ...stringLiteral,
+            data: data1,
+        },
+    ],
+};
+
+function exampleNodeUtil(node: Node) {}
+
+const inferredNode = { type: 'example' };
+const inferredNotNode = { notType: 'whoops' };
+
+exampleNodeUtil(inferredNode);
+// @ts-expect-error
+exampleNodeUtil(inferredNotNode);
+
+function exampleLiteralUtil(node: Literal) {}
+
+const inferredLiteral = { type: 'example', value: 'value' };
+const inferredNotLiteral = { type: 'example' };
+
+exampleLiteralUtil(inferredLiteral);
+// @ts-expect-error
+exampleLiteralUtil(inferredNotLiteral);
+
+function exampleParentUtil(node: Parent) {}
+
+const inferredParent = { type: 'example', children: [inferredNode] };
+const inferredNotParent = { type: 'example', children1: [] };
+
+exampleParentUtil(inferredParent);
+// @ts-expect-error
+exampleParentUtil(inferredNotParent);

--- a/types/xast/v1/index.d.ts
+++ b/types/xast/v1/index.d.ts
@@ -1,0 +1,152 @@
+// Type definitions for non-npm package xast 1.0
+// Project: https://github.com/syntax-tree/xast
+// Definitions by: stefanprobst <https://github.com/stefanprobst>
+//                 Titus Wormer <https://github.com/wooorm>
+//                 Christian Murphy <https://github.com/ChristianMurphy>
+//                 Junyoung Choi <https://github.com/rokt33r>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+
+export { UnistNode as Node };
+export { UnistParent as Parent };
+
+/**
+ * Node in xast containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * This map registers valid children for a xast root node.
+ *
+ * For example to register a custom node type as a valid xast rppt child:
+ *
+ * ```ts
+ * interface Custom extends Node {
+ *   type: 'custom';
+ * }
+ *
+ * declare module 'xast' {
+ *   interface RootChildMap {
+ *     custom: Custom;
+ *   }
+ * }
+ * ```
+ */
+export interface RootChildMap {
+    cdata: Cdata;
+    comment: Comment;
+    doctype: Doctype;
+    element: Element;
+    instruction: Instruction;
+    text: Text;
+}
+
+/**
+ * Document fragment or a whole document.
+ * Should be used as the root of a tree and must not be used as a child.
+ *
+ * XML specifies that documents should have exactly one element child,
+ * therefore a root should have exactly one element child when representing a
+ * whole document.
+ */
+export interface Root extends UnistParent {
+    type: 'root';
+    children: Array<RootChildMap[keyof RootChildMap]>;
+}
+
+/**
+ * This map registers valid children for a xast element node.
+ *
+ * For example to register a custom node type as a valid xast element child:
+ *
+ * ```ts
+ * interface Custom extends Node {
+ *   type: 'custom';
+ * }
+ *
+ * declare module 'xast' {
+ *   interface ElementChildMap {
+ *     custom: Custom;
+ *   }
+ * }
+ * ```
+ */
+export interface ElementChildMap {
+    element: Element;
+    text: Text;
+    comment: Comment;
+    instruction: Instruction;
+    cdata: Cdata;
+}
+
+/**
+ * An XML element.
+ */
+export interface Element extends UnistParent {
+    type: 'element';
+    /**
+     * The element's qualified name.
+     */
+    name: string;
+    /**
+     * Information associated with the element.
+     */
+    attributes?: Attributes | undefined;
+    children: Array<ElementChildMap[keyof ElementChildMap]>;
+}
+
+/**
+ * Information associated with an element.
+ */
+export interface Attributes {
+    [name: string]: string | null | undefined;
+}
+
+/**
+ * XML character data.
+ */
+export interface Text extends Literal {
+    type: 'text';
+}
+
+/**
+ * XML comment.
+ */
+export interface Comment extends Literal {
+    type: 'comment';
+}
+
+/**
+ * XML doctype.
+ */
+export interface Doctype extends UnistNode {
+    type: 'doctype';
+    name: string;
+    /**
+     * The document’s public identifier.
+     */
+    public?: string | undefined;
+    /**
+     * The document’s system identifier.
+     */
+    system?: string | undefined;
+}
+
+/**
+ * XML processing instruction.
+ */
+export interface Instruction extends Literal {
+    type: 'instruction';
+    name: string;
+}
+
+/**
+ * XML CDATA section.
+ */
+export interface Cdata extends Literal {
+    type: 'cdata';
+}

--- a/types/xast/v1/tsconfig.json
+++ b/types/xast/v1/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "unist": ["unist/v2"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "xast-tests.ts"]
+}

--- a/types/xast/v1/tsconfig.json
+++ b/types/xast/v1/tsconfig.json
@@ -9,7 +9,8 @@
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
-            "unist": ["unist/v2"]
+            "unist": ["unist/v2"],
+            "xast": ["xast/v1"]
         },
         "types": [],
         "noEmit": true,

--- a/types/xast/v1/tslint.json
+++ b/types/xast/v1/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/xast/v1/xast-tests.ts
+++ b/types/xast/v1/xast-tests.ts
@@ -1,0 +1,148 @@
+import { Data, Node, Point, Position } from 'unist';
+import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
+
+const data: Data = {
+    string: 'string',
+    number: 1,
+    object: {
+        key: 'value',
+    },
+    array: [],
+    boolean: true,
+    null: null,
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0,
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+    indent: [1],
+};
+
+const literal: Literal = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const comment: Comment = {
+    type: 'comment',
+    data,
+    position,
+    value: 'value',
+};
+
+const text: Text = {
+    type: 'text',
+    data,
+    position,
+    value: 'value',
+};
+
+const docType: Doctype = {
+    type: 'doctype',
+    data,
+    position,
+    name: 'name',
+    public: 'public',
+    system: 'system',
+};
+
+const cdata: Cdata = {
+    type: 'cdata',
+    data,
+    position,
+    value: 'value',
+};
+
+const instruction: Instruction = {
+    type: 'instruction',
+    data,
+    position,
+    name: 'name',
+    value: 'value',
+};
+
+let element: Element = getElement();
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, instruction, cdata],
+};
+
+let root: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, instruction, cdata],
+};
+
+const attributes: Attributes = {
+    attributeName1: 'attributeValue',
+    attributeName2: null,
+    attributeName3: undefined,
+};
+
+function getElement(): Element {
+    return {
+        type: 'element',
+        name: 'name',
+        attributes,
+        children: [element, comment, text, cdata, instruction],
+    };
+}
+
+// Test custom xast node registration
+interface Custom extends Node {
+    type: 'custom';
+}
+
+declare module 'xast' {
+    interface RootChildMap {
+        custom: Custom;
+    }
+
+    interface ElementChildMap {
+        custom: Custom;
+    }
+}
+
+root = {
+    type: 'root',
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+element = {
+    type: 'element',
+    name: 'foo',
+    data,
+    position,
+    children: [{ type: 'custom' }],
+};
+
+root = {
+    type: 'root',
+    data,
+    position,
+    // @ts-expect-error
+    children: [{ type: 'invalid' }],
+};
+
+element = {
+    type: 'element',
+    name: 'foo',
+    data,
+    position,
+    // @ts-expect-error
+    children: [{ type: 'invalid' }],
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65789#issuecomment-1628765420
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR should release a new version for each package under the previous major version with the correct dependency on `@types/unist@2` instead of `@types/unist@*`.