### PR TITLE
Mapbox-GL: update Fog interface with missing options

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -598,7 +598,11 @@ declare namespace mapboxgl {
         touchPitch: TouchPitchHandler;
 
         getFog(): Fog | null;
-        setFog(fog: Fog): this;
+        /**
+         * @param fog If `null` or `undefined` is provided, function removes fog from
+         * the map.
+         */
+        setFog(fog: Fog | null | undefined): this;
 
         getProjection(): Projection;
         setProjection(projection: Projection | string): this;
@@ -1340,6 +1344,9 @@ declare namespace mapboxgl {
         color?: string | Expression | undefined;
         'horizon-blend'?: number | Expression | undefined;
         range?: number[] | Expression | undefined;
+        'high-color'?: string | Expression | undefined;
+        'space-color'?: string | Expression | undefined;
+        'star-intensity'?: number | Expression | undefined;
     }
 
     export interface Sources {

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1006,6 +1006,23 @@ map.getMinPitch();
 // $ExpectType number
 map.getMaxPitch();
 
+// $ExpectType Map
+map.setFog({
+    color: 'blue',
+    'horizon-blend': 0.5,
+    range: [4, 15],
+    'high-color': 'red',
+    'space-color': 'black',
+    'star-intensity': 0.5,
+});
+// $ExpectType Map
+map.setFog(null);
+// $ExpectType Map
+map.setFog(undefined);
+
+// $ExpectType Fog | null
+map.getFog();
+
 /*
  * Map Events
  */


### PR DESCRIPTION
Changes:
- Update `Fog` interface to include `high-color`, `space-color`, and `star-intensity` fields based on the style spec https://docs.mapbox.com/mapbox-gl-js/style-spec/fog/
- Update `setFog` method to allow for `null` and `undefined` to be passed as args, as they are the documented way of removing a fog layer from a map. https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfog
- Added tests for `setFog` and `getFog`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Fog style spec: https://docs.mapbox.com/mapbox-gl-js/style-spec/fog/
  - `setFog` documentation: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfog
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
