### PR TITLE
[node:test] add setup and watch for RunOptions

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -76,10 +76,11 @@
  *
  * If any tests fail, the process exit code is set to `1`.
  * @since v18.0.0, v16.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.2.0/lib/test.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.4.0/lib/test.js)
  */
 declare module 'node:test' {
     import { Readable } from 'node:stream';
+    import { AsyncResource } from 'node:async_hooks';
     /**
      * ```js
      * import { tap } from 'node:test/reporters';
@@ -295,6 +296,23 @@ declare module 'node:test' {
          * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
+         * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
+         */
+        setup?: (root: Test) => void | Promise<void>;
+        /**
+         * Whether to run in watch mode or not. Default: false.
+         */
+        watch?: boolean;
+    }
+    class Test extends AsyncResource {
+        concurrency: number;
+        nesting: number;
+        only: boolean;
+        reporter: TestsStream;
+        runOnlySubtests: boolean;
+        testNumber: number;
+        timeout: number | null;
     }
     /**
      * A successful call to `run()` method will return a new `TestsStream` object, streaming a series of events representing the execution of the tests.`TestsStream` will emit events, in the

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -20,6 +20,8 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ['executed'],
+    setup: (root) => {},
+    watch: true
 });
 
 // TestsStream should be a NodeJS.ReadableStream

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -80,6 +80,7 @@
  */
 declare module 'node:test' {
     import { Readable } from 'node:stream';
+    import { AsyncResource } from 'node:async_hooks';
     /**
      * ```js
      * import { tap } from 'node:test/reporters';
@@ -295,6 +296,23 @@ declare module 'node:test' {
          * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
+         * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
+         */
+        setup?: (root: unknown) => void | Promise<void>;
+        /**
+         * Whether to run in watch mode or not. Default: false.
+         */
+        watch?: boolean;
+    }
+    class Test extends AsyncResource {
+        concurrency: number;
+        nesting: number;
+        only: boolean;
+        reporter: TestsStream;
+        runOnlySubtests: boolean;
+        testNumber: number;
+        timeout: number | null;
     }
     /**
      * A successful call to `run()` method will return a new `TestsStream` object, streaming a series of events representing the execution of the tests.`TestsStream` will emit events, in the

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -20,6 +20,8 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ['executed'],
+    setup: (root) => {},
+    watch: true
 });
 
 // TestsStream should be a NodeJS.ReadableStream

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -3,6 +3,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/test.js)
  */
 declare module 'node:test' {
+    import { AsyncResource } from 'node:async_hooks';
     /**
      * Programmatically start the test runner.
      * @since v18.9.0
@@ -178,6 +179,19 @@ declare module 'node:test' {
          * incremented from the primary's `process.debugPort`.
          */
         inspectPort?: number | (() => number) | undefined;
+        /**
+         * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
+         */
+        setup?: (root: Test) => void | Promise<void>;
+    }
+    class Test extends AsyncResource {
+        concurrency: number;
+        nesting: number;
+        only: boolean;
+        reporter: TestsStream;
+        runOnlySubtests: boolean;
+        testNumber: number;
+        timeout: number | null;
     }
 
     /**

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -18,6 +18,7 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    setup: (root) => {},
 });
 
 // TestsStream should be a NodeJS.ReadableStream


### PR DESCRIPTION
- add `setup` and `watch` options

The implementation of the setup function includes arguments, but the Node.js documentation does not provide any description of the argument types.
https://nodejs.org/docs/latest-v20.x/api/test.html#runoptions
https://github.com/nodejs/node/blob/v20.4.0/lib/internal/test_runner/runner.js#L510
https://github.com/nodejs/node/blob/v20.4.0/lib/internal/test_runner/harness.js#L29-L31

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/docs/latest-v20.x/api/test.html#runoptions>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
