### PR TITLE
[node] Update `fs.createReadStream` and `fs.createWriteStream` options

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3618,15 +3618,28 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+        signal?: AbortSignal | null | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 KiB default `highWaterMark` for a `stream.Readable`, the stream
@@ -3720,7 +3733,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -526,6 +526,7 @@ async () => {
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createWriteStream('./index.d.ts', { fs: { write: fs.write }, signal: new AbortSignal() });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
@@ -534,6 +535,7 @@ async () => {
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createReadStream('./index.d.ts', { fs: { read: fs.read }, signal: new AbortSignal() });
 }
 
 async () => {

--- a/types/node/ts4.8/fs.d.ts
+++ b/types/node/ts4.8/fs.d.ts
@@ -3618,15 +3618,28 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+        signal?: AbortSignal | null | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 KiB default `highWaterMark` for a `stream.Readable`, the stream
@@ -3720,7 +3733,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -2071,41 +2071,47 @@ declare module 'fs' {
      */
     export function accessSync(path: PathLike, mode?: number): void;
 
-    /**
-     * Returns a new `ReadStream` object.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * URL support is _experimental_.
-     */
-    export function createReadStream(path: PathLike, options?: BufferEncoding | {
+    interface StreamOptions {
         flags?: string | undefined;
         encoding?: BufferEncoding | undefined;
         fd?: number | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
+    }
+    interface FSImplementation {
+        open: (...args: any[]) => any;
+        close: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
+    }
+    interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
         highWaterMark?: number | undefined;
-    }): ReadStream;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
+    }
+    /**
+     * Returns a new `ReadStream` object.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    export function createReadStream(path: PathLike, options?: BufferEncoding | ReadStreamOptions): ReadStream;
 
     /**
      * Returns a new `WriteStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | {
-        flags?: string | undefined;
-        encoding?: BufferEncoding | undefined;
-        fd?: number | undefined;
-        mode?: number | undefined;
-        autoClose?: boolean | undefined;
-        emitClose?: boolean | undefined;
-        start?: number | undefined;
-        highWaterMark?: number | undefined;
-    }): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
 
     /**
      * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -428,6 +428,7 @@ async () => {
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createWriteStream('./index.d.ts', { fs: { write: fs.write, open: fs.open, close: fs.close } });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
@@ -436,6 +437,7 @@ async () => {
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createReadStream('./index.d.ts', { fs: { read: fs.read, open: fs.open, close: fs.close } });
 }
 
 {

--- a/types/node/v14/ts4.8/fs.d.ts
+++ b/types/node/v14/ts4.8/fs.d.ts
@@ -2071,41 +2071,47 @@ declare module 'fs' {
      */
     export function accessSync(path: PathLike, mode?: number): void;
 
+    interface StreamOptions {
+        flags?: string | undefined;
+        encoding?: BufferEncoding | null | undefined;
+        fd?: number | promises.FileHandle | null | undefined;
+        mode?: number | undefined;
+        autoClose?: boolean | undefined;
+        emitClose?: boolean | undefined;
+        start?: number | undefined;
+    }
+    interface FSImplementation {
+        open: (...args: any[]) => any;
+        close: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
+    }
+    interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
+        end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
+    }
     /**
      * Returns a new `ReadStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createReadStream(path: PathLike, options?: BufferEncoding | {
-        flags?: string | undefined;
-        encoding?: BufferEncoding | undefined;
-        fd?: number | undefined;
-        mode?: number | undefined;
-        autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
-        emitClose?: boolean | undefined;
-        start?: number | undefined;
-        end?: number | undefined;
-        highWaterMark?: number | undefined;
-    }): ReadStream;
+    export function createReadStream(path: PathLike, options?: BufferEncoding | ReadStreamOptions): ReadStream;
 
     /**
      * Returns a new `WriteStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | {
-        flags?: string | undefined;
-        encoding?: BufferEncoding | undefined;
-        fd?: number | undefined;
-        mode?: number | undefined;
-        autoClose?: boolean | undefined;
-        emitClose?: boolean | undefined;
-        start?: number | undefined;
-        highWaterMark?: number | undefined;
-    }): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
 
     /**
      * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/v16/fs.d.ts
+++ b/types/node/v16/fs.d.ts
@@ -3397,15 +3397,27 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 kb default `highWaterMark` for a `stream.Readable`, the stream
@@ -3499,7 +3511,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -506,6 +506,7 @@ async () => {
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createWriteStream('./index.d.ts', { fs: { write: fs.write } });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
@@ -514,6 +515,7 @@ async () => {
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createReadStream('./index.d.ts', { fs: { read: fs.read } });
 }
 
 async () => {

--- a/types/node/v16/ts4.8/fs.d.ts
+++ b/types/node/v16/ts4.8/fs.d.ts
@@ -2839,6 +2839,7 @@ declare module 'fs' {
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * @param listener The callback listener will be called each time the file is accessed.
      */
     export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
@@ -3396,15 +3397,27 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 kb default `highWaterMark` for a `stream.Readable`, the stream
@@ -3498,7 +3511,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -3577,15 +3577,27 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 kb default `highWaterMark` for a `stream.Readable`, the stream
@@ -3679,7 +3691,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/node/v18/test/fs.ts
+++ b/types/node/v18/test/fs.ts
@@ -523,6 +523,7 @@ async () => {
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createWriteStream('./index.d.ts', { fs: { write: fs.write } });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
@@ -531,6 +532,7 @@ async () => {
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
     // @ts-expect-error
     fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
+    fs.createReadStream('./index.d.ts', { fs: { read: fs.read } });
 }
 
 async () => {

--- a/types/node/v18/ts4.8/fs.d.ts
+++ b/types/node/v18/ts4.8/fs.d.ts
@@ -3577,15 +3577,27 @@ declare module 'fs' {
         fd?: number | promises.FileHandle | undefined;
         mode?: number | undefined;
         autoClose?: boolean | undefined;
-        /**
-         * @default false
-         */
         emitClose?: boolean | undefined;
         start?: number | undefined;
-        highWaterMark?: number | undefined;
+    }
+    interface FSImplementation {
+        open?: (...args: any[]) => any;
+        close?: (...args: any[]) => any;
+    }
+    interface CreateReadStreamFSImplementation extends FSImplementation {
+        read: (...args: any[]) => any;
+    }
+    interface CreateWriteStreamFSImplementation extends FSImplementation {
+        write: (...args: any[]) => any;
+        writev?: (...args: any[]) => any;
     }
     interface ReadStreamOptions extends StreamOptions {
+        fs?: CreateReadStreamFSImplementation | null | undefined;
         end?: number | undefined;
+        highWaterMark?: number | undefined;
+    }
+    interface WriteStreamOptions extends StreamOptions {
+        fs?: CreateWriteStreamFSImplementation | null | undefined;
     }
     /**
      * Unlike the 16 kb default `highWaterMark` for a `stream.Readable`, the stream
@@ -3679,7 +3691,7 @@ declare module 'fs' {
      * If `options` is a string, then it specifies the encoding.
      * @since v0.1.31
      */
-    export function createWriteStream(path: PathLike, options?: BufferEncoding | StreamOptions): WriteStream;
+    export function createWriteStream(path: PathLike, options?: BufferEncoding | WriteStreamOptions): WriteStream;
     /**
      * Forces all currently queued I/O operations associated with the file to the
      * operating system's synchronized I/O completion state. Refer to the POSIX [`fdatasync(2)`](http://man7.org/linux/man-pages/man2/fdatasync.2.html) documentation for details. No arguments other

--- a/types/write/write-tests.ts
+++ b/types/write/write-tests.ts
@@ -44,4 +44,4 @@ data;
 // $ExpectType WriteStream
 write.stream("1.txt");
 
-write.stream("1.txt", { highWaterMark: 8, overwrite: true });
+write.stream("1.txt", { overwrite: true });


### PR DESCRIPTION
Fixed #66037

Doc:
- https://nodejs.org/docs/latest-v20.x/api/fs.html#fscreatereadstreampath-options
- https://nodejs.org/docs/latest-v20.x/api/fs.html#fscreatewritestreampath-options
