### PR TITLE
fix: bare-module import

### DIFF
--- a/types/rdfjs__environment/index.d.ts
+++ b/types/rdfjs__environment/index.d.ts
@@ -4,4 +4,6 @@
 //                 Jesse Wright <https://github.com/jeswr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export {};
+import { default as Environment } from './Environment.js';
+
+export default Environment;

--- a/types/rdfjs__environment/rdfjs__environment-tests.ts
+++ b/types/rdfjs__environment/rdfjs__environment-tests.ts
@@ -1,5 +1,5 @@
 import { NamedNode, Stream } from '@rdfjs/types';
-import Environment from '@rdfjs/environment/Environment.js';
+import Environment from '@rdfjs/environment';
 import FormatsFactory from '@rdfjs/environment/FormatsFactory.js';
 import NamespaceFactory from '@rdfjs/environment/NamespaceFactory.js';
 import TermMapSetFactory from '@rdfjs/environment/TermMapSetFactory.js';


### PR DESCRIPTION
I don't know if this is the right thing to do. `@rdfjs/environment` uses `Environment.js` as its default module. I don't know if there was a better way to reflect that in types package so I simply faked the `index.d.ts` to have it resolved when importing from the package name only

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdfjs-base/environment/blob/master/package.json#L6>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
