### PR TITLE
fix(react-input-mask): change children type

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -9,58 +9,59 @@
 import * as React from 'react';
 
 export interface Selection {
-  start: number;
-  end: number;
+    start: number;
+    end: number;
 }
 
 export interface InputState {
-  value: string;
-  selection: Selection | null;
+    value: string;
+    selection: Selection | null;
 }
 
 export interface BeforeMaskedStateChangeStates {
-  previousState: InputState;
-  currentState: InputState;
-  nextState: InputState;
+    previousState: InputState;
+    currentState: InputState;
+    nextState: InputState;
 }
 
 export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
-  /**
-   * Mask string. Format characters are:
-   * * `9`: `0-9`
-   * * `a`: `A-Z, a-z`
-   * * `\*`: `A-Z, a-z, 0-9`
-   *
-   * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
-   * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
-   */
-  mask: string | Array<(string | RegExp)>;
-  /**
-   * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
-   */
-  maskChar?: string | null | undefined;
-  maskPlaceholder?: string | null | undefined;
-  /**
-   * Show mask even in empty input without focus.
-   */
-  alwaysShowMask?: boolean | undefined;
-  /**
-   * Use inputRef instead of ref if you need input node to manage focus, selection, etc.
-   */
-  inputRef?: React.Ref<HTMLInputElement> | undefined;
-  /**
-   * In case you need to implement more complex masking behavior, you can provide
-   * beforeMaskedStateChange function to change masked value and cursor position
-   * before it will be applied to the input.
-   *
-   * * previousState: Input state before change. Only defined on change event.
-   * * currentState: Current raw input state. Not defined during component render.
-   * * nextState: Input state with applied mask. Contains value and selection fields.
-   */
-  beforeMaskedStateChange?(states: BeforeMaskedStateChangeStates): InputState;
+    /**
+     * Mask string. Format characters are:
+     * * `9`: `0-9`
+     * * `a`: `A-Z, a-z`
+     * * `\*`: `A-Z, a-z, 0-9`
+     *
+     * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
+     * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
+     */
+    mask: string | Array<string | RegExp>;
+    /**
+     * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
+     */
+    maskChar?: string | null | undefined;
+    maskPlaceholder?: string | null | undefined;
+    /**
+     * Show mask even in empty input without focus.
+     */
+    alwaysShowMask?: boolean | undefined;
+    /**
+     * Use inputRef instead of ref if you need input node to manage focus, selection, etc.
+     */
+    inputRef?: React.Ref<HTMLInputElement> | undefined;
+    /**
+     * In case you need to implement more complex masking behavior, you can provide
+     * beforeMaskedStateChange function to change masked value and cursor position
+     * before it will be applied to the input.
+     *
+     * * previousState: Input state before change. Only defined on change event.
+     * * currentState: Current raw input state. Not defined during component render.
+     * * nextState: Input state with applied mask. Contains value and selection fields.
+     */
+    beforeMaskedStateChange?(states: BeforeMaskedStateChangeStates): InputState;
+
+    children?: (props: React.InputHTMLAttributes<HTMLInputElement>) => JSX.Element | React.ReactNode;
 }
 
-export class ReactInputMask extends React.Component<Props> {
-}
+export class ReactInputMask extends React.Component<Props> {}
 
 export default ReactInputMask;


### PR DESCRIPTION
This PR extends the `ReactInputMask` inteface by adding a `children` field.

P.S. Is it possible to change interfaces into types? I don't know how to override `children` field using an extended interface and avoid package's `tslint` errors simultaneously.

Error: 
```
Interface 'Props' incorrectly extends interface 'InputHTMLAttributes<HTMLInputElement>'.
  Types of property 'children' are incompatible.
    Type '((props: InputHTMLAttributes<HTMLInputElement>) => ReactNode | Element) | ReactNode' is not assignable to type 'ReactNode'.
      Type '(props: InputHTMLAttributes<HTMLInputElement>) => ReactNode | Element' is not assignable to type 'ReactNode'.ts(2430)
```
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).