### PR TITLE
dagre: change isMultiGraph to isMultigraph for graphlib Graph

### DIFF
--- a/types/dagre/index.d.ts
+++ b/types/dagre/index.d.ts
@@ -15,7 +15,7 @@ export namespace graphlib {
 
         graph(): GraphLabel;
         isDirected(): boolean;
-        isMultiGraph(): boolean;
+        isMultigraph(): boolean;
         setGraph(label: GraphLabel): Graph<T>;
 
         edge(edgeObj: Edge): GraphEdge;


### PR DESCRIPTION
declaration of isMultigraph in graphlib source:
https://github.com/dagrejs/graphlib/blob/master/lib/graph.js#L91