### PR TITLE
fix(toastify-js): Add missing `ariaLive` option

### DIFF
--- a/types/toastify-js/index.d.ts
+++ b/types/toastify-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for toastify-js 1.11
+// Type definitions for toastify-js 1.12
 // Project: https://github.com/apvarun/toastify-js#readme
 // Definitions by: adblanc <https://github.com/adblanc>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -21,6 +21,11 @@ declare namespace StartToastifyInstance {
         close?: boolean | undefined;
         gravity?: 'top' | 'bottom' | undefined;
         position?: 'left' | 'center' | 'right' | undefined;
+        /**
+         * Announce the toast to screen readers
+         * @default 'polite'
+         */
+        ariaLive?: 'off' | 'polite' | 'assertive' | undefined;
         /**
          * @deprecated use style.background option instead
          */

--- a/types/toastify-js/toastify-js-tests.ts
+++ b/types/toastify-js/toastify-js-tests.ts
@@ -19,6 +19,7 @@ Toastify({
     text: 'This is a toast',
     backgroundColor: 'linear-gradient(to right, #00b09b, #96c93d)',
     className: 'info',
+    ariaLive: 'assertive',
 }).showToast();
 
 Toastify({


### PR DESCRIPTION
Update `toastify-js` type for 1.12 where `ariaLive` option was added, see commit: https://github.com/apvarun/toastify-js/commit/e94359e6ba58dfdf3bbb47de69e6ae32e925095f

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apvarun/toastify-js/commit/e94359e6ba58dfdf3bbb47de69e6ae32e925095f
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
