### PR TITLE
Create umami-browser type definitions

### DIFF
--- a/types/umami-browser/index.d.ts
+++ b/types/umami-browser/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for non-npm package umami-browser 2.3
+// Project: https://github.com/umami-software/umami
+// Definitions by: Christian Rackerseder <https://github.com/screendriver>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var umami: umami.umami;
+
+declare namespace umami {
+    interface TrackPayload {
+        website: string;
+        hostname?: string;
+        language?: string;
+        referrer?: string;
+        screen?: string;
+        title?: string;
+        url?: string;
+    }
+
+    interface umami {
+        track(payloadOrCallback?: TrackPayload | ((properties: TrackPayload) => TrackPayload)): void;
+        track(eventName?: string, eventData?: Record<string, unknown>): void;
+    }
+}

--- a/types/umami-browser/tsconfig.json
+++ b/types/umami-browser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "umami-browser-tests.ts"
+    ]
+}

--- a/types/umami-browser/tslint.json
+++ b/types/umami-browser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/umami-browser/umami-browser-tests.ts
+++ b/types/umami-browser/umami-browser-tests.ts
@@ -1,0 +1,17 @@
+umami.track();
+
+umami.track({ website: '' });
+umami.track({ website: '', hostname: '' });
+umami.track({ website: '', language: '' });
+umami.track({ website: '', referrer: '' });
+umami.track({ website: '', screen: '' });
+umami.track({ website: '', title: '' });
+umami.track({ website: '', url: '' });
+
+umami.track(properties => {
+    return { ...properties, url: '', title: '' };
+});
+
+umami.track('custom_event');
+
+umami.track('custom_event', { name: 'newsletter', id: 123 });


### PR DESCRIPTION
Umami defines a global "window.umami" object that is able to track events manually on user interactions (https://umami.is/docs/track-events)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
