### PR TITLE
[gremlin] Fix types for gremlin.process.Translator

### DIFF
--- a/types/gremlin/gremlin-tests.ts
+++ b/types/gremlin/gremlin-tests.ts
@@ -105,6 +105,7 @@ function processTests() {
     const graphTraversalSource = new GraphTraversalSource(null, traversalStrategies, bytecode);
     const transaction = new Transaction(graphTraversalSource);
     const translator = new Translator(graphTraversalSource);
+    const translatorWithString = new Translator('g');
     const anonymousTraversalSource = new AnonymousTraversalSource();
 
     bytecode.addSource('test');
@@ -174,7 +175,9 @@ function processTests() {
 
     translator.getTraversalSource();
     translator.of(graphTraversalSource);
+    translator.of('g');
     translator.translate(bytecode);
+    translator.translate(graphTraversal);
     translator.convert({});
 
     transaction.begin();

--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -497,10 +497,10 @@ declare namespace process {
     const statics: Statics;
 
     class Translator {
-        constructor(traversalSource: AnonymousTraversalSource | GraphTraversalSource);
-        getTraversalSource(): Translator;
+        constructor(traversalSource: AnonymousTraversalSource | GraphTraversalSource | string);
+        getTraversalSource(): AnonymousTraversalSource | GraphTraversalSource | string;
         of(traversalSource: AnonymousTraversalSource | GraphTraversalSource | string): void;
-        translate(bytecode: Bytecode, child?: boolean): string;
+        translate(bytecodeOrTraversal: Bytecode | Traversal, child?: boolean): string;
         convert(anyObject: any): string;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Tests using string in constructor](https://github.com/apache/tinkerpop/blob/a3126fa12f8914a7854b8a0c61f61b359061c601/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/translator-test.js#L34)
  - [Use of string in constructor from docs](https://tinkerpop.apache.org/docs/current/reference/#translators)
  - [`traversalSource` of `constructor` should be the same type as `of`](https://github.com/apache/tinkerpop/blob/b5afd0540dbbef4040d0e1dcc8b0f5d38c11ed30/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/translator.js#L41)
  - [`getTraversalSource()` returns `_traversalSource`, not `Translator`](https://github.com/apache/tinkerpop/blob/b5afd0540dbbef4040d0e1dcc8b0f5d38c11ed30/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/translator.js#L33)
  - [`Translator` allows `Traversal` or `Bytecode` for translation](https://github.com/apache/tinkerpop/blob/b5afd0540dbbef4040d0e1dcc8b0f5d38c11ed30/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/translator.js#L52)



Reading the documentation, source code, and tests, I see no instances where `AnonymousTraversalSource` or `GraphTraversalSource` are used as `traversalSource`. As the [translate function](https://github.com/apache/tinkerpop/blob/b5afd0540dbbef4040d0e1dcc8b0f5d38c11ed30/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/translator.js#L50) seems to only use string operations on `traversalSource`, I would assume that this is not valid, but due to the lack of documentation around this, I have left them as they are.