### PR TITLE
[@types/node] update 'net.LookupFunction' to reflect that it looks up all addresses instead of one

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -16,7 +16,7 @@ declare module 'net' {
     import * as stream from 'node:stream';
     import { Abortable, EventEmitter } from 'node:events';
     import * as dns from 'node:dns';
-    type LookupFunction = (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
+    type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
     interface AddressInfo {
         address: string;
         family: string;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -647,7 +647,7 @@ import * as dns from 'node:dns';
 {
   http.request({ lookup: undefined });
   http.request({ lookup: dns.lookup });
-  http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
+  http.request({ lookup: (hostname, options, cb) => { cb(null, [{ address: '', family: 1 }]); } });
 }
 
 {

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -595,5 +595,5 @@ import * as dns from 'node:dns';
 {
   https.request({ lookup: undefined });
   https.request({ lookup: dns.lookup });
-  https.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
+  https.request({ lookup: (hostname, options, cb) => { cb(null, [{ address: '', family: 1 }]); } });
 }

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { LookupOneOptions } from 'node:dns';
+import { LookupAddress, LookupAllOptions } from 'node:dns';
 import { Socket } from 'node:dgram';
 
 {
@@ -106,7 +106,7 @@ import { Socket } from 'node:dgram';
         host: "localhost",
         localAddress: "10.0.0.1",
         localPort: 1234,
-        lookup: (_hostname: string, _options: LookupOneOptions, _callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void): void => {
+        lookup: (_hostname: string, _options: LookupAllOptions, _callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void): void => {
             // nothing
         },
         port: 80,

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -16,7 +16,7 @@ declare module 'net' {
     import * as stream from 'node:stream';
     import { Abortable, EventEmitter } from 'node:events';
     import * as dns from 'node:dns';
-    type LookupFunction = (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
+    type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
     interface AddressInfo {
         address: string;
         family: string;

--- a/types/node/ts4.8/test/http.ts
+++ b/types/node/ts4.8/test/http.ts
@@ -623,7 +623,7 @@ import * as dns from 'node:dns';
 {
   http.request({ lookup: undefined });
   http.request({ lookup: dns.lookup });
-  http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
+  http.request({ lookup: (hostname, options, cb) => { cb(null, [{ address: '', family: 1 }]); } });
 }
 
 {

--- a/types/node/ts4.8/test/https.ts
+++ b/types/node/ts4.8/test/https.ts
@@ -595,5 +595,5 @@ import * as dns from 'node:dns';
 {
   https.request({ lookup: undefined });
   https.request({ lookup: dns.lookup });
-  https.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
+  https.request({ lookup: (hostname, options, cb) => { cb(null, [{ address: '', family: 1 }]); } });
 }

--- a/types/node/ts4.8/test/net.ts
+++ b/types/node/ts4.8/test/net.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { LookupOneOptions } from 'node:dns';
+import { LookupAddress, LookupAllOptions } from 'node:dns';
 import { Socket } from 'node:dgram';
 
 {
@@ -106,7 +106,7 @@ import { Socket } from 'node:dgram';
         host: "localhost",
         localAddress: "10.0.0.1",
         localPort: 1234,
-        lookup: (_hostname: string, _options: LookupOneOptions, _callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void): void => {
+        lookup: (_hostname: string, _options: LookupAllOptions, _callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void): void => {
             // nothing
         },
         port: 80,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

  - The `autoSelectFamily` option was added to net here: nodejs/node#44731
  - As part of this it sets `all` to `true` in the options provided to `dns.lookup`: https://github.com/nodejs/node/blob/73c632e7bc4f3092e758400eec306f819a5095e8/lib/net.js#L1345
  - `autoSelectFamily` was defaulted to `true` in Node 20.0.0: nodejs/node#46790
  - This means that `all` is always set to `true` by default

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
