### PR TITLE
fix: remove non-crucial methods

### DIFF
--- a/types/rdfjs__data-model/Factory.d.ts
+++ b/types/rdfjs__data-model/Factory.d.ts
@@ -19,7 +19,6 @@ declare class DataFactory {
         'quad',
         'variable'
     ];
-    init(): void;
 }
 
 export default DataFactory;

--- a/types/rdfjs__data-model/rdfjs__data-model-tests.ts
+++ b/types/rdfjs__data-model/rdfjs__data-model-tests.ts
@@ -16,11 +16,14 @@ const exports: [
 
 const fromCtor = new Factory(); // $ExpectType DataFactory
 const asFactory: RDF.DataFactory = fromCtor;
-fromCtor.init();
 
-const env = new Environment([Factory]); // $ExpectType Environment<DataFactory>
+class FooFactory {
+    init() {}
+}
 
-const myQuad = factory.quad(
+const env = new Environment([Factory, FooFactory]); // $ExpectType Environment<DataFactory>
+
+const myQuad = env.quad(
   factory.namedNode('http://example.org/subject'),
   factory.namedNode('http://example.org/predicate'),
   factory.namedNode('http://example.org/object'),

--- a/types/rdfjs__dataset/rdfjs__dataset-tests.ts
+++ b/types/rdfjs__dataset/rdfjs__dataset-tests.ts
@@ -7,10 +7,14 @@ import Environment from '@rdfjs/environment/Environment.js';
 const exports: ['dataset'] = Factory.exports;
 let dataset: RDF.DatasetCore = rdf.dataset();
 
-const env = new Environment([Factory]); // $ExpectType Environment<Factory>
+class FooFactory {
+    init() {}
+}
+
+const env = new Environment([Factory, FooFactory]); // $ExpectType Environment<Factory>
 
 const quads: RDF.Quad[] = <any> {};
-dataset = rdf.dataset(quads);
+dataset = env.dataset(quads);
 
 dataset = new DatasetCore();
 dataset = new DatasetCore(quads);

--- a/types/rdfjs__environment/FormatsFactory.d.ts
+++ b/types/rdfjs__environment/FormatsFactory.d.ts
@@ -1,15 +1,5 @@
 import Formats from './lib/Formats.js';
 
-export interface FormatsFactory {
+export default class FormatsFactory {
     formats: Formats;
-    init(): void;
-    clone(original: FormatsFactory): void;
 }
-
-interface FormatsFactoryCtor {
-    new(): FormatsFactory;
-}
-
-declare const formatsFactory: FormatsFactoryCtor;
-
-export default formatsFactory;

--- a/types/rdfjs__environment/rdfjs__environment-tests.ts
+++ b/types/rdfjs__environment/rdfjs__environment-tests.ts
@@ -78,3 +78,13 @@ function formatsImport() {
 
     env.formats.import(formatsCommon);
 }
+
+class InitOnly {
+    init() {}
+}
+const envOneFactoryInitOnly = new Environment([
+    FormatsFactory,
+    InitOnly,
+]);
+
+envOneFactoryInitOnly.formats.import(envOneFactoryInitOnly.formats);

--- a/types/rdfjs__fetch-lite/Factory.d.ts
+++ b/types/rdfjs__fetch-lite/Factory.d.ts
@@ -12,15 +12,6 @@ interface Fetch {
     Headers: Headers;
 }
 
-export interface FetchFactory {
+export default class FetchFactory {
     fetch: Fetch;
-    clone(original: FetchFactory): FetchFactory;
 }
-
-interface FetchFactoryCtor {
-    new(): FetchFactory;
-}
-
-declare const factory: FetchFactoryCtor;
-
-export default factory;

--- a/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
+++ b/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
@@ -35,9 +35,14 @@ async function fetchTypedStream(): Promise<Stream<QuadExt>> {
     return response.quadStream();
 }
 
+class FooFactory {
+    init() {}
+}
+
 async function environmentRawFetch(): Promise<Stream> {
     const environmentTest = new Environment([
-        FetchFactory
+        FetchFactory,
+        FooFactory
     ]);
 
     environmentTest.fetch.config('foo', 'bar');

--- a/types/rdfjs__namespace/rdfjs__namespace-tests.ts
+++ b/types/rdfjs__namespace/rdfjs__namespace-tests.ts
@@ -1,6 +1,7 @@
 import namespace, { NamespaceBuilder } from '@rdfjs/namespace';
 import Factory from '@rdfjs/namespace/Factory';
 import { DataFactory, NamedNode } from '@rdfjs/types';
+import Environment from '@rdfjs/environment/Environment.js';
 
 const factory: DataFactory = {} as any;
 
@@ -28,5 +29,11 @@ const bazProp = restrictedBuilder.baz;
 // @ts-expect-error
 const bazArg = restrictedBuilder('baz');
 
+class FooFactory {
+    init() {}
+}
+
+const env = new Environment([Factory, FooFactory])
+
 const exports: ['namespace'] = Factory.exports;
-const builderFromFactory: NamespaceBuilder = new Factory().namespace('http://example.com/');
+const builderFromFactory: NamespaceBuilder = env.namespace('http://example.com/');

--- a/types/rdfjs__prefix-map/rdfjs__prefix-map-tests.ts
+++ b/types/rdfjs__prefix-map/rdfjs__prefix-map-tests.ts
@@ -4,7 +4,11 @@ import PrefixMapFactory from '@rdfjs/prefix-map/Factory';
 
 const term: NamedNode = <any> {};
 
-const environment = new Environment([PrefixMapFactory]);
+class FooFactory {
+    init() {}
+}
+
+const environment = new Environment([PrefixMapFactory, FooFactory]);
 const prefixMap = environment.prefixMap([
     ['schema', term]
 ]);

--- a/types/rdfjs__score/rdfjs__score-tests.ts
+++ b/types/rdfjs__score/rdfjs__score-tests.ts
@@ -24,6 +24,7 @@ import {
 } from '@rdfjs/score';
 import Factory from '@rdfjs/score/Factory';
 import Environment from '@rdfjs/environment/Environment';
+import DataFactory from '@rdfjs/data-model/Factory.js';
 
 const score: ScoreCb = <any> {};
 const clownfacePointer: MultiPointer = <any> {};
@@ -177,11 +178,15 @@ function test_type() {
     type(typeTerm)(ptrs);
 }
 
+class FooFactory {
+    init() {}
+}
+
 function test_Factory() {
     // $ExpectType ScoreFactory
     const constructed = new Factory();
 
-    const fromEnv = new Environment([Factory]);
+    const fromEnv = new Environment([Factory, FooFactory]);
     const {
         combine,
         concat,

--- a/types/rdfjs__term-map/rdfjs__term-map-tests.ts
+++ b/types/rdfjs__term-map/rdfjs__term-map-tests.ts
@@ -1,6 +1,7 @@
 import TermMap from '@rdfjs/term-map';
 import Factory from '@rdfjs/term-map/Factory';
 import { Term, Literal, BlankNode, NamedNode } from '@rdfjs/types';
+import Environment from '@rdfjs/environment/Environment.js';
 
 const literal: Literal = <any> {};
 const blank: BlankNode = <any> {};
@@ -18,8 +19,12 @@ const specificKeyMap: Map<NamedNode, string> = new TermMap<NamedNode, string>([
     [named, 'foo']
 ]);
 
+class FooFactory {
+    init() {}
+}
+
 const exports: ['termMap'] = Factory.exports;
-const factory = new Factory();
+const factory = new Environment([Factory, FooFactory]);
 let fromFactory: Map<NamedNode, number> = factory.termMap();
 fromFactory = factory.termMap([
     [named, 5]

--- a/types/rdfjs__term-set/rdfjs__term-set-tests.ts
+++ b/types/rdfjs__term-set/rdfjs__term-set-tests.ts
@@ -1,3 +1,4 @@
+import Environment from '@rdfjs/environment/Environment.js';
 import TermSet from '@rdfjs/term-set';
 import Factory from '@rdfjs/term-set/Factory';
 import { Term } from '@rdfjs/types';
@@ -7,5 +8,11 @@ const type2: Term = <any> {};
 
 const set: Set<Term> = new TermSet([type1, type2]);
 
+class FooFactory {
+    init() {}
+}
+
+const env = new Environment([Factory, FooFactory]);
+
 const exports: ['termSet'] = Factory.exports;
-const fromFactory: Set<Term> = new Factory().termSet([type1, type2]);
+const fromFactory: Set<Term> = env.termSet([type1, type2]);

--- a/types/rdfjs__traverser/rdfjs__traverser-tests.ts
+++ b/types/rdfjs__traverser/rdfjs__traverser-tests.ts
@@ -9,7 +9,11 @@ function filter(arg: { dataset: DatasetCore; quad: Quad; level: number }): boole
     return true;
 }
 
-const env = new Environment([TraverserFactory]);
+class FooFactory {
+    init() {}
+}
+
+const env = new Environment([TraverserFactory, FooFactory]);
 let traverser = env.traverser(filter);
 
 traverser = new Traverser(filter);


### PR DESCRIPTION
I found that when the factories used with RDF/JS Environment have the `init` and `clone` methods somehow they interfer with the others and some methods disappear when used together with any environment which has **only** `init`

I removed `init` and `clone` where there existed in factories and added relevant test in every package which exports a factory

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
