### PR TITLE
 fix(maxmsp): some file constructor parameters are optional

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -236,7 +236,7 @@ declare class File {
      * which is located at /Library/Application Support/Cycling ’74 on Macintosh and C:\Program Files\Common Files\Cycling ’74 on Windows. By default, typelist is empty.
      * If able to, the File constructor opens the file specified by filename, provided it is one of the types in typelist.
      */
-    constructor(filename: string, access: string, typelist: string);
+    constructor(filename: string, access?: 'read' | 'write' | 'readwrite', typelist?: string);
 
     /**
      * File access permissions: "read", "write", or "readwrite". By default, this value is "read".
@@ -309,7 +309,7 @@ declare class File {
      * Reads and returns a string containing up to maximum_count characters or up to the first line break as read from the file,
      *  starting at the current file position. The file position is updated accordingly.
      */
-    readline(maximum_count: number): string;
+    readline(maximum_count?: number): string;
 
     /**
      * Writes the characters contained in the string argument as characters to the file, starting at the current file position.

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -24,9 +24,14 @@ const colorValue = myDict.get('color');
 const keys = myDict.getkeys();
 
 // File usage example
-const file = new File('test.txt', 'write', 'TEXT');
+let file = new File('test.txt', 'write', 'TEXT');
 file.writeline('This is a test.');
 file.writestring('Some random text.');
+file.close();
+
+file = new File('test.txt');
+file.readline();
+file.readline(2);
 file.close();
 
 // Folder usage example


### PR DESCRIPTION
Certain parameters are optional.
- Based on function description, see above
- tested on max too