### PR TITLE
@rdfjs/environment: some factories broke environment type

### DIFF
--- a/types/rdfjs__environment/Environment.d.ts
+++ b/types/rdfjs__environment/Environment.d.ts
@@ -13,10 +13,10 @@ export type Environment<T> = {
     clone(): Environment<T>
 } & Omit<{
     [K in keyof UnionToIntersection<T>]: UnionToIntersection<T>[K]
-}, 'init'>;
+}, 'init' | 'clone'>;
 
 interface EnvironmentCtor {
-    new<F extends FactoryConstructor>(factories: F[], options?: { bind: boolean }): Environment<Distribute<F>>;
+    new<const F extends ReadonlyArray<FactoryConstructor<any>>>(factories: F, options?: { bind: boolean }): Environment<Distribute<F[number]>>;
 }
 
 declare const environment: EnvironmentCtor;

--- a/types/rdfjs__environment/Environment.d.ts
+++ b/types/rdfjs__environment/Environment.d.ts
@@ -1,9 +1,13 @@
 interface FactoryConstructor<F = {}> {
     new (...args: any[]): F;
-    exports?: string[];
 }
 
-type ReturnFactory<C> = C extends FactoryConstructor<infer X> ? X : never;
+type Narrow<T> =
+    | (T extends infer U ? U : never)
+    | Extract<T, number | string | boolean | bigint | symbol | null | undefined | []>
+    | ([T] extends [[]] ? [] : { [K in keyof T]: Narrow<T[K]> });
+
+type ReturnFactory<C> = C extends FactoryConstructor<infer X> ? X : C;
 type Distribute<U> = U extends any ? ReturnFactory<U> : never;
 
 type UnionToIntersection<U> =
@@ -11,12 +15,10 @@ type UnionToIntersection<U> =
 
 export type Environment<T> = {
     clone(): Environment<T>
-} & Omit<{
-    [K in keyof UnionToIntersection<T>]: UnionToIntersection<T>[K]
-}, 'init' | 'clone'>;
+} & Omit<UnionToIntersection<T>, 'init' | 'clone'>;
 
 interface EnvironmentCtor {
-    new<const F extends ReadonlyArray<FactoryConstructor<any>>>(factories: F, options?: { bind: boolean }): Environment<Distribute<F[number]>>;
+    new<F extends ReadonlyArray<FactoryConstructor<any>>>(factories: Narrow<F>, options?: { bind: boolean }): Environment<Distribute<F[number]>>;
 }
 
 declare const environment: EnvironmentCtor;

--- a/types/rdfjs__environment/rdfjs__environment-tests.ts
+++ b/types/rdfjs__environment/rdfjs__environment-tests.ts
@@ -82,7 +82,7 @@ function formatsImport() {
 class InitOnly {
     init() {}
     clone(): InitOnly {
-        return this
+        return this;
     }
 }
 const envOneFactoryInitOnly = new Environment([

--- a/types/rdfjs__environment/rdfjs__environment-tests.ts
+++ b/types/rdfjs__environment/rdfjs__environment-tests.ts
@@ -78,3 +78,16 @@ function formatsImport() {
 
     env.formats.import(formatsCommon);
 }
+
+class InitOnly {
+    init() {}
+    clone(): InitOnly {
+        return this
+    }
+}
+const envOneFactoryInitOnly = new Environment([
+    FormatsFactory,
+    InitOnly,
+]);
+
+envOneFactoryInitOnly.formats.import(envOneFactoryInitOnly.formats);


### PR DESCRIPTION
This fixes a problem I found that when the factories used with RDF/JS Environment have the `init` and `clone` methods somehow they interfere with the others and some methods disappear when used together with any environment which has **only** `init`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://discord.com/channels/508357248330760243/1128405219680735242>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
