### PR TITLE
fix(@types/keychain): Callback for setPassword is optional

### DIFF
--- a/types/keychain/index.d.ts
+++ b/types/keychain/index.d.ts
@@ -34,7 +34,7 @@ declare function getPassword(
 
 declare function setPassword(
     options: keychainTypes.KeyChainBaseOptions,
-    callback: (err: keychainTypes.KeychainError) => void,
+    callback?: (err: keychainTypes.KeychainError) => void,
 ): void;
 
 declare function deletePassword(

--- a/types/keychain/keychain-tests.ts
+++ b/types/keychain/keychain-tests.ts
@@ -5,20 +5,15 @@ import keychain = require('keychain');
  */
 
 // @ts-expect-error
-// Errors when doesn't have the required properties
-keychain.setPassword({ account: 'some-account' }, err => {
-    if (err) {
-        err; // $ExpectType KeychainError
-    }
-});
-
-// @ts-expect-error
 // Another error when missing options
 keychain.setPassword({ account: 'some-account', password: 'some-pass' }, err => {
     if (err) {
         err; // $ExpectType KeychainError
     }
 });
+
+// Should pass
+keychain.setPassword({ account: 'some-account', password: 'some-pass', service: 'some-service' });
 
 // Should pass
 keychain.setPassword({ account: 'some-account', password: 'some-pass', service: 'some-service' }, err => {


### PR DESCRIPTION
The callback method for the setPassword function is optional.

Based on package [documentation](https://github.com/drudge/node-keychain#usage)