### PR TITLE
koa: Fix vary field parameter

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -333,7 +333,7 @@ declare interface ContextDelegatedResponse {
     /**
      * Vary on `field`.
      */
-    vary(field: string): void;
+    vary(field: string | string[]): void;
 
     /**
      * Perform a 302 redirect to `url`.
@@ -442,7 +442,7 @@ declare interface ContextDelegatedResponse {
 
 declare class Application<
     StateT = Application.DefaultState,
-    ContextT = Application.DefaultContext
+    ContextT = Application.DefaultContext,
 > extends EventEmitter {
     proxy: boolean;
     proxyIpHeader: string;
@@ -468,12 +468,12 @@ declare class Application<
      *
      */
     constructor(options?: {
-        env?: string | undefined,
-        keys?: string[] | undefined,
-        proxy?: boolean | undefined,
-        subdomainOffset?: number | undefined,
-        proxyIpHeader?: string | undefined,
-        maxIpsCount?: number | undefined
+        env?: string | undefined;
+        keys?: string[] | undefined;
+        proxy?: boolean | undefined;
+        subdomainOffset?: number | undefined;
+        proxyIpHeader?: string | undefined;
+        maxIpsCount?: number | undefined;
     });
 
     /**
@@ -509,7 +509,7 @@ declare class Application<
      * Old-style middleware will be converted.
      */
     use<NewStateT = {}, NewContextT = {}>(
-        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT>
+        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT>,
     ): Application<StateT & NewStateT, ContextT & NewContextT>;
 
     /**
@@ -732,10 +732,11 @@ declare namespace Application {
         respond?: boolean | undefined;
     }
 
-    type ParameterizedContext<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT = unknown> = ExtendableContext
-        & { state: StateT; }
-        & ContextT
-        & { body: ResponseBodyT; response: { body: ResponseBodyT }; };
+    type ParameterizedContext<
+        StateT = DefaultState,
+        ContextT = DefaultContext,
+        ResponseBodyT = unknown,
+    > = ExtendableContext & { state: StateT } & ContextT & { body: ResponseBodyT; response: { body: ResponseBodyT } };
 
     interface Context extends ParameterizedContext {}
 

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -442,7 +442,7 @@ declare interface ContextDelegatedResponse {
 
 declare class Application<
     StateT = Application.DefaultState,
-    ContextT = Application.DefaultContext,
+    ContextT = Application.DefaultContext
 > extends EventEmitter {
     proxy: boolean;
     proxyIpHeader: string;
@@ -468,12 +468,12 @@ declare class Application<
      *
      */
     constructor(options?: {
-        env?: string | undefined;
-        keys?: string[] | undefined;
-        proxy?: boolean | undefined;
-        subdomainOffset?: number | undefined;
-        proxyIpHeader?: string | undefined;
-        maxIpsCount?: number | undefined;
+        env?: string | undefined,
+        keys?: string[] | undefined,
+        proxy?: boolean | undefined,
+        subdomainOffset?: number | undefined,
+        proxyIpHeader?: string | undefined,
+        maxIpsCount?: number | undefined
     });
 
     /**
@@ -509,7 +509,7 @@ declare class Application<
      * Old-style middleware will be converted.
      */
     use<NewStateT = {}, NewContextT = {}>(
-        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT>,
+        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT>
     ): Application<StateT & NewStateT, ContextT & NewContextT>;
 
     /**
@@ -732,11 +732,10 @@ declare namespace Application {
         respond?: boolean | undefined;
     }
 
-    type ParameterizedContext<
-        StateT = DefaultState,
-        ContextT = DefaultContext,
-        ResponseBodyT = unknown,
-    > = ExtendableContext & { state: StateT } & ContextT & { body: ResponseBodyT; response: { body: ResponseBodyT } };
+    type ParameterizedContext<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT = unknown> = ExtendableContext
+        & { state: StateT; }
+        & ContextT
+        & { body: ResponseBodyT; response: { body: ResponseBodyT }; };
 
     interface Context extends ParameterizedContext {}
 

--- a/types/koa/test/index.ts
+++ b/types/koa/test/index.ts
@@ -63,8 +63,8 @@ app.use(ctx => {
     ctx.is(''); // $ExpectType string | false | null
     ctx.is(['']); // $ExpectType string | false | null
 
-    ctx.vary("Origin");
-    ctx.vary(["Origin", "User-Agent"]);
+    ctx.vary("Origin"); // $ExpectType void
+    ctx.vary(["Origin", "User-Agent"]); // $ExpectType void
 });
 
 // response

--- a/types/koa/test/index.ts
+++ b/types/koa/test/index.ts
@@ -62,6 +62,9 @@ app.use(ctx => {
     ctx.acceptsLanguages(['']); // $ExpectType string | false
     ctx.is(''); // $ExpectType string | false | null
     ctx.is(['']); // $ExpectType string | false | null
+
+    ctx.vary("Origin");
+    ctx.vary(["Origin", "User-Agent"]);
 });
 
 // response


### PR DESCRIPTION
Vary can accept either a single string or an array of strings, as per vary's [docs](https://github.com/jshttp/vary#varyres-field) and [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1b85e933696518a58ca05d48c31065e0d20430ca/types/vary/index.d.ts#L10)

Please fill in this template.

- ✔️ Use a meaningful title for the pull request. Include the name of the package modified.
- ✔️ Test the change in your own code. (Compile and run.)
- ✔️ [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- ✔️ Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- ✔️ Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- ✔️ [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- ✔️ Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1b85e933696518a58ca05d48c31065e0d20430ca/types/vary/index.d.ts#L10
- ✔️ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

