### PR TITLE
Add `toHaveAccessibleErrorMessage` to `@testing-library/jest-dom` Types

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -17,6 +17,6 @@ declare global {
     }
 }
 
-declare module "expect" {
+declare module 'expect' {
     interface Matchers<R = void, T = unknown> extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
 }

--- a/types/testing-library__jest-dom/matchers.d.ts
+++ b/types/testing-library__jest-dom/matchers.d.ts
@@ -503,6 +503,47 @@ declare namespace matchers {
          * [testing-library/jest-dom#tohaveaccessibledescription](https://github.com/testing-library/jest-dom#tohaveaccessibledescription)
          */
         toHaveAccessibleDescription(text?: string | RegExp | E): R;
+
+        /**
+         * @description
+         * This allows you to assert that an element has the expected
+         * [accessible error message](https://w3c.github.io/aria/#aria-errormessage).
+         *
+         * You can pass the exact string of the expected accessible error message.
+         * Alternatively, you can perform a partial match by passing a regular expression
+         * or by using either
+         * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring)
+         * or [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+         *
+         * @example
+         * <input aria-label="Has Error" aria-invalid="true" aria-errormessage="error-message" />
+         * <div id="error-message" role="alert">This field is invalid</div>
+         *
+         * <input aria-label="No Error Attributes" />
+         * <input aria-label="Not Invalid" aria-invalid="false" aria-errormessage="error-message" />
+         *
+         * // Inputs with Valid Error Messages
+         * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage()
+         * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage('This field is invalid')
+         * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage(/invalid/i)
+         * expect(
+         *   getByRole('textbox', {name: 'Has Error'}),
+         * ).not.toHaveAccessibleErrorMessage('This field is absolutely correct!')
+         *
+         * // Inputs without Valid Error Messages
+         * expect(
+         *   getByRole('textbox', {name: 'No Error Attributes'}),
+         * ).not.toHaveAccessibleErrorMessage()
+         *
+         * expect(
+         *   getByRole('textbox', {name: 'Not Invalid'}),
+         * ).not.toHaveAccessibleErrorMessage()
+         *
+         * @see
+         * [testing-library/jest-dom#tohaveaccessibleerrormessage](https://github.com/testing-library/jest-dom#tohaveaccessibleerrormessage)
+         */
+        toHaveAccessibleErrorMessage(text?: string | RegExp | E): R;
+
         /**
          * @description
          * This allows to assert that an element has the expected [accessible name](https://w3c.github.io/accname/).
@@ -573,8 +614,10 @@ declare namespace matchers {
          */
         toBePartiallyChecked(): R;
         /**
-         * @description
+         * @deprecated
+         * since v5.17.0
          *
+         * @description
          * Check whether the given element has an [ARIA error message](https://www.w3.org/TR/wai-aria/#aria-errormessage) or not.
          *
          * Use the `aria-errormessage` attribute to reference another element that contains

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-extend-matchers-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-extend-matchers-tests.ts
@@ -56,6 +56,12 @@ customExpect(element).toHaveAccessibleDescription('some description');
 customExpect(element).toHaveAccessibleDescription(/some description/);
 customExpect(element).toHaveAccessibleDescription(expect.stringContaining('partial'));
 customExpect(element).toHaveAccessibleDescription();
+
+customExpect(element).toHaveAccessibleErrorMessage();
+customExpect(element).toHaveAccessibleErrorMessage('Invalid time: the time must be between 9:00 AM and 5:00 PM');
+customExpect(element).toHaveAccessibleErrorMessage(/invalid time/i);
+customExpect(element).toHaveAccessibleErrorMessage(expect.stringContaining('Invalid time'));
+
 customExpect(element).toHaveAccessibleName('a label');
 customExpect(element).toHaveAccessibleName(/a label/);
 customExpect(element).toHaveAccessibleName(expect.stringContaining('partial label'));
@@ -105,6 +111,11 @@ customExpect(element).not.toHaveDescription('some description');
 customExpect(element).not.toHaveDescription();
 customExpect(element).not.toHaveAccessibleDescription('some description');
 customExpect(element).not.toHaveAccessibleDescription();
+
+customExpect(element).not.toHaveAccessibleErrorMessage();
+customExpect(element).not.toHaveAccessibleErrorMessage('There is no date');
+customExpect(element).not.toHaveAccessibleErrorMessage(/everything is valid/i);
+
 customExpect(element).not.toHaveAccessibleName('a label');
 customExpect(element).not.toHaveAccessibleName();
 customExpect(element).not.toBePartiallyChecked();


### PR DESCRIPTION
~~Will circle back to the checklist tomorrow.~~

Created in response to (and thus depends on):
- testing-library/jest-dom#503

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes (see above)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. ~~(Waiting for other PR to be merged first.)~~
   - New library version is mentioned in the JSDocs.
