### PR TITLE
underscore: Expand types for zip and friends

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -4628,7 +4628,7 @@ declare module _ {
          * matching list indexes.
          * @returns The zipped version of the wrapped list and `lists`.
          **/
-        zip(): [T][]; // eslint-disable-line no-single-element-tuple-type
+        zip(): V extends List<infer A> ? [A][] : []; // eslint-disable-line no-single-element-tuple-type
         zip<A, B>(...lists: [List<A>, List<B>]): [T, A, B][];
         zip<A>(list: List<A>): [T, A][];
         zip(...lists: List<T>[]): T[][];
@@ -5888,7 +5888,7 @@ declare module _ {
          * @returns A chain wrapper around the zipped version of the wrapped
          * list and `lists`.
          **/
-        zip(): _Chain<[T]>; // eslint-disable-line no-single-element-tuple-type
+        zip(): V extends List<infer A> ? _Chain<[A]> : _Chain<never, []>; // eslint-disable-line no-single-element-tuple-type
         zip<A, B>(...arrays: [List<A>, List<B>]): _Chain<[T, A, B]>;
         zip<A>(array: List<A>): _Chain<[T, A]>;
         zip(...arrays: List<T>[]): _Chain<T[]>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -4649,7 +4649,7 @@ declare module _ {
             ? [A[]] // eslint-disable-line no-single-element-tuple-type
             : T extends List<infer A>
             ? A[][]
-            : never[];
+            : [];
         transpose(): T extends [infer A, infer B, infer C]
             ? [A[], B[], C[]]
             : T extends [infer A, infer B]
@@ -4658,7 +4658,7 @@ declare module _ {
             ? [A[]] // eslint-disable-line no-single-element-tuple-type
             : T extends List<infer A>
             ? A[][]
-            : never[];
+            : [];
 
         /**
          * Converts lists into objects. Call on either a wrapped list of
@@ -5910,7 +5910,7 @@ declare module _ {
             ? _Chain<A[], [A[]]> // eslint-disable-line no-single-element-tuple-type
             : T extends List<infer A>
             ? _Chain<A[]>
-            : _Chain<never>;
+            : _Chain<never, []>;
         transpose(): T extends [infer A, infer B, infer C]
             ? _Chain<A[] | B[] | C[], [A[], B[], C[]]>
             : T extends [infer A, infer B]
@@ -5919,7 +5919,7 @@ declare module _ {
             ? _Chain<A[], [A[]]> // eslint-disable-line no-single-element-tuple-type
             : T extends List<infer A>
             ? _Chain<A[]>
-            : _Chain<never>;
+            : _Chain<never, []>;
 
         /**
          * Converts lists into objects. Call on either a wrapped list of

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -9,6 +9,7 @@
 //                 Regev Brody <https://github.com/regevbr>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Michael Ness <https://github.com/reubenrybnik>
+//                 Luke Tsekouras <https://github.com/LukeGT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -859,6 +860,11 @@ declare module _ {
          * @param lists The lists to zip.
          * @returns The zipped version of `lists`.
          **/
+        zip(): [];
+        zip<T, U, V>(...lists: [List<T>, List<U>, List<V>]): [T, U, V][];
+        zip<T, U>(...lists: [List<T>, List<U>]): [T, U][];
+        zip<T>(...lists: [List<T>]): [T][]; // eslint-disable-line no-single-element-tuple-type
+        zip<T>(...lists: List<T>[]): T[][];
         zip(...lists: List<any>[]): any[][];
 
         /**
@@ -869,8 +875,18 @@ declare module _ {
          * @param lists The lists to unzip.
          * @returns The unzipped version of `lists`.
          **/
+        unzip<T, U, V>(lists: List<[T, U, V]>): [T[], U[], V[]];
+        unzip<T, U>(lists: List<[T, U]>): [T[], U[]];
+        unzip<T>(lists: List<[T]>): [T[]]; // eslint-disable-line no-single-element-tuple-type
+        unzip<T>(lists: List<List<T>>): T[][];
         unzip(lists: List<List<any>>): any[][];
+        unzip(): [];
+        transpose<T, U, V>(lists: List<[T, U, V]>): [T[], U[], V[]];
+        transpose<T, U>(lists: List<[T, U]>): [T[], U[]];
+        transpose<T>(lists: List<[T]>): [T[]]; // eslint-disable-line no-single-element-tuple-type
+        transpose<T>(lists: List<List<T>>): T[][];
         transpose(lists: List<List<any>>): any[][];
+        transpose(): [];
 
         /**
          * Converts lists into objects. Pass either a single `list` of
@@ -4612,6 +4628,10 @@ declare module _ {
          * matching list indexes.
          * @returns The zipped version of the wrapped list and `lists`.
          **/
+        zip(): [T][]; // eslint-disable-line no-single-element-tuple-type
+        zip<A, B>(...lists: [List<A>, List<B>]): [T, A, B][];
+        zip<A>(list: List<A>): [T, A][];
+        zip(...lists: List<T>[]): T[][];
         zip(...lists: List<any>[]): any[][];
 
         /**
@@ -4621,8 +4641,24 @@ declare module _ {
          * the second elements, and so on. (alias: transpose)
          * @returns The unzipped version of the wrapped lists.
          **/
-        unzip(): any[][];
-        transpose(): any[][];
+        unzip(): T extends [infer A, infer B, infer C]
+            ? [A[], B[], C[]]
+            : T extends [infer A, infer B]
+            ? [A[], B[]]
+            : T extends [infer A] // eslint-disable-line no-single-element-tuple-type
+            ? [A[]] // eslint-disable-line no-single-element-tuple-type
+            : T extends List<infer A>
+            ? A[][]
+            : never[];
+        transpose(): T extends [infer A, infer B, infer C]
+            ? [A[], B[], C[]]
+            : T extends [infer A, infer B]
+            ? [A[], B[]]
+            : T extends [infer A] // eslint-disable-line no-single-element-tuple-type
+            ? [A[]] // eslint-disable-line no-single-element-tuple-type
+            : T extends List<infer A>
+            ? A[][]
+            : never[];
 
         /**
          * Converts lists into objects. Call on either a wrapped list of
@@ -5852,6 +5888,10 @@ declare module _ {
          * @returns A chain wrapper around the zipped version of the wrapped
          * list and `lists`.
          **/
+        zip(): _Chain<[T]>; // eslint-disable-line no-single-element-tuple-type
+        zip<A, B>(...arrays: [List<A>, List<B>]): _Chain<[T, A, B]>;
+        zip<A>(array: List<A>): _Chain<[T, A]>;
+        zip(...arrays: List<T>[]): _Chain<T[]>;
         zip(...arrays: List<any>[]): _Chain<any[]>;
 
         /**
@@ -5862,8 +5902,24 @@ declare module _ {
          * @returns A chain wrapper around the unzipped version of the wrapped
          * lists.
          **/
-        unzip(): _Chain<any[]>;
-        transpose(): _Chain<any[]>;
+        unzip(): T extends [infer A, infer B, infer C]
+            ? _Chain<A[] | B[] | C[], [A[], B[], C[]]>
+            : T extends [infer A, infer B]
+            ? _Chain<A[] | B[], [A[], B[]]>
+            : T extends [infer A] // eslint-disable-line no-single-element-tuple-type
+            ? _Chain<A[], [A[]]> // eslint-disable-line no-single-element-tuple-type
+            : T extends List<infer A>
+            ? _Chain<A[]>
+            : _Chain<never>;
+        transpose(): T extends [infer A, infer B, infer C]
+            ? _Chain<A[] | B[] | C[], [A[], B[], C[]]>
+            : T extends [infer A, infer B]
+            ? _Chain<A[] | B[], [A[], B[]]>
+            : T extends [infer A] // eslint-disable-line no-single-element-tuple-type
+            ? _Chain<A[], [A[]]> // eslint-disable-line no-single-element-tuple-type
+            : T extends List<infer A>
+            ? _Chain<A[]>
+            : _Chain<never>;
 
         /**
          * Converts lists into objects. Call on either a wrapped list of

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -40,6 +40,8 @@ type ExplicitDictionaryLiteral = {
     c: StringRecord;
 };
 
+type StringOrNumberList = string[] | number[];
+
 declare const shallowProperty: 'a';
 declare const deepProperty: ['a', 'length'];
 declare const matcher: Partial<StringRecord>;
@@ -2480,7 +2482,6 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     _(tupleList).unzip(); // $ExpectType [string[], number[]]
     // Typescript 4.6 and below arbitrarily swaps the string[] | number[] union to number[] | string[],
     // so we create a type alias to normalise the union.
-    type StringOrNumberList = string[] | number[];
     const string_or_number_list: _._Chain<StringOrNumberList, [string[], number[]]> = _.chain(tupleList).unzip()
     extractChainTypes(string_or_number_list); // $ExpectType ChainType<[string[], number[]], StringOrNumberList>
 
@@ -2515,7 +2516,6 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     _(tupleList).transpose(); // $ExpectType [string[], number[]]
     // Typescript 4.6 and below arbitrarily swaps the string[] | number[] union to number[] | string[],
     // so we create a type alias to normalise the union.
-    type StringOrNumberList = string[] | number[];
     const string_or_number_list: _._Chain<StringOrNumberList, [string[], number[]]> = _.chain(tupleList).transpose()
     extractChainTypes(string_or_number_list); // $ExpectType ChainType<[string[], number[]], StringOrNumberList>
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2492,8 +2492,8 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     _.unzip(); // $ExpectType []
 
     // no arrays
-    _(numberList).unzip(); // $ExpectType never[]
-    extractChainTypes(_.chain(numberList).unzip()); // $ExpectType ChainType<never[], never>
+    _(numberList).unzip(); // $ExpectType []
+    extractChainTypes(_.chain(numberList).unzip()); // $ExpectType ChainType<[], never>
 }
 
 // transpose
@@ -2527,8 +2527,8 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     _.transpose(); // $ExpectType []
 
     // no arrays
-    _(numberList).transpose(); // $ExpectType never[]
-    extractChainTypes(_.chain(numberList).transpose()); // $ExpectType ChainType<never[], never>
+    _(numberList).transpose(); // $ExpectType []
+    extractChainTypes(_.chain(numberList).transpose()); // $ExpectType ChainType<[], never>
 }
 
 // object

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2462,6 +2462,10 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     // no arguments
     _.zip(); // $ExpectType []
 
+    // invalid object arguments
+    _({a: 1}).zip(); // $ExpectType []
+    extractChainTypes(_.chain({a: 1}).zip()); // $ExpectType ChainType<[], never>
+
     // Ensure that checking for undefined doesn't break compilation
     // This is valid if the zipped lists have different lengths
     for (const [left, right] of _.zip(numberList, stringList)) {
@@ -2503,6 +2507,14 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     // no arguments
     _.unzip(); // $ExpectType []
 
+    // invalid object arguments
+    _({a: 1}).unzip(); // $ExpectType []
+    extractChainTypes(_.chain({a: 1}).unzip()); // $ExpectType ChainType<[], never>
+
+    // invalid shallow list arguments
+    _(numberList).unzip(); // $ExpectType []
+    extractChainTypes(_.chain(numberList).unzip()); // $ExpectType ChainType<[], never>
+
     // no arrays
     _(numberList).unzip(); // $ExpectType []
     extractChainTypes(_.chain(numberList).unzip()); // $ExpectType ChainType<[], never>
@@ -2536,6 +2548,14 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
 
     // no arguments
     _.transpose(); // $ExpectType []
+
+    // invalid object arguments
+    _({a: 1}).transpose(); // $ExpectType []
+    extractChainTypes(_.chain({a: 1}).transpose()); // $ExpectType ChainType<[], never>
+
+    // invalid shallow list arguments
+    _(numberList).transpose(); // $ExpectType []
+    extractChainTypes(_.chain(numberList).transpose()); // $ExpectType ChainType<[], never>
 
     // no arrays
     _(numberList).transpose(); // $ExpectType []

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2459,6 +2459,17 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
 
     // no arguments
     _.zip(); // $ExpectType []
+
+    // Ensure that checking for undefined doesn't break compilation
+    // This is valid if the zipped lists have different lengths
+    for (const [left, right] of _.zip(numberList, stringList)) {
+        if (left === undefined) {
+            const left_check: undefined = left;
+        }
+        if (right === undefined) {
+            const right_check: undefined = right;
+        }
+    }
 }
 
 // unzip

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -163,6 +163,8 @@ declare const mixedIterabilityValue: number | number[];
 declare const stringy: StringRecord | string;
 declare const level2UnionList: _.List<_.List<string | number>>;
 declare const tupleList: _.List<[string, number]>;
+declare const unaryTupleList: _.List<[string]>; // eslint-disable-line no-single-element-tuple-type
+declare const homogeneousTupleList: _.List<[string, string, string, string]>;
 declare const maybeFunction: (() => void) | undefined;
 
 // concrete example types
@@ -2437,46 +2439,92 @@ _.uniq([1, 2, 1, 3, 1, 4]); // $ExpectType number[]
 // zip
 
 // merging together lists of values at a set of positions
-_.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $ExpectType any[][]
+_.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $ExpectType [string, number, boolean][]
 
 {
     // multiple arguments
-    _.zip(stringList, numberList, recordList); // $ExpectType any[][]
-    _(stringList).zip(numberList, recordList); // $ExpectType any[][]
-    extractChainTypes(_.chain(stringList).zip(numberList, recordList)); // $ExpectType ChainType<any[][], any[]>
+    _.zip(stringList, numberList, recordList); // $ExpectType [string, number, StringRecord][]
+    _(stringList).zip(numberList, recordList); // $ExpectType [string, number, StringRecord][]
+    extractChainTypes(_.chain(stringList).zip(numberList, recordList)); // $ExpectType ChainType<[string, number, StringRecord][], [string, number, StringRecord]>
 
     // single arguments
-    _.zip(stringList); // $ExpectType any[][]
-    _(stringList).zip(); // $ExpectType any[][]
-    extractChainTypes(_.chain(stringList).zip()); // $ExpectType ChainType<any[][], any[]>
+    _.zip(stringList); // $ExpectType [string][]
+    _(stringList).zip(); // $ExpectType [string][]
+    extractChainTypes(_.chain(stringList).zip()); // $ExpectType ChainType<[string][], [string]>
+
+    // many homogeneous arguments
+    _.zip(numberList, numberList, numberList, numberList); // $ExpectType number[][]
+    _(numberList).zip(numberList, numberList, numberList); // $ExpectType number[][]
+    extractChainTypes(_.chain(numberList).zip(numberList, numberList, numberList)) // $ExpectType ChainType<number[][], number[]>
+
+    // no arguments
+    _.zip(); // $ExpectType []
 }
 
 // unzip
 
 {
     // tuple lists
-    _.unzip(tupleList); // $ExpectType any[][]
-    _(tupleList).unzip(); // $ExpectType any[][]
-    extractChainTypes(_.chain(tupleList).unzip()); // $ExpectType ChainType<any[][], any[]>
+    _.unzip(tupleList); // $ExpectType [string[], number[]]
+    _(tupleList).unzip(); // $ExpectType [string[], number[]]
+    // This test fails for Typescript 4.6 and below only because it
+    // arbitrarily swaps the string[] | number[] union to number[] | string[]
+    // extractChainTypes(_.chain(tupleList).unzip()); // $ExpectType ChainType<[string[], number[]], string[] | number[]>
 
     // nested lists
-    _.unzip(level2UnionList); // $ExpectType any[][]
-    _(level2UnionList).unzip(); // $ExpectType any[][]
-    extractChainTypes(_.chain(level2UnionList).unzip()); // $ExpectType ChainType<any[][], any[]>
+    _.unzip(level2UnionList); // $ExpectType (string | number)[][]
+    _(level2UnionList).unzip(); // $ExpectType (string | number)[][]
+    extractChainTypes(_.chain(level2UnionList).unzip()); // $ExpectType ChainType<(string | number)[][], (string | number)[]>
+
+    // unary tuple list
+    _.unzip(unaryTupleList); // $ExpectType [string[]]
+    _(unaryTupleList).unzip(); // $ExpectType [string[]]
+    extractChainTypes(_.chain(unaryTupleList).unzip()) // $ExpectType ChainType<[string[]], string[]>
+
+    // homogeneous tuple list
+    _.unzip(homogeneousTupleList); // $ExpectType string[][]
+    _(homogeneousTupleList).unzip(); // $ExpectType string[][]
+    extractChainTypes(_.chain(homogeneousTupleList).unzip()) // $ExpectType ChainType<string[][], string[]>
+
+    // no arguments
+    _.unzip(); // $ExpectType []
+
+    // no arrays
+    _(numberList).unzip(); // $ExpectType never[]
+    extractChainTypes(_.chain(numberList).unzip()); // $ExpectType ChainType<never[], never>
 }
 
 // transpose
 
 {
     // tuple lists
-    _.transpose(tupleList); // $ExpectType any[][]
-    _(tupleList).transpose(); // $ExpectType any[][]
-    extractChainTypes(_.chain(tupleList).transpose()); // $ExpectType ChainType<any[][], any[]>
+    _.transpose(tupleList); // $ExpectType [string[], number[]]
+    _(tupleList).transpose(); // $ExpectType [string[], number[]]
+    // This test fails for Typescript 4.6 and below only because it
+    // arbitrarily swaps the string[] | number[] union to number[] | string[]
+    // extractChainTypes(_.chain(tupleList).transpose()); // $ExpectType ChainType<[string[], number[]], string[] | number[]>
 
     // nested lists
-    _.transpose(level2UnionList); // $ExpectType any[][]
-    _(level2UnionList).transpose(); // $ExpectType any[][]
-    extractChainTypes(_.chain(level2UnionList).transpose()); // $ExpectType ChainType<any[][], any[]>
+    _.transpose(level2UnionList); // $ExpectType (string | number)[][]
+    _(level2UnionList).transpose(); // $ExpectType (string | number)[][]
+    extractChainTypes(_.chain(level2UnionList).transpose()); // $ExpectType ChainType<(string | number)[][], (string | number)[]>
+
+    // unary tuple list
+    _.transpose(unaryTupleList); // $ExpectType [string[]]
+    _(unaryTupleList).transpose(); // $ExpectType [string[]]
+    extractChainTypes(_.chain(unaryTupleList).transpose()) // $ExpectType ChainType<[string[]], string[]>
+
+    // homogeneous tuple list
+    _.transpose(homogeneousTupleList); // $ExpectType string[][]
+    _(homogeneousTupleList).transpose(); // $ExpectType string[][]
+    extractChainTypes(_.chain(homogeneousTupleList).transpose()) // $ExpectType ChainType<string[][], string[]>
+
+    // no arguments
+    _.transpose(); // $ExpectType []
+
+    // no arrays
+    _(numberList).transpose(); // $ExpectType never[]
+    extractChainTypes(_.chain(numberList).transpose()); // $ExpectType ChainType<never[], never>
 }
 
 // object
@@ -3552,13 +3600,13 @@ _.chain({
     .uniq()
     .value();
 
-// $ExpectType any[][]
+// $ExpectType [("one" | "two")[], number[]]
 _.chain({ one: 1, two: 2 })
     .pairs()
     .unzip()
     .value();
 
-// $ExpectType any[][]
+// $ExpectType [("one" | "two")[], number[]]
 _.chain({ one: 1, two: 2 })
     .pairs()
     .transpose()

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2467,9 +2467,11 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     // tuple lists
     _.unzip(tupleList); // $ExpectType [string[], number[]]
     _(tupleList).unzip(); // $ExpectType [string[], number[]]
-    // This test fails for Typescript 4.6 and below only because it
-    // arbitrarily swaps the string[] | number[] union to number[] | string[]
-    // extractChainTypes(_.chain(tupleList).unzip()); // $ExpectType ChainType<[string[], number[]], string[] | number[]>
+    // Typescript 4.6 and below arbitrarily swaps the string[] | number[] union to number[] | string[],
+    // so we create a type alias to normalise the union.
+    type StringOrNumberList = string[] | number[];
+    const string_or_number_list: _._Chain<StringOrNumberList, [string[], number[]]> = _.chain(tupleList).unzip()
+    extractChainTypes(string_or_number_list); // $ExpectType ChainType<[string[], number[]], StringOrNumberList>
 
     // nested lists
     _.unzip(level2UnionList); // $ExpectType (string | number)[][]
@@ -2500,9 +2502,11 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]); // $Expect
     // tuple lists
     _.transpose(tupleList); // $ExpectType [string[], number[]]
     _(tupleList).transpose(); // $ExpectType [string[], number[]]
-    // This test fails for Typescript 4.6 and below only because it
-    // arbitrarily swaps the string[] | number[] union to number[] | string[]
-    // extractChainTypes(_.chain(tupleList).transpose()); // $ExpectType ChainType<[string[], number[]], string[] | number[]>
+    // Typescript 4.6 and below arbitrarily swaps the string[] | number[] union to number[] | string[],
+    // so we create a type alias to normalise the union.
+    type StringOrNumberList = string[] | number[];
+    const string_or_number_list: _._Chain<StringOrNumberList, [string[], number[]]> = _.chain(tupleList).transpose()
+    extractChainTypes(string_or_number_list); // $ExpectType ChainType<[string[], number[]], StringOrNumberList>
 
     // nested lists
     _.transpose(level2UnionList); // $ExpectType (string | number)[][]


### PR DESCRIPTION
This adds more specific type overloads to zip, unzip and transpose methods. It caters to the typical usecase where 3 or less lists are passed in, or when the contents of all passed lists have the same type.

The output types are technically wrong in situations where the input lists are of different lengths. In these cases the returned list might contain undefined elements.

I could add optionality to the types where appropriate, but this would not be in line with Typescript's own opinions on a similar concept with respect to accessing arrays - Typescript assumes that array access returns an object of the array's type without adding `undefined`, even though `undefined` is a possible value. There is a flag to account for these undefined accesses, but it's not even part of the "strict' Typescript setting. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/#zip, https://underscorejs.org/#unzip
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
