### PR TITLE
[@types/node-forge] - change return type of publicKeyFromAsn1() and privateKeyFromAsn1()

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -679,11 +679,11 @@ declare module 'node-forge' {
 
         function encryptRsaPrivateKey(privateKey: PrivateKey, password: string, options?: EncryptionOptions): PEM;
 
-        function privateKeyFromAsn1(privateKey: asn1.Asn1): PrivateKey;
+        function privateKeyFromAsn1(privateKey: asn1.Asn1): rsa.PrivateKey;
 
         function privateKeyToAsn1(privateKey: PrivateKey): asn1.Asn1;
 
-        function publicKeyFromAsn1(publicKey: asn1.Asn1): PublicKey;
+        function publicKeyFromAsn1(publicKey: asn1.Asn1): rsa.PublicKey;
 
         function publicKeyToAsn1(publicKey: PublicKey): asn1.Asn1;
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -15,13 +15,17 @@ forge.pki.setRsaPrivateKey(
 );
 let privateKeyPem = forge.pki.privateKeyToPem(keypair.privateKey);
 let publicKeyPem = forge.pki.publicKeyToPem(keypair.publicKey);
+let privateKeyAsn1 = forge.pki.privateKeyToAsn1(keypair.privateKey);
+let publicKeyAsn1 = forge.pki.publicKeyToAsn1(keypair.publicKey);
 let publicKeyRSAPem: forge.pki.PEM = forge.pki.publicKeyToRSAPublicKeyPem(keypair.publicKey);
 let key = forge.pki.decryptRsaPrivateKey(privateKeyPem);
 let x: string = forge.ssh.privateKeyToOpenSSH(key);
 let pemKey: forge.pki.PEM = publicKeyPem;
 let publicKeyRsa = forge.pki.publicKeyFromPem(pemKey);
 let publicKeyFromRsaPem = forge.pki.publicKeyFromPem(publicKeyRSAPem);
+let publicKeyFromAsn1 = forge.pki.publicKeyFromAsn1(publicKeyAsn1);
 let privateKeyRsa = forge.pki.privateKeyFromPem(privateKeyPem);
+let privateKeyFromAsn1 = forge.pki.privateKeyFromAsn1(privateKeyAsn1);
 let byteBufferString = forge.pki.pemToDer(privateKeyPem);
 let cert = forge.pki.createCertificate();
 cert.publicKey = keypair.publicKey;
@@ -779,6 +783,14 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     let plainText = 'content';
     let cipher = publicKeyRsa.encrypt(plainText);
     let result = privateKeyRsa.decrypt(cipher);
+    if (result !== plainText) {
+        throw new Error('decrypt result not match');
+    }
+}
+{
+    let plainText = 'content';
+    let cipher = publicKeyFromAsn1.encrypt(plainText);
+    let result = privateKeyFromAsn1.decrypt(cipher);
     if (result !== plainText) {
         throw new Error('decrypt result not match');
     }


### PR DESCRIPTION
#45292 fixes `publicKeyFromPem()` and `privateKeyFromPem()`, but doesn't address `publicKeyFromAsn1()` and `privateKeyFromAsn1()`.
This PR aims to fix the return type definitions of `publicKeyFromAsn1()` and `privateKeyFromAsn1()`.

Related to #38541, especially [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38541#issuecomment-607791831).

Notes:
- [`privateKeyFromPem()`](https://github.com/digitalbazaar/forge/blob/v1.3.1/lib/pki.js#L51-L68) returns `privateKeyFromAsn1()` internally so the return types should be the same.
- [`publicKeyFromPem()`](https://github.com/digitalbazaar/forge/blob/v1.3.1/lib/x509.js#L849-L866) returns `publicKeyFromAsn1()` internally so the return types should be the same.
- There are 43 `no-outside-dependencies` errors when running `npm test node-forge`. This issue persists even in the latest version.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see the description of this PR
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
