### PR TITLE
Add dnsTimeout to SMTPConnection.options

### DIFF
--- a/types/nodemailer/lib/smtp-connection/index.d.ts
+++ b/types/nodemailer/lib/smtp-connection/index.d.ts
@@ -153,6 +153,8 @@ declare namespace SMTPConnection {
         greetingTimeout?: ms | undefined;
         /** how many milliseconds of inactivity to allow */
         socketTimeout?: ms | undefined;
+        /** how many milliseconds to wait for the DNS requests to be resolved */
+        dnsTimeout?: ms | undefined;
         /** optional bunyan compatible logger instance. If set to true then logs to console. If value is not set or is false then nothing is logged */
         logger?: shared.Logger | boolean | undefined;
         /** if set to true, then logs SMTP traffic without message content */


### PR DESCRIPTION
Add dnsTimeout to SMTPConnection.options
This is aligned with the documentation in: https://nodemailer.com/extras/smtp-connection/

Please fill in this template.

- [ V] Use a meaningful title for the pull request. Include the name of the package modified.
- [ V] Test the change in your own code. (Compile and run.)

If adding a new definition:

If changing an existing definition:
- [V ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>