### PR TITLE
[node] Update typings to v18.17

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -295,6 +295,35 @@ declare module 'events' {
          */
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v19.9.0
+         */
+        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+        /**
          * ```js
          * import { setMaxListeners, EventEmitter } from 'node:events';
          *

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -82,6 +82,13 @@ declare module 'fs/promises' {
         emitClose?: boolean | undefined;
         start?: number | undefined;
     }
+    interface ReadableWebStreamOptions {
+        /**
+         * Whether to open a normal or a `'bytes'` stream.
+         * @since v20.0.0
+         */
+        type?: 'bytes' | undefined;
+    }
     // TODO: Add `EventEmitter` close
     interface FileHandle {
         /**
@@ -240,7 +247,7 @@ declare module 'fs/promises' {
          * @since v17.0.0
          * @experimental
          */
-        readableWebStream(): ReadableStream;
+        readableWebStream(options?: ReadableWebStreamOptions): ReadableStream;
         /**
          * Asynchronously reads the entire contents of a file.
          *

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -622,6 +622,12 @@ addAbortSignal(new AbortSignal(), new Readable());
     // When the param includes unsupported DuplexOptions
     // @ts-expect-error
     Duplex.fromWeb({ readable, writable }, { emitClose: true });
+
+    // $ExpectType Duplex
+    Duplex.from(readable);
+
+    // $ExpectType Duplex
+    Duplex.from(writable);
 }
 
 async function testReadableStream() {

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -295,6 +295,35 @@ declare module 'events' {
          */
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v19.9.0
+         */
+        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+        /**
          * ```js
          * import { setMaxListeners, EventEmitter } from 'node:events';
          *

--- a/types/node/ts4.8/fs/promises.d.ts
+++ b/types/node/ts4.8/fs/promises.d.ts
@@ -82,6 +82,13 @@ declare module 'fs/promises' {
         emitClose?: boolean | undefined;
         start?: number | undefined;
     }
+    interface ReadableWebStreamOptions {
+        /**
+         * Whether to open a normal or a `'bytes'` stream.
+         * @since v20.0.0
+         */
+        type?: 'bytes' | undefined;
+    }
     // TODO: Add `EventEmitter` close
     interface FileHandle {
         /**
@@ -240,7 +247,7 @@ declare module 'fs/promises' {
          * @since v17.0.0
          * @experimental
          */
-        readableWebStream(): ReadableStream;
+        readableWebStream(options?: ReadableWebStreamOptions): ReadableStream;
         /**
          * Asynchronously reads the entire contents of a file.
          *
@@ -720,7 +727,8 @@ declare module 'fs/promises' {
      * autodetect `target` type and use `'file'` or `'dir'`. If the `target` does not
      * exist, `'file'` will be used. Windows junction points require the destination
      * path to be absolute. When using `'junction'`, the `target` argument will
-     * automatically be normalized to absolute path.
+     * automatically be normalized to absolute path. Junction points on NTFS volumes
+     * can only point to directories.
      * @since v10.0.0
      * @param [type='null']
      * @return Fulfills with `undefined` upon success.

--- a/types/node/ts4.8/url.d.ts
+++ b/types/node/ts4.8/url.d.ts
@@ -394,6 +394,20 @@ declare module 'url' {
          * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
          */
         static revokeObjectURL(objectUrl: string): void;
+        /**
+         * Checks if an `input` relative to the `base` can be parsed to a `URL`.
+         *
+         * ```js
+         * const isValid = URL.canParse('/foo', 'https://example.org/'); // true
+         *
+         * const isNotValid = URL.canParse('/foo'); // false
+         * ```
+         * @since v19.9.0
+         * @param input The absolute or relative input URL to parse. If `input` is relative, then `base` is required. If `input` is absolute, the `base` is ignored. If `input` is not a string, it is
+         * `converted to a string` first.
+         * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
+         */
+        static canParse(input: string, base?: string): boolean;
         constructor(input: string, base?: string | URL);
         /**
          * Gets and sets the fragment portion of the URL.

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -394,6 +394,20 @@ declare module 'url' {
          * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
          */
         static revokeObjectURL(objectUrl: string): void;
+        /**
+         * Checks if an `input` relative to the `base` can be parsed to a `URL`.
+         *
+         * ```js
+         * const isValid = URL.canParse('/foo', 'https://example.org/'); // true
+         *
+         * const isNotValid = URL.canParse('/foo'); // false
+         * ```
+         * @since v19.9.0
+         * @param input The absolute or relative input URL to parse. If `input` is relative, then `base` is required. If `input` is absolute, the `base` is ignored. If `input` is not a string, it is
+         * `converted to a string` first.
+         * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
+         */
+        static canParse(input: string, base?: string): boolean;
         constructor(input: string, base?: string | URL);
         /**
          * Gets and sets the fragment portion of the URL.

--- a/types/node/v18/dns.d.ts
+++ b/types/node/v18/dns.d.ts
@@ -485,6 +485,14 @@ declare module 'dns' {
      */
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
     /**
+     * Get the default value for `verbatim` in {@link lookup} and `dnsPromises.lookup()`. The value could be:
+     *
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
+     * @since v18.17.0
+     */
+    export function getDefaultResultOrder(): 'ipv4first' | 'verbatim';
+    /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted
      * addresses. If the port is the IANA default DNS port (53) it can be omitted.

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -298,6 +298,35 @@ declare module 'events' {
          */
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v18.17.0
+         */
+        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+        /**
          * ```js
          * const {
          *   setMaxListeners,

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -1881,6 +1881,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | undefined
@@ -1898,6 +1899,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer',
         callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
@@ -1912,6 +1914,7 @@ declare module 'fs' {
         options:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | undefined
@@ -1932,6 +1935,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void
     ): void;
@@ -1947,6 +1951,7 @@ declare module 'fs' {
                 | {
                       encoding: BufferEncoding | null;
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
                 | BufferEncoding
                 | null
@@ -1963,6 +1968,7 @@ declare module 'fs' {
                 | {
                       encoding: 'buffer';
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
         ): Promise<Buffer[]>;
         /**
@@ -1975,6 +1981,7 @@ declare module 'fs' {
             options?:
                 | (ObjectEncodingOptions & {
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   })
                 | BufferEncoding
                 | null
@@ -1988,6 +1995,7 @@ declare module 'fs' {
             path: PathLike,
             options: ObjectEncodingOptions & {
                 withFileTypes: true;
+                recursive?: boolean | undefined;
             }
         ): Promise<Dirent[]>;
     }
@@ -2010,6 +2018,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | null
@@ -2025,6 +2034,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Buffer[];
@@ -2038,6 +2048,7 @@ declare module 'fs' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -2051,6 +2062,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Dirent[];
     /**
@@ -3914,6 +3926,10 @@ declare module 'fs' {
          * @default true
          */
         force?: boolean;
+        /**
+         * Modifiers for copy operation. See `mode` flag of {@link copyFileSync()}
+         */
+        mode?: number;
         /**
          * When `true` timestamps from `src` will
          * be preserved.

--- a/types/node/v18/fs/promises.d.ts
+++ b/types/node/v18/fs/promises.d.ts
@@ -83,6 +83,13 @@ declare module 'fs/promises' {
         emitClose?: boolean | undefined;
         start?: number | undefined;
     }
+    interface ReadableWebStreamOptions {
+        /**
+         * Whether to open a normal or a `'bytes'` stream.
+         * @since v18.17.0
+         */
+        type?: 'bytes' | undefined;
+    }
     // TODO: Add `EventEmitter` close
     interface FileHandle {
         /**
@@ -239,7 +246,7 @@ declare module 'fs/promises' {
          * @since v17.0.0
          * @experimental
          */
-        readableWebStream(): ReadableStream;
+        readableWebStream(options?: ReadableWebStreamOptions): ReadableStream;
         /**
          * Asynchronously reads the entire contents of a file.
          *
@@ -633,6 +640,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -648,6 +656,7 @@ declare module 'fs/promises' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Promise<Buffer[]>;
@@ -661,6 +670,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -674,6 +684,7 @@ declare module 'fs/promises' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Promise<Dirent[]>;
     /**

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -186,6 +186,13 @@ declare module 'http' {
          */
         connectionsCheckingInterval?: number | undefined;
         /**
+         * Optionally overrides all `socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
+         * This affects `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
+         * Default: @see stream.getDefaultHighWaterMark().
+         * @since v18.17.0
+         */
+        highWaterMark?: number | undefined;
+        /**
          * Use an insecure HTTP parser that accepts invalid HTTP headers when `true`.
          * Using the insecure parser should be avoided.
          * See --insecure-http-parser for more information.

--- a/types/node/v18/index.d.ts
+++ b/types/node/v18/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 18.16
+// Type definitions for non-npm package Node.js 18.17
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -1097,6 +1097,20 @@ declare module 'stream' {
          * @param stream a stream to attach a signal to
          */
         function addAbortSignal<T extends Stream>(signal: AbortSignal, stream: T): T;
+        /**
+         * Returns the default highWaterMark used by streams.
+         * Defaults to `16384` (16 KiB), or `16` for `objectMode`.
+         * @since v18.17.0
+         * @param objectMode
+         */
+        function getDefaultHighWaterMark(objectMode: boolean): number;
+        /**
+         * Sets the default highWaterMark used by streams.
+         * @since v18.17.0
+         * @param objectMode
+         * @param value highWaterMark value
+         */
+        function setDefaultHighWaterMark(objectMode: boolean, value: number): void;
         interface FinishedOptions extends Abortable {
             error?: boolean | undefined;
             readable?: boolean | undefined;

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -58,7 +58,10 @@ declare module 'node:test' {
             it,
             run,
             mock,
-            test
+            test,
+            skip,
+            todo,
+            only
         };
     }
     /**
@@ -129,6 +132,30 @@ declare module 'node:test' {
         function only(options?: TestOptions, fn?: TestFn): void;
         function only(fn?: TestFn): void;
     }
+    /**
+     * Shorthand for skipping a test, same as `test([name], { skip: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(name?: string, fn?: TestFn): Promise<void>;
+    function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(fn?: TestFn): Promise<void>;
+    /**
+     * Shorthand for marking a test as `TODO`, same as `test([name], { todo: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(name?: string, fn?: TestFn): Promise<void>;
+    function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(fn?: TestFn): Promise<void>;
+    /**
+     * Shorthand for marking a test as `only`, same as `test([name], { only: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(name?: string, fn?: TestFn): Promise<void>;
+    function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(fn?: TestFn): Promise<void>;
 
     /**
      * The type of a function under test. The first argument to this function is a
@@ -192,152 +219,49 @@ declare module 'node:test' {
         addListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         addListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         addListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        addListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        addListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         addListener(event: string, listener: (...args: any[]) => void): this;
         emit(event: 'test:diagnostic', data: DiagnosticData): boolean;
         emit(event: 'test:fail', data: TestFail): boolean;
         emit(event: 'test:pass', data: TestPass): boolean;
         emit(event: 'test:plan', data: TestPlan): boolean;
         emit(event: 'test:start', data: TestStart): boolean;
+        emit(event: 'test:stderr', data: TestStderr): boolean;
+        emit(event: 'test:stdout', data: TestStdout): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         on(event: 'test:fail', listener: (data: TestFail) => void): this;
         on(event: 'test:pass', listener: (data: TestPass) => void): this;
         on(event: 'test:plan', listener: (data: TestPlan) => void): this;
         on(event: 'test:start', listener: (data: TestStart) => void): this;
+        on(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        on(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         on(event: string, listener: (...args: any[]) => void): this;
         once(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         once(event: 'test:fail', listener: (data: TestFail) => void): this;
         once(event: 'test:pass', listener: (data: TestPass) => void): this;
         once(event: 'test:plan', listener: (data: TestPlan) => void): this;
         once(event: 'test:start', listener: (data: TestStart) => void): this;
+        once(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        once(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         prependListener(event: 'test:fail', listener: (data: TestFail) => void): this;
         prependListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         prependListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         prependListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        prependListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        prependListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         prependOnceListener(event: 'test:fail', listener: (data: TestFail) => void): this;
         prependOnceListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         prependOnceListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         prependOnceListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        prependOnceListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        prependOnceListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-    }
-
-    interface DiagnosticData {
-        /**
-         * The diagnostic message.
-         */
-        message: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-    }
-
-    interface TestFail {
-        /**
-         * Additional execution metadata.
-         */
-        details: {
-            /**
-             * The duration of the test in milliseconds.
-             */
-            duration: number;
-
-            /**
-             * The error thrown by the test.
-             */
-            error: Error;
-        };
-
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The ordinal number of the test.
-         */
-        testNumber: number;
-
-        /**
-         * Present if `context.todo` is called.
-         */
-        todo?: string | boolean;
-
-        /**
-         * Present if `context.skip` is called.
-         */
-        skip?: string | boolean;
-    }
-
-    interface TestPass {
-        /**
-         * Additional execution metadata.
-         */
-        details: {
-            /**
-             * The duration of the test in milliseconds.
-             */
-            duration: number;
-        };
-
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The ordinal number of the test.
-         */
-        testNumber: number;
-
-        /**
-         * Present if `context.todo` is called.
-         */
-        todo?: string | boolean;
-
-        /**
-         * Present if `context.skip` is called.
-         */
-        skip?: string | boolean;
-    }
-
-    interface TestPlan {
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The number of subtests that have ran.
-         */
-        count: number;
-    }
-
-    interface TestStart {
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
     }
 
     /**
@@ -346,6 +270,15 @@ declare module 'node:test' {
      * @since v18.0.0
      */
     interface TestContext {
+        /**
+         * This function is used to create a hook running before subtest of the current test.
+         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
+         *    the second argument. Default: A no-op function.
+         * @param options Configuration options for the hook.
+         * @since v18.17.0
+         */
+        before: typeof before;
+
         /**
          * This function is used to create a hook running before each subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -780,4 +713,190 @@ declare module 'node:test' {
     }
 
     export { test as default, run, test, describe, it, before, after, beforeEach, afterEach, mock };
+}
+
+interface DiagnosticData {
+    /**
+     * The diagnostic message.
+     */
+    message: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestFail {
+    /**
+     * Additional execution metadata.
+     */
+    details: {
+        /**
+         * The duration of the test in milliseconds.
+         */
+        duration: number;
+        /**
+         * The error thrown by the test.
+         */
+        error: Error;
+    };
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The ordinal number of the test.
+     */
+    testNumber: number;
+    /**
+     * Present if `context.todo` is called.
+     */
+    todo?: string | boolean;
+    /**
+     * Present if `context.skip` is called.
+     */
+    skip?: string | boolean;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestPass {
+    /**
+     * Additional execution metadata.
+     */
+    details: {
+        /**
+         * The duration of the test in milliseconds.
+         */
+        duration: number;
+    };
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The ordinal number of the test.
+     */
+    testNumber: number;
+    /**
+     * Present if `context.todo` is called.
+     */
+    todo?: string | boolean;
+    /**
+     * Present if `context.skip` is called.
+     */
+    skip?: string | boolean;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestPlan {
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The number of subtests that have ran.
+     */
+    count: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestStart {
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestStderr {
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The message written to `stderr`
+     */
+    message: string;
+}
+interface TestStdout {
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The message written to `stdout`
+     */
+    message: string;
+}
+
+/**
+ * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
+ * To access it:
+ *
+ * ```js
+ * import test from 'node:test/reporters';
+ * ```
+ *
+ * This module is only available under the `node:` scheme. The following will not
+ * work:
+ *
+ * ```js
+ * import test from 'test/reporters';
+ * ```
+ * @since v18.17.0
+ * @see [source](https://github.com/nodejs/node/blob/v18.17.0/lib/test/reporters.js)
+ */
+declare module 'node:test/reporters' {
+    import { Transform } from 'node:stream';
+
+    type TestEvent =
+        | { type: 'test:diagnostic', data: DiagnosticData }
+        | { type: 'test:fail', data: TestFail }
+        | { type: 'test:pass', data: TestPass }
+        | { type: 'test:plan', data: TestPlan }
+        | { type: 'test:start', data: TestStart }
+        | { type: 'test:stderr', data: TestStderr }
+        | { type: 'test:stdout', data: TestStdout };
+    type TestEventGenerator = AsyncGenerator<TestEvent, void>;
+
+    /**
+     * The `dot` reporter outputs the test results in a compact format,
+     * where each passing test is represented by a `.`,
+     * and each failing test is represented by a `X`.
+     */
+    function dot(source: TestEventGenerator): AsyncGenerator<'\n' | '.' | 'X', void>;
+    /**
+     * The `tap` reporter outputs the test results in the [TAP](https://testanything.org/) format.
+     */
+    function tap(source: TestEventGenerator): AsyncGenerator<string, void>;
+    /**
+     * The `spec` reporter outputs the test results in a human-readable format.
+     */
+    class Spec extends Transform {
+        constructor();
+    }
+    export { dot, tap, Spec as spec };
 }

--- a/types/node/v18/ts4.8/dns.d.ts
+++ b/types/node/v18/ts4.8/dns.d.ts
@@ -485,6 +485,14 @@ declare module 'dns' {
      */
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void): void;
     /**
+     * Get the default value for `verbatim` in {@link lookup} and `dnsPromises.lookup()`. The value could be:
+     *
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
+     * @since v18.17.0
+     */
+    export function getDefaultResultOrder(): 'ipv4first' | 'verbatim';
+    /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted
      * addresses. If the port is the IANA default DNS port (53) it can be omitted.

--- a/types/node/v18/ts4.8/events.d.ts
+++ b/types/node/v18/ts4.8/events.d.ts
@@ -298,6 +298,35 @@ declare module 'events' {
          */
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v18.17.0
+         */
+        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+        /**
          * ```js
          * const {
          *   setMaxListeners,

--- a/types/node/v18/ts4.8/fs.d.ts
+++ b/types/node/v18/ts4.8/fs.d.ts
@@ -131,6 +131,42 @@ declare module 'fs' {
      * @since v0.1.21
      */
     export class Stats {}
+
+    export interface StatsFsBase<T> {
+        /** Type of file system. */
+        type: T;
+        /**  Optimal transfer block size. */
+        bsize: T;
+        /**  Total data blocks in file system. */
+        blocks: T;
+        /** Free blocks in file system. */
+        bfree: T;
+        /** Available blocks for unprivileged users */
+        bavail: T;
+        /** Total file nodes in file system. */
+        files: T;
+        /** Free file nodes in file system. */
+        ffree: T;
+    }
+
+    export interface StatsFs extends StatsFsBase<number> {}
+
+    /**
+     * Provides information about a mounted file system
+     *
+     * Objects returned from {@link statfs} and {@link statfsSync} are of this type.
+     * If `bigint` in the `options` passed to those methods is true, the numeric values
+     * will be `bigint` instead of `number`.
+     * @since  v18.15.0
+     */
+    export class StatsFs {}
+
+    export interface BigIntStatsFs extends StatsFsBase<bigint> {}
+
+    export interface StatFsOptions {
+        bigint?: boolean | undefined;
+    }
+
     /**
      * A representation of a directory entry, which can be a file or a subdirectory
      * within the directory, as returned by reading from an `fs.Dir`. The
@@ -1082,6 +1118,70 @@ declare module 'fs' {
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
     /**
+     * Asynchronous statfs(2). Returns information about the mounted file system which contains path. The callback gets two arguments (err, stats) where stats is an <fs.StatFs> object.
+     * In case of an error, the err.code will be one of Common System Errors.
+     * @param path A path to an existing file or directory on the file system to be queried.
+     * @param callback
+     */
+    export function statfs(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: StatsFs) => void): void;
+    export function statfs(
+        path: PathLike,
+        options:
+            | (StatFsOptions & {
+                  bigint?: false | undefined;
+              })
+            | undefined,
+        callback: (err: NodeJS.ErrnoException | null, stats: StatsFs) => void
+    ): void;
+    export function statfs(
+        path: PathLike,
+        options: StatFsOptions & {
+            bigint: true;
+        },
+        callback: (err: NodeJS.ErrnoException | null, stats: BigIntStatsFs) => void
+    ): void;
+    export function statfs(path: PathLike, options: StatFsOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: StatsFs | BigIntStatsFs) => void): void;
+    export namespace statfs {
+        /**
+         * Asynchronous statfs(2) - Returns information about the mounted file system which contains path. The callback gets two arguments (err, stats) where stats is an <fs.StatFs> object.
+         * @param path A path to an existing file or directory on the file system to be queried.
+         */
+        function __promisify__(
+            path: PathLike,
+            options?: StatFsOptions & {
+                bigint?: false | undefined;
+            }
+        ): Promise<StatsFs>;
+        function __promisify__(
+            path: PathLike,
+            options: StatFsOptions & {
+                bigint: true;
+            }
+        ): Promise<BigIntStatsFs>;
+        function __promisify__(path: PathLike, options?: StatFsOptions): Promise<StatsFs | BigIntStatsFs>;
+    }
+
+    /**
+     * Synchronous statfs(2). Returns information about the mounted file system which contains path. The callback gets two arguments (err, stats) where stats is an <fs.StatFs> object.
+     * In case of an error, the err.code will be one of Common System Errors.
+     * @param path A path to an existing file or directory on the file system to be queried.
+     * @param callback
+     */
+    export function statfsSync(
+        path: PathLike,
+        options?: StatFsOptions & {
+            bigint?: false | undefined;
+        }
+    ): StatsFs;
+    export function statfsSync(
+        path: PathLike,
+        options: StatFsOptions & {
+            bigint: true;
+        }
+    ): BigIntStatsFs;
+
+    export function statfsSync(path: PathLike, options?: StatFsOptions): StatsFs | BigIntStatsFs;
+    /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
@@ -1781,6 +1881,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | undefined
@@ -1798,6 +1899,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer',
         callback: (err: NodeJS.ErrnoException | null, files: Buffer[]) => void
@@ -1812,6 +1914,7 @@ declare module 'fs' {
         options:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | undefined
@@ -1832,6 +1935,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void
     ): void;
@@ -1847,6 +1951,7 @@ declare module 'fs' {
                 | {
                       encoding: BufferEncoding | null;
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
                 | BufferEncoding
                 | null
@@ -1863,6 +1968,7 @@ declare module 'fs' {
                 | {
                       encoding: 'buffer';
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   }
         ): Promise<Buffer[]>;
         /**
@@ -1875,6 +1981,7 @@ declare module 'fs' {
             options?:
                 | (ObjectEncodingOptions & {
                       withFileTypes?: false | undefined;
+                      recursive?: boolean | undefined;
                   })
                 | BufferEncoding
                 | null
@@ -1888,6 +1995,7 @@ declare module 'fs' {
             path: PathLike,
             options: ObjectEncodingOptions & {
                 withFileTypes: true;
+                recursive?: boolean | undefined;
             }
         ): Promise<Dirent[]>;
     }
@@ -1910,6 +2018,7 @@ declare module 'fs' {
             | {
                   encoding: BufferEncoding | null;
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | BufferEncoding
             | null
@@ -1925,6 +2034,7 @@ declare module 'fs' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Buffer[];
@@ -1938,6 +2048,7 @@ declare module 'fs' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -1951,6 +2062,7 @@ declare module 'fs' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Dirent[];
     /**
@@ -2913,8 +3025,9 @@ declare module 'fs' {
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * @param listener The callback listener will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): StatWatcher;
+    export function watchFile(filename: PathLike, listener: StatsListener): StatWatcher;
     /**
      * Stop watching for changes on `filename`. If `listener` is specified, only that
      * particular listener is removed. Otherwise, _all_ listeners are removed,
@@ -3813,6 +3926,10 @@ declare module 'fs' {
          * @default true
          */
         force?: boolean;
+        /**
+         * Modifiers for copy operation. See `mode` flag of {@link copyFileSync()}
+         */
+        mode?: number;
         /**
          * When `true` timestamps from `src` will
          * be preserved.

--- a/types/node/v18/ts4.8/fs/promises.d.ts
+++ b/types/node/v18/ts4.8/fs/promises.d.ts
@@ -14,6 +14,7 @@ declare module 'fs/promises' {
     import { ReadableStream } from 'node:stream/web';
     import {
         BigIntStats,
+        BigIntStatsFs,
         BufferEncodingOption,
         constants as fsConstants,
         CopyOptions,
@@ -30,7 +31,9 @@ declare module 'fs/promises' {
         RmDirOptions,
         RmOptions,
         StatOptions,
+        StatFsOptions,
         Stats,
+        StatsFs,
         TimeLike,
         WatchEventType,
         WatchOptions,
@@ -79,6 +82,13 @@ declare module 'fs/promises' {
         autoClose?: boolean | undefined;
         emitClose?: boolean | undefined;
         start?: number | undefined;
+    }
+    interface ReadableWebStreamOptions {
+        /**
+         * Whether to open a normal or a `'bytes'` stream.
+         * @since v18.17.0
+         */
+        type?: 'bytes' | undefined;
     }
     // TODO: Add `EventEmitter` close
     interface FileHandle {
@@ -236,7 +246,7 @@ declare module 'fs/promises' {
          * @since v17.0.0
          * @experimental
          */
-        readableWebStream(): ReadableStream;
+        readableWebStream(options?: ReadableWebStreamOptions): ReadableStream;
         /**
          * Asynchronously reads the entire contents of a file.
          *
@@ -630,6 +640,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -645,6 +656,7 @@ declare module 'fs/promises' {
             | {
                   encoding: 'buffer';
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               }
             | 'buffer'
     ): Promise<Buffer[]>;
@@ -658,6 +670,7 @@ declare module 'fs/promises' {
         options?:
             | (ObjectEncodingOptions & {
                   withFileTypes?: false | undefined;
+                  recursive?: boolean | undefined;
               })
             | BufferEncoding
             | null
@@ -671,6 +684,7 @@ declare module 'fs/promises' {
         path: PathLike,
         options: ObjectEncodingOptions & {
             withFileTypes: true;
+            recursive?: boolean | undefined;
         }
     ): Promise<Dirent[]>;
     /**
@@ -745,6 +759,24 @@ declare module 'fs/promises' {
         }
     ): Promise<BigIntStats>;
     function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
+    /**
+     * @since v18.15.0
+     * @return Fulfills with an {fs.StatFs} for the file system.
+     */
+    function statfs(
+        path: PathLike,
+        opts?: StatFsOptions & {
+            bigint?: false | undefined;
+        }
+    ): Promise<StatsFs>;
+    function statfs(
+        path: PathLike,
+        opts: StatFsOptions & {
+            bigint: true;
+        }
+    ): Promise<BigIntStatsFs>;
+    function statfs(path: PathLike, opts?: StatFsOptions): Promise<StatsFs | BigIntStatsFs>;
+
     /**
      * Creates a new link from the `existingPath` to the `newPath`. See the POSIX [`link(2)`](http://man7.org/linux/man-pages/man2/link.2.html) documentation for more detail.
      * @since v10.0.0

--- a/types/node/v18/ts4.8/stream.d.ts
+++ b/types/node/v18/ts4.8/stream.d.ts
@@ -124,12 +124,12 @@ declare module 'stream' {
             readonly readableObjectMode: boolean;
             /**
              * Is `true` after `readable.destroy()` has been called.
-             * @since v18.0.0
+             * @since v8.0.0
              */
             destroyed: boolean;
             /**
              * Is true after 'close' has been emitted.
-             * @since v8.0.0
+             * @since v18.0.0
              */
             readonly closed: boolean;
             /**
@@ -579,7 +579,7 @@ declare module 'stream' {
             destroyed: boolean;
             /**
              * Is true after 'close' has been emitted.
-             * @since v8.0.0
+             * @since v18.0.0
              */
             readonly closed: boolean;
             /**
@@ -1097,6 +1097,20 @@ declare module 'stream' {
          * @param stream a stream to attach a signal to
          */
         function addAbortSignal<T extends Stream>(signal: AbortSignal, stream: T): T;
+        /**
+         * Returns the default highWaterMark used by streams.
+         * Defaults to `16384` (16 KiB), or `16` for `objectMode`.
+         * @since v18.17.0
+         * @param objectMode
+         */
+        function getDefaultHighWaterMark(objectMode: boolean): number;
+        /**
+         * Sets the default highWaterMark used by streams.
+         * @since v18.17.0
+         * @param objectMode
+         * @param value highWaterMark value
+         */
+        function setDefaultHighWaterMark(objectMode: boolean, value: number): void;
         interface FinishedOptions extends Abortable {
             error?: boolean | undefined;
             readable?: boolean | undefined;

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -10,7 +10,6 @@ declare module 'node:test' {
      * @returns A {@link TestsStream} that emits events about the test execution.
      */
     function run(options?: RunOptions): TestsStream;
-
     /**
      * The `test()` function is the value imported from the test module. Each invocation of this
      * function results in reporting the test to the {@link TestsStream}.
@@ -59,7 +58,10 @@ declare module 'node:test' {
             it,
             run,
             mock,
-            test
+            test,
+            skip,
+            todo,
+            only
         };
     }
     /**
@@ -130,6 +132,30 @@ declare module 'node:test' {
         function only(options?: TestOptions, fn?: TestFn): void;
         function only(fn?: TestFn): void;
     }
+    /**
+     * Shorthand for skipping a test, same as `test([name], { skip: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(name?: string, fn?: TestFn): Promise<void>;
+    function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(fn?: TestFn): Promise<void>;
+    /**
+     * Shorthand for marking a test as `TODO`, same as `test([name], { todo: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(name?: string, fn?: TestFn): Promise<void>;
+    function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(fn?: TestFn): Promise<void>;
+    /**
+     * Shorthand for marking a test as `only`, same as `test([name], { only: true }[, fn])`.
+     * @since v18.17.0
+     */
+    function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(name?: string, fn?: TestFn): Promise<void>;
+    function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(fn?: TestFn): Promise<void>;
 
     /**
      * The type of a function under test. The first argument to this function is a
@@ -193,152 +219,49 @@ declare module 'node:test' {
         addListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         addListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         addListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        addListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        addListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         addListener(event: string, listener: (...args: any[]) => void): this;
         emit(event: 'test:diagnostic', data: DiagnosticData): boolean;
         emit(event: 'test:fail', data: TestFail): boolean;
         emit(event: 'test:pass', data: TestPass): boolean;
         emit(event: 'test:plan', data: TestPlan): boolean;
         emit(event: 'test:start', data: TestStart): boolean;
+        emit(event: 'test:stderr', data: TestStderr): boolean;
+        emit(event: 'test:stdout', data: TestStdout): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         on(event: 'test:fail', listener: (data: TestFail) => void): this;
         on(event: 'test:pass', listener: (data: TestPass) => void): this;
         on(event: 'test:plan', listener: (data: TestPlan) => void): this;
         on(event: 'test:start', listener: (data: TestStart) => void): this;
+        on(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        on(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         on(event: string, listener: (...args: any[]) => void): this;
         once(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         once(event: 'test:fail', listener: (data: TestFail) => void): this;
         once(event: 'test:pass', listener: (data: TestPass) => void): this;
         once(event: 'test:plan', listener: (data: TestPlan) => void): this;
         once(event: 'test:start', listener: (data: TestStart) => void): this;
+        once(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        once(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         prependListener(event: 'test:fail', listener: (data: TestFail) => void): this;
         prependListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         prependListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         prependListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        prependListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        prependListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: 'test:diagnostic', listener: (data: DiagnosticData) => void): this;
         prependOnceListener(event: 'test:fail', listener: (data: TestFail) => void): this;
         prependOnceListener(event: 'test:pass', listener: (data: TestPass) => void): this;
         prependOnceListener(event: 'test:plan', listener: (data: TestPlan) => void): this;
         prependOnceListener(event: 'test:start', listener: (data: TestStart) => void): this;
+        prependOnceListener(event: 'test:stderr', listener: (data: TestStderr) => void): this;
+        prependOnceListener(event: 'test:stdout', listener: (data: TestStdout) => void): this;
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-    }
-
-    interface DiagnosticData {
-        /**
-         * The diagnostic message.
-         */
-        message: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-    }
-
-    interface TestFail {
-        /**
-         * Additional execution metadata.
-         */
-        details: {
-            /**
-             * The duration of the test in milliseconds.
-             */
-            duration: number;
-
-            /**
-             * The error thrown by the test.
-             */
-            error: Error;
-        };
-
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The ordinal number of the test.
-         */
-        testNumber: number;
-
-        /**
-         * Present if `context.todo` is called.
-         */
-        todo?: string | boolean;
-
-        /**
-         * Present if `context.skip` is called.
-         */
-        skip?: string | boolean;
-    }
-
-    interface TestPass {
-        /**
-         * Additional execution metadata.
-         */
-        details: {
-            /**
-             * The duration of the test in milliseconds.
-             */
-            duration: number;
-        };
-
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The ordinal number of the test.
-         */
-        testNumber: number;
-
-        /**
-         * Present if `context.todo` is called.
-         */
-        todo?: string | boolean;
-
-        /**
-         * Present if `context.skip` is called.
-         */
-        skip?: string | boolean;
-    }
-
-    interface TestPlan {
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
-
-        /**
-         * The number of subtests that have ran.
-         */
-        count: number;
-    }
-
-    interface TestStart {
-        /**
-         * The test name.
-         */
-        name: string;
-
-        /**
-         * The nesting level of the test.
-         */
-        nesting: number;
     }
 
     /**
@@ -347,6 +270,15 @@ declare module 'node:test' {
      * @since v18.0.0
      */
     interface TestContext {
+        /**
+         * This function is used to create a hook running before subtest of the current test.
+         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
+         *    the second argument. Default: A no-op function.
+         * @param options Configuration options for the hook.
+         * @since v18.17.0
+         */
+        before: typeof before;
+
         /**
          * This function is used to create a hook running before each subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -781,4 +713,190 @@ declare module 'node:test' {
     }
 
     export { test as default, run, test, describe, it, before, after, beforeEach, afterEach, mock };
+}
+
+interface DiagnosticData {
+    /**
+     * The diagnostic message.
+     */
+    message: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestFail {
+    /**
+     * Additional execution metadata.
+     */
+    details: {
+        /**
+         * The duration of the test in milliseconds.
+         */
+        duration: number;
+        /**
+         * The error thrown by the test.
+         */
+        error: Error;
+    };
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The ordinal number of the test.
+     */
+    testNumber: number;
+    /**
+     * Present if `context.todo` is called.
+     */
+    todo?: string | boolean;
+    /**
+     * Present if `context.skip` is called.
+     */
+    skip?: string | boolean;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestPass {
+    /**
+     * Additional execution metadata.
+     */
+    details: {
+        /**
+         * The duration of the test in milliseconds.
+         */
+        duration: number;
+    };
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The ordinal number of the test.
+     */
+    testNumber: number;
+    /**
+     * Present if `context.todo` is called.
+     */
+    todo?: string | boolean;
+    /**
+     * Present if `context.skip` is called.
+     */
+    skip?: string | boolean;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestPlan {
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The number of subtests that have ran.
+     */
+    count: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestStart {
+    /**
+     * The test name.
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+}
+interface TestStderr {
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The message written to `stderr`
+     */
+    message: string;
+}
+interface TestStdout {
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The message written to `stdout`
+     */
+    message: string;
+}
+
+/**
+ * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
+ * To access it:
+ *
+ * ```js
+ * import test from 'node:test/reporters';
+ * ```
+ *
+ * This module is only available under the `node:` scheme. The following will not
+ * work:
+ *
+ * ```js
+ * import test from 'test/reporters';
+ * ```
+ * @since v18.17.0
+ * @see [source](https://github.com/nodejs/node/blob/v18.17.0/lib/test/reporters.js)
+ */
+declare module 'node:test/reporters' {
+    import { Transform } from 'node:stream';
+
+    type TestEvent =
+        | { type: 'test:diagnostic', data: DiagnosticData }
+        | { type: 'test:fail', data: TestFail }
+        | { type: 'test:pass', data: TestPass }
+        | { type: 'test:plan', data: TestPlan }
+        | { type: 'test:start', data: TestStart }
+        | { type: 'test:stderr', data: TestStderr }
+        | { type: 'test:stdout', data: TestStdout };
+    type TestEventGenerator = AsyncGenerator<TestEvent, void>;
+
+    /**
+     * The `dot` reporter outputs the test results in a compact format,
+     * where each passing test is represented by a `.`,
+     * and each failing test is represented by a `X`.
+     */
+    function dot(source: TestEventGenerator): AsyncGenerator<'\n' | '.' | 'X', void>;
+    /**
+     * The `tap` reporter outputs the test results in the [TAP](https://testanything.org/) format.
+     */
+    function tap(source: TestEventGenerator): AsyncGenerator<string, void>;
+    /**
+     * The `spec` reporter outputs the test results in a human-readable format.
+     */
+    class Spec extends Transform {
+        constructor();
+    }
+    export { dot, tap, Spec as spec };
 }

--- a/types/node/v18/ts4.8/url.d.ts
+++ b/types/node/v18/ts4.8/url.d.ts
@@ -404,6 +404,20 @@ declare module 'url' {
          * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
          */
         static revokeObjectURL(objectUrl: string): void;
+        /**
+         * Checks if an `input` relative to the `base` can be parsed to a `URL`.
+         *
+         * ```js
+         * const isValid = URL.canParse('/foo', 'https://example.org/'); // true
+         *
+         * const isNotValid = URL.canParse('/foo'); // false
+         * ```
+         * @since v18.17.0
+         * @param input The absolute or relative input URL to parse. If `input` is relative, then `base` is required. If `input` is absolute, the `base` is ignored. If `input` is not a string, it is
+         * `converted to a string` first.
+         * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
+         */
+        static canParse(input: string, base?: string): boolean;
         constructor(input: string, base?: string | URL);
         /**
          * Gets and sets the fragment portion of the URL.

--- a/types/node/v18/url.d.ts
+++ b/types/node/v18/url.d.ts
@@ -404,6 +404,20 @@ declare module 'url' {
          * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
          */
         static revokeObjectURL(objectUrl: string): void;
+        /**
+         * Checks if an `input` relative to the `base` can be parsed to a `URL`.
+         *
+         * ```js
+         * const isValid = URL.canParse('/foo', 'https://example.org/'); // true
+         *
+         * const isNotValid = URL.canParse('/foo'); // false
+         * ```
+         * @since v18.17.0
+         * @param input The absolute or relative input URL to parse. If `input` is relative, then `base` is required. If `input` is absolute, the `base` is ignored. If `input` is not a string, it is
+         * `converted to a string` first.
+         * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
+         */
+        static canParse(input: string, base?: string): boolean;
         constructor(input: string, base?: string | URL);
         /**
          * Gets and sets the fragment portion of the URL.


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v18.17.0

- dns: expose getDefaultResultOrder
- events: add getMaxListeners method // added also to v20
- fs: add support for mode flag to specify the copy behavior
- fs: add recursive option to readdir and opendir
- fs: implement byob mode for readableWebStream() // added also to v20
- http: add highWaterMark opt in http.createServer
- lib: add webstreams to Duplex.from() // already supported by types, added test
- stream: add setter & getter for default highWaterMark
- test_runner: add shorthands to test
- test_runner: execute before hook on test
- test_runner: expose reporter for use in run api
- url: implement URL.canParse // added also to v20
