### PR TITLE
[openui5] Register custom JSDoc tags, use; add some missing event types

### DIFF
--- a/types/openui5/.eslintrc.json
+++ b/types/openui5/.eslintrc.json
@@ -1,6 +1,12 @@
 {
     "rules": {
         "no-any-union": "off",
-        "no-unnecessary-generics": "off"
+        "no-unnecessary-generics": "off",
+        "jsdoc/check-tag-names": [
+            "error",
+            {
+                "definedTags": ["ui5-protected", "experimental"]
+            }
+        ]
     }
 }

--- a/types/openui5/index.d.ts
+++ b/types/openui5/index.d.ts
@@ -12,13 +12,7 @@
  */
 
 /**
- * This is a Beta version of the OpenUI5 TypeScript signatures.
- * Significant changes may occur in future versions,
- * including potential breaking changes.
- */
-
-/**
- * For further important notes, please read README.md!
+ * For important notes, please read README.md!
  *
  * These *.d.ts files are generated. In case of issues, either the generator or the JSDoc in the original
  * OpenUI5 repository must be fixed. While the latest version of the generator is not yet available at

--- a/types/openui5/openui5-tests.ts
+++ b/types/openui5/openui5-tests.ts
@@ -17,7 +17,7 @@ import Dialog from "sap/m/Dialog";
 import MessageBox from "sap/m/MessageBox";
 import FileUploader, { FileUploader$UploadCompleteEvent } from "sap/ui/unified/FileUploader";
 import FileUploaderParameter from "sap/ui/unified/FileUploaderParameter";
-import ODataV4ListBinding from "sap/ui/model/odata/v4/ODataListBinding";
+import ODataV4ListBinding, { ODataListBinding$CreateCompletedEvent } from "sap/ui/model/odata/v4/ODataListBinding";
 import Target from "sap/ui/core/routing/Target";
 import { TitleLevel } from "sap/ui/core/library";
 import DateTimePicker from "sap/m/DateTimePicker";
@@ -204,4 +204,9 @@ Mobile.setIcons({precomposed: false});
 sap.ui.require(["sap/m/Button", "sap/m/Input"], (B: typeof Button, I: typeof Input) => {
     const b = new B({text: "Hello"});
     const i = new I();
+});
+
+// 1.116.1: more event parameters defined
+odataV4ListBinding.attachCreateCompleted((evt: ODataListBinding$CreateCompletedEvent) => {
+    const contect = evt.getParameter("context");
 });

--- a/types/openui5/sap.f.d.ts
+++ b/types/openui5/sap.f.d.ts
@@ -39,7 +39,7 @@ declare module "sap/f/library" {
 
   /**
    * @since 1.73
-   * Experimental (since 1.73)
+   * @experimental (since 1.73)
    *
    * Group modes for the {@link sap.f.AvatarGroup} control.
    */
@@ -169,7 +169,7 @@ declare module "sap/f/library" {
 
   /**
    * @since 1.63
-   * Experimental (since 1.63) - that provides only limited functionality. Also, it can be removed in future
+   * @experimental (since 1.63) - that provides only limited functionality. Also, it can be removed in future
    * versions.
    *
    * Interface for controls suitable for the `additionalContent` aggregation of `{@link sap.f.ShellBar}`.
@@ -512,7 +512,7 @@ declare module "sap/f/AvatarGroup" {
 
   /**
    * @since 1.73
-   * Experimental (since 1.73) - This class is experimental and provides only limited functionality. Also
+   * @experimental (since 1.73) - This class is experimental and provides only limited functionality. Also
    * the API might be changed in future.
    *
    * Displays a group of avatars arranged horizontally. It is useful to visually showcase a group of related
@@ -686,7 +686,7 @@ declare module "sap/f/AvatarGroup" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -971,7 +971,7 @@ declare module "sap/f/AvatarGroupItem" {
 
   /**
    * @since 1.73
-   * Experimental (since 1.73) - This class is experimental and provides only limited functionality. Also
+   * @experimental (since 1.73) - This class is experimental and provides only limited functionality. Also
    * the API might be changed in future.
    *
    * Represents a single avatar item displayed in the {@link sap.f.AvatarGroup} control.
@@ -1435,7 +1435,7 @@ declare module "sap/f/CardBase" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM Element that should get the focus.
      *
@@ -1586,7 +1586,7 @@ declare module "sap/f/cards/BaseHeader" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.86
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Destroys the toolbar in the aggregation {@link #getToolbar toolbar}.
      *
@@ -1594,7 +1594,7 @@ declare module "sap/f/cards/BaseHeader" {
      */
     destroyToolbar(): this;
     /**
-     * Experimental (since 1.89) - this feature is experimental and the API may change.
+     * @experimental (since 1.89) - this feature is experimental and the API may change.
      *
      * Gets current value of property {@link #getDataTimestamp dataTimestamp}.
      *
@@ -1611,7 +1611,7 @@ declare module "sap/f/cards/BaseHeader" {
      */
     getDataTimestamp(): string;
     /**
-     * Experimental (since 1.116) - this feature is experimental and the API may change.
+     * @experimental (since 1.116) - this feature is experimental and the API may change.
      *
      * Gets current value of property {@link #getStatusVisible statusVisible}.
      *
@@ -1624,7 +1624,7 @@ declare module "sap/f/cards/BaseHeader" {
     getStatusVisible(): boolean;
     /**
      * @since 1.86
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Gets content of aggregation {@link #getToolbar toolbar}.
      *
@@ -1632,7 +1632,7 @@ declare module "sap/f/cards/BaseHeader" {
      */
     getToolbar(): Control;
     /**
-     * Experimental (since 1.116) - this feature is experimental and the API may change.
+     * @experimental (since 1.116) - this feature is experimental and the API may change.
      *
      * Sets a new value for property {@link #getStatusVisible statusVisible}.
      *
@@ -1652,7 +1652,7 @@ declare module "sap/f/cards/BaseHeader" {
     ): this;
     /**
      * @since 1.86
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Sets the aggregated {@link #getToolbar toolbar}.
      *
@@ -1668,7 +1668,7 @@ declare module "sap/f/cards/BaseHeader" {
 
   export interface $BaseHeaderSettings extends $ControlSettings {
     /**
-     * Experimental (since 1.89) - this feature is experimental and the API may change.
+     * @experimental (since 1.89) - this feature is experimental and the API may change.
      *
      * Defines the timestamp of the oldest data in the card. Use this to show to the end user how fresh the
      * information in the card is.
@@ -1680,7 +1680,7 @@ declare module "sap/f/cards/BaseHeader" {
     dataTimestamp?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.116) - this feature is experimental and the API may change.
+     * @experimental (since 1.116) - this feature is experimental and the API may change.
      *
      * Defines the status text visibility.
      */
@@ -1688,7 +1688,7 @@ declare module "sap/f/cards/BaseHeader" {
 
     /**
      * @since 1.86
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Defines the toolbar.
      */
@@ -1854,7 +1854,7 @@ declare module "sap/f/cards/Header" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is a hook for the RenderManager that gets called during the rendering of child Controls.
      * It allows to add, remove and update existing accessibility attributes (ARIA) of those controls.
@@ -1874,7 +1874,7 @@ declare module "sap/f/cards/Header" {
       }
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -1887,7 +1887,7 @@ declare module "sap/f/cards/Header" {
       mParameters?: object
     ): this;
     /**
-     * Experimental (since 1.81) - this feature is experimental and the API may change.
+     * @experimental (since 1.81) - this feature is experimental and the API may change.
      *
      * Gets current value of property {@link #getIconAlt iconAlt}.
      *
@@ -1899,7 +1899,7 @@ declare module "sap/f/cards/Header" {
      */
     getIconAlt(): string;
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Gets current value of property {@link #getIconBackgroundColor iconBackgroundColor}.
      *
@@ -1941,7 +1941,7 @@ declare module "sap/f/cards/Header" {
      */
     getIconSrc(): URI;
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Gets current value of property {@link #getIconVisible iconVisible}.
      *
@@ -1973,7 +1973,7 @@ declare module "sap/f/cards/Header" {
      */
     getSubtitle(): string;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Gets current value of property {@link #getSubtitleMaxLines subtitleMaxLines}.
      *
@@ -1995,7 +1995,7 @@ declare module "sap/f/cards/Header" {
      */
     getTitle(): string;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Gets current value of property {@link #getTitleMaxLines titleMaxLines}.
      *
@@ -2007,7 +2007,7 @@ declare module "sap/f/cards/Header" {
      */
     getTitleMaxLines(): int;
     /**
-     * Experimental (since 1.81) - this feature is experimental and the API may change.
+     * @experimental (since 1.81) - this feature is experimental and the API may change.
      *
      * Sets a new value for property {@link #getIconAlt iconAlt}.
      *
@@ -2026,7 +2026,7 @@ declare module "sap/f/cards/Header" {
       sIconAlt?: string
     ): this;
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Sets a new value for property {@link #getIconBackgroundColor iconBackgroundColor}.
      *
@@ -2096,7 +2096,7 @@ declare module "sap/f/cards/Header" {
       sIconSrc?: URI
     ): this;
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Sets a new value for property {@link #getIconVisible iconVisible}.
      *
@@ -2149,7 +2149,7 @@ declare module "sap/f/cards/Header" {
       sSubtitle?: string
     ): this;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Sets a new value for property {@link #getSubtitleMaxLines subtitleMaxLines}.
      *
@@ -2185,7 +2185,7 @@ declare module "sap/f/cards/Header" {
       sTitle?: string
     ): this;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Sets a new value for property {@link #getTitleMaxLines titleMaxLines}.
      *
@@ -2212,7 +2212,7 @@ declare module "sap/f/cards/Header" {
     title?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Limits the number of lines for the title.
      */
@@ -2224,7 +2224,7 @@ declare module "sap/f/cards/Header" {
     subtitle?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Limits the number of lines for the subtitle.
      */
@@ -2254,14 +2254,14 @@ declare module "sap/f/cards/Header" {
     iconInitials?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.81) - this feature is experimental and the API may change.
+     * @experimental (since 1.81) - this feature is experimental and the API may change.
      *
      * Defines an alt text for the avatar or icon.
      */
     iconAlt?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Defines a background color for the avatar or icon.
      */
@@ -2271,7 +2271,7 @@ declare module "sap/f/cards/Header" {
       | `{${string}}`;
 
     /**
-     * Experimental (since 1.83) - this feature is experimental and the API may change.
+     * @experimental (since 1.83) - this feature is experimental and the API may change.
      *
      * Defines whether the card icon is visible.
      */
@@ -2292,13 +2292,13 @@ declare module "sap/f/cards/loading/PlaceholderBaseRenderer" {
   import RenderManager from "sap/ui/core/RenderManager";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * PlaceholderBase renderer.
    */
   interface PlaceholderBaseRenderer {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is reserved for derived classes to add their respective attributes.
      */
@@ -2313,7 +2313,7 @@ declare module "sap/f/cards/loading/PlaceholderBaseRenderer" {
       oRm: RenderManager
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is reserved for derived classes to render their respective content.
      */
@@ -2513,7 +2513,7 @@ declare module "sap/f/cards/NumericHeader" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is a hook for the RenderManager that gets called during the rendering of child Controls.
      * It allows to add, remove and update existing accessibility attributes (ARIA) of those controls.
@@ -2533,7 +2533,7 @@ declare module "sap/f/cards/NumericHeader" {
       }
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -2554,7 +2554,7 @@ declare module "sap/f/cards/NumericHeader" {
      */
     getDetails(): string;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Gets current value of property {@link #getDetailsMaxLines detailsMaxLines}.
      *
@@ -2616,7 +2616,7 @@ declare module "sap/f/cards/NumericHeader" {
       | cards.NumericHeaderSideIndicatorsAlignment
       | keyof typeof cards.NumericHeaderSideIndicatorsAlignment;
     /**
-     * Experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getState state}.
@@ -2647,7 +2647,7 @@ declare module "sap/f/cards/NumericHeader" {
      */
     getSubtitle(): string;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Gets current value of property {@link #getSubtitleMaxLines subtitleMaxLines}.
      *
@@ -2667,7 +2667,7 @@ declare module "sap/f/cards/NumericHeader" {
      */
     getTitle(): string;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Gets current value of property {@link #getTitleMaxLines titleMaxLines}.
      *
@@ -2760,7 +2760,7 @@ declare module "sap/f/cards/NumericHeader" {
       sDetails: string
     ): this;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Sets a new value for property {@link #getDetailsMaxLines detailsMaxLines}.
      *
@@ -2850,7 +2850,7 @@ declare module "sap/f/cards/NumericHeader" {
         | keyof typeof cards.NumericHeaderSideIndicatorsAlignment
     ): this;
     /**
-     * Experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets a new value for property {@link #getState state}.
@@ -2902,7 +2902,7 @@ declare module "sap/f/cards/NumericHeader" {
       sSubtitle: string
     ): this;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Sets a new value for property {@link #getSubtitleMaxLines subtitleMaxLines}.
      *
@@ -2936,7 +2936,7 @@ declare module "sap/f/cards/NumericHeader" {
       sTitle: string
     ): this;
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Sets a new value for property {@link #getTitleMaxLines titleMaxLines}.
      *
@@ -2995,7 +2995,7 @@ declare module "sap/f/cards/NumericHeader" {
     title?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Limits the number of lines for the title.
      */
@@ -3007,7 +3007,7 @@ declare module "sap/f/cards/NumericHeader" {
     subtitle?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Limits the number of lines for the subtitle.
      */
@@ -3052,7 +3052,7 @@ declare module "sap/f/cards/NumericHeader" {
       | `{${string}}`;
 
     /**
-     * Experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * The semantic color which represents the state of the main number indicator.
@@ -3068,7 +3068,7 @@ declare module "sap/f/cards/NumericHeader" {
     details?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.101)
+     * @experimental (since 1.101)
      *
      * Limits the number of lines for the details.
      */
@@ -3190,7 +3190,7 @@ declare module "sap/f/cards/NumericSideIndicator" {
      */
     getNumber(): string;
     /**
-     * Experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getState state}.
@@ -3230,7 +3230,7 @@ declare module "sap/f/cards/NumericSideIndicator" {
       sValue: string
     ): this;
     /**
-     * Experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets a new value for property {@link #getState state}.
@@ -3290,7 +3290,7 @@ declare module "sap/f/cards/NumericSideIndicator" {
     unit?: string | PropertyBindingInfo;
 
     /**
-     * Experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.95) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * The semantic color which represents the state of the side indicator.
@@ -3318,7 +3318,7 @@ declare module "sap/f/dnd/GridDropInfo" {
 
   /**
    * @since 1.68
-   * Experimental (since 1.68) - This class is experimental. The API may change.
+   * @experimental (since 1.68) - This class is experimental. The API may change.
    *
    * Provides enhanced configuration for drop operations inside grid-based controls.
    *
@@ -3715,7 +3715,7 @@ declare module "sap/f/DynamicPage" {
     ): this;
     /**
      * @since 1.93
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pinnedStateChange pinnedStateChange} to attached listeners.
      *
@@ -5305,7 +5305,7 @@ declare module "sap/f/DynamicPageTitle" {
     ): this;
     /**
      * @since 1.54
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stateChange stateChange} to attached listeners.
      *
@@ -7058,7 +7058,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterBeginColumnNavigate afterBeginColumnNavigate} to attached listeners.
      *
@@ -7071,7 +7071,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$AfterBeginColumnNavigateEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterEndColumnNavigate afterEndColumnNavigate} to attached listeners.
      *
@@ -7084,7 +7084,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$AfterEndColumnNavigateEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterMidColumnNavigate afterMidColumnNavigate} to attached listeners.
      *
@@ -7097,7 +7097,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$AfterMidColumnNavigateEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beginColumnNavigate beginColumnNavigate} to attached listeners.
      *
@@ -7114,7 +7114,7 @@ declare module "sap/f/FlexibleColumnLayout" {
     ): boolean;
     /**
      * @since 1.76
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnResize columnResize} to attached listeners.
      *
@@ -7127,7 +7127,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$ColumnResizeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:endColumnNavigate endColumnNavigate} to attached listeners.
      *
@@ -7143,7 +7143,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$EndColumnNavigateEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:midColumnNavigate midColumnNavigate} to attached listeners.
      *
@@ -7159,7 +7159,7 @@ declare module "sap/f/FlexibleColumnLayout" {
       mParameters?: FlexibleColumnLayout$MidColumnNavigateEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stateChange stateChange} to attached listeners.
      *
@@ -9631,7 +9631,7 @@ declare module "sap/f/GridContainer" {
      */
     destroyLayoutXL(): this;
     /**
-     * Experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Destroys the layoutXS in the aggregation {@link #getLayoutXS layoutXS}.
@@ -9693,7 +9693,7 @@ declare module "sap/f/GridContainer" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:borderReached borderReached} to attached listeners.
      *
@@ -9706,7 +9706,7 @@ declare module "sap/f/GridContainer" {
       mParameters?: GridContainer$BorderReachedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnsChange columnsChange} to attached listeners.
      *
@@ -9719,7 +9719,7 @@ declare module "sap/f/GridContainer" {
       mParameters?: GridContainer$ColumnsChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:layoutChange layoutChange} to attached listeners.
      *
@@ -9732,7 +9732,7 @@ declare module "sap/f/GridContainer" {
       mParameters?: GridContainer$LayoutChangeEventParameters
     ): this;
     /**
-     * Experimental (since 1.81) - Behavior might change.
+     * @experimental (since 1.81) - Behavior might change.
      *
      * Focuses the item on the given index. Should be called after successful drop operation.
      *
@@ -9745,7 +9745,7 @@ declare module "sap/f/GridContainer" {
       iIndex: int
     ): void;
     /**
-     * Experimental (since 1.85) - Behavior might change.
+     * @experimental (since 1.85) - Behavior might change.
      *
      * Focuses an item in the given direction - up, down, left or right, from the starting position specified
      * by row and column.
@@ -9779,7 +9779,7 @@ declare module "sap/f/GridContainer" {
      */
     getActiveLayoutSettings(): GridContainerSettings;
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getAllowDenseFill allowDenseFill}.
@@ -9814,7 +9814,7 @@ declare module "sap/f/GridContainer" {
      */
     getContainerQuery(): boolean;
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getInlineBlockLayout inlineBlockLayout}.
@@ -9873,7 +9873,7 @@ declare module "sap/f/GridContainer" {
      */
     getLayoutXL(): GridContainerSettings;
     /**
-     * Experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets content of aggregation {@link #getLayoutXS layoutXS}.
@@ -9882,7 +9882,7 @@ declare module "sap/f/GridContainer" {
      */
     getLayoutXS(): GridContainerSettings;
     /**
-     * Experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Gets current value of property {@link #getMinHeight minHeight}.
@@ -10001,7 +10001,7 @@ declare module "sap/f/GridContainer" {
       vItem: int | string | Control
     ): Control | null;
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets a new value for property {@link #getAllowDenseFill allowDenseFill}.
@@ -10042,7 +10042,7 @@ declare module "sap/f/GridContainer" {
       bContainerQuery?: boolean
     ): this;
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets a new value for property {@link #getInlineBlockLayout inlineBlockLayout}.
@@ -10121,7 +10121,7 @@ declare module "sap/f/GridContainer" {
       oLayoutXL: GridContainerSettings
     ): this;
     /**
-     * Experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets the aggregated {@link #getLayoutXS layoutXS}.
@@ -10135,7 +10135,7 @@ declare module "sap/f/GridContainer" {
       oLayoutXS: GridContainerSettings
     ): this;
     /**
-     * Experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Sets a new value for property {@link #getMinHeight minHeight}.
@@ -10201,7 +10201,7 @@ declare module "sap/f/GridContainer" {
     width?: CSSSize | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.81) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Defines the minimum height of the grid.
@@ -10224,7 +10224,7 @@ declare module "sap/f/GridContainer" {
     snapToRow?: boolean | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Increases the density when arranging the items. Smaller items will take up all of the available space,
@@ -10235,7 +10235,7 @@ declare module "sap/f/GridContainer" {
     allowDenseFill?: boolean | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.66) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Makes the grid items act like an inline-block elements. They will be arranged in rows with height equal
@@ -10263,7 +10263,7 @@ declare module "sap/f/GridContainer" {
     layout?: GridContainerSettings;
 
     /**
-     * Experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.71) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * The sap.f.GridContainerSettings applied for size "XS". Range: up to 374px.
@@ -10371,7 +10371,7 @@ declare module "sap/f/GridContainerItemLayoutData" {
 
   /**
    * @since 1.65
-   * Experimental (since 1.65) - This class is experimental. The API may change.
+   * @experimental (since 1.65) - This class is experimental. The API may change.
    *
    * Holds layout data for an item inside a `sap.f.GridContainer`.
    */
@@ -10464,7 +10464,7 @@ declare module "sap/f/GridContainerItemLayoutData" {
      */
     getMinRows(): int;
     /**
-     * Experimental (since 1.65) - this property may soon be removed, use minRows instead
+     * @experimental (since 1.65) - this property may soon be removed, use minRows instead
      *
      * Gets current value of property {@link #getRows rows}.
      *
@@ -10511,7 +10511,7 @@ declare module "sap/f/GridContainerItemLayoutData" {
       iMinRows: int
     ): this;
     /**
-     * Experimental (since 1.65) - this property may soon be removed, use minRows instead
+     * @experimental (since 1.65) - this property may soon be removed, use minRows instead
      *
      * Sets a new value for property {@link #getRows rows}.
      *
@@ -10547,7 +10547,7 @@ declare module "sap/f/GridContainerItemLayoutData" {
     minRows?: int | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.65) - this property may soon be removed, use minRows instead
+     * @experimental (since 1.65) - this property may soon be removed, use minRows instead
      *
      * Specifies the number of rows, which the item should take.
      */
@@ -10568,7 +10568,7 @@ declare module "sap/f/GridContainerSettings" {
 
   /**
    * @since 1.65
-   * Experimental (since 1.65) - This class is experimental. The API may change.
+   * @experimental (since 1.65) - This class is experimental. The API may change.
    *
    * Holds a set of settings that define the dimensions of `sap.f.GridContainer`.
    *
@@ -11073,7 +11073,7 @@ declare module "sap/f/GridList" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:borderReached borderReached} to attached listeners.
      *
@@ -11086,7 +11086,7 @@ declare module "sap/f/GridList" {
       mParameters?: GridList$BorderReachedEventParameters
     ): this;
     /**
-     * Experimental (since 1.87) - Behavior might change.
+     * @experimental (since 1.87) - Behavior might change.
      *
      * Focuses an item in the given direction - up, down, left or right, from the starting position specified
      * by row and column.
@@ -11120,7 +11120,7 @@ declare module "sap/f/GridList" {
      */
     getCustomLayout(): GridLayoutBase;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Implements IGridConfigurable interface.
      *
@@ -11128,7 +11128,7 @@ declare module "sap/f/GridList" {
      */
     getGridDomRefs(): HTMLElement[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Implements IGridConfigurable interface.
      *
@@ -11608,7 +11608,7 @@ declare module "sap/f/ProductSwitch" {
 
   /**
    * @since 1.72
-   * Experimental (since 1.72) - This class is experimental and provides only limited functionality. Also
+   * @experimental (since 1.72) - This class is experimental and provides only limited functionality. Also
    * the API might be changed in future.
    *
    * A layout control that provides specific configuration about how the items should be displayed.
@@ -11754,7 +11754,7 @@ declare module "sap/f/ProductSwitch" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -11882,7 +11882,7 @@ declare module "sap/f/ProductSwitchItem" {
 
   /**
    * @since 1.72
-   * Experimental (since 1.72) - This class is experimental and provides only limited functionality. Also
+   * @experimental (since 1.72) - This class is experimental and provides only limited functionality. Also
    * the API might be changed in future.
    *
    * A control that is used as a child of `ProductSwitch`
@@ -13027,7 +13027,7 @@ declare module "sap/f/SearchManager" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -13040,7 +13040,7 @@ declare module "sap/f/SearchManager" {
       mParameters?: SearchManager$LiveChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -13053,7 +13053,7 @@ declare module "sap/f/SearchManager" {
       mParameters?: SearchManager$SearchEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggest suggest} to attached listeners.
      *
@@ -17993,7 +17993,7 @@ declare module "sap/f/ShellBar" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets classes according to the context of the page. Possible contexts are header, footer, and subheader.
      *
@@ -18002,7 +18002,7 @@ declare module "sap/f/ShellBar" {
     _applyContextClassFor(): IBar;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the HTML tag according to the context of the page. Possible contexts are header, footer, and subheader.
      *
@@ -18022,7 +18022,7 @@ declare module "sap/f/ShellBar" {
     ): this;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets classes and HTML tag according to the context of the page. Possible contexts are header, footer,
      * and subheader
@@ -18575,7 +18575,7 @@ declare module "sap/f/ShellBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:avatarPressed avatarPressed} to attached listeners.
      *
@@ -18588,7 +18588,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$AvatarPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:copilotPressed copilotPressed} to attached listeners.
      *
@@ -18601,7 +18601,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$CopilotPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:homeIconPressed homeIconPressed} to attached listeners.
      *
@@ -18614,7 +18614,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$HomeIconPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:menuButtonPressed menuButtonPressed} to attached listeners.
      *
@@ -18627,7 +18627,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$MenuButtonPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navButtonPressed navButtonPressed} to attached listeners.
      *
@@ -18640,7 +18640,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$NavButtonPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:notificationsPressed notificationsPressed} to attached listeners.
      *
@@ -18653,7 +18653,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$NotificationsPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:productSwitcherPressed productSwitcherPressed} to attached listeners.
      *
@@ -18666,7 +18666,7 @@ declare module "sap/f/ShellBar" {
       mParameters?: ShellBar$ProductSwitcherPressedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:searchButtonPressed searchButtonPressed} to attached listeners.
      *
@@ -18688,7 +18688,7 @@ declare module "sap/f/ShellBar" {
     getAdditionalContent(): IShellBar[];
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the available Bar contexts.
      *
@@ -18719,7 +18719,7 @@ declare module "sap/f/ShellBar" {
     getHomeIconTooltip(): string;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the HTML tag of the root DOM Reference.
      *
@@ -18872,7 +18872,7 @@ declare module "sap/f/ShellBar" {
     ): this;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns if the bar is sensitive to the container context. Implementation of the IBar interface
      *
@@ -18936,7 +18936,7 @@ declare module "sap/f/ShellBar" {
     ): this;
     /**
      * @since 1.65
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the HTML tag of the root DOM Reference.
      *
@@ -19597,7 +19597,7 @@ declare module "sap/f/SidePanel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggle toggle} to attached listeners.
      *

--- a/types/openui5/sap.tnt.d.ts
+++ b/types/openui5/sap.tnt.d.ts
@@ -596,7 +596,7 @@ declare module "sap/tnt/NavigationList" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemSelect itemSelect} to attached listeners.
      *
@@ -1015,7 +1015,7 @@ declare module "sap/tnt/NavigationListItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -1038,7 +1038,7 @@ declare module "sap/tnt/NavigationListItem" {
      */
     getExpanded(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM Element that should get the focus.
      *
@@ -1082,7 +1082,7 @@ declare module "sap/tnt/NavigationListItem" {
     getItems(): NavigationListItem[];
     /**
      * @since 1.116
-     * Experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Gets current value of property {@link #getSelectable selectable}.
@@ -1235,7 +1235,7 @@ declare module "sap/tnt/NavigationListItem" {
     ): this;
     /**
      * @since 1.116
-     * Experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Sets a new value for property {@link #getSelectable selectable}.
@@ -1319,7 +1319,7 @@ declare module "sap/tnt/NavigationListItem" {
 
     /**
      * @since 1.116
-     * Experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.116) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release.
      *
      * Specifies if the item can be selected.
@@ -1551,7 +1551,7 @@ declare module "sap/tnt/SideNavigation" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemSelect itemSelect} to attached listeners.
      *

--- a/types/openui5/sap.ui.codeeditor.d.ts
+++ b/types/openui5/sap.ui.codeeditor.d.ts
@@ -221,7 +221,7 @@ declare module "sap/ui/codeeditor/CodeEditor" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -234,7 +234,7 @@ declare module "sap/ui/codeeditor/CodeEditor" {
       mParameters?: CodeEditor$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *

--- a/types/openui5/sap.ui.commons.d.ts
+++ b/types/openui5/sap.ui.commons.d.ts
@@ -930,7 +930,7 @@ declare module "sap/ui/commons/Accordion" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sectionClose sectionClose} to attached listeners.
      *
@@ -943,7 +943,7 @@ declare module "sap/ui/commons/Accordion" {
       mParameters?: Accordion$SectionCloseEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sectionOpen sectionOpen} to attached listeners.
      *
@@ -956,7 +956,7 @@ declare module "sap/ui/commons/Accordion" {
       mParameters?: Accordion$SectionOpenEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sectionsReorder sectionsReorder} to attached listeners.
      *
@@ -1315,7 +1315,7 @@ declare module "sap/ui/commons/AccordionSection" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:scroll scroll} to attached listeners.
      *
@@ -1669,7 +1669,7 @@ declare module "sap/ui/commons/ApplicationHeader" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:logoff logoff} to attached listeners.
      *
@@ -2183,7 +2183,7 @@ declare module "sap/ui/commons/AutoComplete" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggest suggest} to attached listeners.
      *
@@ -3002,7 +3002,7 @@ declare module "sap/ui/commons/Button" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -3019,7 +3019,7 @@ declare module "sap/ui/commons/Button" {
      */
     focus(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -4003,7 +4003,7 @@ declare module "sap/ui/commons/CalloutBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -4019,7 +4019,7 @@ declare module "sap/ui/commons/CalloutBase" {
       mParameters?: CalloutBase$BeforeOpenEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -4032,7 +4032,7 @@ declare module "sap/ui/commons/CalloutBase" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -4046,7 +4046,7 @@ declare module "sap/ui/commons/CalloutBase" {
     ): this;
     /**
      * @since 1.11.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:opened opened} to attached listeners.
      *
@@ -4295,7 +4295,7 @@ declare module "sap/ui/commons/Carousel" {
      */
     getFirstVisibleIndex(): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM Element that should get the focus.
      *
@@ -4817,7 +4817,7 @@ declare module "sap/ui/commons/CheckBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -4830,7 +4830,7 @@ declare module "sap/ui/commons/CheckBox" {
       mParameters?: CheckBox$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -5358,7 +5358,7 @@ declare module "sap/ui/commons/ComboBox" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Compares the previous value with the current value and fires the "Change" event if the ComboBox is editable
      * and the value has changed or whether the value has been changed e.g. via up/down or auto-complete feature
@@ -5406,7 +5406,7 @@ declare module "sap/ui/commons/ComboBox" {
      */
     destroyItems(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fire event change to attached listeners.
      *
@@ -5423,7 +5423,7 @@ declare module "sap/ui/commons/ComboBox" {
       mArguments?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -5443,7 +5443,7 @@ declare module "sap/ui/commons/ComboBox" {
      */
     getDisplaySecondaryValues(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM element which represents the icon for value help. Could be overwritten in child-classes.
      *
@@ -5525,7 +5525,7 @@ declare module "sap/ui/commons/ComboBox" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle sapenter pseudo events on the control
      */
@@ -5536,7 +5536,7 @@ declare module "sap/ui/commons/ComboBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle sapescape pseudo events on the control
      */
@@ -5547,7 +5547,7 @@ declare module "sap/ui/commons/ComboBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle saphide pseudo events on the control
      */
@@ -5558,7 +5558,7 @@ declare module "sap/ui/commons/ComboBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle sapnextmodifiers pseudo events on the control if in toolbar prevent item navigation if popup is
      * opened.
@@ -5570,7 +5570,7 @@ declare module "sap/ui/commons/ComboBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle sapshow pseudo events on the control
      */
@@ -5836,7 +5836,7 @@ declare module "sap/ui/commons/DatePicker" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fire event change to attached listeners.
      *
@@ -5859,7 +5859,7 @@ declare module "sap/ui/commons/DatePicker" {
       bInvalidValue?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -6133,7 +6133,7 @@ declare module "sap/ui/commons/Dialog" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -6211,7 +6211,7 @@ declare module "sap/ui/commons/Dialog" {
      */
     getDefaultButton(): ID;
     /**
-     * Experimental - Whether a dialog is regarded as "enabled" during the state transitions (OPENING, CLOSING)
+     * @experimental - Whether a dialog is regarded as "enabled" during the state transitions (OPENING, CLOSING)
      * is not fully decided. Currently, it is enabled during the OPENING phase and disabled during the CLOSING
      * phase. The only potential change would be to treat the OPENING phase as disabled as well. Applications
      * should be prepared to receive events from "enabled" controls after they called open() on the dialog until
@@ -7111,7 +7111,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:searchHelp searchHelp} to attached listeners.
      *
@@ -7178,7 +7178,7 @@ declare module "sap/ui/commons/DropdownBox" {
      */
     getTooltip_AsString(): string | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Ensure that handed in ListBoxes are taken from the visible UI immediately.
      */
@@ -7189,7 +7189,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle the click event happening in the DropdownBox
      */
@@ -7200,7 +7200,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle focusin event Ensures the text gets selected when focus gets into the field
      */
@@ -7211,7 +7211,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle keydown event
      */
@@ -7222,7 +7222,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle keypress event
      */
@@ -7233,7 +7233,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle keyup event This must only be considered if it is from Backspace-key in IE or after paste. In
      * case there is a keyup with a tab this results from being entered via tabbing and can be ignored, too.
@@ -7245,7 +7245,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle paste event
      */
@@ -7256,7 +7256,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle pseudo event onsapdelete. If triggered with open dropdown and current item provided by history
      * feature, removes the selected item from this instance's history.
@@ -7268,7 +7268,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle pseudo event onsaphome
      */
@@ -7279,7 +7279,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Move the cursor one step to the left (and adapt selection)
      */
@@ -7290,7 +7290,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Move the cursor one step to the right (and adapt selection)
      */
@@ -7301,7 +7301,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle sapshow pseudo events on the control
      */
@@ -7312,7 +7312,7 @@ declare module "sap/ui/commons/DropdownBox" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle the select event happening in the DropdownBox
      */
@@ -7656,19 +7656,19 @@ declare module "sap/ui/commons/TextField" {
   import Event from "sap/ui/base/Event";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The object representing the serialized focus information.
    */
   export type FocusInfo = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * ID of the component
      */
     id?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * User input
      */
@@ -7746,7 +7746,7 @@ declare module "sap/ui/commons/TextField" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Compares the previous value with the current value and fires the change event if the TextField is editable
      * and the value has changed.
@@ -7924,7 +7924,7 @@ declare module "sap/ui/commons/TextField" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -7937,7 +7937,7 @@ declare module "sap/ui/commons/TextField" {
       mParameters?: TextField$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -7950,7 +7950,7 @@ declare module "sap/ui/commons/TextField" {
       mParameters?: TextField$LiveChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -8007,7 +8007,7 @@ declare module "sap/ui/commons/TextField" {
      */
     getEnabled(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an object representing the serialized focus information
      *
@@ -8035,7 +8035,7 @@ declare module "sap/ui/commons/TextField" {
      */
     getImeMode(): ImeMode | keyof typeof ImeMode;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Method for accessing the DOM Ref of the input element.
      *
@@ -8139,7 +8139,7 @@ declare module "sap/ui/commons/TextField" {
      */
     getWidth(): CSSSize;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler called when control is receiving the focus
      */
@@ -8150,7 +8150,7 @@ declare module "sap/ui/commons/TextField" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler for keyup. fire the liveChange event
      */
@@ -8161,7 +8161,7 @@ declare module "sap/ui/commons/TextField" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler called when enter key is pressed.
      * See:
@@ -8174,7 +8174,7 @@ declare module "sap/ui/commons/TextField" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler called when control is losing the focus
      */
@@ -8185,7 +8185,7 @@ declare module "sap/ui/commons/TextField" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler called when text selection starts. When the text field is disabled, the text should not
      * be selectable, so cancel the event.
@@ -10096,7 +10096,7 @@ declare module "sap/ui/commons/Image" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -10485,7 +10485,7 @@ declare module "sap/ui/commons/ImageMap" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -10833,7 +10833,7 @@ declare module "sap/ui/commons/InPlaceEdit" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -10847,7 +10847,7 @@ declare module "sap/ui/commons/InPlaceEdit" {
     ): this;
     /**
      * @since 1.16.5
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -10860,7 +10860,7 @@ declare module "sap/ui/commons/InPlaceEdit" {
       mParameters?: InPlaceEdit$LiveChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -11162,7 +11162,7 @@ declare module "sap/ui/commons/Label" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -14183,7 +14183,7 @@ declare module "sap/ui/commons/Link" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -14203,7 +14203,7 @@ declare module "sap/ui/commons/Link" {
      */
     focus(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -14686,7 +14686,7 @@ declare module "sap/ui/commons/ListBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -15963,7 +15963,7 @@ declare module "sap/ui/commons/MenuButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemSelected itemSelected} to attached listeners.
      *
@@ -15976,7 +15976,7 @@ declare module "sap/ui/commons/MenuButton" {
       mParameters?: MenuButton$ItemSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      * See:
@@ -17387,7 +17387,7 @@ declare module "sap/ui/commons/MessageToast" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:next next} to attached listeners.
      *
@@ -17601,7 +17601,7 @@ declare module "sap/ui/commons/Paginator" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:page page} to attached listeners.
      *
@@ -17897,7 +17897,7 @@ declare module "sap/ui/commons/Panel" {
      */
     getEnabled(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an object representing the serialized focus information.
      *
@@ -18472,7 +18472,7 @@ declare module "sap/ui/commons/ProgressIndicator" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -18858,7 +18858,7 @@ declare module "sap/ui/commons/RadioButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -19441,7 +19441,7 @@ declare module "sap/ui/commons/RadioButtonGroup" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -20123,7 +20123,7 @@ declare module "sap/ui/commons/RatingIndicator" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -20136,7 +20136,7 @@ declare module "sap/ui/commons/RatingIndicator" {
       mParameters?: RatingIndicator$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -20655,7 +20655,7 @@ declare module "sap/ui/commons/ResponsiveContainer" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rangeSwitch rangeSwitch} to attached listeners.
      *
@@ -21148,7 +21148,7 @@ declare module "sap/ui/commons/RichTooltip" {
      */
     getValueStateText(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Calculates the height of the RichTooltip to set a proper min-height. Additionally the ARIA attributes
      * are set to the corresponding elements.
@@ -21465,7 +21465,7 @@ declare module "sap/ui/commons/RoadMap" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stepExpanded stepExpanded} to attached listeners.
      *
@@ -21478,7 +21478,7 @@ declare module "sap/ui/commons/RoadMap" {
       mParameters?: RoadMap$StepExpandedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stepSelected stepSelected} to attached listeners.
      *
@@ -22446,7 +22446,7 @@ declare module "sap/ui/commons/RowRepeater" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:filter filter} to attached listeners.
      *
@@ -22459,7 +22459,7 @@ declare module "sap/ui/commons/RowRepeater" {
       mParameters?: RowRepeater$FilterEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:page page} to attached listeners.
      *
@@ -22472,7 +22472,7 @@ declare module "sap/ui/commons/RowRepeater" {
       mParameters?: RowRepeater$PageEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:resize resize} to attached listeners.
      *
@@ -22485,7 +22485,7 @@ declare module "sap/ui/commons/RowRepeater" {
       mParameters?: RowRepeater$ResizeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sort sort} to attached listeners.
      *
@@ -23601,7 +23601,7 @@ declare module "sap/ui/commons/SearchField" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -23614,7 +23614,7 @@ declare module "sap/ui/commons/SearchField" {
       mParameters?: SearchField$SearchEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggest suggest} to attached listeners.
      *
@@ -24534,7 +24534,7 @@ declare module "sap/ui/commons/SegmentedButton" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Rerendering of the Buttons
      */
@@ -24619,7 +24619,7 @@ declare module "sap/ui/commons/SegmentedButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -24991,7 +24991,7 @@ declare module "sap/ui/commons/Slider" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -25004,7 +25004,7 @@ declare module "sap/ui/commons/Slider" {
       mParameters?: Slider$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -26508,7 +26508,7 @@ declare module "sap/ui/commons/TabStrip" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -26521,7 +26521,7 @@ declare module "sap/ui/commons/TabStrip" {
       mParameters?: TabStrip$CloseEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -27171,7 +27171,7 @@ declare module "sap/ui/commons/TextView" {
       oBindingInfo: PropertyBindingInfo
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -27766,7 +27766,7 @@ declare module "sap/ui/commons/ToggleButton" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -28564,7 +28564,7 @@ declare module "sap/ui/commons/Tree" {
      */
     expandAll(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -28580,7 +28580,7 @@ declare module "sap/ui/commons/Tree" {
       mParameters?: Tree$SelectEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -29242,7 +29242,7 @@ declare module "sap/ui/commons/TreeNode" {
       bDisableExpandFinishedHandler: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selected selected} to attached listeners.
      *
@@ -29255,7 +29255,7 @@ declare module "sap/ui/commons/TreeNode" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleOpenState toggleOpenState} to attached listeners.
      *
@@ -29732,7 +29732,7 @@ declare module "sap/ui/commons/TriStateCheckBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -30153,7 +30153,7 @@ declare module "sap/ui/commons/ValueHelpField" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:valueHelpRequest valueHelpRequest} to attached listeners.
      *
@@ -30193,7 +30193,7 @@ declare module "sap/ui/commons/ValueHelpField" {
      */
     getIconURL(): URI;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handle F4 event
      */

--- a/types/openui5/sap.ui.core.d.ts
+++ b/types/openui5/sap.ui.core.d.ts
@@ -3269,13 +3269,13 @@ declare module "sap/ui/core/InvisibleRenderer" {
 
   /**
    * @since 1.66.0
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Provides the default renderer for the controls that have set their `visible` property to `false`.
    */
   interface InvisibleRenderer {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates the ID to be used for the invisible placeholder DOM element.
      *
@@ -3288,7 +3288,7 @@ declare module "sap/ui/core/InvisibleRenderer" {
       oControl: Control
     ): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the placeholder DOM element of the provided control.
      *
@@ -3301,7 +3301,7 @@ declare module "sap/ui/core/InvisibleRenderer" {
       oControl: Control
     ): HTMLElement | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Renders an invisible placeholder to identify the location of the invisible control within the DOM tree.
      *
@@ -4987,7 +4987,7 @@ declare module "sap/ui/app/Application" {
 
   /**
    * @deprecated (since 1.15.1) - The Component class is enhanced to take care about the Application code.
-   * Experimental (since 1.11.1) - The Application class is still under construction, so some implementation
+   * @experimental (since 1.11.1) - The Application class is still under construction, so some implementation
    * details can be changed in future.
    *
    * Abstract application class. Extend this class to create a central application class.
@@ -5055,7 +5055,7 @@ declare module "sap/ui/app/Application" {
      */
     static getMetadata(): ComponentMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates and returns the root component. Override this method in your application implementation, if you
      * want to override the default creation by metadata.
@@ -5188,7 +5188,7 @@ declare module "sap/ui/app/MockServer" {
 
   /**
    * @deprecated (since 1.15.1) - The mock server code has been moved to sap.ui.core.util - see {@link sap.ui.core.util.MockServer}
-   * Experimental (since 1.13.0) - The mock server is still under construction, so some implementation details
+   * @experimental (since 1.13.0) - The mock server is still under construction, so some implementation details
    * can be changed in future.
    *
    * Class to mock a server.
@@ -5573,7 +5573,7 @@ declare module "sap/ui/base/Event" {
      */
     getSource(): EventProvider;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Init this event with its data.
      *
@@ -5605,7 +5605,7 @@ declare module "sap/ui/base/Event" {
      */
     preventDefault(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Reset event data, needed for pooling.
      * See:
@@ -5795,7 +5795,7 @@ declare module "sap/ui/base/EventProvider" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires an {@link sap.ui.base.Event event} with the given settings and notifies all attached event handlers.
      *
@@ -5823,7 +5823,7 @@ declare module "sap/ui/base/EventProvider" {
       bEnableEventBubbling?: boolean
     ): this | boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the parent in the eventing hierarchy of this object.
      *
@@ -5835,7 +5835,7 @@ declare module "sap/ui/base/EventProvider" {
      */
     getEventingParent(): EventProvider | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether there are any registered event handlers for the event with the given identifier.
      *
@@ -6352,7 +6352,7 @@ declare module "sap/ui/base/ManagedObject" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds some entity `oObject` to the aggregation identified by `sAggregationName`.
      *
@@ -6384,7 +6384,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds some object with the ID `sId` to the association identified by `sAssociationName` and marks this
      * ManagedObject as changed.
@@ -6912,7 +6912,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Destroys (all) the managed object(s) in the aggregation named `sAggregationName` and empties the aggregation.
      * If the aggregation did contain any object, this ManagedObject is marked as changed.
@@ -7051,7 +7051,7 @@ declare module "sap/ui/base/ManagedObject" {
       bIncludeBindingTemplates?: boolean
     ): ManagedObject[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:formatError formatError} to attached listeners.
      *
@@ -7064,7 +7064,7 @@ declare module "sap/ui/base/ManagedObject" {
       mParameters?: ManagedObject$FormatErrorEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:modelContextChange modelContextChange} to attached listeners.
      *
@@ -7077,7 +7077,7 @@ declare module "sap/ui/base/ManagedObject" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:parseError parseError} to attached listeners.
      *
@@ -7090,7 +7090,7 @@ declare module "sap/ui/base/ManagedObject" {
       mParameters?: ManagedObject$ParseErrorEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:validationError validationError} to attached listeners.
      *
@@ -7103,7 +7103,7 @@ declare module "sap/ui/base/ManagedObject" {
       mParameters?: ManagedObject$ValidationErrorEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:validationSuccess validationSuccess} to attached listeners.
      *
@@ -7116,7 +7116,7 @@ declare module "sap/ui/base/ManagedObject" {
       mParameters?: ManagedObject$ValidationSuccessEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the aggregated object(s) for the named aggregation of this ManagedObject.
      *
@@ -7149,7 +7149,7 @@ declare module "sap/ui/base/ManagedObject" {
       oDefaultForCreation?: ManagedObject | any[]
     ): ManagedObject | ManagedObject[] | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the content of the association with the given name.
      *
@@ -7217,7 +7217,7 @@ declare module "sap/ui/base/ManagedObject" {
       sModelName?: string
     ): Context | null | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the binding info for the given property or aggregation.
      *
@@ -7235,7 +7235,7 @@ declare module "sap/ui/base/ManagedObject" {
       sName: string
     ): PropertyBindingInfo | AggregationBindingInfo;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Get the binding path for a specific aggregation/property.
      *
@@ -7248,7 +7248,7 @@ declare module "sap/ui/base/ManagedObject" {
       sName: string
     ): string | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the parent managed object as new eventing parent to enable control event bubbling or `null` if
      * this object hasn't been added to a parent yet.
@@ -7398,7 +7398,7 @@ declare module "sap/ui/base/ManagedObject" {
      */
     getParent(): ManagedObject | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the value for the property with the given `sPropertyName`.
      *
@@ -7423,7 +7423,7 @@ declare module "sap/ui/base/ManagedObject" {
      */
     hasModel(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Searches for the provided ManagedObject in the named aggregation and returns its 0-based index if found,
      * or -1 otherwise. Returns -2 if the given named aggregation is of cardinality 0..1 and doesn't reference
@@ -7446,7 +7446,7 @@ declare module "sap/ui/base/ManagedObject" {
       oObject: ManagedObject
     ): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Inserts managed object `oObject` to the aggregation named `sAggregationName` at position `iIndex`.
      *
@@ -7488,7 +7488,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Marks this object and its aggregated children as 'invalid'.
      *
@@ -7525,7 +7525,7 @@ declare module "sap/ui/base/ManagedObject" {
     isDestroyed(): boolean;
     /**
      * @since 1.93
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if an object's destruction has been started. During the descruction of an object its ID is still
      * registered, and child objects could be still aggregated. Creating another object with the same ID would
@@ -7535,7 +7535,7 @@ declare module "sap/ui/base/ManagedObject" {
      */
     isDestroyStarted(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether re-rendering is currently suppressed on this ManagedObject.
      *
@@ -7543,7 +7543,7 @@ declare module "sap/ui/base/ManagedObject" {
      */
     isInvalidateSuppressed(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether the given property value is initial and has not been explicitly set or bound. Even after
      * setting the default value or setting null/undefined (which also causes the default value to be set),
@@ -7558,7 +7558,7 @@ declare module "sap/ui/base/ManagedObject" {
       sPropertyName: string
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is used internally and should only be overridden by a tree managed object which utilizes
      * the tree binding. In this case and if the aggregation is a tree node the overridden method should then
@@ -7575,7 +7575,7 @@ declare module "sap/ui/base/ManagedObject" {
     ): boolean;
     /**
      * @since 1.28
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Generic method which is called, whenever messages for this object exist.
      */
@@ -7590,7 +7590,7 @@ declare module "sap/ui/base/ManagedObject" {
       aMessages: any[]
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Generic method which can be called, when an aggregation needs to be refreshed. This method does not make
      * any change on the aggregation, but just calls the `getContexts` method of the binding to trigger fetching
@@ -7607,7 +7607,7 @@ declare module "sap/ui/base/ManagedObject" {
       sName: string
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes an object from the aggregation named `sAggregationName` with cardinality 0..n.
      *
@@ -7643,7 +7643,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): ManagedObject | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes all objects from the 0..n-aggregation named `sAggregationName`.
      *
@@ -7672,7 +7672,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): ManagedObject[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes all the objects in the 0..n-association named `sAssociationName` and returns an array with their
      * IDs. This ManagedObject is marked as changed, if the association contained any objects.
@@ -7694,7 +7694,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): any[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes a `ManagedObject` from the association named `sAssociationName`.
      *
@@ -7729,7 +7729,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): string | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Resets the given property to the default value and also restores the "initial" state (like it has never
      * been set).
@@ -7749,7 +7749,7 @@ declare module "sap/ui/base/ManagedObject" {
       sPropertyName: string
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets a new object in the named 0..1 aggregation of this ManagedObject and marks this ManagedObject as
      * changed.
@@ -7795,7 +7795,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressInvalidate?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the associated object for the given managed association of cardinality '0..1' and marks this ManagedObject
      * as changed.
@@ -7890,7 +7890,7 @@ declare module "sap/ui/base/ManagedObject" {
       sName?: string
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the given value for the given property after validating and normalizing it, marks this object as
      * changed.
@@ -7995,7 +7995,7 @@ declare module "sap/ui/base/ManagedObject" {
       bSuppressReset: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Generic method which is called whenever an aggregation binding has changed.
      *
@@ -8033,7 +8033,7 @@ declare module "sap/ui/base/ManagedObject" {
       }
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks whether the given value is of the proper type for the given aggregation name.
      *
@@ -8057,7 +8057,7 @@ declare module "sap/ui/base/ManagedObject" {
       bMultiple: boolean
     ): ManagedObject | any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks whether the given value is of the proper type for the given property name.
      *
@@ -8989,7 +8989,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds information to the given oAggregatedObject about its original API parent (or a subsequent API parent
      * in case of multiple forwarding). MUST be called before an element is forwarded to another internal aggregation
@@ -9014,7 +9014,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
       sAggregationName: string
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Completes the information about the original API parent of the given element. MUST be called after an
      * element is forwarded to another internal aggregation. For every call to ManagedObjectMetadata.addAPIParentInfoBegin(...)
@@ -9148,7 +9148,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
      */
     getAllEvents(): Record<string, MetadataOptions1.Event>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a map of info objects for all private (hidden) aggregations of the described class, including
      * private aggregations from the ancestor classes.
@@ -9164,7 +9164,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
      */
     getAllPrivateAggregations(): Record<string, MetadataOptions1.Aggregation>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a map of info objects for all private (hidden) associations of the described class, including
      * private associations from the ancestor classes.
@@ -9180,7 +9180,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
      */
     getAllPrivateAssociations(): Record<string, MetadataOptions1.Association>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a map of info objects for all private (hidden) properties of the described class, including private
      * properties from the ancestor classes.
@@ -9305,7 +9305,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
      */
     getLibraryName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the info object for the named public or private aggregation declared by the described class or
      * by any of its ancestors.
@@ -9326,7 +9326,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
       sAggregationName: string
     ): MetadataOptions1.Aggregation | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the info object for the named public or private association declared by the described class or
      * by any of its ancestors.
@@ -9344,7 +9344,7 @@ declare module "sap/ui/base/ManagedObjectMetadata" {
       sName: string
     ): MetadataOptions1.Association | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the info object for the named public or private property declared by the described class or by
      * any of its ancestors.
@@ -9950,7 +9950,7 @@ declare module "sap/ui/base/ObjectPool" {
     __implements__sap_ui_base_Poolable: boolean;
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Called by the `ObjectPool` when this instance will be activated for a caller.
      *
@@ -9966,7 +9966,7 @@ declare module "sap/ui/base/ObjectPool" {
       ...args: any[]
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Called by the object pool when an instance is returned to the pool.
      *
@@ -10021,56 +10021,56 @@ declare module "sap/ui/core/library" {
 
   /**
    * @since 1.110
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The object contains accessibility information for a control.
    */
   export type AccessibilityInfo = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The WAI-ARIA role which is implemented by the control.
      */
     role?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * A translated text that represents the control type. Might correlate with the role.
      */
     type?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Describes the most relevant control state (e.g. the input's value) - it should be a translated text.
      * **Note:** The type and the enabled/editable state shouldn`t be handled here.
      */
     description?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the control can get the focus.
      */
     focusable?: boolean;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the control is enabled. If not relevant, it shouldn`t be set or `null` can be provided.
      */
     enabled?: boolean | null;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the control is editable. If not relevant, it shouldn`t be set or `null` can be provided.
      */
     editable?: boolean | null;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the control is readonly. If not relevant, it shouldn`t be set or `null` can be provided.
      */
     readonly?: boolean | null;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * A list of elements or controls that are aggregated by the given control (e.g. when the control is a layout).
      * Primitive values in the list will be ignored. **Note:** Children should only be provided when it is helpful
@@ -10562,37 +10562,37 @@ declare module "sap/ui/core/library" {
 
   /**
    * @since 1.111
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The object contains focus information for input controls.
    */
   export type FocusInfo = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The ID of the focused control.
      */
     id?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The position of the cursor.
      */
     cursorPos?: int;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The start position of selection.
      */
     selectionStart?: int;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The end position of selection.
      */
     selectionEnd?: int;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Prevents scrolling.
      */
@@ -10626,7 +10626,7 @@ declare module "sap/ui/core/library" {
   }
   /**
    * @since 1.104
-   * Experimental (since 1.104)
+   * @experimental (since 1.104)
    *
    * Implementing this interface allows a control to be accessible via access keys.
    */
@@ -10635,7 +10635,7 @@ declare module "sap/ui/core/library" {
 
     /**
      * @since 1.104
-     * Experimental (since 1.104)
+     * @experimental (since 1.104)
      *
      * Returns a refence to DOM element to be focused during Access key navigation. If not implemented getFocusDomRef()
      * method is used.
@@ -10643,14 +10643,14 @@ declare module "sap/ui/core/library" {
     getAccessKeysFocusTarget?(): void;
     /**
      * @since 1.104
-     * Experimental (since 1.104)
+     * @experimental (since 1.104)
      *
      * If implemented called when access keys feature is enabled and highlighting is over
      */
     onAccKeysHighlightEnd?(): void;
     /**
      * @since 1.104
-     * Experimental (since 1.104)
+     * @experimental (since 1.104)
      *
      * If implemented called when access keys feature is enabled and highlighting is ongoing
      */
@@ -10685,7 +10685,7 @@ declare module "sap/ui/core/library" {
 
   /**
    * @since 1.98
-   * Experimental (since 1.98)
+   * @experimental (since 1.98)
    *
    * Marker interface for controls that can serve as a menu for a table column header.
    *
@@ -10696,7 +10696,7 @@ declare module "sap/ui/core/library" {
 
     /**
      * @since 1.98.0
-     * Experimental (since 1.98)
+     * @experimental (since 1.98)
      *
      * Returns the sap.ui.core.aria.HasPopup<\code> type of the menu.
      *
@@ -10705,7 +10705,7 @@ declare module "sap/ui/core/library" {
     getAriaHasPopupType(): aria.HasPopup | keyof typeof aria.HasPopup;
     /**
      * @since 1.98
-     * Experimental (since 1.98)
+     * @experimental (since 1.98)
      *
      * Opens the menu using the column header.
      */
@@ -10906,7 +10906,7 @@ declare module "sap/ui/core/library" {
   }
   /**
    * @since 1.78
-   * Experimental (since 1.73)
+   * @experimental (since 1.73)
    *
    * Enumeration for different mode behaviors of the `InvisibleMessage`.
    */
@@ -10939,7 +10939,7 @@ declare module "sap/ui/core/library" {
 
   /**
    * @since 1.86.0
-   * Experimental (since 1.86)
+   * @experimental (since 1.86)
    *
    * Marker interface for controls that can be used as content of `sap.ui.layout.form.SemanticFormElement`.
    *
@@ -10954,7 +10954,7 @@ declare module "sap/ui/core/library" {
 
     /**
      * @since 1.86.0
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Returns the formatted value of a control used in a `SemanticFormElement`.
      *
@@ -10971,7 +10971,7 @@ declare module "sap/ui/core/library" {
     getFormFormattedValue?(): string | Promise<string>;
     /**
      * @since 1.86.0
-     * Experimental (since 1.86)
+     * @experimental (since 1.86)
      *
      * Returns the name of the value-holding property of a control used in a `SemanticFormElement`.
      *
@@ -11915,7 +11915,7 @@ declare module "sap/ui/core/CommandExecution" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:execute execute} to attached listeners.
      *
@@ -12486,7 +12486,7 @@ declare module "sap/ui/core/Component" {
           }
     ): Component | Promise<Component>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Cleans up the Component instance before destruction.
      *
@@ -12644,7 +12644,7 @@ declare module "sap/ui/core/Component" {
       sLocalServiceAlias: string
     ): Promise</* was: sap.ui.core.service.Service */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes the Component instance after creation.
      *
@@ -12656,7 +12656,7 @@ declare module "sap/ui/core/Component" {
     init(): void;
     /**
      * @since 1.88
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called after the component is activated
      */
@@ -12675,7 +12675,7 @@ declare module "sap/ui/core/Component" {
     ): void;
     /**
      * @since 1.88
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called after the component is deactivated
      */
@@ -13123,7 +13123,7 @@ declare module "sap/ui/core/ComponentContainer" {
     ): this;
     /**
      * @since 1.50
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:componentCreated componentCreated} to attached listeners.
      *
@@ -13137,7 +13137,7 @@ declare module "sap/ui/core/ComponentContainer" {
     ): this;
     /**
      * @since 1.60
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:componentFailed componentFailed} to attached listeners.
      *
@@ -13826,7 +13826,7 @@ declare module "sap/ui/core/ComponentMetadata" {
     getManifestObject(): Manifest;
     /**
      * @since 1.27.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the version of the metadata which could be 1 or 2. 1 is for legacy metadata whereas 2 is for
      * the manifest.
@@ -13869,7 +13869,7 @@ declare module "sap/ui/core/ComponentMetadata" {
     getVersion(): string;
     /**
      * @since 1.33.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether the class of this metadata is a component base class or not.
      *
@@ -15278,7 +15278,7 @@ declare module "sap/ui/core/Control" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:validateFieldGroup validateFieldGroup} to attached listeners.
      *
@@ -15292,7 +15292,7 @@ declare module "sap/ui/core/Control" {
     ): this;
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This function (if available on the concrete control) provides the current accessibility state of the
      * control.
@@ -15402,7 +15402,7 @@ declare module "sap/ui/core/Control" {
      */
     getIdForLabel(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a renderer for this control instance.
      *
@@ -15439,7 +15439,7 @@ declare module "sap/ui/core/Control" {
       sStyleClass: string
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Marks this control and its children for a re-rendering, usually because its state has changed and now
      * differs from the rendered DOM.
@@ -15469,7 +15469,7 @@ declare module "sap/ui/core/Control" {
      */
     isBusy(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Function is called when the rendering of the control is completed.
      *
@@ -15484,7 +15484,7 @@ declare module "sap/ui/core/Control" {
       oEvent: jQuery.Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Function is called before the rendering of the control is started.
      *
@@ -15547,7 +15547,7 @@ declare module "sap/ui/core/Control" {
      * async re-rendering.
      *
      * The recommended alternative is to rely on invalidation and standard re-rendering.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Synchronously updates the DOM of this control to reflect the current object state.
      *
@@ -16531,7 +16531,7 @@ declare module "sap/ui/core/Core" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:formatError formatError} to attached listeners.
      *
@@ -16569,7 +16569,7 @@ declare module "sap/ui/core/Core" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:parseError parseError} to attached listeners.
      *
@@ -16607,7 +16607,7 @@ declare module "sap/ui/core/Core" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:validationError validationError} to attached listeners.
      *
@@ -16645,7 +16645,7 @@ declare module "sap/ui/core/Core" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:validationSuccess validationSuccess} to attached listeners.
      *
@@ -17019,7 +17019,7 @@ declare module "sap/ui/core/Core" {
      */
     isMobile(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks whether the given DOM element is the root of the static area.
      *
@@ -17989,7 +17989,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Delegate for touch scrolling on mobile devices.
    *
@@ -18001,7 +18001,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
    */
   export default class ScrollEnablement extends BaseObject {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a ScrollEnablement delegate that can be attached to Controls requiring capabilities for scrolling
      * of a certain part of their DOM.
@@ -18051,7 +18051,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.core.delegate.ScrollEnablement with name `sClassName` and enriches
      * it with the information contained in `oClassInfo`.
@@ -18076,7 +18076,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.core.delegate.ScrollEnablement.
      *
@@ -18084,7 +18084,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Destroys this Scrolling delegate.
      *
@@ -18092,7 +18092,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
      */
     destroy(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Calculates scroll position of a child of a container.
      *
@@ -18106,7 +18106,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     ): object;
     /**
      * @since 1.9.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Get current setting for horizontal scrolling.
      *
@@ -18115,7 +18115,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     getHorizontal(): boolean;
     /**
      * @since 1.9.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Get current setting for vertical scrolling.
      *
@@ -18123,7 +18123,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
      */
     getVertical(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Refreshes this Scrolling delegate.
      */
@@ -18168,7 +18168,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
       fnScrollEndCallback: Function
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Scrolls to an element within a container.
      */
@@ -18197,7 +18197,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     /**
      * @since 1.17
      * @deprecated (since 1.42)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Setter for property `bounce`.
      */
@@ -18209,7 +18209,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     ): void;
     /**
      * @since 1.11.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets GrowingList control to scroll container
      */
@@ -18228,7 +18228,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
       fnOverflowChange: Function
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enable or disable horizontal scrolling.
      */
@@ -18240,7 +18240,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     ): void;
     /**
      * @since 1.16.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets IconTabBar control to scroll container
      */
@@ -18260,7 +18260,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
     ): void;
     /**
      * @since 1.9.2
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Set overflow control on top of scroll container.
      */
@@ -18271,7 +18271,7 @@ declare module "sap/ui/core/delegate/ScrollEnablement" {
       oControl: Control
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enable or disable vertical scrolling.
      */
@@ -18668,7 +18668,7 @@ declare module "sap/ui/core/dnd/DragDropInfo" {
     ): this;
     /**
      * @since 1.56
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragEnd dragEnd} to attached listeners.
      *
@@ -18681,7 +18681,7 @@ declare module "sap/ui/core/dnd/DragDropInfo" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragStart dragStart} to attached listeners.
      *
@@ -19011,7 +19011,7 @@ declare module "sap/ui/core/dnd/DragInfo" {
     ): this;
     /**
      * @since 1.56
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragEnd dragEnd} to attached listeners.
      *
@@ -19024,7 +19024,7 @@ declare module "sap/ui/core/dnd/DragInfo" {
       mParameters?: DragInfo$DragEndEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragStart dragStart} to attached listeners.
      *
@@ -19169,25 +19169,25 @@ declare module "sap/ui/core/dnd/DragAndDrop" {
       sKey: string
     ): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the dragged control, if available within the same UI5 application frame.
      */
     getDragControl(): UI5Element | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * The valid drop target underneath the dragged control.
      */
     getDropControl(): UI5Element | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the drop configuration corresponding to the drop control.
      */
     getDropInfo(): DropInfo | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the calculated position of the drop action relative to the valid dropped control.
      */
@@ -19195,7 +19195,7 @@ declare module "sap/ui/core/dnd/DragAndDrop" {
       | dnd.RelativeDropPosition
       | keyof typeof dnd.RelativeDropPosition;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the drop indicator.
      *
@@ -19203,7 +19203,7 @@ declare module "sap/ui/core/dnd/DragAndDrop" {
      */
     getIndicator(): HTMLElement | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the visual configuration of the drop indicator.
      *
@@ -19244,13 +19244,13 @@ declare module "sap/ui/core/dnd/DragAndDrop" {
       sData: string
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Set the valid drop control.
      */
     setDropControl(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Defines the visual configuration of the drop indicator for the current `DropInfo`.
      */
@@ -19553,7 +19553,7 @@ declare module "sap/ui/core/dnd/DropInfo" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragEnter dragEnter} to attached listeners.
      *
@@ -19570,7 +19570,7 @@ declare module "sap/ui/core/dnd/DropInfo" {
     ): boolean;
     /**
      * @since 1.56
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dragOver dragOver} to attached listeners.
      *
@@ -19583,7 +19583,7 @@ declare module "sap/ui/core/dnd/DropInfo" {
       mParameters?: DropInfo$DragOverEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:drop drop} to attached listeners.
      *
@@ -20109,7 +20109,7 @@ declare module "sap/ui/core/Element" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the best suitable DOM node that represents this Element wrapped as jQuery object. I.e. the element
      * returned by {@link sap.ui.core.Element#getDomRef} is wrapped and returned.
@@ -20212,7 +20212,7 @@ declare module "sap/ui/core/Element" {
       oThis?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Applies the focus info.
      *
@@ -20401,7 +20401,7 @@ declare module "sap/ui/core/Element" {
      */
     destroyTooltip(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Allows the parent of a control to enhance the ARIA information during rendering.
      *
@@ -20425,7 +20425,7 @@ declare module "sap/ui/core/Element" {
       mAriaProps: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Hook method for cleaning up the element instance before destruction.
      *
@@ -20501,7 +20501,7 @@ declare module "sap/ui/core/Element" {
      */
     getDependents(): UI5Element[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the best suitable DOM Element that represents this UI5 Element. By default the DOM Element with
      * the same ID as this Element is returned. Subclasses should override this method if the lookup via id
@@ -20551,7 +20551,7 @@ declare module "sap/ui/core/Element" {
       sModelName?: string
     ): ContextBinding | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM Element that should get the focus or `null` if there's no such element currently.
      *
@@ -20561,7 +20561,7 @@ declare module "sap/ui/core/Element" {
      */
     getFocusDomRef(): Element | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an object representing the serialized focus information.
      *
@@ -20663,7 +20663,7 @@ declare module "sap/ui/core/Element" {
       oDragDropConfig: DragDropBase
     ): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes the element instance after creation.
      *
@@ -20846,7 +20846,7 @@ declare module "sap/ui/core/Element" {
       oDelegate: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This triggers immediate rerendering of its parent and thus of itself and its children.
      *
@@ -23449,13 +23449,13 @@ declare module "sap/ui/core/History" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * History handles the history of certain controls (e.g. sap.ui.commons.SearchField).
    */
   export default class History extends BaseObject {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates an instance of the History.
      *
@@ -23474,7 +23474,7 @@ declare module "sap/ui/core/History" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.core.History with name `sClassName` and enriches it with the information
      * contained in `oClassInfo`.
@@ -23499,7 +23499,7 @@ declare module "sap/ui/core/History" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.core.History.
      *
@@ -23666,7 +23666,7 @@ declare module "sap/ui/core/HTML" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterRendering afterRendering} to attached listeners.
      *
@@ -24122,7 +24122,7 @@ declare module "sap/ui/core/hyphenation/Hyphenation" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:error error} to attached listeners.
      *
@@ -24374,7 +24374,7 @@ declare module "sap/ui/core/Icon" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -24387,7 +24387,7 @@ declare module "sap/ui/core/Icon" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -25869,7 +25869,7 @@ declare module "sap/ui/core/LabelEnablement" {
 
   /**
    * @since 1.28.0
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Helper functionality for enhancement of a `Label` with common label functionality.
    * See:
@@ -25877,7 +25877,7 @@ declare module "sap/ui/core/LabelEnablement" {
    */
   interface LabelEnablement {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This function should be called on a label control to enrich its functionality.
      *
@@ -25932,7 +25932,7 @@ declare module "sap/ui/core/LabelEnablement" {
       oElement: UI5Element
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Helper function for the `Label` control to render the HTML 'for' attribute.
      *
@@ -27522,7 +27522,7 @@ declare module "sap/ui/core/Manifest" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Function to load the manifest by URL
      *
@@ -27965,13 +27965,13 @@ declare module "sap/ui/core/message/ControlMessageProcessor" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Check Messages and update controls with messages
      */
     checkMessages(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Set Messages to check
      */
@@ -28526,7 +28526,7 @@ declare module "sap/ui/core/message/MessageParser" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the registered processor on which the events for message handling can be fired
      *
@@ -28547,7 +28547,7 @@ declare module "sap/ui/core/message/MessageParser" {
       oRequest: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is used by the model to register itself as MessageProcessor for this parser
      *
@@ -28674,7 +28674,7 @@ declare module "sap/ui/core/message/MessageProcessor" {
     ): this;
     /**
      * @deprecated - 1.115 Use {@link sap.ui.core.messages.MessageManager#updateMessages} instead
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:messageChange messageChange} to attached listeners.
      *
@@ -28987,7 +28987,7 @@ declare module "sap/ui/core/mvc/Controller" {
       }
     ): Promise<Control | Control[]>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called every time the View is rendered, after the HTML is placed in the DOM-Tree. It can
      * be used to apply additional changes to the DOM after the Renderer has finished. (Even though this method
@@ -28998,7 +28998,7 @@ declare module "sap/ui/core/mvc/Controller" {
      */
     onAfterRendering(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called every time the View is rendered, before the Renderer is called and the HTML is
      * placed in the DOM-Tree. It can be used to perform clean-up-tasks before re-rendering. (Even though this
@@ -29009,7 +29009,7 @@ declare module "sap/ui/core/mvc/Controller" {
      */
     onBeforeRendering(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called upon desctuction of the View. The controller should perform its internal destruction
      * in this hook. It is only called once per View instance, unlike the onBeforeRendering and onAfterRendering
@@ -29018,7 +29018,7 @@ declare module "sap/ui/core/mvc/Controller" {
      */
     onExit(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is called upon initialization of the View. The controller can perform its internal setup
      * in this hook. It is only called once per View instance, unlike the onBeforeRendering and onAfterRendering
@@ -29904,7 +29904,7 @@ declare module "sap/ui/core/mvc/View" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.30
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Register a preprocessor for all views of a specific type.
      *
@@ -30282,7 +30282,7 @@ declare module "sap/ui/core/mvc/View" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterInit afterInit} to attached listeners.
      *
@@ -30295,7 +30295,7 @@ declare module "sap/ui/core/mvc/View" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterRendering afterRendering} to attached listeners.
      *
@@ -30308,7 +30308,7 @@ declare module "sap/ui/core/mvc/View" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeExit beforeExit} to attached listeners.
      *
@@ -30321,7 +30321,7 @@ declare module "sap/ui/core/mvc/View" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeRendering beforeRendering} to attached listeners.
      *
@@ -30335,7 +30335,7 @@ declare module "sap/ui/core/mvc/View" {
     ): this;
     /**
      * @since 1.88
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * A method to be implemented by typed views, returning the flag whether to prefix the IDs of controls automatically
      * or not, if the controls are created inside the {@link sap.ui.core.mvc.View#createContent} function. By
@@ -30405,7 +30405,7 @@ declare module "sap/ui/core/mvc/View" {
       sId: string
     ): string | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the info object which is also passed to the preprocessors
      * See:
@@ -30454,7 +30454,7 @@ declare module "sap/ui/core/mvc/View" {
      */
     getWidth(): CSSSize;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if any preprocessors are active for the specified type
      *
@@ -30527,7 +30527,7 @@ declare module "sap/ui/core/mvc/View" {
       vContent: int | string | Control
     ): Control | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Executes preprocessors for a type of source
      *
@@ -31577,7 +31577,7 @@ declare module "sap/ui/core/Popup" {
      */
     exit(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -31590,7 +31590,7 @@ declare module "sap/ui/core/Popup" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:opened opened} to attached listeners.
      *
@@ -32155,7 +32155,7 @@ declare module "sap/ui/core/Renderer" {
       oRendererInfo?: object
     ): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the TextAlignment for the provided configuration.
      *
@@ -32355,7 +32355,7 @@ declare module "sap/ui/core/RenderManager" {
     constructor();
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates the ID to be used for the invisible Placeholder DOM element. This method can be used to get direct
      * access to the placeholder DOM element. Also statically available as RenderManager.createInvisiblePlaceholderId()
@@ -33719,7 +33719,7 @@ declare module "sap/ui/core/routing/Route" {
     ): this;
     /**
      * @since 1.46.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeMatched beforeMatched} to attached listeners.
      *
@@ -34184,7 +34184,7 @@ declare module "sap/ui/core/routing/Target" {
     static getMetadata(): Metadata;
     /**
      * @since 1.46.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This function is called between the target view is loaded and the view is added to the container.
      *
@@ -34252,7 +34252,7 @@ declare module "sap/ui/core/routing/Target" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Destroys the target, will be called by {@link sap.m.routing.Targets} don't call this directly.
      *
@@ -34296,7 +34296,7 @@ declare module "sap/ui/core/routing/Target" {
       control: Control;
     }>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:created created} to attached listeners.
      *
@@ -34402,7 +34402,7 @@ declare module "sap/ui/core/routing/HashChanger" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the hashChanger to a new instance, destroys the old one and copies all its event listeners to the
      * new one
@@ -34414,7 +34414,7 @@ declare module "sap/ui/core/routing/HashChanger" {
       oHashChanger: HashChanger
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Cleans the event registration
      * See:
@@ -34422,7 +34422,7 @@ declare module "sap/ui/core/routing/HashChanger" {
      */
     destroy(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires the hashchanged event, may be extended to modify the hash before fireing the event
      */
@@ -34443,7 +34443,7 @@ declare module "sap/ui/core/routing/HashChanger" {
      */
     getHash(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Defines the events and its parameters which should be used for tracking the hash changes
      *
@@ -34480,25 +34480,25 @@ declare module "sap/ui/core/routing/HashChanger" {
   }
   /**
    * @since 1.82.0
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The object containing the event info for the events that are forwarded to {@link sap.ui.core.routing.RouterHashChanger}.
    */
   export type HashChangerEventInfo = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The name of the event that is fired by the HashChanger and should be forwarded to the RouterHashChanger
      */
     name: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The optional defined parameter name mapping that is used for forwarding the event to the {@link sap.ui.core.routing.RouterHashChanger}.
      */
     paramMapping?: HashChangerEventParameterMapping;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Indicates whether the event is ignored by every RouterHashChanger instance and is only relevant for the
      * other routing classes, for example {@link sap.ui.core.routing.History}.
@@ -34508,13 +34508,13 @@ declare module "sap/ui/core/routing/HashChanger" {
 
   /**
    * @since 1.82.0
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The object containing the parameter mapping for forwarding the event to the {@link sap.ui.core.routing.RouterHashChanger}.
    */
   export type HashChangerEventParameterMapping = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The name of the parameter whose value is used as the `newHash` parameter in the event that is forwarded
      * to the {@link sap.ui.core.routing.RouterHashChanger}. If this isn't set, the value is taken from the
@@ -34522,7 +34522,7 @@ declare module "sap/ui/core/routing/HashChanger" {
      */
     newHash?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The name of the parameter whose value is used as the `oldHash` parameter in the event that is forwarded
      * to the {@link sap.ui.core.routing.RouterHashChanger}. If this isn't set, the value is taken from the
@@ -34530,7 +34530,7 @@ declare module "sap/ui/core/routing/HashChanger" {
      */
     oldHash?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * The name of the parameter whose value is used as the `fullHash` parameter in the event that is forwarded
      * to the {@link sap.ui.core.routing.RouterHashChanger}. If this isn't set, the value is taken from the
@@ -34559,7 +34559,7 @@ declare module "sap/ui/core/routing/HashChangerBase" {
   import Event from "sap/ui/base/Event";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Base Class for manipulating and receiving changes of hash segment.
    *
@@ -34567,12 +34567,12 @@ declare module "sap/ui/core/routing/HashChangerBase" {
    */
   export default class HashChangerBase extends EventProvider {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor();
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.core.routing.HashChangerBase with name `sClassName` and enriches
      * it with the information contained in `oClassInfo`.
@@ -34597,7 +34597,7 @@ declare module "sap/ui/core/routing/HashChangerBase" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.core.routing.HashChangerBase.
      *
@@ -34605,7 +34605,7 @@ declare module "sap/ui/core/routing/HashChangerBase" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Replaces the hash with a certain value. When using the replace function, no browser history entry is
      * written. If you want to have an entry in the browser history, please use the {@link #setHash} function.
@@ -34628,7 +34628,7 @@ declare module "sap/ui/core/routing/HashChangerBase" {
         | keyof typeof routing.HistoryDirection
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the hash to a certain value. When using this function, a browser history entry is written. If you
      * do not want to have an entry in the browser history, please use the {@link #replaceHash} function.
@@ -35428,7 +35428,7 @@ declare module "sap/ui/core/routing/Router" {
       oListener: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeRouteMatched beforeRouteMatched} to attached listeners.
      *
@@ -35441,7 +35441,7 @@ declare module "sap/ui/core/routing/Router" {
       oParameters?: Router$BeforeRouteMatchedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:bypassed bypassed} to attached listeners.
      *
@@ -35456,7 +35456,7 @@ declare module "sap/ui/core/routing/Router" {
       oParameters?: Router$BypassedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:routeMatched routeMatched} to attached listeners.
      *
@@ -35469,7 +35469,7 @@ declare module "sap/ui/core/routing/Router" {
       oParameters?: Router$RouteMatchedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:routePatternMatched routePatternMatched} to attached listeners.
      *
@@ -35486,7 +35486,7 @@ declare module "sap/ui/core/routing/Router" {
     ): this;
     /**
      * @deprecated (since 1.28) - use {@link #getViews} instead.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:viewCreated viewCreated} to attached listeners.
      *
@@ -35794,7 +35794,7 @@ declare module "sap/ui/core/routing/Router" {
       bReplace?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Will trigger routing events + place targets for routes matching the string.
      */
@@ -36015,7 +36015,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
   import Router from "sap/ui/core/routing/Router";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Class for manipulating and receiving changes of the relevant hash segment which belongs to a router.
    * This Class doesn't change the browser hash directly, but informs its parent RouterHashChanger and finally
@@ -36023,12 +36023,12 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
    */
   export default class RouterHashChanger extends HashChangerBase {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor();
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.core.routing.RouterHashChanger with name `sClassName` and enriches
      * it with the information contained in `oClassInfo`.
@@ -36053,7 +36053,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.core.routing.RouterHashChanger.
      *
@@ -36061,7 +36061,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Save the given hash and potentially fires a "hashChanged" event; may be extended to modify the hash before
      * firing the event.
@@ -36082,7 +36082,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
       bUpdateHashOnly: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the current hash
      *
@@ -36090,7 +36090,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
      */
     getHash(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Replaces the hash with a certain value. When using the replace function, no browser history entry is
      * written. If you want to have an entry in the browser history, please use the {@link #setHash} function.
@@ -36122,7 +36122,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
       bSuppressActiveHashCollect?: boolean
     ): Promise<any> | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Reset the hash if the given router is the active router that is saved in this RouterHashChanger
      *
@@ -36138,7 +36138,7 @@ declare module "sap/ui/core/routing/RouterHashChanger" {
       oRouter: Router
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the hash to a certain value. When using this function, a browser history entry is written. If you
      * do not want to have an entry in the browser history, please use the {@link #replaceHash} function.
@@ -36186,32 +36186,32 @@ declare module "sap/ui/core/routing/Targets" {
 
   /**
    * @since 1.84.0
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Object containing the target info for displaying targets
    */
   export type TargetInfo = {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Defines the name of the target that is going to be displayed
      */
     name: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * A prefix that is used for reserving a dedicated section in the browser hash for the router of this target.
      * This needs to be set only for target that has type "Component"
      */
     prefix?: string;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the titleChanged event from this target should be propagated to the parent or not
      */
     propagateTitle?: boolean;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Whether the target is relevant to the current matched route or not. If 'true', then the dynamic target
      * is linked to the route's life cycle. When switching to a different route, then the dynamic target will
@@ -36219,7 +36219,7 @@ declare module "sap/ui/core/routing/Targets" {
      */
     routeRelevant?: boolean;
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Since 1.90. Whether the router of the "Component" target ignores the browser hash when it's re-initialized.
      * This parameter only has effect when the target is of type "Component" and its router is currently stopped.
@@ -36672,7 +36672,7 @@ declare module "sap/ui/core/routing/Views" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:created created} to attached listeners.
      *
@@ -36895,7 +36895,7 @@ declare module "sap/ui/core/ScrollBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:scroll scroll} to attached listeners.
      *
@@ -38568,7 +38568,7 @@ declare module "sap/ui/core/tmpl/Template" {
       mSettings?: $TemplateSettings
     );
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * parses the given path and extracts the model and path
      */
@@ -38939,7 +38939,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a pseudo binding for an aggregation to get notified once the property changes to invalidate the
      * control and trigger a re-rendering.
@@ -38953,7 +38953,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       sPath: string
     ): any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a pseudo binding for a property to get notified once the property changes to invalidate the control
      * and trigger a re-rendering.
@@ -38967,7 +38967,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       sPath: string
     ): any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * compiles (creates and registers) a new control
      *
@@ -38990,7 +38990,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oView: View
     ): Control;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * compiles (creates and registers) a new control
      *
@@ -39009,7 +39009,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oView: View
     ): Control;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * compiles (creates and registers) a new control
      *
@@ -39028,7 +39028,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oView: View
     ): Control;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * compiles (creates and registers) a new control
      *
@@ -39043,7 +39043,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oView: View
     ): Control;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * compiles (creates and registers) a new DOM element
      *
@@ -39100,7 +39100,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterRendering afterRendering} to attached listeners.
      *
@@ -39113,7 +39113,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeRendering beforeRendering} to attached listeners.
      *
@@ -39140,7 +39140,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
      */
     getTemplate(): ID;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the instance specific renderer for an anonymous template control.
      *
@@ -39148,7 +39148,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
      */
     getTemplateRenderer(): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * checks whether the control is inline or not
      *
@@ -39185,7 +39185,7 @@ declare module "sap/ui/core/tmpl/TemplateControl" {
       oTemplate: ID | Template
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the instance specific renderer for an anonymous template control.
      *
@@ -39378,7 +39378,7 @@ declare module "sap/ui/core/TooltipBase" {
     ): this;
     /**
      * @since 1.11.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -39837,7 +39837,7 @@ declare module "sap/ui/core/UIArea" {
      */
     destroyDependents(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provide getBindingContext, as UIArea can be parent of an element.
      *
@@ -39858,7 +39858,7 @@ declare module "sap/ui/core/UIArea" {
      */
     getDependents(): Control[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the Core's event provider as new eventing parent to enable control event bubbling to the core
      * to ensure compatibility with the core validation events.
@@ -39893,7 +39893,7 @@ declare module "sap/ui/core/UIArea" {
      */
     getRootNode(): Element;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns this UI area. Needed to stop recursive calls from an element to its parent.
      *
@@ -39959,7 +39959,7 @@ declare module "sap/ui/core/UIArea" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Triggers asynchronous re-rendering of the `UIArea`'s content.
      *
@@ -39968,7 +39968,7 @@ declare module "sap/ui/core/UIArea" {
      */
     invalidate(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks whether the control is still valid (is in the DOM)
      *
@@ -39976,7 +39976,7 @@ declare module "sap/ui/core/UIArea" {
      */
     isActive(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether re-rendering is currently suppressed on this UIArea.
      *
@@ -40380,7 +40380,7 @@ declare module "sap/ui/core/UIComponent" {
     ): string;
     /**
      * @since 1.15.1
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * A method to be implemented by UIComponents, returning the flag whether to prefix the IDs of controls
      * automatically or not if the controls are created inside the {@link sap.ui.core.UIComponent#createContent }
@@ -40393,7 +40393,7 @@ declare module "sap/ui/core/UIComponent" {
      */
     getAutoPrefixId(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the parent in the eventing hierarchy of this object which will be the UIArea of the containing
      * ComponentContainer or null.
@@ -40419,7 +40419,7 @@ declare module "sap/ui/core/UIComponent" {
     ): string | null;
     /**
      * @since 1.44.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the content of {@link sap.ui.core.UIComponent#createContent}. If you specified a `rootView` in
      * your metadata or in the descriptor file (manifest.json), you will get the instance of the root view.
@@ -40470,7 +40470,7 @@ declare module "sap/ui/core/UIComponent" {
      */
     getUIArea(): UIArea;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes the component instance after creation.
      *
@@ -40482,7 +40482,7 @@ declare module "sap/ui/core/UIComponent" {
      */
     init(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Function is called when the rendering of the ComponentContainer is completed.
      *
@@ -40492,7 +40492,7 @@ declare module "sap/ui/core/UIComponent" {
      */
     onAfterRendering(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Function is called when the rendering of the ComponentContainer is started.
      *
@@ -41463,7 +41463,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the generation process of the file.
      *
@@ -41477,7 +41477,7 @@ declare module "sap/ui/core/util/ExportType" {
       oExport: Export
     ): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a cell "generator" (inspired by ES6 Generators)
      *
@@ -41485,7 +41485,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     cellGenerator(): Generator;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a column "generator" (inspired by ES6 Generators)
      *
@@ -41493,7 +41493,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     columnGenerator(): Generator;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Generates the file content.
      *  Should be implemented by the individual types!
@@ -41520,7 +41520,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     getCharset(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the number of columns.
      *
@@ -41544,7 +41544,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     getMimeType(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the number of rows.
      *
@@ -41552,7 +41552,7 @@ declare module "sap/ui/core/util/ExportType" {
      */
     getRowCount(): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a row "generator" (inspired by ES6 Generators)
      *
@@ -41736,7 +41736,7 @@ declare module "sap/ui/core/util/ExportTypeCSV" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Generates the file content.
      *
@@ -42871,7 +42871,7 @@ declare module "sap/ui/core/ws/SapPcpWebSocket" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:message message} to attached listeners.
      *
@@ -43239,7 +43239,7 @@ declare module "sap/ui/core/ws/WebSocket" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -43252,7 +43252,7 @@ declare module "sap/ui/core/ws/WebSocket" {
       oParameters?: WebSocket$CloseEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:error error} to attached listeners.
      *
@@ -43265,7 +43265,7 @@ declare module "sap/ui/core/ws/WebSocket" {
       oParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:message message} to attached listeners.
      *
@@ -43278,7 +43278,7 @@ declare module "sap/ui/core/ws/WebSocket" {
       oParameters?: WebSocket$MessageEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -43378,7 +43378,7 @@ declare module "sap/ui/core/XMLComposite" {
   /**
    * @since 1.56.0
    * @deprecated (since 1.88) - use {@link topic:c1512f6ce1454ff1913e3857bad56392 Standard Composite Controls}
-   * Experimental (since 1.56.0)
+   * @experimental (since 1.56.0)
    *
    * Base Class for XMLComposite controls.
    */
@@ -43537,7 +43537,7 @@ declare module "sap/ui/core/XMLComposite" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an element by its ID in the context of the XMLComposite.
      *
@@ -43552,7 +43552,7 @@ declare module "sap/ui/core/XMLComposite" {
       sId: string
     ): UI5Element | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is a hook for the RenderManager that gets called during the rendering of child Controls.
      * It allows to add, remove and update existing accessibility attributes (ARIA) of those controls.
@@ -44049,7 +44049,7 @@ declare module "sap/ui/Device" {
       bSuppressClasses?: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes a previously initialized range set and detaches all registered handlers.
      *
@@ -44471,8 +44471,8 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
   import Sorter from "sap/ui/model/Sorter";
 
   /**
-   * Experimental - This module is only for experimental use!
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @experimental - This module is only for experimental use!
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Tree binding implementation for OData entity sets with aggregate semantics.
    *
@@ -44487,7 +44487,7 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
    */
   export default class AnalyticalBinding extends TreeBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor(
       /**
@@ -44555,7 +44555,7 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.model.analytics.AnalyticalBinding with name `sClassName` and enriches
      * it with the information contained in `oClassInfo`.
@@ -44580,7 +44580,7 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.model.analytics.AnalyticalBinding.
      *
@@ -45008,7 +45008,7 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
       aSorter: Sorter | any[]
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Updates the binding's structure with new analytical information.
      *
@@ -45055,7 +45055,7 @@ declare module "sap/ui/model/analytics/AnalyticalBinding" {
 declare module "sap/ui/model/analytics/AnalyticalTreeBindingAdapter" {
   export default class AnalyticalTreeBindingAdapter {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adapter for TreeBindings to add the ListBinding functionality and use the tree structure in list based
      * controls.
@@ -45063,7 +45063,7 @@ declare module "sap/ui/model/analytics/AnalyticalTreeBindingAdapter" {
     constructor();
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Retrieves the currently set number of expanded levels from the Binding (commonly an AnalyticalBinding).
      *
@@ -45077,7 +45077,7 @@ declare module "sap/ui/model/analytics/AnalyticalTreeBindingAdapter" {
      */
     hasTotaledMeasures(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the number of expanded levels on the TreeBinding (commonly an AnalyticalBinding). This is NOT the
      * same as AnalyticalTreeBindingAdapter#collapse or AnalyticalTreeBindingAdapter#expand. Setting the number
@@ -45184,8 +45184,8 @@ declare module "sap/ui/model/analytics/odata4analytics" {
   import Sorter from "sap/ui/model/Sorter";
 
   /**
-   * Experimental - This module is only for experimental use!
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @experimental - This module is only for experimental use!
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * The OData4Analytics API is purely experimental, not yet functionally complete and not meant for productive
    * usage. At present, its only purpose is to demonstrate how easy analytical extensions of OData4SAP can
@@ -47010,7 +47010,7 @@ declare module "sap/ui/model/base/ManagedObjectModel" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Experimental (since 1.58)
+   * @experimental (since 1.58)
    *
    * The ManagedObjectModel class can be used for data binding of properties and aggregations for managed
    * objects.
@@ -47063,7 +47063,7 @@ declare module "sap/ui/model/base/ManagedObjectModel" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Private method iterating the registered bindings of this model instance and initiating their check for
      * update
@@ -47078,7 +47078,7 @@ declare module "sap/ui/model/base/ManagedObjectModel" {
       fnFilter: Function
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Private method iterating the registered bindings of this model instance and initiating their check for
      * update
@@ -47177,7 +47177,7 @@ declare module "sap/ui/model/Binding" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the {@link #event:AggregatedDataStateChange AggregatedDataStateChange }
      * event of this `sap.ui.model.Binding`.
@@ -47244,7 +47244,7 @@ declare module "sap/ui/model/Binding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches the `fnFunction` event handler to the {@link #event:DataStateChange DataStateChange} event of
      * thi `sap.ui.model.Binding`.
@@ -47263,7 +47263,7 @@ declare module "sap/ui/model/Binding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attach multiple events.
      *
@@ -47276,7 +47276,7 @@ declare module "sap/ui/model/Binding" {
       oEvents: Record<string, Function>
     ): Binding;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the {@link #event:refresh refresh} event of this `sap.ui.model.Binding`.
      *
@@ -47301,7 +47301,7 @@ declare module "sap/ui/model/Binding" {
      */
     destroy(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:AggregatedDataStateChange AggregatedDataStateChange }
      * event of this `sap.ui.model.Binding`.
@@ -47357,7 +47357,7 @@ declare module "sap/ui/model/Binding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:DataStateChange DataStateChange} event of
      * this `sap.ui.model.Binding`.
@@ -47373,7 +47373,7 @@ declare module "sap/ui/model/Binding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detach multiple events.
      *
@@ -47386,7 +47386,7 @@ declare module "sap/ui/model/Binding" {
       oEvents: Record<string, Function>
     ): Binding;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:refresh refresh} event of this `sap.ui.model.Binding`.
      */
@@ -47401,7 +47401,7 @@ declare module "sap/ui/model/Binding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dataReceived dataReceived} to attached listeners.
      *
@@ -47414,7 +47414,7 @@ declare module "sap/ui/model/Binding" {
       oParameters: Binding$DataReceivedEventParameters
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dataRequested dataRequested} to attached listeners.
      */
@@ -47473,7 +47473,7 @@ declare module "sap/ui/model/Binding" {
      */
     getResolvedPath(): string | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initialize the binding. The message should be called when creating a binding. The default implementation
      * calls checkUpdate(true).
@@ -47566,7 +47566,7 @@ declare module "sap/ui/model/Binding" {
      */
     suspend(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines if the binding should be updated by comparing the current model against a specified model.
      *
@@ -47783,13 +47783,13 @@ declare module "sap/ui/model/ClientListBinding" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * List binding implementation for client models.
    */
   export default class ClientListBinding extends ListBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new ClientListBinding.
      *
@@ -47825,7 +47825,7 @@ declare module "sap/ui/model/ClientListBinding" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.model.ClientListBinding with name `sClassName` and enriches it
      * with the information contained in `oClassInfo`.
@@ -47850,7 +47850,7 @@ declare module "sap/ui/model/ClientListBinding" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.model.ClientListBinding.
      *
@@ -47880,7 +47880,7 @@ declare module "sap/ui/model/ClientListBinding" {
       sFilterType?: FilterType | keyof typeof FilterType
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an array of binding contexts for the bound target list.
      *
@@ -48009,13 +48009,13 @@ declare module "sap/ui/model/ClientPropertyBinding" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Property binding implementation for client models.
    */
   export default class ClientPropertyBinding extends PropertyBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new ClientPropertyBinding.
      *
@@ -48043,7 +48043,7 @@ declare module "sap/ui/model/ClientPropertyBinding" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.model.ClientPropertyBinding with name `sClassName` and enriches
      * it with the information contained in `oClassInfo`.
@@ -48068,7 +48068,7 @@ declare module "sap/ui/model/ClientPropertyBinding" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.model.ClientPropertyBinding.
      *
@@ -48094,7 +48094,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
   import Metadata from "sap/ui/base/Metadata";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Tree binding implementation for client models.
    *
@@ -48107,7 +48107,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
    */
   export default class ClientTreeBinding extends TreeBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new ClientTreeBinding.
      *
@@ -48144,7 +48144,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new subclass of class sap.ui.model.ClientTreeBinding with name `sClassName` and enriches it
      * with the information contained in `oClassInfo`.
@@ -48169,7 +48169,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a metadata object for class sap.ui.model.ClientTreeBinding.
      *
@@ -48209,7 +48209,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
      */
     getCount(): number | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Return node contexts for the tree
      *
@@ -48230,7 +48230,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
       iLength: int
     ): Context[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Return root contexts for the tree
      *
@@ -48275,7 +48275,7 @@ declare module "sap/ui/model/ClientTreeBinding" {
 declare module "sap/ui/model/ClientTreeBindingAdapter" {
   export default class ClientTreeBindingAdapter {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adapter for TreeBindings to add the ListBinding functionality and use the tree structure in list based
      * controls.
@@ -48358,7 +48358,7 @@ declare module "sap/ui/model/CompositeBinding" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the `AggregatedDataStateChange` event of this `sap.ui.model.CompositeBinding`.
      *
@@ -48376,7 +48376,7 @@ declare module "sap/ui/model/CompositeBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the `change` event of this `sap.ui.model.CompositeBinding`.
      *
@@ -48394,7 +48394,7 @@ declare module "sap/ui/model/CompositeBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the `DataStateChange` event of this `sap.ui.model.CompositeBinding`.
      *
@@ -48412,7 +48412,7 @@ declare module "sap/ui/model/CompositeBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the `AggregatedDataStateChange` event of this `sap.ui.model.CompositeBinding`.
      */
@@ -48427,7 +48427,7 @@ declare module "sap/ui/model/CompositeBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the `change` event of this `sap.ui.model.CompositeBinding`.
      */
@@ -48442,7 +48442,7 @@ declare module "sap/ui/model/CompositeBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the `DataStateChange` event of this `sap.ui.model.CompositeBinding`.
      */
@@ -48507,7 +48507,7 @@ declare module "sap/ui/model/CompositeBinding" {
      */
     getValue(): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initialize the binding. The method should be called when creating a binding. The default implementation
      * calls checkUpdate(true). Prevent checkUpdate to be triggered while initializing nested bindings, it is
@@ -48603,7 +48603,7 @@ declare module "sap/ui/model/CompositeBinding" {
      */
     suspend(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines if the property bindings in the composite binding should be updated by calling updateRequired
      * on all property bindings with the specified model.
@@ -48662,7 +48662,7 @@ declare module "sap/ui/model/CompositeDataState" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns or sets whether the data state is changed. As long as changed was not set to false the data state
      * is dirty and the corresponding binding will fire data state change events.
@@ -48714,7 +48714,7 @@ declare module "sap/ui/model/CompositeDataState" {
      */
     getControlMessages(): Message[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an array of values for the given property in the inner datastates.
      *
@@ -48910,7 +48910,7 @@ declare module "sap/ui/model/CompositeType" {
     ): any[] | any;
     /**
      * @since 1.100.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Processes the types of the parts of this composite type. A concrete composite type may override this
      * method if it needs to derive information from the types of the parts.
@@ -49205,7 +49205,7 @@ declare module "sap/ui/model/DataState" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether the data state is changed, or resets the data state in case the parameter `bNewState`
      * is false; reset data state means that the data state properties are replaced with the changed properties.
@@ -49298,7 +49298,7 @@ declare module "sap/ui/model/DataState" {
      */
     isLaundering(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets an array of control state messages.
      *
@@ -49311,7 +49311,7 @@ declare module "sap/ui/model/DataState" {
       aMessages: Message[]
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the dirty value that was rejected by the type validation.
      *
@@ -49324,7 +49324,7 @@ declare module "sap/ui/model/DataState" {
       vInvalidValue: any
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the laundering state of the data state.
      *
@@ -49348,7 +49348,7 @@ declare module "sap/ui/model/DataState" {
       aMessages?: Message[]
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the formatted original value of the data.
      *
@@ -49361,7 +49361,7 @@ declare module "sap/ui/model/DataState" {
       vOriginalValue: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the formatted value of the data state,
      *
@@ -49817,13 +49817,13 @@ declare module "sap/ui/model/json/JSONListBinding" {
   import Filter from "sap/ui/model/Filter";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * List binding implementation for JSON format.
    */
   export default class JSONListBinding extends ClientListBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new JSONListBinding.
      *
@@ -50057,13 +50057,13 @@ declare module "sap/ui/model/json/JSONPropertyBinding" {
   import Context from "sap/ui/model/Context";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Property binding implementation for JSON format.
    */
   export default class JSONPropertyBinding extends ClientPropertyBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new JSONListBinding.
      *
@@ -50100,7 +50100,7 @@ declare module "sap/ui/model/json/JSONTreeBinding" {
   import Filter from "sap/ui/model/Filter";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Tree binding implementation for JSON format.
    *
@@ -50110,7 +50110,7 @@ declare module "sap/ui/model/json/JSONTreeBinding" {
    */
   export default class JSONTreeBinding extends ClientTreeBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new JSONListBinding.
      *
@@ -50238,7 +50238,7 @@ declare module "sap/ui/model/ListBinding" {
     /**
      * @deprecated (since 1.11) - use the `change` event. It now contains a parameter `(reason : "filter")`
      * when a filter event is fired.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the {@link #event:filter filter} event of this `sap.ui.model.ListBinding`.
      *
@@ -50258,7 +50258,7 @@ declare module "sap/ui/model/ListBinding" {
     /**
      * @deprecated (since 1.11) - use the `change` event. It now contains a parameter `(reason : "sort")` when
      * a sorter event is fired.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the {@link #event:sort sort} event of this `sap.ui.model.ListBinding`.
      *
@@ -50277,7 +50277,7 @@ declare module "sap/ui/model/ListBinding" {
     ): void;
     /**
      * @deprecated (since 1.11) - use the `change` event.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:filter filter} event of this `sap.ui.model.ListBinding`.
      */
@@ -50293,7 +50293,7 @@ declare module "sap/ui/model/ListBinding" {
     ): void;
     /**
      * @deprecated (since 1.11) - use the `change` event.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:sort sort} event of this `sap.ui.model.ListBinding`.
      */
@@ -50308,7 +50308,7 @@ declare module "sap/ui/model/ListBinding" {
       oListener?: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Calculates delta of specified old data array and new data array.
      *
@@ -50331,7 +50331,7 @@ declare module "sap/ui/model/ListBinding" {
       index: int;
     }>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enable extended change detection. When extended change detection is enabled, the list binding provides
      * detailed information about changes, for example which entries have been removed or inserted. This can
@@ -50400,7 +50400,7 @@ declare module "sap/ui/model/ListBinding" {
      */
     getAllCurrentContexts(): Context[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an array of binding contexts for the bound target list.
      *
@@ -50474,7 +50474,7 @@ declare module "sap/ui/model/ListBinding" {
       sPath: string
     ): any[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the string key for the given model context, which is a unique representation of the context's
      * data. This key is used in extended change detection to compute the difference between current and previous
@@ -50547,7 +50547,7 @@ declare module "sap/ui/model/ListBinding" {
     isLengthFinal(): boolean;
     /**
      * @since 1.77.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Requests a {@link sap.ui.model.Filter} object which can be used to filter the list binding by entries
      * with model messages. With the filter callback, you can define if a message is considered when creating
@@ -50592,7 +50592,7 @@ declare module "sap/ui/model/ListBinding" {
       aSorters: Sorter | Sorter[]
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Update the list and apply sorting and filtering. Called after creation of the list binding on enabling
      * extended change detection, see {@link sap.ui.model.ListBinding#enableExtendedChangeDetection}.
@@ -51262,7 +51262,7 @@ declare module "sap/ui/model/Model" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:parseError parseError} to attached listeners.
      *
@@ -51276,7 +51276,7 @@ declare module "sap/ui/model/Model" {
       oParameters?: Model$ParseErrorEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:propertyChange propertyChange} to attached listeners.
      *
@@ -51289,7 +51289,7 @@ declare module "sap/ui/model/Model" {
       oParameters?: Model$PropertyChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestCompleted requestCompleted} to attached listeners.
      *
@@ -51302,7 +51302,7 @@ declare module "sap/ui/model/Model" {
       oParameters?: Model$RequestCompletedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestFailed requestFailed} to attached listeners.
      *
@@ -51315,7 +51315,7 @@ declare module "sap/ui/model/Model" {
       oParameters?: Model$RequestFailedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestSent requestSent} to attached listeners.
      *
@@ -51350,7 +51350,7 @@ declare module "sap/ui/model/Model" {
       oContext: Context
     ): Message[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns model messages for which the target matches the given resolved binding path.
      *
@@ -51644,7 +51644,7 @@ declare module "sap/ui/model/Model" {
 
 declare module "sap/ui/model/odata/ODataTreeBindingAdapter" {
   /**
-   * Experimental - This module is only for experimental and internal use!
+   * @experimental - This module is only for experimental and internal use!
    *
    * Adapter for TreeBindings to add the ListBinding functionality and use the tree structure in list based
    * controls. Only usable with the sap.ui.table.TreeTable control. The functions defined here are only available
@@ -52334,7 +52334,7 @@ declare module "sap/ui/model/odata/ODataAnnotations" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:failed failed} to attached listeners.
      *
@@ -52364,7 +52364,7 @@ declare module "sap/ui/model/odata/ODataAnnotations" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:loaded loaded} to attached listeners.
      *
@@ -52629,7 +52629,7 @@ declare module "sap/ui/model/odata/ODataListBinding" {
       bReturnSuccess?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Return contexts for the list
      *
@@ -53006,7 +53006,7 @@ declare module "sap/ui/model/odata/ODataMetadata" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:failed failed} to attached listeners.
      *
@@ -53036,7 +53036,7 @@ declare module "sap/ui/model/odata/ODataMetadata" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:loaded loaded} to attached listeners.
      *
@@ -54178,7 +54178,7 @@ declare module "sap/ui/model/odata/ODataModel" {
          */
         tokenHandling?: boolean;
         /**
-         * experimental - true when user credentials are to be included in a cross-origin request. Please note that
+         * @experimental - true when user credentials are to be included in a cross-origin request. Please note that
          * this works only if all requests are asynchronous.
          */
         withCredentials?: boolean;
@@ -54263,7 +54263,7 @@ declare module "sap/ui/model/odata/ODataModel" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds (a) new URL(s) to the be parsed for OData annotations, which are then merged into the annotations
      * object which can be retrieved by calling the getServiceAnnotations()-method. If a $metadata url is passed
@@ -54283,7 +54283,7 @@ declare module "sap/ui/model/odata/ODataModel" {
       vUrl: string | string[]
     ): Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds new xml content to be parsed for OData annotations, which are then merged into the annotations object
      * which can be retrieved by calling the getServiceAnnotations()-method.
@@ -54786,7 +54786,7 @@ declare module "sap/ui/model/odata/ODataModel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:annotationsFailed annotationsFailed} to attached listeners.
      *
@@ -54816,7 +54816,7 @@ declare module "sap/ui/model/odata/ODataModel" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:annotationsLoaded annotationsLoaded} to attached listeners.
      *
@@ -54834,7 +54834,7 @@ declare module "sap/ui/model/odata/ODataModel" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:metadataFailed metadataFailed} to attached listeners.
      *
@@ -54864,7 +54864,7 @@ declare module "sap/ui/model/odata/ODataModel" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:metadataLoaded metadataLoaded} to attached listeners.
      *
@@ -55491,7 +55491,7 @@ declare module "sap/ui/model/odata/ODataPropertyBinding" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the current value of the bound target
      *
@@ -55499,7 +55499,7 @@ declare module "sap/ui/model/odata/ODataPropertyBinding" {
      */
     getValue(): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initialize the binding. The message should be called when creating a binding. If metadata is not yet
      * available, do nothing, method will be called again when metadata is loaded.
@@ -55894,7 +55894,7 @@ declare module "sap/ui/model/odata/type/Byte" {
      */
     getName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the type's supported range as object with properties `minimum` and `maximum`.
      *
@@ -56743,7 +56743,7 @@ declare module "sap/ui/model/odata/type/DateTimeWithTimezone" {
      */
     getPartsIgnoringMessages(): number[];
     /**
-     * Experimental (since 1.114.0)
+     * @experimental (since 1.114.0)
      *
      * Returns a language-dependent placeholder text such as "e.g. " where  is formatted
      * using this type.
@@ -57419,7 +57419,7 @@ declare module "sap/ui/model/odata/type/Int16" {
      */
     getName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the type's supported range as object with properties `minimum` and `maximum`.
      *
@@ -57507,7 +57507,7 @@ declare module "sap/ui/model/odata/type/Int32" {
      */
     getName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the type's supported range as object with properties `minimum` and `maximum`.
      *
@@ -57731,7 +57731,7 @@ declare module "sap/ui/model/odata/type/ODataType" {
      */
     static getMetadata(): Metadata;
     /**
-     * Experimental (since 1.114.0)
+     * @experimental (since 1.114.0)
      *
      * Returns a language-dependent placeholder text such as "e.g. " where  is formatted
      * using this type.
@@ -57929,7 +57929,7 @@ declare module "sap/ui/model/odata/type/SByte" {
      */
     getName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the type's supported range as object with properties `minimum` and `maximum`.
      *
@@ -60037,7 +60037,7 @@ declare module "sap/ui/model/odata/v2/ODataListBinding" {
      */
     getAllCurrentContexts(): Context1[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Return contexts for the list.
      *
@@ -60152,7 +60152,7 @@ declare module "sap/ui/model/odata/v2/ODataListBinding" {
     ): void;
     /**
      * @since 1.77.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Requests a {@link sap.ui.model.Filter} object which can be used to filter the list binding by entries
      * with model messages. With the filter callback, you can define if a message is considered when creating
@@ -60462,7 +60462,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds (a) new URL(s) whose content should be parsed as OData annotations, which are then merged into the
      * annotations object which can be retrieved by calling the {@link #getServiceAnnotations}-method. If a
@@ -60482,7 +60482,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       vUrl: string | string[]
     ): Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adds new XML content to be parsed for OData annotations, which are then merged into the annotations object
      * which can be retrieved by calling the {@link #getServiceAnnotations}-method.
@@ -61648,7 +61648,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:annotationsFailed annotationsFailed} to attached listeners.
      *
@@ -61661,7 +61661,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters?: ODataModel$AnnotationsFailedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:annotationsLoaded annotationsLoaded} to attached listeners.
      *
@@ -61674,7 +61674,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters?: ODataModel$AnnotationsLoadedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:batchRequestCompleted batchRequestCompleted} to attached listeners.
      *
@@ -61687,7 +61687,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters: ODataModel$BatchRequestCompletedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:batchRequestFailed batchRequestFailed} to attached listeners.
      *
@@ -61700,7 +61700,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters: ODataModel$BatchRequestFailedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:batchRequestSent batchRequestSent} to attached listeners.
      *
@@ -61713,7 +61713,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters?: ODataModel$BatchRequestSentEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:metadataFailed metadataFailed} to attached listeners.
      *
@@ -61726,7 +61726,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
       oParameters?: ODataModel$MetadataFailedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:metadataLoaded metadataLoaded} to attached listeners.
      *
@@ -64192,7 +64192,7 @@ declare module "sap/ui/model/odata/v4/Context" {
      */
     isKeepAlive(): boolean;
     /**
-     * Experimental (since 1.111.0)
+     * @experimental (since 1.111.0)
      *
      * Tells whether this context is currently selected, but not {@link #delete deleted} on the client.
      * See:
@@ -64514,7 +64514,7 @@ declare module "sap/ui/model/odata/v4/Context" {
       bRetry?: boolean
     ): Promise<any>;
     /**
-     * Experimental (since 1.111.0)
+     * @experimental (since 1.111.0)
      *
      * Determines whether this context is currently selected. If the preconditions of {@link #setKeepAlive }
      * hold, a best effort is made to implicitly keep a selected context alive in order to preserve the selection
@@ -64725,7 +64725,7 @@ declare module "sap/ui/model/odata/v4/ODataContextBinding" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataContextBinding$PatchCompletedEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -64903,7 +64903,7 @@ declare module "sap/ui/model/odata/v4/ODataContextBinding" {
     ): boolean;
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes the OData context binding: Fires a 'change' event in case the binding has a resolved path
      * and its root binding is not suspended.
@@ -65059,7 +65059,13 @@ declare module "sap/ui/model/odata/v4/ODataContextBinding" {
   export type ODataContextBinding$ChangeEvent = Event<ODataContextBinding$ChangeEventParameters>;
 
   export interface ODataContextBinding$DataReceivedEventParameters
-    extends Binding$DataReceivedEventParameters {}
+    extends Binding$DataReceivedEventParameters {
+    /**
+     * The error object if a back-end request failed. If there are multiple failed back-end requests, the error
+     * of the first one is provided.
+     */
+    error?: Error;
+  }
 
   export type ODataContextBinding$DataReceivedEvent = Event<ODataContextBinding$DataReceivedEventParameters>;
 
@@ -65068,7 +65074,12 @@ declare module "sap/ui/model/odata/v4/ODataContextBinding" {
 
   export type ODataContextBinding$DataRequestedEvent = Event<ODataContextBinding$DataRequestedEventParameters>;
 
-  export interface ODataContextBinding$PatchCompletedEventParameters {}
+  export interface ODataContextBinding$PatchCompletedEventParameters {
+    /**
+     * Whether all PATCHes are successfully processed
+     */
+    success?: boolean;
+  }
 
   export type ODataContextBinding$PatchCompletedEvent = Event<ODataContextBinding$PatchCompletedEventParameters>;
 
@@ -65103,6 +65114,8 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
   } from "sap/ui/model/Binding";
 
   import Event from "sap/ui/base/Event";
+
+  import ChangeReason from "sap/ui/model/ChangeReason";
 
   /**
    * @since 1.37.0
@@ -65396,7 +65409,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataListBinding$CreateCompletedEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -65413,7 +65426,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataListBinding$CreateSentEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -65430,7 +65443,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataListBinding$PatchCompletedEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -65535,7 +65548,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     getAllCurrentContexts(): Context[];
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns already created binding contexts for all entities in this list binding for the range determined
      * by the given start index `iStart` and `iLength`. If at least one of the entities in the given range has
@@ -65767,7 +65780,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     ): boolean;
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes the OData list binding: Fires an event in case the binding has a resolved path and its root
      * binding is not suspended. If the model's parameter `autoExpandSelect` is used (see {@link sap.ui.model.odata.v4.ODataModel#constructor}),
@@ -65885,7 +65898,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     requestDownloadUrl(): Promise<string>;
     /**
      * @since 1.86.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Requests an {@link sap.ui.model.Filter} object which can be used to filter the list binding by entries
      * with model messages. With the filter callback, you can define if a message is considered when creating
@@ -66089,7 +66102,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     toString(): string;
     /**
      * @since 1.53.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Updates the binding's system query option `$apply` based on the given data aggregation information. Its
      * value is "groupby((<dimension_1,...,dimension_N,unit_or_text_1,...,unit_or_text_K>), aggregate(<measure>
@@ -66164,7 +66177,14 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
   }
 
   export interface ODataListBinding$ChangeEventParameters
-    extends Binding$ChangeEventParameters {}
+    extends Binding$ChangeEventParameters {
+    /**
+     * During automatic determination of $expand and $select, a "virtual" context is first added with detailed
+     * reason "AddVirtualContext" and then removed with detailed reason "RemoveVirtualContext" (since 1.69.0);
+     * `undefined` is used in all other cases
+     */
+    detailedReason?: string;
+  }
 
   export type ODataListBinding$ChangeEvent = Event<ODataListBinding$ChangeEventParameters>;
 
@@ -66172,16 +66192,38 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
 
   export type ODataListBinding$CreateActivateEvent = Event<ODataListBinding$CreateActivateEventParameters>;
 
-  export interface ODataListBinding$CreateCompletedEventParameters {}
+  export interface ODataListBinding$CreateCompletedEventParameters {
+    /**
+     * The context for the created entity
+     */
+    context?: Context;
+
+    /**
+     * Whether the POST was successfully processed; in case of an error, the error is already reported to the
+     * {@link sap.ui.core.message.MessageManager}
+     */
+    success?: boolean;
+  }
 
   export type ODataListBinding$CreateCompletedEvent = Event<ODataListBinding$CreateCompletedEventParameters>;
 
-  export interface ODataListBinding$CreateSentEventParameters {}
+  export interface ODataListBinding$CreateSentEventParameters {
+    /**
+     * The context for the created entity
+     */
+    context?: Context;
+  }
 
   export type ODataListBinding$CreateSentEvent = Event<ODataListBinding$CreateSentEventParameters>;
 
   export interface ODataListBinding$DataReceivedEventParameters
-    extends Binding$DataReceivedEventParameters {}
+    extends Binding$DataReceivedEventParameters {
+    /**
+     * The error object if a back-end request failed. If there are multiple failed back-end requests, the error
+     * of the first one is provided.
+     */
+    error?: Error;
+  }
 
   export type ODataListBinding$DataReceivedEvent = Event<ODataListBinding$DataReceivedEventParameters>;
 
@@ -66190,7 +66232,12 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
 
   export type ODataListBinding$DataRequestedEvent = Event<ODataListBinding$DataRequestedEventParameters>;
 
-  export interface ODataListBinding$PatchCompletedEventParameters {}
+  export interface ODataListBinding$PatchCompletedEventParameters {
+    /**
+     * Whether all PATCHes are successfully processed
+     */
+    success?: boolean;
+  }
 
   export type ODataListBinding$PatchCompletedEvent = Event<ODataListBinding$PatchCompletedEventParameters>;
 
@@ -66198,7 +66245,22 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
 
   export type ODataListBinding$PatchSentEvent = Event<ODataListBinding$PatchSentEventParameters>;
 
-  export interface ODataListBinding$RefreshEventParameters {}
+  export interface ODataListBinding$RefreshEventParameters {
+    /**
+     * The reason for the 'refresh' event could be
+     * 	 {@link sap.ui.model.ChangeReason.Context Context} when the binding's parent context is changed,
+     * {@link sap.ui.model.ChangeReason.Filter Filter} on {@link #filter} and {@link #setAggregation},
+     * {@link sap.ui.model.ChangeReason.Refresh Refresh} on {@link #refresh}, or when the binding is initialized,
+     *  {@link sap.ui.model.ChangeReason.Sort Sort} on {@link #sort}.  {@link #changeParameters} leads
+     * to {@link sap.ui.model.ChangeReason.Filter Filter} if one of the parameters '$filter' and '$search' is
+     * changed, otherwise it leads to {@link sap.ui.model.ChangeReason.Sort Sort} if the parameter '$orderby'
+     * is changed; in other cases, it leads to {@link sap.ui.model.ChangeReason.Change Change}.
+     *  If APIs that would normally fire change events have been called while the binding is suspended, {@link #resume }
+     * leads to the "strongest" change reason in the order {@link sap.ui.model.ChangeReason.Filter Filter},
+     * {@link sap.ui.model.ChangeReason.Sort Sort}, {@link sap.ui.model.ChangeReason.Refresh Refresh}, {@link sap.ui.model.ChangeReason.Change Change}.
+     */
+    reason?: ChangeReason;
+  }
 
   export type ODataListBinding$RefreshEvent = Event<ODataListBinding$RefreshEventParameters>;
 }
@@ -67694,7 +67756,7 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataModel$DataReceivedEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -67711,7 +67773,7 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
       /**
        * The function to call when the event occurs
        */
-      fnFunction: Function,
+      fnFunction: (evt: ODataModel$DataRequestedEvent) => void,
       /**
        * Object on which to call the given function
        */
@@ -68055,11 +68117,33 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
     toString(): string;
   }
 
-  export interface ODataModel$DataReceivedEventParameters {}
+  export interface ODataModel$DataReceivedEventParameters {
+    /**
+     * An empty data object if a back-end request succeeds
+     */
+    data?: object;
+
+    /**
+     * The error object if a back-end request failed.
+     */
+    error?: Error;
+
+    /**
+     * The absolute path to the entity which caused the event. The path is only provided for additional property
+     * requests; for other requests it is `undefined`.
+     */
+    path?: string;
+  }
 
   export type ODataModel$DataReceivedEvent = Event<ODataModel$DataReceivedEventParameters>;
 
-  export interface ODataModel$DataRequestedEventParameters {}
+  export interface ODataModel$DataRequestedEventParameters {
+    /**
+     * The absolute path to the entity which caused the event. The path is only provided for additional property
+     * requests; for other requests it is `undefined`.
+     */
+    path?: string;
+  }
 
   export type ODataModel$DataRequestedEvent = Event<ODataModel$DataRequestedEventParameters>;
 
@@ -68069,7 +68153,18 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
   export type ODataModel$ParseErrorEvent = Event<ODataModel$ParseErrorEventParameters>;
 
   export interface ODataModel$PropertyChangeEventParameters
-    extends Model$PropertyChangeEventParameters {}
+    extends Model$PropertyChangeEventParameters {
+    /**
+     * A promise on the outcome of the PATCH request, much like {@link sap.ui.model.odata.v4.Context#setProperty }
+     * provides it for `bRetry === true`; missing in case there is no PATCH
+     */
+    promise?: Promise<any>;
+
+    /**
+     * The property binding's {@link sap.ui.model.Binding#getResolvedPath resolved path}
+     */
+    resolvedPath?: string;
+  }
 
   export type ODataModel$PropertyChangeEvent = Event<ODataModel$PropertyChangeEventParameters>;
 
@@ -68448,7 +68543,13 @@ declare module "sap/ui/model/odata/v4/ODataPropertyBinding" {
   export type ODataPropertyBinding$ChangeEvent = Event<ODataPropertyBinding$ChangeEventParameters>;
 
   export interface ODataPropertyBinding$DataReceivedEventParameters
-    extends Binding$DataReceivedEventParameters {}
+    extends Binding$DataReceivedEventParameters {
+    /**
+     * The error object if a back-end request failed. If there are multiple failed back-end requests, the error
+     * of the first one is provided.
+     */
+    error?: Error;
+  }
 
   export type ODataPropertyBinding$DataReceivedEvent = Event<ODataPropertyBinding$DataReceivedEventParameters>;
 
@@ -68746,7 +68847,7 @@ declare module "sap/ui/model/PropertyBinding" {
      */
     resume(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the binding mode.
      */
@@ -69225,7 +69326,7 @@ declare module "sap/ui/model/SelectionModel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChanged selectionChanged} to attached listeners.
      *
@@ -69466,7 +69567,7 @@ declare module "sap/ui/model/SimpleType" {
       sTargetType: string
     ): any | Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns an object with `format` and `parse` methods. `format` converts the internal value which has a
      * JavaScript primitive type or is a built-in object such as Date which can be used by a control to the
@@ -69695,20 +69796,20 @@ declare module "sap/ui/model/StaticBinding" {
 
 declare module "sap/ui/model/TreeAutoExpandMode" {
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Different modes for setting the auto expand mode on tree or analytical bindings.
    */
   enum TreeAutoExpandMode {
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * If supported by a backend provider with analytical capabilities, the requests needed for an automatic
      * node expansion are bundled.
      */
     Bundled = "Bundled",
     /**
-     * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+     * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
      *
      * Tree nodes will be expanded in sequence, level by level (Single requests are sent).
      */
@@ -69802,7 +69903,7 @@ declare module "sap/ui/model/TreeBinding" {
     /**
      * @deprecated (since 1.11) - use the `change` event. It now contains a parameter `(reason : "filter")`
      * when a filter event is fired.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Attaches event handler `fnFunction` to the {@link #event:_filter _filter} event of this `sap.ui.model.TreeBinding`.
      *
@@ -69821,7 +69922,7 @@ declare module "sap/ui/model/TreeBinding" {
     ): void;
     /**
      * @deprecated (since 1.11) - use the `change` event.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Detaches event handler `fnFunction` from the {@link #event:_filter _filter} event of this `sap.ui.model.TreeBinding`.
      *
@@ -69936,7 +70037,7 @@ declare module "sap/ui/model/TreeBindingAdapter" {
 
   export default class TreeBindingAdapter {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adapter for TreeBindings to add the ListBinding functionality and use the tree structure in list based
      * controls.
@@ -70009,7 +70110,7 @@ declare module "sap/ui/model/TreeBindingAdapter" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChanged selectionChanged} to attached listeners.
      *
@@ -70035,7 +70136,7 @@ declare module "sap/ui/model/TreeBindingAdapter" {
       }
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets an array of contexts for the requested part of the tree.
      *
@@ -70069,11 +70170,11 @@ declare module "sap/ui/model/TreeBindingCompatibilityAdapter" {
 
   /**
    * @deprecated (since 1.96.0) - use {@link sap.ui.model.TreeBindingAdapter} instead
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    */
   export default class TreeBindingCompatibilityAdapter {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Adapter for TreeBindings to add the ListBinding functionality and use the tree structure in list based
      * controls.
@@ -70455,7 +70556,7 @@ declare module "sap/ui/model/type/Date" {
      */
     static getMetadata(): Metadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the output pattern.
      * See:
@@ -70465,7 +70566,7 @@ declare module "sap/ui/model/type/Date" {
      */
     getOutputPattern(): string;
     /**
-     * Experimental (since 1.114.0)
+     * @experimental (since 1.114.0)
      *
      * Returns a language-dependent placeholder text such as "e.g. " where  is formatted
      * using this type.
@@ -70602,7 +70703,7 @@ declare module "sap/ui/model/type/DateInterval" {
       sTargetType: string
     ): string;
     /**
-     * Experimental (since 1.114.0)
+     * @experimental (since 1.114.0)
      *
      * Returns a language-dependent placeholder text such as "e.g. " where  is formatted
      * using this type.
@@ -71650,13 +71751,13 @@ declare module "sap/ui/model/xml/XMLTreeBinding" {
   import Context from "sap/ui/model/Context";
 
   /**
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Tree binding implementation for XML format
    */
   export default class XMLTreeBinding extends ClientTreeBinding {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor(
       oModel: XMLModel,
@@ -71678,7 +71779,7 @@ declare module "sap/ui/model/xml/XMLTreeBinding" {
       mParameters?: object
     );
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor(
       /**
@@ -71700,7 +71801,7 @@ declare module "sap/ui/model/xml/XMLTreeBinding" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Return node contexts for the tree
      *
@@ -71778,7 +71879,7 @@ declare module "sap/ui/test/actions/Action" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the matcher is matching - will get an instance of sap.ui.core.Control as parameter Should be
      * overwritten by subclasses
@@ -75754,7 +75855,7 @@ declare module "sap/ui/test/matchers/Matcher" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the matcher is matching - will get an instance of sap.ui.core.Control as parameter.
      *
@@ -77463,18 +77564,18 @@ declare module "sap/ui/test/PageObjectFactory" {
 
   /**
    * @since 1.26
-   * Protected:  DO NOT USE IN APPLICATIONS (only for related classes in the framework)
+   * @ui5-protected DO NOT USE IN APPLICATIONS (only for related classes in the framework)
    *
    * Page Object Factory.
    */
   export default class PageObjectFactory extends BaseObject {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      */
     constructor();
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a set of page objects, each consisting of actions and assertions, and adds them to the Opa configuration.
      *
@@ -80415,8 +80516,8 @@ declare namespace sap {
        */
       namespace analytics {
         /**
-         * Experimental - This module is only for experimental use!
-         * Protected:  Do not call from applications (only from related classes in the framework)
+         * @experimental - This module is only for experimental use!
+         * @ui5-protected Do not call from applications (only from related classes in the framework)
          *
          * If called on an instance of an (v1/v2) ODataModel it will enrich it with analytics capabilities.
          */

--- a/types/openui5/sap.ui.fl.d.ts
+++ b/types/openui5/sap.ui.fl.d.ts
@@ -7,7 +7,7 @@ declare module "sap/ui/fl/apply/api/ControlVariantApplyAPI" {
 
   /**
    * @since 1.67
-   * Experimental (since 1.67)
+   * @experimental (since 1.67)
    *
    * Provides an API for applications to work with control variants. See also {@link sap.ui.fl.variants.VariantManagement}.
    */
@@ -615,7 +615,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -628,7 +628,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:initialized initialized} to attached listeners.
      *
@@ -641,7 +641,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:manage manage} to attached listeners.
      *
@@ -654,7 +654,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
       mParameters?: VariantManagement$ManageEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:save save} to attached listeners.
      *
@@ -667,7 +667,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
       mParameters?: VariantManagement$SaveEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -773,7 +773,7 @@ declare module "sap/ui/fl/variants/VariantManagement" {
      */
     getModified(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Required by the {@link sap.m.IOverflowToolbarContent} interface. Registers invalidations event which
      * is fired when width of the control is changed.

--- a/types/openui5/sap.ui.integration.d.ts
+++ b/types/openui5/sap.ui.integration.d.ts
@@ -21,32 +21,32 @@ declare module "sap/ui/integration/library" {
     TwoColumns = "TwoColumns",
   }
   /**
-   * Experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
+   * @experimental (since 1.64) - Disclaimer: this property is in a beta state - incompatible API changes
    * may be done before its official public release. Use at your own discretion.
    *
    * Enumeration of possible card action types.
    */
   export enum CardActionType {
     /**
-     * Experimental (since 1.76)
+     * @experimental (since 1.76)
      *
      * Used for custom actions.
      */
     Custom = "Custom",
     /**
-     * Experimental (since 1.87)
+     * @experimental (since 1.87)
      *
      * Date selection. Available only for Calendar cards.
      */
     DateChange = "DateChange",
     /**
-     * Experimental (since 1.100)
+     * @experimental (since 1.100)
      *
      * Used for hiding the appeared details about the card.
      */
     HideCard = "HideCard",
     /**
-     * Experimental (since 1.87)
+     * @experimental (since 1.87)
      *
      * Month selection. Available only for Calendar cards.
      */
@@ -56,7 +56,7 @@ declare module "sap/ui/integration/library" {
      */
     Navigation = "Navigation",
     /**
-     * Experimental (since 1.100)
+     * @experimental (since 1.100)
      *
      * Used for showing more details about the card.
      */
@@ -86,7 +86,7 @@ declare module "sap/ui/integration/library" {
     Header = "Header",
   }
   /**
-   * Experimental (since 1.114)
+   * @experimental (since 1.114)
    *
    * Card blocking message types.
    */
@@ -106,7 +106,7 @@ declare module "sap/ui/integration/library" {
   }
   /**
    * @since 1.65
-   * Experimental (since 1.65)
+   * @experimental (since 1.65)
    *
    * Possible data modes for `{@link sap.ui.integration.widgets.Card}`.
    */
@@ -126,7 +126,7 @@ declare module "sap/ui/integration/library" {
   }
   /**
    * @since 1.109
-   * Experimental (since 1.109)
+   * @experimental (since 1.109)
    *
    * Possible designs for `{@link sap.ui.integration.widgets.Card}`.
    */
@@ -141,7 +141,7 @@ declare module "sap/ui/integration/library" {
     Transparent = "Transparent",
   }
   /**
-   * Experimental (since 1.79)
+   * @experimental (since 1.79)
    *
    * An object type that represents card menu action properties.
    */
@@ -186,7 +186,7 @@ declare module "sap/ui/integration/library" {
 
   /**
    * @since 1.112
-   * Experimental (since 1.112)
+   * @experimental (since 1.112)
    *
    * Preview modes for `{@link sap.ui.integration.widgets.Card}`. Helpful in scenarios when the end user is
    * choosing or configuring a card.
@@ -224,7 +224,7 @@ declare module "sap/ui/integration/ActionDefinition" {
 
   /**
    * @since 1.85
-   * Experimental (since 1.85) - Disclaimer: this class is in a beta state - incompatible API changes may
+   * @experimental (since 1.85) - Disclaimer: this class is in a beta state - incompatible API changes may
    * be done before its official public release. Use at your own discretion.
    *
    * Represents an action, which appears in the header of {@link sap.ui.integration.widgets.Card}. Useful
@@ -356,7 +356,7 @@ declare module "sap/ui/integration/ActionDefinition" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -637,7 +637,7 @@ declare module "sap/ui/integration/widgets/Card" {
   } from "sap/ui/base/ManagedObject";
 
   /**
-   * Experimental (since 1.114)
+   * @experimental (since 1.114)
    *
    * Settings for blocking message that ocurred in a {@link sap.ui.integration.widgets.Card}
    */
@@ -778,7 +778,7 @@ declare module "sap/ui/integration/widgets/Card" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Adds some actionDefinition to the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -792,7 +792,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oActionDefinition: ActionDefinition
     ): this;
     /**
-     * Experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.widgets.Card`.
@@ -824,7 +824,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.widgets.Card`.
@@ -851,7 +851,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Attaches event handler `fnFunction` to the {@link #event:configurationChange configurationChange} event
      * of this `sap.ui.integration.widgets.Card`.
@@ -880,7 +880,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Attaches event handler `fnFunction` to the {@link #event:configurationChange configurationChange} event
      * of this `sap.ui.integration.widgets.Card`.
@@ -957,7 +957,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.72)
+     * @experimental (since 1.72)
      *
      * Attaches event handler `fnFunction` to the {@link #event:manifestReady manifestReady} event of this `sap.ui.integration.widgets.Card`.
      *
@@ -984,7 +984,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.72)
+     * @experimental (since 1.72)
      *
      * Attaches event handler `fnFunction` to the {@link #event:manifestReady manifestReady} event of this `sap.ui.integration.widgets.Card`.
      *
@@ -1006,7 +1006,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Attaches event handler `fnFunction` to the {@link #event:stateChanged stateChanged} event of this `sap.ui.integration.widgets.Card`.
      *
@@ -1034,7 +1034,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Attaches event handler `fnFunction` to the {@link #event:stateChanged stateChanged} event of this `sap.ui.integration.widgets.Card`.
      *
@@ -1058,7 +1058,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Destroys all the actionDefinitions in the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1067,7 +1067,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     destroyActionDefinitions(): this;
     /**
-     * Experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Detaches event handler `fnFunction` from the {@link #event:action action} event of this `sap.ui.integration.widgets.Card`.
@@ -1087,7 +1087,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Detaches event handler `fnFunction` from the {@link #event:configurationChange configurationChange} event
      * of this `sap.ui.integration.widgets.Card`.
@@ -1125,7 +1125,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.72)
+     * @experimental (since 1.72)
      *
      * Detaches event handler `fnFunction` from the {@link #event:manifestReady manifestReady} event of this
      * `sap.ui.integration.widgets.Card`.
@@ -1145,7 +1145,7 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Detaches event handler `fnFunction` from the {@link #event:stateChanged stateChanged} event of this `sap.ui.integration.widgets.Card`.
      *
@@ -1164,9 +1164,9 @@ declare module "sap/ui/integration/widgets/Card" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:action action} to attached listeners.
      *
@@ -1182,8 +1182,8 @@ declare module "sap/ui/integration/widgets/Card" {
       mParameters?: Card$ActionEventParameters
     ): boolean;
     /**
-     * Experimental (since 1.96)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.96)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:configurationChange configurationChange} to attached listeners.
      *
@@ -1196,7 +1196,7 @@ declare module "sap/ui/integration/widgets/Card" {
       mParameters?: Card$ConfigurationChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:manifestApplied manifestApplied} to attached listeners.
      *
@@ -1209,8 +1209,8 @@ declare module "sap/ui/integration/widgets/Card" {
       mParameters?: object
     ): this;
     /**
-     * Experimental (since 1.72)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.72)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:manifestReady manifestReady} to attached listeners.
      *
@@ -1223,8 +1223,8 @@ declare module "sap/ui/integration/widgets/Card" {
       mParameters?: object
     ): this;
     /**
-     * Experimental (since 1.107)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.107)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stateChanged stateChanged} to attached listeners.
      *
@@ -1238,7 +1238,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets content of aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1249,7 +1249,7 @@ declare module "sap/ui/integration/widgets/Card" {
     getActionDefinitions(): ActionDefinition[];
     /**
      * @since 1.70
-     * Experimental (since 1.70)
+     * @experimental (since 1.70)
      *
      * Gets current value of property {@link #getBaseUrl baseUrl}.
      *
@@ -1260,7 +1260,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getBaseUrl(): URI;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Get information about the blocking message in the card.
      *
@@ -1268,7 +1268,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getBlockingMessage(): BlockingMessageSettings | null;
     /**
-     * Experimental (since 1.77)
+     * @experimental (since 1.77)
      *
      * Gets values of manifest parameters combined with the parameters from `parameters` property.
      *
@@ -1283,7 +1283,7 @@ declare module "sap/ui/integration/widgets/Card" {
     getCombinedParameters(): Record<string, any>;
     /**
      * @since 1.65
-     * Experimental (since 1.65)
+     * @experimental (since 1.65)
      *
      * Gets current value of property {@link #getDataMode dataMode}.
      *
@@ -1296,7 +1296,7 @@ declare module "sap/ui/integration/widgets/Card" {
     getDataMode(): CardDataMode | keyof typeof CardDataMode;
     /**
      * @since 1.109
-     * Experimental (since 1.109)
+     * @experimental (since 1.109)
      *
      * Gets current value of property {@link #getDesign design}.
      *
@@ -1308,7 +1308,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getDesign(): CardDesign | keyof typeof CardDesign;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the DOM Element that should get the focus.
      *
@@ -1320,7 +1320,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getHost(): ID;
     /**
-     * Experimental (since 1.77)
+     * @experimental (since 1.77)
      *
      * Gets the instance of the `host` association.
      *
@@ -1335,7 +1335,7 @@ declare module "sap/ui/integration/widgets/Card" {
     getManifest(): string | Object;
     /**
      * @since 1.76
-     * Experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
+     * @experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
      * is implemented.
      *
      * Gets current value of property {@link #getManifestChanges manifestChanges}.
@@ -1381,7 +1381,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getManifestChanges(): object[];
     /**
-     * Experimental (since 1.77)
+     * @experimental (since 1.77)
      *
      * Returns a value from the Manifest based on the specified path.
      *
@@ -1397,7 +1397,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): any;
     /**
      * @since 1.112
-     * Experimental (since 1.112)
+     * @experimental (since 1.112)
      *
      * Gets current value of property {@link #getPreviewMode previewMode}.
      *
@@ -1425,7 +1425,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getReferenceId(): string;
     /**
-     * Experimental (since 1.83) - The API might change.
+     * @experimental (since 1.83) - The API might change.
      *
      * Gets translated text from the i18n properties files configured for this card.
      *
@@ -1453,7 +1453,7 @@ declare module "sap/ui/integration/widgets/Card" {
       bIgnoreKeyFallback?: boolean
     ): string;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Hide the blocking message that is shown in the card by `showBlockingMessage` call.
      */
@@ -1470,7 +1470,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): void;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Checks for the provided `sap.ui.integration.ActionDefinition` in the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1486,7 +1486,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): int;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Inserts a actionDefinition into the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1506,14 +1506,14 @@ declare module "sap/ui/integration/widgets/Card" {
       iIndex: int
     ): this;
     /**
-     * Experimental (since 1.65) - The API might change.
+     * @experimental (since 1.65) - The API might change.
      *
      *
      * @returns If the card is ready or not.
      */
     isReady(): boolean;
     /**
-     * Experimental (since 1.73)
+     * @experimental (since 1.73)
      *
      * Loads the module designtime/Card.designtime or the module given in "sap.card": { "designtime": "designtime/Own.designtime"
      * } This file should contain the designtime configuration for the card.
@@ -1526,7 +1526,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     loadDesigntime(): Promise<object>;
     /**
-     * Experimental (since 1.65) - The API might change.
+     * @experimental (since 1.65) - The API might change.
      *
      * Refreshes the card by re-applying the manifest settings and triggering all data requests.
      */
@@ -1539,7 +1539,7 @@ declare module "sap/ui/integration/widgets/Card" {
     refreshData(): void;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Removes a actionDefinition from the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1554,7 +1554,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): ActionDefinition | null;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Removes all the controls from the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1565,7 +1565,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     removeAllActionDefinitions(): ActionDefinition[];
     /**
-     * Experimental (since 1.79)
+     * @experimental (since 1.79)
      *
      * Performs an HTTP request using the given configuration.
      *
@@ -1620,7 +1620,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): Promise<string>;
     /**
      * @since 1.70
-     * Experimental (since 1.70)
+     * @experimental (since 1.70)
      *
      * Sets a new value for property {@link #getBaseUrl baseUrl}.
      *
@@ -1639,7 +1639,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.65
-     * Experimental (since 1.65) - API might change.
+     * @experimental (since 1.65) - API might change.
      *
      * Sets a new value for the `dataMode` property.
      *
@@ -1653,7 +1653,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.109
-     * Experimental (since 1.109)
+     * @experimental (since 1.109)
      *
      * Sets a new value for property {@link #getDesign design}.
      *
@@ -1702,7 +1702,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.76
-     * Experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
+     * @experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
      * is implemented.
      *
      * Sets a new value for property {@link #getManifestChanges manifestChanges}.
@@ -1756,7 +1756,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.112
-     * Experimental (since 1.112)
+     * @experimental (since 1.112)
      *
      * Sets a new value for property {@link #getPreviewMode previewMode}.
      *
@@ -1798,7 +1798,7 @@ declare module "sap/ui/integration/widgets/Card" {
       sReferenceId?: string
     ): this;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Show blocking message in the card's content area. Should be used after the `manifestApplied` event or
      * after the `cardReady` lifecycle hook in Component cards and Extensions.
@@ -1821,7 +1821,7 @@ declare module "sap/ui/integration/widgets/Card" {
       eCardArea?: CardArea | keyof typeof CardArea
     ): void;
     /**
-     * Experimental (since 1.81)
+     * @experimental (since 1.81)
      *
      * Displays a message strip above the content with the given text. There can be only 1 message displayed.
      * If there is a previous message, it is removed. Can be used only after the `manifestApplied` event is
@@ -1838,7 +1838,7 @@ declare module "sap/ui/integration/widgets/Card" {
       sType: MessageType | keyof typeof MessageType
     ): void;
     /**
-     * Experimental (since 1.84)
+     * @experimental (since 1.84)
      *
      * Triggers an action inside the card.
      *
@@ -1884,7 +1884,7 @@ declare module "sap/ui/integration/widgets/Card" {
     validateControls(): boolean;
   }
   /**
-   * Experimental (since 1.79)
+   * @experimental (since 1.79)
    *
    * Facade of the {@link sap.ui.integration.widgets.Card} control.
    */
@@ -1893,7 +1893,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Adds some actionDefinition to the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -1908,7 +1908,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): this;
     /**
      * @since 1.70
-     * Experimental (since 1.70)
+     * @experimental (since 1.70)
      *
      * Gets current value of property {@link #getBaseUrl baseUrl}.
      *
@@ -1919,7 +1919,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getBaseUrl(): URI;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Get information about the blocking message in the card.
      *
@@ -1927,7 +1927,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getBlockingMessage(): BlockingMessageSettings | null;
     /**
-     * Experimental (since 1.77)
+     * @experimental (since 1.77)
      *
      * Gets values of manifest parameters combined with the parameters from `parameters` property.
      *
@@ -1941,7 +1941,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getCombinedParameters(): Record<string, any>;
     /**
-     * Experimental (since 1.77)
+     * @experimental (since 1.77)
      *
      * Returns a value from the Manifest based on the specified path.
      *
@@ -1956,7 +1956,7 @@ declare module "sap/ui/integration/widgets/Card" {
       sPath: string
     ): any;
     /**
-     * Experimental (since 1.65) - This property might be changed in future.
+     * @experimental (since 1.65) - This property might be changed in future.
      *
      * Gets current value of property {@link #getParameters parameters}.
      *
@@ -1967,7 +1967,7 @@ declare module "sap/ui/integration/widgets/Card" {
      */
     getParameters(): object;
     /**
-     * Experimental (since 1.83) - The API might change.
+     * @experimental (since 1.83) - The API might change.
      *
      * Gets translated text from the i18n properties files configured for this card.
      *
@@ -1995,7 +1995,7 @@ declare module "sap/ui/integration/widgets/Card" {
       bIgnoreKeyFallback?: boolean
     ): string;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Hide the blocking message that is shown in the card by `showBlockingMessage` call.
      */
@@ -2012,7 +2012,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): void;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Checks for the provided `sap.ui.integration.ActionDefinition` in the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -2028,7 +2028,7 @@ declare module "sap/ui/integration/widgets/Card" {
     ): int;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Inserts a actionDefinition into the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -2048,7 +2048,7 @@ declare module "sap/ui/integration/widgets/Card" {
       iIndex: int
     ): this;
     /**
-     * Experimental (since 1.65) - The API might change.
+     * @experimental (since 1.65) - The API might change.
      *
      * Refreshes the card by re-applying the manifest settings and triggering all data requests.
      */
@@ -2061,7 +2061,7 @@ declare module "sap/ui/integration/widgets/Card" {
     refreshData(): void;
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Removes a actionDefinition from the aggregation {@link #getActionDefinitions actionDefinitions}.
@@ -2075,7 +2075,7 @@ declare module "sap/ui/integration/widgets/Card" {
       vActionDefinition: int | string | ActionDefinition
     ): ActionDefinition | null;
     /**
-     * Experimental (since 1.79)
+     * @experimental (since 1.79)
      *
      * Performs an HTTP request using the given configuration.
      *
@@ -2129,7 +2129,7 @@ declare module "sap/ui/integration/widgets/Card" {
       sKey: string
     ): Promise<string>;
     /**
-     * Experimental (since 1.114)
+     * @experimental (since 1.114)
      *
      * Show blocking message in the card's content area. Should be used after the `manifestApplied` event or
      * after the `cardReady` lifecycle hook in Component cards and Extensions.
@@ -2152,7 +2152,7 @@ declare module "sap/ui/integration/widgets/Card" {
       eCardArea?: CardArea | keyof typeof CardArea
     ): void;
     /**
-     * Experimental (since 1.81)
+     * @experimental (since 1.81)
      *
      * Displays a message strip above the content with the given text. There can be only 1 message displayed.
      * If there is a previous message, it is removed. Can be used only after the `manifestApplied` event is
@@ -2169,7 +2169,7 @@ declare module "sap/ui/integration/widgets/Card" {
       sType: MessageType | keyof typeof MessageType
     ): void;
     /**
-     * Experimental (since 1.84)
+     * @experimental (since 1.84)
      *
      * Triggers an action inside the card.
      *
@@ -2228,7 +2228,7 @@ declare module "sap/ui/integration/widgets/Card" {
     manifest?: any | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.65) - This property might be changed in future.
+     * @experimental (since 1.65) - This property might be changed in future.
      *
      * Overrides the default values of the parameters, which are defined in the manifest. The value is an object
      * containing parameters in format `{parameterKey: parameterValue}`.
@@ -2237,7 +2237,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.65
-     * Experimental (since 1.65)
+     * @experimental (since 1.65)
      *
      * Defines the state of the `Card`. When set to `Inactive`, the `Card` doesn't make requests.
      */
@@ -2248,7 +2248,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.70
-     * Experimental (since 1.70)
+     * @experimental (since 1.70)
      *
      * Defines the base URL of the card manifest. It should be used when manifest property is an object instead
      * of a URL. If both manifest URL and base URL are defined - the base URL will be used for loading dependencies.
@@ -2257,7 +2257,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.76
-     * Experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
+     * @experimental (since 1.76) - This API might be removed when a permanent solution for flexibility changes
      * is implemented.
      *
      * Defines a list of configuration settings, which will be merged into the original manifest.
@@ -2300,7 +2300,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.109
-     * Experimental (since 1.109)
+     * @experimental (since 1.109)
      *
      * Defines the design of the `Card`.
      */
@@ -2311,7 +2311,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.112
-     * Experimental (since 1.112)
+     * @experimental (since 1.112)
      *
      * Preview mode of the `Card`. Helpful in scenarios when the end user is choosing or configuring a card.
      *
@@ -2327,7 +2327,7 @@ declare module "sap/ui/integration/widgets/Card" {
 
     /**
      * @since 1.85
-     * Experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
+     * @experimental (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Actions definitions from which actions in the header menu of the card are created. **Note**: This aggregation
@@ -2345,7 +2345,7 @@ declare module "sap/ui/integration/widgets/Card" {
     host?: Control | string;
 
     /**
-     * Experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.64) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered on the card.
@@ -2357,7 +2357,7 @@ declare module "sap/ui/integration/widgets/Card" {
     action?: (oEvent: Card$ActionEvent) => void;
 
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Fired when some configuration settings are changed as a result of user interaction. For example - filter
      * value is changed.
@@ -2365,7 +2365,7 @@ declare module "sap/ui/integration/widgets/Card" {
     configurationChange?: (oEvent: Card$ConfigurationChangeEvent) => void;
 
     /**
-     * Experimental (since 1.72)
+     * @experimental (since 1.72)
      *
      * Fired when the manifest is loaded.
      */
@@ -2380,7 +2380,7 @@ declare module "sap/ui/integration/widgets/Card" {
     manifestApplied?: (oEvent: Event) => void;
 
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Fired when the state of the card is changed. For example - the card is ready, new page is selected, a
      * filter is changed or data is refreshed.
@@ -2455,7 +2455,7 @@ declare module "sap/ui/integration/Designtime" {
 
   /**
    * @since 1.75
-   * Experimental (since 1.75)
+   * @experimental (since 1.75)
    *
    * Brings JavaScript capabilities for an {@link sap.ui.integration.widgets.Card} where custom logic can
    * be implemented.
@@ -2541,7 +2541,7 @@ declare module "sap/ui/integration/Designtime" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsBoolean" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value is a boolean or binding string.
    */
@@ -2565,7 +2565,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsBoolean" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsDate" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value can be parsed to a valid date.
    */
@@ -2589,7 +2589,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsDate" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsInteger" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value is an integer or binding string.
    */
@@ -2613,7 +2613,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsInteger" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsNumber" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value is a number or binding string.
    */
@@ -2637,7 +2637,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsNumber" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsSelectedKey" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value is one of the given keys.
    */
@@ -2670,7 +2670,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsSelectedKey
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsStringList" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if none of the provided values is an invalid binding.
    */
@@ -2694,7 +2694,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsStringList"
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsUniqueKey" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided key is unique in a list of given keys.
    */
@@ -2731,7 +2731,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsUniqueKey" 
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsUniqueList" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided list contains no duplicates.
    */
@@ -2755,7 +2755,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsUniqueList"
 declare module "sap/ui/integration/designtime/baseEditor/validator/IsValidBinding" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value is a valid binding.
    */
@@ -2788,7 +2788,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/IsValidBindin
 declare module "sap/ui/integration/designtime/baseEditor/validator/MaxLength" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value doesn't exceed the maximum length.
    */
@@ -2812,7 +2812,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/MaxLength" {
 declare module "sap/ui/integration/designtime/baseEditor/validator/NotABinding" {
   /**
    * @since 1.81
-   * Experimental - 1.81
+   * @experimental - 1.81
    *
    * Validates if the provided value doesn't contain a binding.
    */
@@ -2835,7 +2835,7 @@ declare module "sap/ui/integration/designtime/baseEditor/validator/NotABinding" 
 
 declare module "sap/ui/integration/editor/Editor" {
   /**
-   * Experimental (since 1.94)
+   * @experimental (since 1.94)
    *
    * Facade of the {@link sap.ui.integration.editor.Editor} control.
    */
@@ -2843,7 +2843,7 @@ declare module "sap/ui/integration/editor/Editor" {
     __implements__sap_ui_integration_editor_EditorFacade: boolean;
 
     /**
-     * Experimental (since 1.94)
+     * @experimental (since 1.94)
      *
      * Performs an HTTP request using the given configuration.
      *
@@ -3028,7 +3028,7 @@ declare module "sap/ui/integration/Extension" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.Extension`.
@@ -3060,7 +3060,7 @@ declare module "sap/ui/integration/Extension" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.Extension`.
@@ -3087,7 +3087,7 @@ declare module "sap/ui/integration/Extension" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Detaches event handler `fnFunction` from the {@link #event:action action} event of this `sap.ui.integration.Extension`.
@@ -3107,7 +3107,7 @@ declare module "sap/ui/integration/Extension" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.113) - The API might change.
+     * @experimental (since 1.113) - The API might change.
      *
      * Starts the process of fetching a resource from the network, returning a promise that is fulfilled once
      * the response is available. Use this method to override the default behavior when fetching network resources.
@@ -3131,9 +3131,9 @@ declare module "sap/ui/integration/Extension" {
       mRequestSettings: object
     ): Promise<Response>;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:action action} to attached listeners.
      *
@@ -3150,7 +3150,7 @@ declare module "sap/ui/integration/Extension" {
     ): boolean;
     /**
      * @deprecated (since 1.85) - This property is replaced by the `actions` aggregation of the card;
-     * Experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getActions actions}.
@@ -3175,7 +3175,7 @@ declare module "sap/ui/integration/Extension" {
      */
     getFormatters(): Record<string, () => void> | undefined;
     /**
-     * Experimental (since 1.108)
+     * @experimental (since 1.108)
      *
      * Override this method to lazy load dependencies for the extension.
      *
@@ -3206,7 +3206,7 @@ declare module "sap/ui/integration/Extension" {
   export interface $ExtensionSettings extends $ManagedObjectSettings {
     /**
      * @deprecated (since 1.85) - This property is replaced by the `actions` aggregation of the card;
-     * Experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * The actions configuration.
@@ -3214,14 +3214,14 @@ declare module "sap/ui/integration/Extension" {
     actions?: CardMenuAction[] | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.79)
+     * @experimental (since 1.79)
      *
      * The formatters that can be used in the manifest.
      */
     formatters?: object | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered in the card.
@@ -3280,7 +3280,7 @@ declare module "sap/ui/integration/Host" {
 
   /**
    * @since 1.75
-   * Experimental (since 1.75)
+   * @experimental (since 1.75)
    *
    * Provides application-level functions and services to an integration card.
    *
@@ -3348,7 +3348,7 @@ declare module "sap/ui/integration/Host" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.Host`.
@@ -3380,7 +3380,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Attaches event handler `fnFunction` to the {@link #event:action action} event of this `sap.ui.integration.Host`.
@@ -3407,7 +3407,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardConfigurationChange cardConfigurationChange }
      * event of this `sap.ui.integration.Host`.
@@ -3436,7 +3436,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardConfigurationChange cardConfigurationChange }
      * event of this `sap.ui.integration.Host`.
@@ -3460,7 +3460,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.116)
+     * @experimental (since 1.116)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardInitialized cardInitialized} event of this
      * `sap.ui.integration.Host`.
@@ -3489,7 +3489,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.116)
+     * @experimental (since 1.116)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardInitialized cardInitialized} event of this
      * `sap.ui.integration.Host`.
@@ -3513,7 +3513,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardStateChanged cardStateChanged} event of
      * this `sap.ui.integration.Host`.
@@ -3542,7 +3542,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Attaches event handler `fnFunction` to the {@link #event:cardStateChanged cardStateChanged} event of
      * this `sap.ui.integration.Host`.
@@ -3566,7 +3566,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.91)
+     * @experimental (since 1.91)
      *
      * Attaches event handler `fnFunction` to the {@link #event:message message} event of this `sap.ui.integration.Host`.
      *
@@ -3593,7 +3593,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.91)
+     * @experimental (since 1.91)
      *
      * Attaches event handler `fnFunction` to the {@link #event:message message} event of this `sap.ui.integration.Host`.
      *
@@ -3615,7 +3615,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.97)
+     * @experimental (since 1.97)
      *
      * This function is called when a CSRF token has expired.
      */
@@ -3628,7 +3628,7 @@ declare module "sap/ui/integration/Host" {
       }
     ): void;
     /**
-     * Experimental (since 1.97)
+     * @experimental (since 1.97)
      *
      * This function is called when a CSRF token is fetched.
      */
@@ -3645,7 +3645,7 @@ declare module "sap/ui/integration/Host" {
       pCSRFTokenValuePromise: Promise<string>
     ): void;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Detaches event handler `fnFunction` from the {@link #event:action action} event of this `sap.ui.integration.Host`.
@@ -3665,7 +3665,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Detaches event handler `fnFunction` from the {@link #event:cardConfigurationChange cardConfigurationChange }
      * event of this `sap.ui.integration.Host`.
@@ -3685,7 +3685,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.116)
+     * @experimental (since 1.116)
      *
      * Detaches event handler `fnFunction` from the {@link #event:cardInitialized cardInitialized} event of
      * this `sap.ui.integration.Host`.
@@ -3705,7 +3705,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Detaches event handler `fnFunction` from the {@link #event:cardStateChanged cardStateChanged} event of
      * this `sap.ui.integration.Host`.
@@ -3725,7 +3725,7 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.91)
+     * @experimental (since 1.91)
      *
      * Detaches event handler `fnFunction` from the {@link #event:message message} event of this `sap.ui.integration.Host`.
      *
@@ -3744,9 +3744,9 @@ declare module "sap/ui/integration/Host" {
       oListener?: object
     ): this;
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:action action} to attached listeners.
      *
@@ -3762,8 +3762,8 @@ declare module "sap/ui/integration/Host" {
       mParameters?: Host$ActionEventParameters
     ): boolean;
     /**
-     * Experimental (since 1.96)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.96)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cardConfigurationChange cardConfigurationChange} to attached listeners.
      *
@@ -3776,8 +3776,8 @@ declare module "sap/ui/integration/Host" {
       mParameters?: Host$CardConfigurationChangeEventParameters
     ): this;
     /**
-     * Experimental (since 1.116)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.116)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cardInitialized cardInitialized} to attached listeners.
      *
@@ -3790,8 +3790,8 @@ declare module "sap/ui/integration/Host" {
       mParameters?: Host$CardInitializedEventParameters
     ): this;
     /**
-     * Experimental (since 1.107)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.107)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cardStateChanged cardStateChanged} to attached listeners.
      *
@@ -3804,8 +3804,8 @@ declare module "sap/ui/integration/Host" {
       mParameters?: Host$CardStateChangedEventParameters
     ): this;
     /**
-     * Experimental (since 1.91)
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @experimental (since 1.91)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:message message} to attached listeners.
      *
@@ -3818,7 +3818,7 @@ declare module "sap/ui/integration/Host" {
       mParameters?: Host$MessageEventParameters
     ): this;
     /**
-     * Experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Gets current value of property {@link #getActions actions}.
@@ -3867,7 +3867,7 @@ declare module "sap/ui/integration/Host" {
       sPath: string
     ): Promise<null>;
     /**
-     * Experimental (since 1.97)
+     * @experimental (since 1.97)
      *
      * Resolves the CSRF token and returns a Promise with its value.
      *
@@ -3924,7 +3924,7 @@ declare module "sap/ui/integration/Host" {
       | ((p1: string, p2: Card) => string | Promise<string>)
       | undefined;
     /**
-     * Experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * Sets a new value for property {@link #getActions actions}.
@@ -3964,7 +3964,7 @@ declare module "sap/ui/integration/Host" {
 
   export interface $HostSettings extends $ElementSettings {
     /**
-     * Experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
+     * @experimental (since 1.75) - Disclaimer: this property is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
      *
      * The actions configuration.
@@ -3985,7 +3985,7 @@ declare module "sap/ui/integration/Host" {
     resolveDestination?: Function | PropertyBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
+     * @experimental (since 1.75) - Disclaimer: this event is in a beta state - incompatible API changes may
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered.
@@ -3997,7 +3997,7 @@ declare module "sap/ui/integration/Host" {
     action?: (oEvent: Host$ActionEvent) => void;
 
     /**
-     * Experimental (since 1.96)
+     * @experimental (since 1.96)
      *
      * Fired when some card configuration settings are changed as a result of user interaction. For example
      * - filter value is changed.
@@ -4007,7 +4007,7 @@ declare module "sap/ui/integration/Host" {
     ) => void;
 
     /**
-     * Experimental (since 1.107)
+     * @experimental (since 1.107)
      *
      * Fired when the state of a card is changed. For example - the card is ready, new page is selected inside
      * the card, a filter is changed or data is refreshed.
@@ -4015,7 +4015,7 @@ declare module "sap/ui/integration/Host" {
     cardStateChanged?: (oEvent: Host$CardStateChangedEvent) => void;
 
     /**
-     * Experimental (since 1.116)
+     * @experimental (since 1.116)
      *
      * Fired when the card is initially ready for the first time. Will not be fired for consecutive refreshes
      * or data changes.
@@ -4023,7 +4023,7 @@ declare module "sap/ui/integration/Host" {
     cardInitialized?: (oEvent: Host$CardInitializedEvent) => void;
 
     /**
-     * Experimental (since 1.91)
+     * @experimental (since 1.91)
      *
      * Fired when a message from channels like navigator.serviceWorker is received.
      */
@@ -4121,7 +4121,7 @@ declare namespace sap {
             namespace iconEditor {
               /**
                * @since 1.81
-               * Experimental - 1.81
+               * @experimental - 1.81
                *
                * Validates if the provided value belongs to the icon pool.
                */

--- a/types/openui5/sap.ui.layout.d.ts
+++ b/types/openui5/sap.ui.layout.d.ts
@@ -1920,7 +1920,7 @@ declare module "sap/ui/layout/cssgrid/CSSGrid" {
      */
     getGridColumnGap(): CSSSize;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Implements IGridConfigurable interface
      *
@@ -1940,7 +1940,7 @@ declare module "sap/ui/layout/cssgrid/CSSGrid" {
      */
     getGridGap(): cssgrid.CSSGridGapShortHand;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the layout configuration of the `CSSGrid`.
      *
@@ -2721,7 +2721,7 @@ declare module "sap/ui/layout/cssgrid/GridBoxLayout" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a gridTemplateColumns value based on boxWidth and boxMinWidth properties
      *
@@ -3199,7 +3199,7 @@ declare module "sap/ui/layout/cssgrid/GridLayoutBase" {
      */
     static getMetadata(): ManagedObjectMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Removes all display:grid styles from the provided HTML element
      */
@@ -3210,7 +3210,7 @@ declare module "sap/ui/layout/cssgrid/GridLayoutBase" {
       oElement: HTMLElement
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets all display:grid styles to the provided HTML element
      */
@@ -3243,7 +3243,7 @@ declare module "sap/ui/layout/cssgrid/GridLayoutBase" {
      */
     isResponsive(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Hook function for the Grid's onAfterRendering
      */
@@ -3254,7 +3254,7 @@ declare module "sap/ui/layout/cssgrid/GridLayoutBase" {
       oGrid: cssgrid.IGridConfigurable
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Hook function for the Grid's resize. Will be called if the grid layout is responsive.
      */
@@ -3457,7 +3457,7 @@ declare module "sap/ui/layout/cssgrid/GridResponsiveLayout" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:layoutChange layoutChange} to attached listeners.
      *
@@ -4286,7 +4286,7 @@ declare module "sap/ui/layout/cssgrid/ResponsiveColumnLayout" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:layoutChange layoutChange} to attached listeners.
      *
@@ -4576,7 +4576,7 @@ declare module "sap/ui/layout/DynamicSideContent" {
     ): this;
     /**
      * @since 1.32
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:breakpointChanged breakpointChanged} to attached listeners.
      *
@@ -6568,7 +6568,7 @@ declare module "sap/ui/layout/form/FormContainer" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.74.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the editable state of the `FormContainer`.
      *
@@ -7005,7 +7005,7 @@ declare module "sap/ui/layout/form/FormElement" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.74.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the editable state of the `FormElement`.
      *
@@ -7108,7 +7108,7 @@ declare module "sap/ui/layout/form/FormElement" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Labels inside of a Form must be invalidated if "editable" changed on Form
      */
@@ -8669,7 +8669,7 @@ declare module "sap/ui/layout/form/SemanticFormElement" {
 
   /**
    * @since 1.86.0
-   * Experimental (since 1.86)
+   * @experimental (since 1.86)
    *
    * A `SemanticFormElement` element is a special `FormElement` that contains semantically connected fields.
    * These field controls are divided by delimiter controls. In display mode, they are rendered as one condensed
@@ -10519,7 +10519,7 @@ declare module "sap/ui/layout/Grid" {
      */
     destroyContent(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the `Grid` accessibility information.
      * See:
@@ -12107,7 +12107,7 @@ declare module "sap/ui/layout/HorizontalLayout" {
      */
     destroyContent(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -12379,7 +12379,7 @@ declare module "sap/ui/layout/PaneContainer" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:resize resize} to attached listeners.
      *
@@ -13601,7 +13601,7 @@ declare module "sap/ui/layout/Splitter" {
      * @deprecated (since 1.21) - This method is declared as protected in order to assess the need for this
      * feature. It is declared as deprecated because the API might change in case the need for this is high
      * enough to make it part of the official Splitter interface
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Disables the resize handler for this control, this leads to an automatic resize of the contents whenever
      * the control changes its size. The resize handler is enabled in every control instance by default. For
@@ -13615,7 +13615,7 @@ declare module "sap/ui/layout/Splitter" {
       bTemporarily?: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Disables the resizing of the Splitter contents via keyboard. This changes the Splitter bars to non-focusable
      * elements.
@@ -13625,7 +13625,7 @@ declare module "sap/ui/layout/Splitter" {
      * @deprecated (since 1.21) - This method is declared as protected in order to assess the need for this
      * feature. It is declared as deprecated because the API might change in case the need for this is high
      * enough to make it part of the official Splitter interface
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Disables recalculation and resize of the splitter contents while dragging the splitter bar. This means
      * that the contents are resized only once after moving the splitter bar.
@@ -13635,7 +13635,7 @@ declare module "sap/ui/layout/Splitter" {
      * @deprecated (since 1.21) - This method is declared as protected in order to assess the need for this
      * feature. It is declared as deprecated because the API might change in case the need for this is high
      * enough to make it part of the official Splitter interface
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enables the resize handler for this control, this leads to an automatic resize of the contents whenever
      * the control changes its size. The resize handler is enabled in every control instance by default. For
@@ -13648,7 +13648,7 @@ declare module "sap/ui/layout/Splitter" {
       bTemporarily?: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enables the resizing of the Splitter contents via keyboard. This makes the Splitter bars focusable elements.
      */
@@ -13657,14 +13657,14 @@ declare module "sap/ui/layout/Splitter" {
      * @deprecated (since 1.21) - This method is declared as protected in order to assess the need for this
      * feature. It is declared as deprecated because the API might change in case the need for this is high
      * enough to make it part of the official Splitter interface
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Enables recalculation and resize of the splitter contents while dragging the splitter bar. This means
      * that the contents are resized several times per second when moving the splitter bar.
      */
     enableLiveResize(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:resize resize} to attached listeners.
      *
@@ -13680,7 +13680,7 @@ declare module "sap/ui/layout/Splitter" {
      * @deprecated (since 1.21) - This method is declared as protected in order to assess the need for this
      * feature. It is declared as deprecated because the API might change in case the need for this is high
      * enough to make it part of the official Splitter interface
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the current actual content sizes as pixel value - these values can change with every resize.
      *
@@ -13904,7 +13904,7 @@ declare module "sap/ui/layout/SplitterLayoutData" {
 
   /**
    * @since 1.22.0
-   * Experimental (since 1.22.0) - API is not yet finished and might change completely
+   * @experimental (since 1.22.0) - API is not yet finished and might change completely
    *
    * Holds layout data for the splitter contents. Allowed size values are numeric values ending in "px" and
    * "%" and the special case "auto". (The CSS value "auto" is used internally to recalculate the size of
@@ -14177,7 +14177,7 @@ declare module "sap/ui/layout/VerticalLayout" {
      */
     destroyContent(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo

--- a/types/openui5/sap.ui.mdc.d.ts
+++ b/types/openui5/sap.ui.mdc.d.ts
@@ -190,7 +190,7 @@ declare module "sap/ui/mdc/ChartDelegate" {
       oChart: Chart
     ): any[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the filter delegate of the chart that provides basic filter functionality, such as adding filter
      * fields. **Note:** The functionality provided in this delegate acts as a subset of a `FilterBarDelegate`
@@ -1146,7 +1146,7 @@ declare module "sap/ui/mdc/odata/v4/TableDelegate" {
    */
   interface TableDelegate {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Updates the row binding of the table if possible, rebinds otherwise.
      *
@@ -1240,7 +1240,7 @@ declare module "sap/ui/mdc/TableDelegate" {
    */
   interface TableDelegate {
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Collapses all nodes.
      */
@@ -1251,7 +1251,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Expands all nodes.
      */
@@ -1262,7 +1262,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the feature set for exporting data in the MDC Table.
      *
@@ -1275,7 +1275,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Formats the title text of a group header row of the table.
      *
@@ -1296,7 +1296,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       sProperty: string
     ): string | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the filter delegate of the table that provides basic filter functionality, such as adding filter
      * fields. **Note:** The functionality provided in this delegate acts as a subset of a `FilterBarDelegate`
@@ -1308,7 +1308,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       addItem: (p1: Table, p2: string) => Promise<FilterField>;
     };
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns filters that are used when updating the table's binding and are created based on the filter conditions
      * of the table and its associated filter control.
@@ -1322,7 +1322,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): Filter[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a new sorter for the grouping functionality.
      *
@@ -1335,7 +1335,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): Sorter | undefined;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the sort conditions that are used when updating the table's binding.
      *
@@ -1348,7 +1348,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oTable: Table
     ): Sorter[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Rebinds the table.
      */
@@ -1363,7 +1363,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oBindingInfo: AggregationBindingInfo
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Updates the row binding of the table.
      *
@@ -1385,7 +1385,7 @@ declare module "sap/ui/mdc/TableDelegate" {
       oBinding?: ListBinding
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides a hook to update the binding info object that is used to bind the table to the model.
      */
@@ -2855,7 +2855,7 @@ declare module "sap/ui/mdc/Chart" {
 
   /**
    * @since 1.88
-   * Experimental (since 1.88)
+   * @experimental (since 1.88)
    *
    * The `Chart` control creates a chart based on metadata and the configuration specified.
    *  **Note:** The inner chart needs to be assigned `ChartDelegate`.
@@ -3043,7 +3043,7 @@ declare module "sap/ui/mdc/Chart" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionDetailsActionPressed selectionDetailsActionPressed} to attached listeners.
      *
@@ -5541,7 +5541,7 @@ declare module "sap/ui/mdc/Control" {
 
   /**
    * @since 1.61
-   * Experimental (since 1.61)
+   * @experimental (since 1.61)
    *
    * The base class for MDC controls providing delegate-related functionality (see {@link sap.ui.mdc.mixin.DelegateMixin}).
    */
@@ -5579,7 +5579,7 @@ declare module "sap/ui/mdc/Control" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides access to the delegate initialization `Promise`. **Note:** `initControlDelegate` must be called
      * to start the delegate initialization
@@ -5588,7 +5588,7 @@ declare module "sap/ui/mdc/Control" {
      */
     static awaitControlDelegate(): Promise</* was: sap.ui.mdc.BaseDelegate */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides access to the property helper initialization `Promise`.
      *
@@ -5619,7 +5619,7 @@ declare module "sap/ui/mdc/Control" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Finalize the propertyHelper using the control's delegate.
      *
@@ -5654,7 +5654,7 @@ declare module "sap/ui/mdc/Control" {
      */
     static getPayload(): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the property helper instance, if available.
      *
@@ -5669,7 +5669,7 @@ declare module "sap/ui/mdc/Control" {
     static getTypeMap(): /* was: sap.ui.mdc.util.TypeMap */ any;
     /**
      * @deprecated - (since 1.115.0) - please see {@link #getTypeMap}
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the `typeUtil` made available by a delegate module.
      *
@@ -5679,7 +5679,7 @@ declare module "sap/ui/mdc/Control" {
       | any
       | /* was: sap.ui.mdc.util.TypeMap */ any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Loads and initializes the delegate module related to the enhanced control.
      *
@@ -5692,7 +5692,7 @@ declare module "sap/ui/mdc/Control" {
       oPreloadedModule?: /* was: sap.ui.mdc.BaseDelegate */ any
     ): Promise</* was: sap.ui.mdc.BaseDelegate */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Loads and initializes the property helper related to the enhanced control.
      *
@@ -5713,7 +5713,7 @@ declare module "sap/ui/mdc/Control" {
       bFinal?: object[]
     ): Promise</* was: sap.ui.mdc.util.PropertyHelper */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Indicates if the control's propertyHelper already contains all available properties
      *
@@ -5780,7 +5780,7 @@ declare module "sap/ui/mdc/Element" {
 
   /**
    * @since 1.74
-   * Experimental (since 1.74)
+   * @experimental (since 1.74)
    *
    * The base class for MDC composite elements providing delegate-related functionality (see {@link sap.ui.mdc.mixin.DelegateMixin}).
    */
@@ -5818,7 +5818,7 @@ declare module "sap/ui/mdc/Element" {
     );
 
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides access to the delegate initialization `Promise`. **Note:** `initControlDelegate` must be called
      * to start the delegate initialization
@@ -5827,7 +5827,7 @@ declare module "sap/ui/mdc/Element" {
      */
     static awaitControlDelegate(): Promise</* was: sap.ui.mdc.BaseDelegate */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides access to the property helper initialization `Promise`.
      *
@@ -5858,7 +5858,7 @@ declare module "sap/ui/mdc/Element" {
       FNMetaImpl?: Function
     ): Function;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Finalize the propertyHelper using the control's delegate.
      *
@@ -5893,7 +5893,7 @@ declare module "sap/ui/mdc/Element" {
      */
     static getPayload(): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the property helper instance, if available.
      *
@@ -5908,7 +5908,7 @@ declare module "sap/ui/mdc/Element" {
     static getTypeMap(): /* was: sap.ui.mdc.util.TypeMap */ any;
     /**
      * @deprecated - (since 1.115.0) - please see {@link #getTypeMap}
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the `typeUtil` made available by a delegate module.
      *
@@ -5918,7 +5918,7 @@ declare module "sap/ui/mdc/Element" {
       | any
       | /* was: sap.ui.mdc.util.TypeMap */ any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Loads and initializes the delegate module related to the enhanced control.
      *
@@ -5931,7 +5931,7 @@ declare module "sap/ui/mdc/Element" {
       oPreloadedModule?: /* was: sap.ui.mdc.BaseDelegate */ any
     ): Promise</* was: sap.ui.mdc.BaseDelegate */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Loads and initializes the property helper related to the enhanced control.
      *
@@ -5952,7 +5952,7 @@ declare module "sap/ui/mdc/Element" {
       bFinal?: object[]
     ): Promise</* was: sap.ui.mdc.util.PropertyHelper */ any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Indicates if the control's propertyHelper already contains all available properties
      *
@@ -6516,7 +6516,7 @@ declare module "sap/ui/mdc/Field" {
 
   /**
    * @since 1.54.0
-   * Experimental (since 1.54.0)
+   * @experimental (since 1.54.0)
    *
    * The `Field` control is used to bind its value to data of a certain data type. Based on the data type
    * settings, a default control is rendered by the `Field` as follows:
@@ -6695,7 +6695,7 @@ declare module "sap/ui/mdc/Field" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -7670,14 +7670,14 @@ declare module "sap/ui/mdc/field/FieldBase" {
       oBindingInfo: PropertyBindingInfo
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if all needed information is provided to create the internal content control. If possible create
      * internal controls.
      */
     checkCreateInternalContent(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * If the value is the initial value of the type (String types) and the field does not show tokens or operators,
      * no condition must be set as the field is then empty.
@@ -7737,7 +7737,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     destroyFieldInfo(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Destroys the internal content controls.
      */
@@ -7796,13 +7796,13 @@ declare module "sap/ui/mdc/field/FieldBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Here inheriting controls need to fire the control-specific change event.
      */
     fireChangeEvent(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -7815,7 +7815,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
       mParameters?: FieldBase$LiveChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -7829,7 +7829,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
     ): this;
     /**
      * @since 1.82.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:submit submit} to attached listeners.
      *
@@ -7846,7 +7846,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getAriaLabelledBy(): ID[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines the `BaseType` of the currently used data type.
      *
@@ -7949,14 +7949,14 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getContentEdit(): Control1;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      *
      * @returns oContentFactory the ContentFactory of the Field
      */
     getContentFactory(): /* was: sap.ui.mdc.field.content.ContentFactory */ any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the currently used content controls.
      *
@@ -8043,7 +8043,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getFieldInfo(): FieldInfoBase;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides some internals of the field to be used in {@link sap.ui.mdc.field.ConditionsType ConditionsType }
      * for format and parse the conditions.
@@ -8097,7 +8097,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getMultipleLines(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Required by the {@link sap.m.IOverflowToolbarContent} interface. Registers invalidations event that is
      * fired when width of the control is changed.
@@ -8129,7 +8129,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getRequired(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines, based on conditions, the value returned by the `change` event.
      *
@@ -8159,7 +8159,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getShowEmptyIndicator(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the supported operators.
      *
@@ -8194,7 +8194,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getTextDirection(): TextDirection | keyof typeof TextDirection;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides some internals of the unit part of the field to be used in {@link sap.ui.mdc.field.ConditionsType ConditionsType }
      * for format and parse the conditions.
@@ -8239,7 +8239,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     getWidth(): CSSSize;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handler of the `ModelContextChange` event.
      */
@@ -8250,14 +8250,14 @@ declare module "sap/ui/mdc/field/FieldBase" {
       oEvent: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Initializes internal data-types and dependent objects.
      */
     initDataType(): void;
     /**
      * @since 1.115.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the field is already destoyed or destruction has started.
      *
@@ -8267,7 +8267,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     isFieldDestroyed(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether the given property value is initial and has not been explicitly set or no binding exist.
      * Even after setting the default value or setting null/undefined (which also causes the default value to
@@ -8282,7 +8282,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
       sPropertyName: string
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if there is invalid input.
      *
@@ -8291,7 +8291,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
     isInvalidInput(): boolean;
     /**
      * @since 1.115.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the field is configured to be a `SearchField`
      *
@@ -8302,7 +8302,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     isSearchField(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Observes changes.
      *
@@ -8333,7 +8333,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
       vAriaLabelledBy: int | ID | Control1
     ): ID | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Resets invalid input information.
      *
@@ -8773,7 +8773,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
       sWidth?: CSSSize
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Triggers a check if all relevant properties are set to create the internal content control.
      *
@@ -8789,7 +8789,7 @@ declare module "sap/ui/mdc/field/FieldBase" {
      */
     unbindConditions(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Triggers an update of the internal content controls.
      *
@@ -9303,7 +9303,7 @@ declare module "sap/ui/mdc/field/FieldInfoBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if there is a direct navigation or if there is a popover to be opened.
      *
@@ -9346,7 +9346,7 @@ declare module "sap/ui/mdc/field/FieldInfoBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:dataUpdate dataUpdate} to attached listeners.
      *
@@ -9359,7 +9359,7 @@ declare module "sap/ui/mdc/field/FieldInfoBase" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:popoverAfterOpen popoverAfterOpen} to attached listeners.
      *
@@ -9391,7 +9391,7 @@ declare module "sap/ui/mdc/field/FieldInfoBase" {
      */
     getDirectLinkHrefAndTarget(): Promise<DirectLinkObject | null>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the parent control.
      *
@@ -9641,7 +9641,7 @@ declare module "sap/ui/mdc/FilterBar" {
 
   /**
    * @since 1.61.0
-   * Experimental (since 1.61.0)
+   * @experimental (since 1.61.0)
    *
    * The `FilterBar` control is used to display filter attrtibutes in a user-friendly manner to populate values
    * for a query. The filters are arranged in a logical row that is divided depending on the space available
@@ -10099,7 +10099,7 @@ declare module "sap/ui/mdc/filterbar/FilterBarBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:filtersChanged filtersChanged} to attached listeners.
      *
@@ -10112,7 +10112,7 @@ declare module "sap/ui/mdc/filterbar/FilterBarBase" {
       mParameters?: FilterBarBase$FiltersChangedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -10796,7 +10796,7 @@ declare module "sap/ui/mdc/filterbar/vh/FilterBar" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Destroys the `CollectiveSearch` control.
      *
@@ -10806,7 +10806,7 @@ declare module "sap/ui/mdc/filterbar/vh/FilterBar" {
      */
     destroyCollectiveSearch(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the `CollectiveSearch` control
      *
@@ -10853,7 +10853,7 @@ declare module "sap/ui/mdc/filterbar/vh/FilterBar" {
      */
     getFilterFieldThreshold(): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Sets the `CollectiveSearch` control
      *
@@ -11142,7 +11142,7 @@ declare module "sap/ui/mdc/FilterField" {
 
   /**
    * @since 1.48.0
-   * Experimental (since 1.48.0)
+   * @experimental (since 1.48.0)
    *
    * The `FilterField` control is used to filter data based on the conditions. The conditions are managed
    * in the corresponding {@link sap.ui.mdc.condition.ConditionModel ConditionModel}. That is why the `conditions`
@@ -11331,7 +11331,7 @@ declare module "sap/ui/mdc/FilterField" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -11559,7 +11559,7 @@ declare module "sap/ui/mdc/Link" {
 
   /**
    * @since 1.74
-   * Experimental (since 1.74.0)
+   * @experimental (since 1.74.0)
    *
    * A `Link` element can be used inside a `fieldInfo` aggregation of {@link sap.ui.mdc.Field} to enable navigation
    * scenarios with one or more targets through direct navigation or by opening a `Panel`.
@@ -11629,7 +11629,7 @@ declare module "sap/ui/mdc/Link" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Retrieves the relevant metadata for the panel and returns a property info array.
      *
@@ -11642,7 +11642,7 @@ declare module "sap/ui/mdc/Link" {
       oPanel: /* was: sap.ui.mdc.link.Panel */ any
     ): object[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Retrieves the items that are initially part of the baseline which is used when a reset is done.
      *
@@ -12179,7 +12179,7 @@ declare module "sap/ui/mdc/MultiValueField" {
 
   /**
    * @since 1.93.0
-   * Experimental (since 1.93.0)
+   * @experimental (since 1.93.0)
    *
    * A `MultiValueField` control can hold multiple values. The values are stored as items. A `MultiValueField`
    * control can be used to bind its items to data of a certain data type. Based on the data type settings,
@@ -12355,7 +12355,7 @@ declare module "sap/ui/mdc/MultiValueField" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -12738,7 +12738,7 @@ declare module "sap/ui/mdc/Table" {
 
   /**
    * @since 1.58
-   * Experimental (since 1.58.0)
+   * @experimental (since 1.58.0)
    *
    * A metadata-driven table to simplify the usage of existing tables, such as the `ResponsiveTable` and `GridTable`
    * controls. The metadata needs to be provided via the {@link module:sap/ui/mdc/TableDelegate TableDelegate }
@@ -13045,7 +13045,7 @@ declare module "sap/ui/mdc/Table" {
      */
     destroyCopyProvider(): this;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Destroys the creationRow in the aggregation {@link #getCreationRow creationRow}.
      *
@@ -13165,7 +13165,7 @@ declare module "sap/ui/mdc/Table" {
     ): this;
     /**
      * @since 1.75
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeExport beforeExport} to attached listeners.
      *
@@ -13178,7 +13178,7 @@ declare module "sap/ui/mdc/Table" {
       mParameters?: Table$BeforeExportEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:paste paste} to attached listeners.
      *
@@ -13191,7 +13191,7 @@ declare module "sap/ui/mdc/Table" {
       mParameters?: Table$PasteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rowPress rowPress} to attached listeners.
      *
@@ -13204,7 +13204,7 @@ declare module "sap/ui/mdc/Table" {
       mParameters?: Table$RowPressEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -13298,7 +13298,7 @@ declare module "sap/ui/mdc/Table" {
      */
     getCopyProvider(): CopyProvider;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Gets content of aggregation {@link #getCreationRow creationRow}.
      *
@@ -13446,7 +13446,7 @@ declare module "sap/ui/mdc/Table" {
     getHeaderLevel(): TitleLevel | keyof typeof TitleLevel;
     /**
      * @since 1.116
-     * Experimental - Internal use only
+     * @experimental - Internal use only
      *
      * Gets current value of property {@link #getHeaderStyle headerStyle}.
      *
@@ -13870,7 +13870,7 @@ declare module "sap/ui/mdc/Table" {
       oCopyProvider: CopyProvider
     ): this;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Sets the aggregated {@link #getCreationRow creationRow}.
      *
@@ -14094,7 +14094,7 @@ declare module "sap/ui/mdc/Table" {
     ): this;
     /**
      * @since 1.116
-     * Experimental - Internal use only
+     * @experimental - Internal use only
      *
      * Sets a new value for property {@link #getHeaderStyle headerStyle}.
      *
@@ -14477,7 +14477,7 @@ declare module "sap/ui/mdc/Table" {
 
     /**
      * @since 1.116
-     * Experimental - Internal use only
+     * @experimental - Internal use only
      *
      * Defines style of the header. For more information, see {@link sap.m.Title#setTitleStyle}.
      */
@@ -14693,7 +14693,7 @@ declare module "sap/ui/mdc/Table" {
     columns?: Column[] | Column | AggregationBindingInfo | `{${string}}`;
 
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * This row can be used for user input to create new data if {@link sap.ui.mdc.enums.TableType TableType }
      * is "`Table`". **Note:** Once the binding supports creating transient records, this aggregation will be
@@ -14920,7 +14920,7 @@ declare module "sap/ui/mdc/table/Column" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Destroys the creationTemplate in the aggregation {@link #getCreationTemplate creationTemplate}.
      *
@@ -14942,7 +14942,7 @@ declare module "sap/ui/mdc/table/Column" {
      */
     destroyTemplate(): this;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Gets content of aggregation {@link #getCreationTemplate creationTemplate}.
      *
@@ -15078,7 +15078,7 @@ declare module "sap/ui/mdc/table/Column" {
      */
     getWidth(): CSSSize;
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * Sets the aggregated {@link #getCreationTemplate creationTemplate}.
      *
@@ -15388,7 +15388,7 @@ declare module "sap/ui/mdc/table/Column" {
     template?: Control;
 
     /**
-     * Experimental - Do not use
+     * @experimental - Do not use
      *
      * `CreationRow` template.
      *
@@ -16498,7 +16498,7 @@ declare module "sap/ui/mdc/table/RowActionItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -17229,7 +17229,7 @@ declare module "sap/ui/mdc/ValueHelp" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0)
+   * @experimental (since 1.95.0)
    *
    * Element for the `ValueHelp` association in the {@link sap.ui.mdc.field.FieldBase FieldBase} controls.
    */
@@ -17766,7 +17766,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -17779,7 +17779,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:disconnect disconnect} to attached listeners.
      *
@@ -17792,7 +17792,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigated navigated} to attached listeners.
      *
@@ -17805,7 +17805,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: ValueHelp$NavigatedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -17818,7 +17818,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: ValueHelp$OpenEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:opened opened} to attached listeners.
      *
@@ -17831,7 +17831,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: ValueHelp$OpenedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -17844,7 +17844,7 @@ declare module "sap/ui/mdc/ValueHelp" {
       mParameters?: ValueHelp$SelectEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:switchToValueHelp switchToValueHelp} to attached listeners.
      *
@@ -18746,7 +18746,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Binds the content to the container.
      */
@@ -18757,7 +18757,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oContent: Content
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Closes the container control or element.
      */
@@ -18907,7 +18907,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -18920,7 +18920,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -18933,7 +18933,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:confirm confirm} to attached listeners.
      *
@@ -18946,7 +18946,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: Container$ConfirmEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigated navigated} to attached listeners.
      *
@@ -18959,7 +18959,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: Container$NavigatedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:opened opened} to attached listeners.
      *
@@ -18972,7 +18972,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestDelegateContent requestDelegateContent} to attached listeners.
      *
@@ -18985,7 +18985,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: Container$RequestDelegateContentEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestSwitchToDialog requestSwitchToDialog} to attached listeners.
      *
@@ -18998,7 +18998,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -19011,7 +19011,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       mParameters?: Container$SelectEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the configuration for a specific content.
      *
@@ -19024,7 +19024,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oContent: Content
     ): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the container control or element that is opened (for example, a popover or dialog).
      */
@@ -19037,7 +19037,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getContent(): Content[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns control connected to value help.
      *
@@ -19054,7 +19054,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getLocalFilterValue(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the maximum allowed number of conditions, -1 if no limit is set.
      *
@@ -19062,7 +19062,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getMaxConditions(): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the `Promise` for content creation.
      *
@@ -19070,7 +19070,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getRetrieveDelegateContentPromise(): Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the currently used content.
      *
@@ -19088,7 +19088,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getTitle(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the `UIArea` of the content.
      *
@@ -19096,7 +19096,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     getUIAreaForContent(): UIArea | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `cancelled` event of the content.
      *
@@ -19109,7 +19109,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `closed` event of the container control or element.
      */
@@ -19120,7 +19120,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `confirmed` event of the content.
      *
@@ -19133,7 +19133,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `requestSwitchToDialog` event of the content.
      */
@@ -19144,7 +19144,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `opened` event of the container control or element.
      */
@@ -19155,7 +19155,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `navigated` event of the content.
      */
@@ -19166,7 +19166,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Handles the `select` event of the content.
      *
@@ -19208,7 +19208,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns if the value help is used for single selection.
      *
@@ -19216,7 +19216,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
      */
     isSingleSelect(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Triggers navigation in the content of the container.
      */
@@ -19227,7 +19227,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       iStep: int
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Observes property and aggregation changes.
      */
@@ -19238,7 +19238,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       oChanges: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Opens the container control or element.
      */
@@ -19253,7 +19253,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       bTypeahead: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Places the content into the container control or element.
      *
@@ -19318,7 +19318,7 @@ declare module "sap/ui/mdc/valuehelp/base/Container" {
       sTitle?: string
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Unbinds the content from the container.
      */
@@ -19776,7 +19776,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Provides access to the delegate initialization `Promise` of the value help.
      *
@@ -19784,7 +19784,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     awaitValueHelpDelegate(): Promise<any>;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a condition based on the used operator.
      *
@@ -19898,7 +19898,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -19911,7 +19911,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:confirm confirm} to attached listeners.
      *
@@ -19924,7 +19924,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       mParameters?: Content$ConfirmEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigated navigated} to attached listeners.
      *
@@ -19937,7 +19937,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       mParameters?: Content$NavigatedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:requestSwitchToDialog requestSwitchToDialog} to attached listeners.
      *
@@ -19950,7 +19950,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -19987,7 +19987,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     getConfig(): object;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns control connected to value help.
      *
@@ -20015,7 +20015,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     getFilterValue(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the maximum allowed number of conditions, -1 if no limit is set.
      *
@@ -20053,7 +20053,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     getTokenizerTitle(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the used `ValueHelpDelegate`.
      *
@@ -20061,7 +20061,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     getValueHelpDelegate(): /* was: sap.ui.mdc.BaseDelegate */ any;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines the `ValueHelp` instance.
      *
@@ -20079,7 +20079,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     getVisible(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Called if the `conditions` property changed.
      */
@@ -20090,7 +20090,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       oChanges: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Called if the `filterValue` property changed.
      */
@@ -20101,7 +20101,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       oChanges: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the parent container is open.
      *
@@ -20109,7 +20109,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     isContainerOpen(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks if the parent container is opening.
      *
@@ -20117,7 +20117,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     isContainerOpening(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns if the value help is used for single selection.
      *
@@ -20125,7 +20125,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     isSingleSelect(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines if the container of the content is used as `typeAhead` inside the value help.
      *
@@ -20135,7 +20135,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     isTypeahead(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines if delegate of the value help has been initialized.
      *
@@ -20143,7 +20143,7 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
      */
     isValueHelpDelegateInitialized(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Observes property and aggregation changes.
      */
@@ -20154,25 +20154,25 @@ declare module "sap/ui/mdc/valuehelp/base/Content" {
       oChanges: object
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Called if `ValueHelp` connection to a control changed.
      */
     onConnectionChange(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Performs logic needed if the container closes.
      */
     onContainerClose(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Performs logic needed if the container opens.
      */
     onContainerOpen(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Determines if the the content needs to provide a scrolling mechanism like a {@link sap.m.ScrollContainer ScrollContainer}.
      *
@@ -20539,13 +20539,13 @@ declare module "sap/ui/mdc/valuehelp/base/FilterableListContent" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Applies the filter to the content control.
      */
     applyFilters(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a payload for a value.
      *
@@ -20617,7 +20617,7 @@ declare module "sap/ui/mdc/valuehelp/base/FilterableListContent" {
      */
     getGroup(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets an item for a `BindingContext`.
      *
@@ -20645,7 +20645,7 @@ declare module "sap/ui/mdc/valuehelp/base/FilterableListContent" {
      */
     getKeyPath(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the `BindingInfo` of the content.
      *
@@ -20653,7 +20653,7 @@ declare module "sap/ui/mdc/valuehelp/base/FilterableListContent" {
      */
     getListBindingInfo(): AggregationBindingInfo;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the conditions that are selecatble from list content.
      *
@@ -20896,7 +20896,7 @@ declare module "sap/ui/mdc/valuehelp/base/ListContent" {
      */
     getCaseSensitive(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Gets the `ListBinding` of the content.
      *
@@ -22067,7 +22067,7 @@ declare module "sap/ui/mdc/valuehelp/content/MTable" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:contentUpdated contentUpdated} to attached listeners.
      *

--- a/types/openui5/sap.ui.rta.d.ts
+++ b/types/openui5/sap.ui.rta.d.ts
@@ -7,7 +7,7 @@ declare module "sap/ui/rta/api/startAdaptation" {
 
   /**
    * @since 1.83
-   * Experimental (since 1.83)
+   * @experimental (since 1.83)
    *
    * Starts UI adaptation, initiated for an application at the passed root control instance. With this API
    * you are also able to modify the UI adaptation plugins list and or add some event handler functions to
@@ -65,7 +65,7 @@ declare module "sap/ui/rta/api/startKeyUserAdaptation" {
 
   /**
    * @since 1.71
-   * Experimental (since 1.71)
+   * @experimental (since 1.71)
    *
    * Starts key user adaptation, initiated for an application at the passed root control instance. It subsequently
    * extends to all valid child controls.
@@ -88,7 +88,7 @@ declare module "sap/ui/rta/api/startKeyUserAdaptation" {
 declare module "sap/ui/rta/enablement/TestDelegate" {
   /**
    * @since 1.77
-   * Experimental (since 1.77)
+   * @experimental (since 1.77)
    *
    * sap.ui.fl Delegate to be used in elementActionTests.
    */

--- a/types/openui5/sap.ui.suite.d.ts
+++ b/types/openui5/sap.ui.suite.d.ts
@@ -40,7 +40,7 @@ declare module "sap/ui/suite/TaskCircle" {
   /**
    * @deprecated (since 1.108) - there's no replacement for this functionality as no active use cases are
    * known
-   * Experimental (since 1.2) - The API may change. Use with care.
+   * @experimental (since 1.2) - The API may change. Use with care.
    *
    * This control shows a circle which radius and color depends on the given parameters
    */
@@ -190,7 +190,7 @@ declare module "sap/ui/suite/TaskCircle" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -420,7 +420,7 @@ declare module "sap/ui/suite/VerticalProgressIndicator" {
   /**
    * @deprecated (since 1.108) - there's no replacement for this functionality as no active use cases are
    * known
-   * Experimental (since 1.2) - The API may change. Use with care.
+   * @experimental (since 1.2) - The API may change. Use with care.
    *
    * This control shows a vertical progress bar in dependency of the given percentage. Only values between
    * 0 and 100 are valid.
@@ -573,7 +573,7 @@ declare module "sap/ui/suite/VerticalProgressIndicator" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *

--- a/types/openui5/sap.ui.table.d.ts
+++ b/types/openui5/sap.ui.table.d.ts
@@ -430,7 +430,7 @@ declare module "sap/ui/table/AnalyticalColumnMenu" {
   import ElementMetadata from "sap/ui/core/ElementMetadata";
 
   /**
-   * Experimental (since 1.21) - The AnalyticalColumnMenu will be productized soon.
+   * @experimental (since 1.21) - The AnalyticalColumnMenu will be productized soon.
    *
    * A column menu which is used by the analytical column
    */
@@ -874,7 +874,7 @@ declare module "sap/ui/table/AnalyticalTable" {
       iToIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This function is used by some composite controls to force updating the AnalyticalInfo
      */
@@ -1122,7 +1122,7 @@ declare module "sap/ui/table/AnalyticalTable" {
       bSumOnTop?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This function is used by some composite controls to avoid updating the AnalyticalInfo when several column
      * are added to the table. In order to finally update the AnalyticalInfo and request data, resumeUpdateAnalyticalInfo
@@ -1438,7 +1438,7 @@ declare module "sap/ui/table/Column" {
     ): this;
     /**
      * @since 1.33.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnMenuOpen columnMenuOpen} to attached listeners.
      *
@@ -1749,7 +1749,7 @@ declare module "sap/ui/table/Column" {
      */
     getTemplate(): Control | string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns a template clone. It either finds an unused clone or clones a new one from the template.
      *
@@ -2293,7 +2293,7 @@ declare module "sap/ui/table/Column" {
       sWidth?: CSSSize
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns whether the column should be rendered.
      *
@@ -2830,7 +2830,7 @@ declare module "sap/ui/table/plugins/MultiSelectionPlugin" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -3148,7 +3148,7 @@ declare module "sap/ui/table/plugins/SelectionPlugin" {
 
   /**
    * @since 1.64
-   * Experimental (since 1.64)
+   * @experimental (since 1.64)
    *
    * Implements the selection methods for a table.
    */
@@ -3262,7 +3262,7 @@ declare module "sap/ui/table/plugins/SelectionPlugin" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -3827,7 +3827,7 @@ declare module "sap/ui/table/RowActionItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -5270,7 +5270,7 @@ declare module "sap/ui/table/Table" {
       oListener?: object
     ): this;
     /**
-     * Experimental - Experimental! Presently implemented to only work with a very limited set of controls
+     * @experimental - Experimental! Presently implemented to only work with a very limited set of controls
      * (e.g. sap.m.Text).
      *
      * Triggers automatic resizing of a column to the widest content.
@@ -5705,7 +5705,7 @@ declare module "sap/ui/table/Table" {
     ): this;
     /**
      * @deprecated (since 1.56) - replaced by the `sap.ui.export` library.
-     * Experimental - Experimental because the property for the column/cell definitions (sortProperty) could
+     * @experimental - Experimental because the property for the column/cell definitions (sortProperty) could
      * change in future.
      *
      * Creates a new {@link sap.ui.core.util.Export} object and fills row/column information from the table
@@ -5738,7 +5738,7 @@ declare module "sap/ui/table/Table" {
     ): void;
     /**
      * @since 1.54
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpenContextMenu beforeOpenContextMenu} to attached listeners.
      *
@@ -5755,7 +5755,7 @@ declare module "sap/ui/table/Table" {
     ): boolean;
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:busyStateChanged busyStateChanged} to attached listeners.
      *
@@ -5769,7 +5769,7 @@ declare module "sap/ui/table/Table" {
     ): this;
     /**
      * @since 1.21.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cellClick cellClick} to attached listeners.
      *
@@ -5787,7 +5787,7 @@ declare module "sap/ui/table/Table" {
     /**
      * @since 1.21.0
      * @deprecated (since 1.54) - replaced by `beforeOpenContextMenu`.
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cellContextmenu cellContextmenu} to attached listeners.
      *
@@ -5804,7 +5804,7 @@ declare module "sap/ui/table/Table" {
     ): boolean;
     /**
      * @since 1.21.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnFreeze columnFreeze} to attached listeners.
      *
@@ -5820,7 +5820,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$ColumnFreezeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnMove columnMove} to attached listeners.
      *
@@ -5836,7 +5836,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$ColumnMoveEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnResize columnResize} to attached listeners.
      *
@@ -5852,7 +5852,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$ColumnResizeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnSelect columnSelect} to attached listeners.
      *
@@ -5868,7 +5868,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$ColumnSelectEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:columnVisibility columnVisibility} to attached listeners.
      *
@@ -5885,7 +5885,7 @@ declare module "sap/ui/table/Table" {
     ): boolean;
     /**
      * @since 1.23.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:customFilter customFilter} to attached listeners.
      *
@@ -5898,7 +5898,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$CustomFilterEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:filter filter} to attached listeners.
      *
@@ -5915,7 +5915,7 @@ declare module "sap/ui/table/Table" {
     ): boolean;
     /**
      * @since 1.37.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:firstVisibleRowChanged firstVisibleRowChanged} to attached listeners.
      *
@@ -5928,7 +5928,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$FirstVisibleRowChangedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:group group} to attached listeners.
      *
@@ -5945,7 +5945,7 @@ declare module "sap/ui/table/Table" {
     ): boolean;
     /**
      * @since 1.60
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:paste paste} to attached listeners.
      *
@@ -5961,7 +5961,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: Table$PasteEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rowSelectionChange rowSelectionChange} to attached listeners.
      *
@@ -5975,7 +5975,7 @@ declare module "sap/ui/table/Table" {
     ): this;
     /**
      * @since 1.86
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rowsUpdated rowsUpdated} to attached listeners.
      *
@@ -5988,7 +5988,7 @@ declare module "sap/ui/table/Table" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sort sort} to attached listeners.
      *
@@ -6319,7 +6319,7 @@ declare module "sap/ui/table/Table" {
      */
     getFooter(): Control | string;
     /**
-     * Experimental (since 1.28) - This feature has a limited functionality.
+     * @experimental (since 1.28) - This feature has a limited functionality.
      *
      * ID of the element which is the current target of the association {@link #getGroupBy groupBy}, or `null`.
      */
@@ -7198,7 +7198,7 @@ declare module "sap/ui/table/Table" {
       vFooter: Control | string
     ): this;
     /**
-     * Experimental (since 1.28) - This feature has a limited functionality.
+     * @experimental (since 1.28) - This feature has a limited functionality.
      *
      * Sets the associated {@link #getGroupBy groupBy}.
      *
@@ -7979,7 +7979,7 @@ declare module "sap/ui/table/Table" {
       | `{${string}}`;
 
     /**
-     * Experimental (since 1.28) - This feature has a limited functionality.
+     * @experimental (since 1.28) - This feature has a limited functionality.
      *
      * The column by which the table is grouped. Grouping will only be performed if `enableGrouping` is set
      * to `true`. Setting `groupBy` in the view does not work and throws an error. It can only be set if the
@@ -8530,7 +8530,7 @@ declare module "sap/ui/table/TablePersoController" {
      */
     getTable(): ID;
     /**
-     * Experimental (since 1.21.2) - API might change / feature requires the sap.m library!
+     * @experimental (since 1.21.2) - API might change / feature requires the sap.m library!
      *
      * Opens the personalization dialog for the Table to modify the visibility and the order of the columns.
      *
@@ -8922,7 +8922,7 @@ declare module "sap/ui/table/TreeTable" {
       iLevel: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleOpenState toggleOpenState} to attached listeners.
      *
@@ -9283,7 +9283,7 @@ declare module "sap/ui/table/TreeTable" {
       iToIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Allows to hide the tree structure (tree icons, indentation) in tree mode (property `useGroupMode` is
      * set to `false`).

--- a/types/openui5/sap.ui.unified.d.ts
+++ b/types/openui5/sap.ui.unified.d.ts
@@ -26,7 +26,7 @@ declare module "sap/ui/unified/library" {
   }
   /**
    * @since 1.81.0
-   * Experimental (since 1.81.0)
+   * @experimental (since 1.81.0)
    *
    * Types of a calendar appointment display mode
    */
@@ -204,7 +204,7 @@ declare module "sap/ui/unified/library" {
   }
   /**
    * @since 1.16.0
-   * Experimental (since 1.16.0) - API is not yet finished and might change completely
+   * @experimental (since 1.16.0) - API is not yet finished and might change completely
    *
    * Predefined animations for the ContentSwitcher
    */
@@ -763,7 +763,7 @@ declare module "sap/ui/unified/Calendar" {
       oDate: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -776,7 +776,7 @@ declare module "sap/ui/unified/Calendar" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -790,7 +790,7 @@ declare module "sap/ui/unified/Calendar" {
     ): this;
     /**
      * @since 1.34.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:startDateChange startDateChange} to attached listeners.
      *
@@ -804,7 +804,7 @@ declare module "sap/ui/unified/Calendar" {
     ): this;
     /**
      * @since 1.56
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:weekNumberSelect weekNumberSelect} to attached listeners.
      *
@@ -2475,7 +2475,7 @@ declare module "sap/ui/unified/calendar/Header" {
     ): this;
     /**
      * @since 1.32.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressButton0 pressButton0} to attached listeners.
      *
@@ -2488,7 +2488,7 @@ declare module "sap/ui/unified/calendar/Header" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressButton1 pressButton1} to attached listeners.
      *
@@ -2501,7 +2501,7 @@ declare module "sap/ui/unified/calendar/Header" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressButton2 pressButton2} to attached listeners.
      *
@@ -2514,7 +2514,7 @@ declare module "sap/ui/unified/calendar/Header" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressCurrentDate pressCurrentDate} to attached listeners.
      *
@@ -2527,7 +2527,7 @@ declare module "sap/ui/unified/calendar/Header" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressNext pressNext} to attached listeners.
      *
@@ -2540,7 +2540,7 @@ declare module "sap/ui/unified/calendar/Header" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pressPrevious pressPrevious} to attached listeners.
      *
@@ -3506,7 +3506,7 @@ declare module "sap/ui/unified/calendar/Month" {
       oDate: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:focus focus} to attached listeners.
      *
@@ -3519,7 +3519,7 @@ declare module "sap/ui/unified/calendar/Month" {
       mParameters?: Month$FocusEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -3533,7 +3533,7 @@ declare module "sap/ui/unified/calendar/Month" {
     ): this;
     /**
      * @since 1.60
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:weekNumberSelect weekNumberSelect} to attached listeners.
      *
@@ -4532,7 +4532,7 @@ declare module "sap/ui/unified/calendar/MonthPicker" {
     ): this;
     /**
      * @since 1.38.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pageChange pageChange} to attached listeners.
      *
@@ -4545,7 +4545,7 @@ declare module "sap/ui/unified/calendar/MonthPicker" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -5236,7 +5236,7 @@ declare module "sap/ui/unified/calendar/MonthsRow" {
       oDate: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:focus focus} to attached listeners.
      *
@@ -5249,7 +5249,7 @@ declare module "sap/ui/unified/calendar/MonthsRow" {
       mParameters?: MonthsRow$FocusEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -6043,7 +6043,7 @@ declare module "sap/ui/unified/calendar/TimesRow" {
       oDate: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:focus focus} to attached listeners.
      *
@@ -6056,7 +6056,7 @@ declare module "sap/ui/unified/calendar/TimesRow" {
       mParameters?: TimesRow$FocusEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -6839,7 +6839,7 @@ declare module "sap/ui/unified/calendar/YearPicker" {
     ): this;
     /**
      * @since 1.38.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:pageChange pageChange} to attached listeners.
      *
@@ -6852,7 +6852,7 @@ declare module "sap/ui/unified/calendar/YearPicker" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -7329,7 +7329,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     static getMetadata(): ElementMetadata;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Adds some customContent to the aggregation {@link #getCustomContent customContent}.
@@ -7344,7 +7344,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     ): this;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Destroys all the customContent in the aggregation {@link #getCustomContent customContent}.
@@ -7365,7 +7365,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     getColor(): CSSColor;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Gets content of aggregation {@link #getCustomContent customContent}.
@@ -7448,7 +7448,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     getTitle(): string;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Checks for the provided `sap.ui.core.Control` in the aggregation {@link #getCustomContent customContent}.
@@ -7464,7 +7464,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     ): int;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Inserts a customContent into the aggregation {@link #getCustomContent customContent}.
@@ -7485,7 +7485,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     ): this;
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Removes all the controls from the aggregation {@link #getCustomContent customContent}.
@@ -7497,7 +7497,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
     removeAllCustomContent(): Control[];
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Removes a customContent from the aggregation {@link #getCustomContent customContent}.
@@ -7693,7 +7693,7 @@ declare module "sap/ui/unified/CalendarAppointment" {
 
     /**
      * @since 1.93.0
-     * Experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
+     * @experimental (since 1.93) - providing only limited functionality. Also, the API might be changed in
      * the future.
      *
      * Holds the content of the appointment.
@@ -7795,7 +7795,7 @@ declare module "sap/ui/unified/CalendarDateInterval" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * If more than this number of days are displayed, start and end month are displayed on the button.
      *
@@ -7863,7 +7863,7 @@ declare module "sap/ui/unified/CalendarDateInterval" {
       iDays?: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Setter for property `firstDayOfWeek`.
      *
@@ -7878,7 +7878,7 @@ declare module "sap/ui/unified/CalendarDateInterval" {
       iFirstDayOfWeek?: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Setter for property `months`.
      *
@@ -8770,7 +8770,7 @@ declare module "sap/ui/unified/CalendarMonthInterval" {
       oDatetime: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -8783,7 +8783,7 @@ declare module "sap/ui/unified/CalendarMonthInterval" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -8797,7 +8797,7 @@ declare module "sap/ui/unified/CalendarMonthInterval" {
     ): this;
     /**
      * @since 1.34.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:startDateChange startDateChange} to attached listeners.
      *
@@ -9726,7 +9726,7 @@ declare module "sap/ui/unified/CalendarRow" {
     ): this;
     /**
      * @since 1.38.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:intervalSelect intervalSelect} to attached listeners.
      *
@@ -9739,7 +9739,7 @@ declare module "sap/ui/unified/CalendarRow" {
       mParameters?: CalendarRow$IntervalSelectEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:leaveRow leaveRow} to attached listeners.
      *
@@ -9752,7 +9752,7 @@ declare module "sap/ui/unified/CalendarRow" {
       mParameters?: CalendarRow$LeaveRowEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -9765,7 +9765,7 @@ declare module "sap/ui/unified/CalendarRow" {
       mParameters?: CalendarRow$SelectEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:startDateChange startDateChange} to attached listeners.
      *
@@ -9815,7 +9815,7 @@ declare module "sap/ui/unified/CalendarRow" {
       | keyof typeof CalendarAppointmentHeight;
     /**
      * @since 1.81.0
-     * Experimental (since 1.81.0)
+     * @experimental (since 1.81.0)
      *
      * Gets current value of property {@link #getAppointmentRoundWidth appointmentRoundWidth}.
      *
@@ -10234,7 +10234,7 @@ declare module "sap/ui/unified/CalendarRow" {
     ): this;
     /**
      * @since 1.81.0
-     * Experimental (since 1.81.0)
+     * @experimental (since 1.81.0)
      *
      * Sets a new value for property {@link #getAppointmentRoundWidth appointmentRoundWidth}.
      *
@@ -10757,7 +10757,7 @@ declare module "sap/ui/unified/CalendarRow" {
 
     /**
      * @since 1.81.0
-     * Experimental (since 1.81.0)
+     * @experimental (since 1.81.0)
      *
      * Defines rounding of the width of CalendarAppoinment **Note:** This property is applied, when
      * the calendar interval type is day and the view shows more than 20 days
@@ -11254,7 +11254,7 @@ declare module "sap/ui/unified/CalendarTimeInterval" {
       oDate: Date | UI5Date
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -11267,7 +11267,7 @@ declare module "sap/ui/unified/CalendarTimeInterval" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -11281,7 +11281,7 @@ declare module "sap/ui/unified/CalendarTimeInterval" {
     ): this;
     /**
      * @since 1.34.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:startDateChange startDateChange} to attached listeners.
      *
@@ -12076,7 +12076,7 @@ declare module "sap/ui/unified/ColorPicker" {
     ): this;
     /**
      * @since 1.48.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -12090,7 +12090,7 @@ declare module "sap/ui/unified/ColorPicker" {
     ): this;
     /**
      * @since 1.48.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -12619,7 +12619,7 @@ declare module "sap/ui/unified/ColorPickerPopover" {
     ): this;
     /**
      * @since 1.60.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -12633,7 +12633,7 @@ declare module "sap/ui/unified/ColorPickerPopover" {
     ): this;
     /**
      * @since 1.85
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:liveChange liveChange} to attached listeners.
      *
@@ -12924,7 +12924,7 @@ declare module "sap/ui/unified/ContentSwitcher" {
   /**
    * @since 1.16.0
    * @deprecated (since 1.44.0)
-   * Experimental (since 1.16.0) - API is not yet finished and might change completely
+   * @experimental (since 1.16.0) - API is not yet finished and might change completely
    *
    * Switches between two control areas and animates it via CSS transitions
    */
@@ -13327,7 +13327,7 @@ declare module "sap/ui/unified/Currency" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.core.Control#getAccessibilityInfo
@@ -14898,7 +14898,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.102.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterDialogClose afterDialogClose} to attached listeners.
      *
@@ -14912,7 +14912,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.102.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeDialogOpen beforeDialogOpen} to attached listeners.
      *
@@ -14925,7 +14925,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -14938,7 +14938,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: FileUploader$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:fileAllowed fileAllowed} to attached listeners.
      *
@@ -14951,7 +14951,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:fileEmpty fileEmpty} to attached listeners.
      *
@@ -14965,7 +14965,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.24.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:filenameLengthExceed filenameLengthExceed} to attached listeners.
      *
@@ -14978,7 +14978,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: FileUploader$FilenameLengthExceedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:fileSizeExceed fileSizeExceed} to attached listeners.
      *
@@ -14991,7 +14991,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: FileUploader$FileSizeExceedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:typeMissmatch typeMissmatch} to attached listeners.
      *
@@ -15005,7 +15005,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.24.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:uploadAborted uploadAborted} to attached listeners.
      *
@@ -15018,7 +15018,7 @@ declare module "sap/ui/unified/FileUploader" {
       mParameters?: FileUploader$UploadAbortedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:uploadComplete uploadComplete} to attached listeners.
      *
@@ -15032,7 +15032,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.24.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:uploadProgress uploadProgress} to attached listeners.
      *
@@ -15046,7 +15046,7 @@ declare module "sap/ui/unified/FileUploader" {
     ): this;
     /**
      * @since 1.30.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:uploadStart uploadStart} to attached listeners.
      *
@@ -17156,7 +17156,7 @@ declare module "sap/ui/unified/Menu" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemSelect itemSelect} to attached listeners.
      *
@@ -17846,7 +17846,7 @@ declare module "sap/ui/unified/MenuItemBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -17897,7 +17897,7 @@ declare module "sap/ui/unified/MenuItemBase" {
      */
     getVisible(): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Changes the visual hover state of the menu item.
      *
@@ -17914,7 +17914,7 @@ declare module "sap/ui/unified/MenuItemBase" {
       oMenu: Menu
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Informs the item that the item HTML is now applied to the DOM.
      *
@@ -17922,7 +17922,7 @@ declare module "sap/ui/unified/MenuItemBase" {
      */
     onAfterRendering(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Event handler which is called whenever the submenu of the item is opened or closed.
      *
@@ -17935,7 +17935,7 @@ declare module "sap/ui/unified/MenuItemBase" {
       bOpened: boolean
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Produces the HTML of an item and writes it to render-output-buffer during the rendering of the corresponding
      * menu.
@@ -18522,7 +18522,7 @@ declare module "sap/ui/unified/Shell" {
     /**
      * Gets content of aggregation {@link #getSearch search}.
      *
-     * Experimental (This aggregation might change in future!): The search control which should be displayed
+     * @experimental (This aggregation might change in future!): The search control which should be displayed
      * in the shell header. If a custom header is set this aggregation has no effect.
      */
     getSearch(): Control;
@@ -18933,7 +18933,7 @@ declare module "sap/ui/unified/Shell" {
       | `{${string}}`;
 
     /**
-     * Experimental (This aggregation might change in future!): The search control which should be displayed
+     * @experimental (This aggregation might change in future!): The search control which should be displayed
      * in the shell header. If a custom header is set this aggregation has no effect.
      */
     search?: Control;
@@ -19102,7 +19102,7 @@ declare module "sap/ui/unified/ShellHeadItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -19567,7 +19567,7 @@ declare module "sap/ui/unified/ShellHeadUserItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:press press} to attached listeners.
      *
@@ -20265,7 +20265,7 @@ declare module "sap/ui/unified/ShellOverlay" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -20290,7 +20290,7 @@ declare module "sap/ui/unified/ShellOverlay" {
     /**
      * Gets content of aggregation {@link #getSearch search}.
      *
-     * Experimental (This aggregation might change in future!): The search control which should be displayed
+     * @experimental (This aggregation might change in future!): The search control which should be displayed
      * in the overlay header.
      */
     getSearch(): Control;
@@ -20399,7 +20399,7 @@ declare module "sap/ui/unified/ShellOverlay" {
     content?: Control[] | Control | AggregationBindingInfo | `{${string}}`;
 
     /**
-     * Experimental (This aggregation might change in future!): The search control which should be displayed
+     * @experimental (This aggregation might change in future!): The search control which should be displayed
      * in the overlay header.
      */
     search?: Control;
@@ -20440,7 +20440,7 @@ declare module "sap/ui/unified/SplitContainer" {
   /**
    * @since 1.15.0
    * @deprecated (since 1.44.0)
-   * Experimental (since 1.15.0) - API is not yet finished and might change completely
+   * @experimental (since 1.15.0) - API is not yet finished and might change completely
    *
    * Provides a main content and a secondary content area
    */

--- a/types/openui5/sap.ui.ux3.d.ts
+++ b/types/openui5/sap.ui.ux3.d.ts
@@ -3,7 +3,7 @@
 declare module "sap/ui/ux3/library" {
   /**
    * @deprecated (since 1.38)
-   * Experimental (since 1.2) - API is not yet finished and might change completely
+   * @experimental (since 1.2) - API is not yet finished and might change completely
    *
    * Enumeration of available standard actions for 'sap.ui.ux3.ActionBar'. To be used as parameters for function
    * 'sap.ui.ux3.ActionBar.getSocialAction'.
@@ -57,7 +57,7 @@ declare module "sap/ui/ux3/library" {
   }
   /**
    * @deprecated (since 1.38)
-   * Experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
+   * @experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
    * are likely. Especially text presentation (e.g. @-references and formatted text) is not final. Also the
    * Feed model topic is still open.
    *
@@ -201,10 +201,10 @@ declare module "sap/ui/ux3/library" {
 declare module "sap/ui/ux3/ShellPersonalization" {
   /**
    * @deprecated (since 1.36) - This class was never released for productive use and will never be.
-   * Experimental (since 1.0) - The Shell-features Personalization, Color Picker and “Inspect”-Tool are only
-   * experimental work and might change or disappear in future versions.
+   * @experimental (since 1.0) - The Shell-features Personalization, Color Picker and “Inspect”-Tool are only
+   * @experimental work and might change or disappear in future versions.
    *
-   * Experimental implementation of visual Ux3 Shell personalization / branding.
+   * @experimental implementation of visual Ux3 Shell personalization / branding.
    *
    * DO NOT USE PRODUCTIVELY!!!
    *
@@ -453,7 +453,7 @@ declare module "sap/ui/ux3/ActionBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:actionSelected actionSelected} to attached listeners.
      *
@@ -466,7 +466,7 @@ declare module "sap/ui/ux3/ActionBar" {
       mParameters?: ActionBar$ActionSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:feedSubmit feedSubmit} to attached listeners.
      *
@@ -610,7 +610,7 @@ declare module "sap/ui/ux3/ActionBar" {
       oBusinessAction: ThingAction
     ): int;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Checks whether the control is still valid (is in the DOM). ActionBar instance is rendered if and only
      * if 'isActive' returns 'true'. This check is called implicitely by the rendere, MUST not be removed.
@@ -1182,7 +1182,7 @@ declare module "sap/ui/ux3/Collection" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:propertyChanged propertyChanged} to attached listeners.
      *
@@ -1195,7 +1195,7 @@ declare module "sap/ui/ux3/Collection" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChanged selectionChanged} to attached listeners.
      *
@@ -1722,7 +1722,7 @@ declare module "sap/ui/ux3/CollectionInspector" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:collectionSelected collectionSelected} to attached listeners.
      *
@@ -1735,7 +1735,7 @@ declare module "sap/ui/ux3/CollectionInspector" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:editCollection editCollection} to attached listeners.
      *
@@ -1748,7 +1748,7 @@ declare module "sap/ui/ux3/CollectionInspector" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemSelectionChanged itemSelectionChanged} to attached listeners.
      *
@@ -2093,13 +2093,13 @@ declare module "sap/ui/ux3/DataSet" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Rerendering of the FilterArea
      */
     _rerenderFilter(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Rerendering of the Toolbar
      */
@@ -2257,7 +2257,7 @@ declare module "sap/ui/ux3/DataSet" {
      */
     clearSelection(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a view switch button
      *
@@ -2327,7 +2327,7 @@ declare module "sap/ui/ux3/DataSet" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -2340,7 +2340,7 @@ declare module "sap/ui/ux3/DataSet" {
       mParameters?: DataSet$SearchEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChanged selectionChanged} to attached listeners.
      *
@@ -2365,7 +2365,7 @@ declare module "sap/ui/ux3/DataSet" {
      */
     getItems(): DataSetItem[];
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the LeadSelection index
      *
@@ -2391,7 +2391,7 @@ declare module "sap/ui/ux3/DataSet" {
      */
     getSelectedIndices(): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns id of selected Item from given index
      *
@@ -2532,7 +2532,7 @@ declare module "sap/ui/ux3/DataSet" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns true if iIndex is selected
      *
@@ -2606,7 +2606,7 @@ declare module "sap/ui/ux3/DataSet" {
       vView: int | string | DataSetView
     ): DataSetView | null;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Set the LeadSelection index
      */
@@ -2920,7 +2920,7 @@ declare module "sap/ui/ux3/DataSetItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selected selected} to attached listeners.
      *
@@ -3166,7 +3166,7 @@ declare module "sap/ui/ux3/DataSetSimpleView" {
      */
     destroyTemplate(): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * View finalization: Called when leaving the view
      */
@@ -3296,7 +3296,7 @@ declare module "sap/ui/ux3/DataSetSimpleView" {
      */
     getTemplate(): Control;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Eventhandler for the selection of an Item
      */
@@ -3307,7 +3307,7 @@ declare module "sap/ui/ux3/DataSetSimpleView" {
       oEvent: Event
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * View Initialization: Called when selecting the view
      */
@@ -3318,7 +3318,7 @@ declare module "sap/ui/ux3/DataSetSimpleView" {
       aItems: any[]
     ): void;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Check if Item `oItem` is selected
      */
@@ -3524,7 +3524,7 @@ declare module "sap/ui/ux3/DataSetSimpleView" {
       oTemplate: Control
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * View update: Called when pagination adds items
      */
@@ -3639,7 +3639,7 @@ declare module "sap/ui/ux3/Exact" {
 
   /**
    * @deprecated (since 1.38)
-   * Experimental (since 1.2) - API is not yet finished and might change completely
+   * @experimental (since 1.2) - API is not yet finished and might change completely
    *
    * A comprehensive UI design approach with graphical and functional elements for searching data, exploring
    * data, and acting on the data ("Explore and Act (Exact) Pattern").
@@ -3853,7 +3853,7 @@ declare module "sap/ui/ux3/Exact" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:refineSearch refineSearch} to attached listeners.
      *
@@ -3866,7 +3866,7 @@ declare module "sap/ui/ux3/Exact" {
       mParameters?: Exact$RefineSearchEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -4056,7 +4056,7 @@ declare module "sap/ui/ux3/ExactArea" {
 
   /**
    * @deprecated (since 1.38)
-   * Experimental (since 1.6) - API is not yet finished and might change completely
+   * @experimental (since 1.6) - API is not yet finished and might change completely
    *
    * Consists of two sections: A tool bar and a content area where arbitrary controls can be added. The ExactArea
    * is intended to be used for the Exact design approach but alternatively also in a stand alone version.
@@ -4484,7 +4484,7 @@ declare module "sap/ui/ux3/ExactAttribute" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:supplyAttributes supplyAttributes} to attached listeners.
      *
@@ -4704,7 +4704,7 @@ declare module "sap/ui/ux3/ExactAttribute" {
       sListOrder?: ExactOrder | keyof typeof ExactOrder
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * See:
      * 	sap.ui.base.ManagedObject.prototype.setProperty
@@ -5143,7 +5143,7 @@ declare module "sap/ui/ux3/ExactBrowser" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:attributeSelected attributeSelected} to attached listeners.
      *
@@ -5156,7 +5156,7 @@ declare module "sap/ui/ux3/ExactBrowser" {
       mParameters?: ExactBrowser$AttributeSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:save save} to attached listeners.
      *
@@ -5824,7 +5824,7 @@ declare module "sap/ui/ux3/ExactList" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:attributeSelected attributeSelected} to attached listeners.
      *
@@ -6401,7 +6401,7 @@ declare module "sap/ui/ux3/FacetFilterList" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -6692,7 +6692,7 @@ declare module "sap/ui/ux3/Feed" {
 
   /**
    * @deprecated (since 1.38) - Instead, use **any** `sap.ui.layout` container control.
-   * Experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
+   * @experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
    * are likely. Especially text presentation (e.g. @-references and formatted text) is not final. Also the
    * Feed model topic is still open.
    *
@@ -7166,7 +7166,7 @@ declare module "sap/ui/ux3/Feed" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:chunkAdded chunkAdded} to attached listeners.
      *
@@ -7179,7 +7179,7 @@ declare module "sap/ui/ux3/Feed" {
       mParameters?: Feed$ChunkAddedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:filterChange filterChange} to attached listeners.
      *
@@ -7192,7 +7192,7 @@ declare module "sap/ui/ux3/Feed" {
       mParameters?: Feed$FilterChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -7205,7 +7205,7 @@ declare module "sap/ui/ux3/Feed" {
       mParameters?: Feed$SearchEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleLive toggleLive} to attached listeners.
      *
@@ -7218,7 +7218,7 @@ declare module "sap/ui/ux3/Feed" {
       mParameters?: Feed$ToggleLiveEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toolsItemSelected toolsItemSelected} to attached listeners.
      *
@@ -7649,7 +7649,7 @@ declare module "sap/ui/ux3/FeedChunk" {
 
   /**
    * @deprecated (since 1.38) - Instead, use the `sap.m.FeedListItem` control.
-   * Experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
+   * @experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
    * are likely. Especially text presentation (e.g. @-references and formatted text) is not final. Also the
    * Feed model topic is still open.
    *
@@ -8352,7 +8352,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:actionItemSelected actionItemSelected} to attached listeners.
      *
@@ -8365,7 +8365,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: FeedChunk$ActionItemSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:commentAdded commentAdded} to attached listeners.
      *
@@ -8378,7 +8378,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: FeedChunk$CommentAddedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:deleted deleted} to attached listeners.
      *
@@ -8391,7 +8391,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:inspect inspect} to attached listeners.
      *
@@ -8404,7 +8404,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:referenceClicked referenceClicked} to attached listeners.
      *
@@ -8417,7 +8417,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: FeedChunk$ReferenceClickedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:senderClicked senderClicked} to attached listeners.
      *
@@ -8430,7 +8430,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleFavorite toggleFavorite} to attached listeners.
      *
@@ -8443,7 +8443,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: FeedChunk$ToggleFavoriteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleFlagged toggleFlagged} to attached listeners.
      *
@@ -8456,7 +8456,7 @@ declare module "sap/ui/ux3/FeedChunk" {
       mParameters?: FeedChunk$ToggleFlaggedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleShared toggleShared} to attached listeners.
      *
@@ -9250,7 +9250,7 @@ declare module "sap/ui/ux3/Feeder" {
 
   /**
    * @deprecated (since 1.38) - Instead, use the `sap.m.FeedInput` control.
-   * Experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
+   * @experimental (since 1.2) - The whole Feed/Feeder API is still under discussion, significant changes
    * are likely. Especially text presentation (e.g. @-references and formatted text) is not final. Also the
    * Feed model topic is still open.
    *
@@ -9382,7 +9382,7 @@ declare module "sap/ui/ux3/Feeder" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:submit submit} to attached listeners.
      *
@@ -9716,7 +9716,7 @@ declare module "sap/ui/ux3/NavigationBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -10453,7 +10453,7 @@ declare module "sap/ui/ux3/NotificationBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:display display} to attached listeners.
      *
@@ -10467,7 +10467,7 @@ declare module "sap/ui/ux3/NotificationBar" {
     ): this;
     /**
      * @since 1.12.2
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:resize resize} to attached listeners.
      *
@@ -10872,7 +10872,7 @@ declare module "sap/ui/ux3/Notifier" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:messageSelected messageSelected} to attached listeners.
      *
@@ -11358,7 +11358,7 @@ declare module "sap/ui/ux3/Overlay" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -11374,7 +11374,7 @@ declare module "sap/ui/ux3/Overlay" {
       mParameters?: Overlay$CloseEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -11390,7 +11390,7 @@ declare module "sap/ui/ux3/Overlay" {
       mParameters?: Overlay$ClosedEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -11403,7 +11403,7 @@ declare module "sap/ui/ux3/Overlay" {
       mParameters?: Overlay$OpenEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:openNew openNew} to attached listeners.
      *
@@ -12243,7 +12243,7 @@ declare module "sap/ui/ux3/QuickView" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:actionSelected actionSelected} to attached listeners.
      *
@@ -12256,7 +12256,7 @@ declare module "sap/ui/ux3/QuickView" {
       mParameters?: QuickView$ActionSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:feedSubmit feedSubmit} to attached listeners.
      *
@@ -12269,7 +12269,7 @@ declare module "sap/ui/ux3/QuickView" {
       mParameters?: QuickView$FeedSubmitEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigate navigate} to attached listeners.
      *
@@ -13563,7 +13563,7 @@ declare module "sap/ui/ux3/Shell" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:feedSubmit feedSubmit} to attached listeners.
      *
@@ -13576,7 +13576,7 @@ declare module "sap/ui/ux3/Shell" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:logout logout} to attached listeners.
      *
@@ -13589,7 +13589,7 @@ declare module "sap/ui/ux3/Shell" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:paneBarItemSelected paneBarItemSelected} to attached listeners.
      *
@@ -13603,7 +13603,7 @@ declare module "sap/ui/ux3/Shell" {
     ): this;
     /**
      * @since 1.12.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:paneClosed paneClosed} to attached listeners.
      *
@@ -13616,7 +13616,7 @@ declare module "sap/ui/ux3/Shell" {
       mParameters?: Shell$PaneClosedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:search search} to attached listeners.
      *
@@ -13629,7 +13629,7 @@ declare module "sap/ui/ux3/Shell" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:worksetItemSelected worksetItemSelected} to attached listeners.
      *
@@ -13948,7 +13948,7 @@ declare module "sap/ui/ux3/Shell" {
       oWorksetItem: NavigationItem
     ): int;
     /**
-     * Experimental method! Do not use!
+     * @experimental method! Do not use!
      *
      * Makes Shell personalization available and injects the given personalization settings. This should be
      * called before the user can do any adaptations per drag&drop or using the personalization dialog. Otherwise
@@ -14083,7 +14083,7 @@ declare module "sap/ui/ux3/Shell" {
       sPaneBarItemId: string
     ): this;
     /**
-     * Experimental method! Do not use!
+     * @experimental method! Do not use!
      */
     openPersonalizationDialog(): void;
     /**
@@ -14387,7 +14387,7 @@ declare module "sap/ui/ux3/Shell" {
     ): this;
     /**
      * @since 1.7.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Moves the complete Shell away from the right window border by the given number of pixels (left border
      * in RTL case).
@@ -14975,7 +14975,7 @@ declare module "sap/ui/ux3/ThingAction" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -15727,7 +15727,7 @@ declare module "sap/ui/ux3/ThingInspector" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:actionSelected actionSelected} to attached listeners.
      *
@@ -15740,7 +15740,7 @@ declare module "sap/ui/ux3/ThingInspector" {
       mParameters?: ThingInspector$ActionSelectedEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:facetSelected facetSelected} to attached listeners.
      *
@@ -15756,7 +15756,7 @@ declare module "sap/ui/ux3/ThingInspector" {
       mParameters?: ThingInspector$FacetSelectedEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:feedSubmit feedSubmit} to attached listeners.
      *
@@ -16725,7 +16725,7 @@ declare module "sap/ui/ux3/ThingViewer" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:facetSelected facetSelected} to attached listeners.
      *
@@ -17749,7 +17749,7 @@ declare module "sap/ui/ux3/ToolPopup" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -17765,7 +17765,7 @@ declare module "sap/ui/ux3/ToolPopup" {
       mParameters?: object
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:closed closed} to attached listeners.
      *
@@ -17778,7 +17778,7 @@ declare module "sap/ui/ux3/ToolPopup" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:enter enter} to attached listeners.
      *
@@ -17791,7 +17791,7 @@ declare module "sap/ui/ux3/ToolPopup" {
       mParameters?: ToolPopup$EnterEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:iconChanged iconChanged} to attached listeners.
      *
@@ -17804,7 +17804,7 @@ declare module "sap/ui/ux3/ToolPopup" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -17818,7 +17818,7 @@ declare module "sap/ui/ux3/ToolPopup" {
     ): this;
     /**
      * @since 1.19.0
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:opened opened} to attached listeners.
      *

--- a/types/openui5/sap.ui.webc.common.d.ts
+++ b/types/openui5/sap.ui.webc.common.d.ts
@@ -9,7 +9,7 @@ declare module "sap/ui/webc/common/WebComponent" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - The API might change. It is not intended for productive usage yet!
+   * @experimental (since 1.92.0) - The API might change. It is not intended for productive usage yet!
    *
    * Base Class for Web Components. Web Components are agnostic UI elements which can be integrated into the
    * UI5 programming model by using this wrapper control. This wrapper control takes care to propagate the
@@ -65,7 +65,7 @@ declare module "sap/ui/webc/common/WebComponentMetadata" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - The API might change. It is not intended for productive usage yet!
+   * @experimental (since 1.92.0) - The API might change. It is not intended for productive usage yet!
    */
   export default class WebComponentMetadata extends ElementMetadata {
     /**

--- a/types/openui5/sap.ui.webc.fiori.d.ts
+++ b/types/openui5/sap.ui.webc.fiori.d.ts
@@ -3,7 +3,7 @@
 declare module "sap/ui/webc/fiori/library" {
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of Bar design
    */
@@ -27,7 +27,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of FCLLayout.
    */
@@ -101,7 +101,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-page` as header and footer.
    */
@@ -111,7 +111,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.97.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-view-settings-dialog` as filter items
    */
@@ -121,7 +121,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.97.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-filter-item` as values
    */
@@ -131,7 +131,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.106.0
-   * Experimental (since 1.106.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.106.0) - This API is experimental and might change significantly.
    *
    * Different types of IllustrationMessageSize.
    */
@@ -166,7 +166,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.95.0) - This API is experimental and might change significantly.
    *
    * Different illustration types of Illustrated Message.
    */
@@ -546,7 +546,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Interface for components that can be slotted inside `ui5-media-gallery` as items.
    */
@@ -556,7 +556,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted as an action inside `ui5-li-notification` and `ui5-li-notification-group`
    */
@@ -566,7 +566,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a notification list
    */
@@ -576,7 +576,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-product-switch` as items
    */
@@ -586,7 +586,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-shellbar` as items
    */
@@ -596,7 +596,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-side-navigation` as items
    */
@@ -606,7 +606,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-side-navigation-item` as sub-items
    */
@@ -616,7 +616,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.97.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-view-settings-dialog` as sort items
    */
@@ -626,7 +626,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-timeline` as items
    */
@@ -636,7 +636,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-upload-collection` as items
    */
@@ -646,7 +646,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-wizard` as wizard steps
    */
@@ -656,7 +656,7 @@ declare module "sap/ui/webc/fiori/library" {
 
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Defines the layout of the content displayed in the `ui5-media-gallery-item`.
    */
@@ -676,7 +676,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Defines the layout type of the thumbnails list of the `ui5-media-gallery` component.
    */
@@ -696,7 +696,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Defines the horizontal alignment of the thumbnails menu of the `ui5-media-gallery` component.
    */
@@ -712,7 +712,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Types for the vertical alignment of the thumbnails menu of the `ui5-media-gallery` component.
    */
@@ -728,7 +728,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Available Page Background Design.
    */
@@ -748,7 +748,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * SideContent FallDown options.
    */
@@ -772,7 +772,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Side Content position options.
    */
@@ -790,7 +790,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Side Content visibility options.
    */
@@ -818,7 +818,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Available Timeline layout orientation
    */
@@ -834,7 +834,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of UploadState.
    */
@@ -858,7 +858,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Different types of Bar.
    */
@@ -874,7 +874,7 @@ declare module "sap/ui/webc/fiori/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Enumeration for different content layouts of the `ui5-wizard`.
    */
@@ -911,7 +911,7 @@ declare module "sap/ui/webc/fiori/Bar" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The Bar is a container which is primarily used to hold titles, buttons and input elements and
    * its design and functionality is the basis for page headers and footers. The component consists of three
@@ -1333,7 +1333,7 @@ declare module "sap/ui/webc/fiori/BarcodeScannerDialog" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -1543,7 +1543,7 @@ declare module "sap/ui/webc/fiori/BarcodeScannerDialog" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:scanError scanError} to attached listeners.
      *
@@ -1556,7 +1556,7 @@ declare module "sap/ui/webc/fiori/BarcodeScannerDialog" {
       mParameters?: BarcodeScannerDialog$ScanErrorEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:scanSuccess scanSuccess} to attached listeners.
      *
@@ -1635,7 +1635,7 @@ declare module "sap/ui/webc/fiori/DynamicSideContent" {
 
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.99.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -1853,7 +1853,7 @@ declare module "sap/ui/webc/fiori/DynamicSideContent" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:layoutChange layoutChange} to attached listeners.
      *
@@ -2347,7 +2347,7 @@ declare module "sap/ui/webc/fiori/FilterItem" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.97.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -2578,7 +2578,7 @@ declare module "sap/ui/webc/fiori/FilterItemOption" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.97.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -2737,7 +2737,7 @@ declare module "sap/ui/webc/fiori/FlexibleColumnLayout" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -2907,7 +2907,7 @@ declare module "sap/ui/webc/fiori/FlexibleColumnLayout" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:layoutChange layoutChange} to attached listeners.
      *
@@ -3373,7 +3373,7 @@ declare module "sap/ui/webc/fiori/IllustratedMessage" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview: An IllustratedMessage is a recommended combination of a solution-oriented message, an engaging
    * illustration, and conversational tone to better communicate an empty or a success state than just show
@@ -3841,7 +3841,7 @@ declare module "sap/ui/webc/fiori/MediaGallery" {
 
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.99.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -4139,7 +4139,7 @@ declare module "sap/ui/webc/fiori/MediaGallery" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:displayAreaClick displayAreaClick} to attached listeners.
      *
@@ -4152,7 +4152,7 @@ declare module "sap/ui/webc/fiori/MediaGallery" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:overflowClick overflowClick} to attached listeners.
      *
@@ -4165,7 +4165,7 @@ declare module "sap/ui/webc/fiori/MediaGallery" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -4541,7 +4541,7 @@ declare module "sap/ui/webc/fiori/MediaGalleryItem" {
 
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.99.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.fiori.MediaGalleryItem` web component represents the items displayed in the
    * `sap.ui.webc.fiori.MediaGallery` web component.
@@ -4815,7 +4815,7 @@ declare module "sap/ui/webc/fiori/NotificationAction" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.fiori.NotificationAction` represents an abstract action, used in the `sap.ui.webc.fiori.NotificationListItem`
    * and the `sap.ui.webc.fiori.NotificationListGroupItem` items.
@@ -4949,7 +4949,7 @@ declare module "sap/ui/webc/fiori/NotificationAction" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -5174,7 +5174,7 @@ declare module "sap/ui/webc/fiori/NotificationListGroupItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.fiori.NotificationListGroupItem` is a special type of list item, that unlike
    * others can group items within self, usually `sap.ui.webc.fiori.NotificationListItem` items.
@@ -5423,7 +5423,7 @@ declare module "sap/ui/webc/fiori/NotificationListGroupItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -5436,7 +5436,7 @@ declare module "sap/ui/webc/fiori/NotificationListGroupItem" {
       mParameters?: NotificationListGroupItem$CloseEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggle toggle} to attached listeners.
      *
@@ -5917,7 +5917,7 @@ declare module "sap/ui/webc/fiori/NotificationListItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.fiori.NotificationListItem` is a type of list item, meant to display notifications.
    *
@@ -6112,7 +6112,7 @@ declare module "sap/ui/webc/fiori/NotificationListItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -6618,7 +6618,7 @@ declare module "sap/ui/webc/fiori/Page" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -7071,7 +7071,7 @@ declare module "sap/ui/webc/fiori/ProductSwitch" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -7251,7 +7251,7 @@ declare module "sap/ui/webc/fiori/ProductSwitchItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.fiori.ProductSwitchItem` web component represents the items displayed in the
    * `sap.ui.webc.fiori.ProductSwitch` web component.
@@ -7399,7 +7399,7 @@ declare module "sap/ui/webc/fiori/ProductSwitchItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -7653,7 +7653,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -8189,7 +8189,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:coPilotClick coPilotClick} to attached listeners.
      *
@@ -8202,7 +8202,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       mParameters?: ShellBar$CoPilotClickEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:logoClick logoClick} to attached listeners.
      *
@@ -8215,7 +8215,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       mParameters?: ShellBar$LogoClickEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:menuItemClick menuItemClick} to attached listeners.
      *
@@ -8228,7 +8228,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       mParameters?: ShellBar$MenuItemClickEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:notificationsClick notificationsClick} to attached listeners.
      *
@@ -8244,7 +8244,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       mParameters?: ShellBar$NotificationsClickEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:productSwitchClick productSwitchClick} to attached listeners.
      *
@@ -8260,7 +8260,7 @@ declare module "sap/ui/webc/fiori/ShellBar" {
       mParameters?: ShellBar$ProductSwitchClickEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:profileClick profileClick} to attached listeners.
      *
@@ -9041,7 +9041,7 @@ declare module "sap/ui/webc/fiori/ShellBarItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    */
   export default class ShellBarItem
     extends WebComponent
@@ -9170,7 +9170,7 @@ declare module "sap/ui/webc/fiori/ShellBarItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -9324,7 +9324,7 @@ declare module "sap/ui/webc/fiori/SideNavigation" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -9523,7 +9523,7 @@ declare module "sap/ui/webc/fiori/SideNavigation" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -9818,7 +9818,7 @@ declare module "sap/ui/webc/fiori/SideNavigationItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -9971,7 +9971,7 @@ declare module "sap/ui/webc/fiori/SideNavigationItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -10260,7 +10260,7 @@ declare module "sap/ui/webc/fiori/SideNavigationSubItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -10396,7 +10396,7 @@ declare module "sap/ui/webc/fiori/SideNavigationSubItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -10548,7 +10548,7 @@ declare module "sap/ui/webc/fiori/SortItem" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.97.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -10704,7 +10704,7 @@ declare module "sap/ui/webc/fiori/Timeline" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -11019,7 +11019,7 @@ declare module "sap/ui/webc/fiori/TimelineItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -11173,7 +11173,7 @@ declare module "sap/ui/webc/fiori/TimelineItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:nameClick nameClick} to attached listeners.
      *
@@ -11460,7 +11460,7 @@ declare module "sap/ui/webc/fiori/UploadCollection" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: This component allows you to represent files before uploading them to a server, with the help
    * of `sap.ui.webc.fiori.UploadCollectionItem`. It also allows you to show already uploaded files.
@@ -11768,7 +11768,7 @@ declare module "sap/ui/webc/fiori/UploadCollection" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:drop drop} to attached listeners.
      *
@@ -11781,7 +11781,7 @@ declare module "sap/ui/webc/fiori/UploadCollection" {
       mParameters?: UploadCollection$DropEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemDelete itemDelete} to attached listeners.
      *
@@ -11794,7 +11794,7 @@ declare module "sap/ui/webc/fiori/UploadCollection" {
       mParameters?: UploadCollection$ItemDeleteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -12268,7 +12268,7 @@ declare module "sap/ui/webc/fiori/UploadCollectionItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: A component to be used within the `sap.ui.webc.fiori.UploadCollection`.
    */
@@ -12635,7 +12635,7 @@ declare module "sap/ui/webc/fiori/UploadCollectionItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:fileNameClick fileNameClick} to attached listeners.
      *
@@ -12648,7 +12648,7 @@ declare module "sap/ui/webc/fiori/UploadCollectionItem" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rename rename} to attached listeners.
      *
@@ -12661,7 +12661,7 @@ declare module "sap/ui/webc/fiori/UploadCollectionItem" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:retry retry} to attached listeners.
      *
@@ -12674,7 +12674,7 @@ declare module "sap/ui/webc/fiori/UploadCollectionItem" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:terminate terminate} to attached listeners.
      *
@@ -13107,7 +13107,7 @@ declare module "sap/ui/webc/fiori/ViewSettingsDialog" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.fiori.ViewSettingsDialog` component helps the user to sort data within a list
    * or a table. It consists of several lists like `Sort order` which is built-in and `Sort By` and `Filter
@@ -13411,7 +13411,7 @@ declare module "sap/ui/webc/fiori/ViewSettingsDialog" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -13424,7 +13424,7 @@ declare module "sap/ui/webc/fiori/ViewSettingsDialog" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:cancel cancel} to attached listeners.
      *
@@ -13437,7 +13437,7 @@ declare module "sap/ui/webc/fiori/ViewSettingsDialog" {
       mParameters?: ViewSettingsDialog$CancelEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:confirm confirm} to attached listeners.
      *
@@ -13717,7 +13717,7 @@ declare module "sap/ui/webc/fiori/Wizard" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -13936,7 +13936,7 @@ declare module "sap/ui/webc/fiori/Wizard" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:stepChange stepChange} to attached listeners.
      *
@@ -14127,7 +14127,7 @@ declare module "sap/ui/webc/fiori/WizardStep" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *

--- a/types/openui5/sap.ui.webc.main.d.ts
+++ b/types/openui5/sap.ui.webc.main.d.ts
@@ -3,7 +3,7 @@
 declare module "sap/ui/webc/main/library" {
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of AvatarColorScheme.
    */
@@ -32,7 +32,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of AvatarGroupType.
    */
@@ -49,7 +49,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of AvatarShape.
    */
@@ -65,7 +65,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of AvatarSize.
    */
@@ -93,7 +93,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Defines background designs.
    */
@@ -113,7 +113,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Defines border designs.
    */
@@ -129,7 +129,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.95.0) - This API is experimental and might change significantly.
    *
    * Different Breadcrumbs designs.
    */
@@ -146,7 +146,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.95.0) - This API is experimental and might change significantly.
    *
    * Different Breadcrumbs separator styles.
    */
@@ -178,7 +178,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different BusyIndicator sizes.
    */
@@ -198,7 +198,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different Button designs.
    */
@@ -230,7 +230,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different Calendar selection mode.
    */
@@ -250,7 +250,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different Carousel arrows placement.
    */
@@ -266,7 +266,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Different Carousel page indicator styles.
    */
@@ -284,7 +284,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Different filtering types of the ComboBox.
    */
@@ -308,7 +308,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Different types of HasPopup.
    */
@@ -336,7 +336,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that represent an avatar and may be slotted in numerous higher-order components
    * such as `ui5-avatar-group`
@@ -347,7 +347,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.95.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-breadcrumbs` as options
    */
@@ -357,7 +357,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be used as a button inside numerous higher-order components
    */
@@ -367,7 +367,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be used as dates inside `ui5-calendar`
    */
@@ -377,7 +377,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-card` as header
    */
@@ -387,7 +387,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be used inside a `ui5-color-palette` or `ui5-color-palette-popover`
    */
@@ -397,7 +397,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-combobox`
    */
@@ -407,7 +407,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Different Icon semantic designs.
    */
@@ -447,7 +447,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that represent an icon, usable in numerous higher-order components
    */
@@ -457,7 +457,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that represent an input, usable in numerous higher-order components
    */
@@ -467,7 +467,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that represent a suggestion item, usable in `ui5-input`
    */
@@ -477,7 +477,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-list` as items
    */
@@ -487,7 +487,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.102.0
-   * Experimental (since 1.102.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.102.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-menu` as items
    */
@@ -497,7 +497,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-multi-combobox` as items
    */
@@ -507,7 +507,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different input types.
    */
@@ -539,7 +539,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.95.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-segmented-button` as items
    */
@@ -549,7 +549,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-select` as options
    */
@@ -559,7 +559,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside `ui5-tabcontainer`
    */
@@ -569,7 +569,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-table-row` as cells
    */
@@ -579,7 +579,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-table` as columns
    */
@@ -589,7 +589,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that may be slotted inside a `ui5-table` as rows
    */
@@ -599,7 +599,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for components that represent a token and are usable in components such as `ui5-multi-input`
    */
@@ -609,7 +609,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Interface for tree items for the purpose of `ui5-tree`
    */
@@ -619,7 +619,7 @@ declare module "sap/ui/webc/main/library" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different link designs.
    */
@@ -639,7 +639,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different list growing modes.
    */
@@ -659,7 +659,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different list item types.
    */
@@ -684,7 +684,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different list modes.
    */
@@ -721,7 +721,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of list items separators.
    */
@@ -741,7 +741,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * MessageStrip designs.
    */
@@ -765,7 +765,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Panel accessible roles.
    */
@@ -788,7 +788,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Popover horizontal align types.
    */
@@ -812,7 +812,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Popover placement types.
    */
@@ -836,7 +836,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Popover vertical align types.
    */
@@ -858,7 +858,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Popup accessible roles.
    */
@@ -878,7 +878,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of Priority.
    */
@@ -902,7 +902,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Different SegmentedButton modes.
    */
@@ -918,7 +918,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of SemanticColor.
    */
@@ -946,7 +946,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of Switch designs.
    */
@@ -962,7 +962,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Background design for the header and content of TabContainer.
    */
@@ -982,7 +982,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Tab layout of TabContainer.
    */
@@ -998,7 +998,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.115.0) - This API is experimental and might change significantly.
    *
    * Table cell popin display.
    */
@@ -1014,7 +1014,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different table growing modes.
    */
@@ -1034,7 +1034,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different table modes.
    */
@@ -1054,7 +1054,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different table row types.
    */
@@ -1070,7 +1070,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.99.0) - This API is experimental and might change significantly.
    *
    * Tabs overflow mode in TabContainer.
    */
@@ -1086,7 +1086,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of Title level.
    */
@@ -1118,7 +1118,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Toast placement.
    */
@@ -1162,7 +1162,7 @@ declare module "sap/ui/webc/main/library" {
   }
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This API is experimental and might change significantly.
+   * @experimental (since 1.92.0) - This API is experimental and might change significantly.
    *
    * Different types of wrapping.
    */
@@ -1201,7 +1201,7 @@ declare module "sap/ui/webc/main/Avatar" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -1357,7 +1357,7 @@ declare module "sap/ui/webc/main/Avatar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -1820,7 +1820,7 @@ declare module "sap/ui/webc/main/AvatarGroup" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -2080,7 +2080,7 @@ declare module "sap/ui/webc/main/AvatarGroup" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -2093,7 +2093,7 @@ declare module "sap/ui/webc/main/AvatarGroup" {
       mParameters?: AvatarGroup$ClickEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:overflow overflow} to attached listeners.
      *
@@ -2306,7 +2306,7 @@ declare module "sap/ui/webc/main/Badge" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -2562,7 +2562,7 @@ declare module "sap/ui/webc/main/Breadcrumbs" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview: Enables users to navigate between items by providing a list of links to previous steps in the
    * user's navigation path. It helps the user to be aware of their location within the application and allows
@@ -2731,7 +2731,7 @@ declare module "sap/ui/webc/main/Breadcrumbs" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -2987,7 +2987,7 @@ declare module "sap/ui/webc/main/BreadcrumbsItem" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -3244,7 +3244,7 @@ declare module "sap/ui/webc/main/BusyIndicator" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -3655,7 +3655,7 @@ declare module "sap/ui/webc/main/Button" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -3826,7 +3826,7 @@ declare module "sap/ui/webc/main/Button" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -4330,7 +4330,7 @@ declare module "sap/ui/webc/main/Calendar" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -4558,7 +4558,7 @@ declare module "sap/ui/webc/main/Calendar" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectedDatesChange selectedDatesChange} to attached listeners.
      *
@@ -4956,7 +4956,7 @@ declare module "sap/ui/webc/main/CalendarDate" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -5083,7 +5083,7 @@ declare module "sap/ui/webc/main/Card" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -5470,7 +5470,7 @@ declare module "sap/ui/webc/main/CardHeader" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -5654,7 +5654,7 @@ declare module "sap/ui/webc/main/CardHeader" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -5957,7 +5957,7 @@ declare module "sap/ui/webc/main/Carousel" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The Carousel allows the user to browse through a set of items. The component is mostly used
    * for showing a gallery of images, but can hold any other HTML element.
@@ -6139,7 +6139,7 @@ declare module "sap/ui/webc/main/Carousel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigate navigate} to attached listeners.
      *
@@ -6689,7 +6689,7 @@ declare module "sap/ui/webc/main/CheckBox" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -6864,7 +6864,7 @@ declare module "sap/ui/webc/main/CheckBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -7385,7 +7385,7 @@ declare module "sap/ui/webc/main/ColorPalette" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.ColorPalette` provides the users with a range of predefined colors. The
    * colors are fixed and do not change with the theme.
@@ -7537,7 +7537,7 @@ declare module "sap/ui/webc/main/ColorPalette" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -7647,7 +7647,7 @@ declare module "sap/ui/webc/main/ColorPaletteItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -7777,7 +7777,7 @@ declare module "sap/ui/webc/main/ColorPalettePopover" {
 
   /**
    * @since 1.97.0
-   * Experimental (since 1.97.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.97.0) - This control is experimental and its API might change significantly.
    *
    * Overview: Represents a predefined range of colors for easier selection.
    *
@@ -7936,7 +7936,7 @@ declare module "sap/ui/webc/main/ColorPalettePopover" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -8195,7 +8195,7 @@ declare module "sap/ui/webc/main/ColorPicker" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.ColorPicker` allows users to choose any color and provides different
    * input options for selecting colors.
@@ -8332,7 +8332,7 @@ declare module "sap/ui/webc/main/ColorPicker" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -8419,7 +8419,7 @@ declare module "sap/ui/webc/main/ComboBox" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -8755,7 +8755,7 @@ declare module "sap/ui/webc/main/ComboBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -8768,7 +8768,7 @@ declare module "sap/ui/webc/main/ComboBox" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -8781,7 +8781,7 @@ declare module "sap/ui/webc/main/ComboBox" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -9389,7 +9389,7 @@ declare module "sap/ui/webc/main/ComboBoxGroupItem" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.ComboBoxGroupItem` is type of suggestion item, that can be used to split the `sap.ui.webc.main.ComboBox`
    * suggestions into groups.
@@ -9509,7 +9509,7 @@ declare module "sap/ui/webc/main/ComboBoxItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.ComboBoxItem` represents the item for a `sap.ui.webc.main.ComboBox`.
    */
@@ -9667,7 +9667,7 @@ declare module "sap/ui/webc/main/CustomListItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * A component to be used as custom list item within the `sap.ui.webc.main.List` the same way as the standard
    * `sap.ui.webc.main.StandardListItem`.
@@ -9824,7 +9824,7 @@ declare module "sap/ui/webc/main/CustomListItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:detailClick detailClick} to attached listeners.
      *
@@ -10100,7 +10100,7 @@ declare module "sap/ui/webc/main/DatePicker" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -10366,7 +10366,7 @@ declare module "sap/ui/webc/main/DatePicker" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -10382,7 +10382,7 @@ declare module "sap/ui/webc/main/DatePicker" {
       mParameters?: DatePicker$ChangeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -11135,7 +11135,7 @@ declare module "sap/ui/webc/main/DateRangePicker" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The DateRangePicker enables the users to enter a localized date range using touch, mouse, keyboard
    * input, or by selecting a date range in the calendar.
@@ -11360,7 +11360,7 @@ declare module "sap/ui/webc/main/DateRangePicker" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -11376,7 +11376,7 @@ declare module "sap/ui/webc/main/DateRangePicker" {
       mParameters?: DateRangePicker$ChangeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -12178,7 +12178,7 @@ declare module "sap/ui/webc/main/DateTimePicker" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `DateTimePicker` component alows users to select both date (day, month and year) and time
    * (hours, minutes and seconds) and for the purpose it consists of input field and Date/Time picker.
@@ -12438,7 +12438,7 @@ declare module "sap/ui/webc/main/DateTimePicker" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -12454,7 +12454,7 @@ declare module "sap/ui/webc/main/DateTimePicker" {
       mParameters?: DateTimePicker$ChangeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -13210,7 +13210,7 @@ declare module "sap/ui/webc/main/Dialog" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.Dialog` component is used to temporarily display some information in
    * a size-limited window in front of the regular app screen. It is used to prompt the user for an action
@@ -13631,7 +13631,7 @@ declare module "sap/ui/webc/main/Dialog" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterClose afterClose} to attached listeners.
      *
@@ -13644,7 +13644,7 @@ declare module "sap/ui/webc/main/Dialog" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterOpen afterOpen} to attached listeners.
      *
@@ -13657,7 +13657,7 @@ declare module "sap/ui/webc/main/Dialog" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeClose beforeClose} to attached listeners.
      *
@@ -13673,7 +13673,7 @@ declare module "sap/ui/webc/main/Dialog" {
       mParameters?: Dialog$BeforeCloseEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -14426,7 +14426,7 @@ declare module "sap/ui/webc/main/FileUploader" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -14587,7 +14587,7 @@ declare module "sap/ui/webc/main/FileUploader" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -15081,7 +15081,7 @@ declare module "sap/ui/webc/main/GroupHeaderListItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.GroupHeaderListItem` is a special list item, used only to separate other list items
    * into logical groups.
@@ -15272,7 +15272,7 @@ declare module "sap/ui/webc/main/Icon" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -15464,7 +15464,7 @@ declare module "sap/ui/webc/main/Icon" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -15963,7 +15963,7 @@ declare module "sap/ui/webc/main/Input" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -16369,7 +16369,7 @@ declare module "sap/ui/webc/main/Input" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -16382,7 +16382,7 @@ declare module "sap/ui/webc/main/Input" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -16395,7 +16395,7 @@ declare module "sap/ui/webc/main/Input" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggestionItemPreview suggestionItemPreview} to attached listeners.
      *
@@ -16408,7 +16408,7 @@ declare module "sap/ui/webc/main/Input" {
       mParameters?: Input$SuggestionItemPreviewEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggestionItemSelect suggestionItemSelect} to attached listeners.
      *
@@ -17224,7 +17224,7 @@ declare module "sap/ui/webc/main/Label" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -17535,7 +17535,7 @@ declare module "sap/ui/webc/main/Link" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.Link` is a hyperlink component that is used to navigate to other apps
    * and web pages, or to trigger actions. It is a clickable text element, visualized in such a way that it
@@ -17693,7 +17693,7 @@ declare module "sap/ui/webc/main/Link" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -18204,7 +18204,7 @@ declare module "sap/ui/webc/main/List" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -18744,7 +18744,7 @@ declare module "sap/ui/webc/main/List" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -18760,7 +18760,7 @@ declare module "sap/ui/webc/main/List" {
       mParameters?: List$ItemClickEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClose itemClose} to attached listeners.
      *
@@ -18773,7 +18773,7 @@ declare module "sap/ui/webc/main/List" {
       mParameters?: List$ItemCloseEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemDelete itemDelete} to attached listeners.
      *
@@ -18786,7 +18786,7 @@ declare module "sap/ui/webc/main/List" {
       mParameters?: List$ItemDeleteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemToggle itemToggle} to attached listeners.
      *
@@ -18799,7 +18799,7 @@ declare module "sap/ui/webc/main/List" {
       mParameters?: List$ItemToggleEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:loadMore loadMore} to attached listeners.
      *
@@ -18812,7 +18812,7 @@ declare module "sap/ui/webc/main/List" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -19603,7 +19603,7 @@ declare module "sap/ui/webc/main/Menu" {
 
   /**
    * @since 1.102.0
-   * Experimental (since 1.102.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.102.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -20021,7 +20021,7 @@ declare module "sap/ui/webc/main/Menu" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterClose afterClose} to attached listeners.
      *
@@ -20034,7 +20034,7 @@ declare module "sap/ui/webc/main/Menu" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterOpen afterOpen} to attached listeners.
      *
@@ -20047,7 +20047,7 @@ declare module "sap/ui/webc/main/Menu" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeClose beforeClose} to attached listeners.
      *
@@ -20063,7 +20063,7 @@ declare module "sap/ui/webc/main/Menu" {
       mParameters?: Menu$BeforeCloseEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -20079,7 +20079,7 @@ declare module "sap/ui/webc/main/Menu" {
       mParameters?: Menu$BeforeOpenEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -20405,7 +20405,7 @@ declare module "sap/ui/webc/main/MenuItem" {
 
   /**
    * @since 1.102.0
-   * Experimental (since 1.102.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.102.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -20863,7 +20863,7 @@ declare module "sap/ui/webc/main/MessageStrip" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -21008,7 +21008,7 @@ declare module "sap/ui/webc/main/MessageStrip" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -21293,7 +21293,7 @@ declare module "sap/ui/webc/main/MultiComboBox" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -21692,7 +21692,7 @@ declare module "sap/ui/webc/main/MultiComboBox" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -21705,7 +21705,7 @@ declare module "sap/ui/webc/main/MultiComboBox" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -21718,7 +21718,7 @@ declare module "sap/ui/webc/main/MultiComboBox" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:openChange openChange} to attached listeners.
      *
@@ -21731,7 +21731,7 @@ declare module "sap/ui/webc/main/MultiComboBox" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -22388,7 +22388,7 @@ declare module "sap/ui/webc/main/MultiComboBoxGroupItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.MultiComboBoxGroupItem` is type of suggestion item, that can be used to split the
    * `sap.ui.webc.main.MultiComboBox` suggestions into groups.
@@ -22509,7 +22509,7 @@ declare module "sap/ui/webc/main/MultiComboBoxItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.MultiComboBoxItem` represents the item for a `sap.ui.webc.main.MultiComboBox`.
    */
@@ -22712,7 +22712,7 @@ declare module "sap/ui/webc/main/MultiInput" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: A `sap.ui.webc.main.MultiInput` field allows the user to enter multiple values, which are displayed
    * as `sap.ui.webc.main.Token`.
@@ -23238,7 +23238,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -23251,7 +23251,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -23264,7 +23264,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggestionItemPreview suggestionItemPreview} to attached listeners.
      *
@@ -23277,7 +23277,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       mParameters?: MultiInput$SuggestionItemPreviewEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:suggestionItemSelect suggestionItemSelect} to attached listeners.
      *
@@ -23290,7 +23290,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       mParameters?: MultiInput$SuggestionItemSelectEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:tokenDelete tokenDelete} to attached listeners.
      *
@@ -23303,7 +23303,7 @@ declare module "sap/ui/webc/main/MultiInput" {
       mParameters?: MultiInput$TokenDeleteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:valueHelpTrigger valueHelpTrigger} to attached listeners.
      *
@@ -24237,7 +24237,7 @@ declare module "sap/ui/webc/main/Option" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -24528,7 +24528,7 @@ declare module "sap/ui/webc/main/Panel" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -24727,7 +24727,7 @@ declare module "sap/ui/webc/main/Panel" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggle toggle} to attached listeners.
      *
@@ -25210,7 +25210,7 @@ declare module "sap/ui/webc/main/Popover" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -25621,7 +25621,7 @@ declare module "sap/ui/webc/main/Popover" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterClose afterClose} to attached listeners.
      *
@@ -25634,7 +25634,7 @@ declare module "sap/ui/webc/main/Popover" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterOpen afterOpen} to attached listeners.
      *
@@ -25647,7 +25647,7 @@ declare module "sap/ui/webc/main/Popover" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeClose beforeClose} to attached listeners.
      *
@@ -25663,7 +25663,7 @@ declare module "sap/ui/webc/main/Popover" {
       mParameters?: Popover$BeforeCloseEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -26535,7 +26535,7 @@ declare module "sap/ui/webc/main/ProgressIndicator" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: Shows the progress of a process in a graphical way. To indicate the progress, the inside of
    * the component is filled with a color.
@@ -26866,7 +26866,7 @@ declare module "sap/ui/webc/main/RadioButton" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -27024,7 +27024,7 @@ declare module "sap/ui/webc/main/RadioButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -27532,7 +27532,7 @@ declare module "sap/ui/webc/main/RangeSlider" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: Represents a numerical interval and two handles (grips) to select a sub-range within it. The
    * purpose of the component to enable visual selection of sub-ranges within a given interval.
@@ -27767,7 +27767,7 @@ declare module "sap/ui/webc/main/RangeSlider" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -27780,7 +27780,7 @@ declare module "sap/ui/webc/main/RangeSlider" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -28216,7 +28216,7 @@ declare module "sap/ui/webc/main/RatingIndicator" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The Rating Indicator is used to display a specific number of icons that are used to rate an
    * item. Additionally, it is also used to display the average and overall ratings.
@@ -28370,7 +28370,7 @@ declare module "sap/ui/webc/main/RatingIndicator" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -28632,7 +28632,7 @@ declare module "sap/ui/webc/main/ResponsivePopover" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.ResponsivePopover` acts as a Popover on desktop and tablet, while on
    * phone it acts as a Dialog. The component improves tremendously the user experience on mobile.
@@ -29040,7 +29040,7 @@ declare module "sap/ui/webc/main/ResponsivePopover" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterClose afterClose} to attached listeners.
      *
@@ -29053,7 +29053,7 @@ declare module "sap/ui/webc/main/ResponsivePopover" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:afterOpen afterOpen} to attached listeners.
      *
@@ -29066,7 +29066,7 @@ declare module "sap/ui/webc/main/ResponsivePopover" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeClose beforeClose} to attached listeners.
      *
@@ -29082,7 +29082,7 @@ declare module "sap/ui/webc/main/ResponsivePopover" {
       mParameters?: ResponsivePopover$BeforeCloseEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:beforeOpen beforeOpen} to attached listeners.
      *
@@ -29908,7 +29908,7 @@ declare module "sap/ui/webc/main/SegmentedButton" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -30065,7 +30065,7 @@ declare module "sap/ui/webc/main/SegmentedButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -30088,7 +30088,7 @@ declare module "sap/ui/webc/main/SegmentedButton" {
      */
     getAccessibleName(): string;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * `SegmentedButton` must not be stretched in Form because ResizeHandler is used internally in order to
      * manage the width of the SegmentedButton depending on the container size
@@ -30329,7 +30329,7 @@ declare module "sap/ui/webc/main/SegmentedButtonItem" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -30484,7 +30484,7 @@ declare module "sap/ui/webc/main/SegmentedButtonItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -30924,7 +30924,7 @@ declare module "sap/ui/webc/main/Select" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.Select` component is used to create a drop-down list. The items inside
    * the `sap.ui.webc.main.Select` define the available options by using the `sap.ui.webc.main.Option` component.
@@ -31218,7 +31218,7 @@ declare module "sap/ui/webc/main/Select" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -31234,7 +31234,7 @@ declare module "sap/ui/webc/main/Select" {
       mParameters?: Select$ChangeEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:close close} to attached listeners.
      *
@@ -31247,7 +31247,7 @@ declare module "sap/ui/webc/main/Select" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:open open} to attached listeners.
      *
@@ -31703,7 +31703,7 @@ declare module "sap/ui/webc/main/Slider" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The Slider component represents a numerical range and a handle (grip). The purpose of the component
    * is to enable visual selection of a value in a continuous numerical range by moving an adjustable handle.
@@ -31943,7 +31943,7 @@ declare module "sap/ui/webc/main/Slider" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -31956,7 +31956,7 @@ declare module "sap/ui/webc/main/Slider" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -32352,7 +32352,7 @@ declare module "sap/ui/webc/main/SplitButton" {
 
   /**
    * @since 1.99.0
-   * Experimental (since 1.99.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.99.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -32570,7 +32570,7 @@ declare module "sap/ui/webc/main/SplitButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:arrowClick arrowClick} to attached listeners.
      *
@@ -32583,7 +32583,7 @@ declare module "sap/ui/webc/main/SplitButton" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -32886,7 +32886,7 @@ declare module "sap/ui/webc/main/StandardListItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.StandardListItem` represents the simplest type of item for a `sap.ui.webc.main.List`.
    *
@@ -33052,7 +33052,7 @@ declare module "sap/ui/webc/main/StandardListItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:detailClick detailClick} to attached listeners.
      *
@@ -33567,7 +33567,7 @@ declare module "sap/ui/webc/main/StepInput" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -33733,7 +33733,7 @@ declare module "sap/ui/webc/main/StepInput" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -34303,7 +34303,7 @@ declare module "sap/ui/webc/main/SuggestionGroupItem" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.SuggestionGroupItem` is type of suggestion item, that can be used to split the
    * `sap.ui.webc.main.Input` suggestions into groups.
@@ -34425,7 +34425,7 @@ declare module "sap/ui/webc/main/SuggestionItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.SuggestionItem` represents the suggestion item of the `sap.ui.webc.main.Input`.
    */
@@ -34803,7 +34803,7 @@ declare module "sap/ui/webc/main/Switch" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.Switch` component is used for changing between binary states.
    *  The component can display texts, that will be switched, based on the component state, via the `textOn`
@@ -34960,7 +34960,7 @@ declare module "sap/ui/webc/main/Switch" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -35304,7 +35304,7 @@ declare module "sap/ui/webc/main/Tab" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.Tab` represents a selectable item inside a `sap.ui.webc.main.TabContainer`. It
    * defines both the item in the tab strip (top part of the `sap.ui.webc.main.TabContainer`) and the content
@@ -35812,7 +35812,7 @@ declare module "sap/ui/webc/main/TabContainer" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -35993,7 +35993,7 @@ declare module "sap/ui/webc/main/TabContainer" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:tabSelect tabSelect} to attached listeners.
      *
@@ -36578,7 +36578,7 @@ declare module "sap/ui/webc/main/Table" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -36987,7 +36987,7 @@ declare module "sap/ui/webc/main/Table" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:loadMore loadMore} to attached listeners.
      *
@@ -37000,7 +37000,7 @@ declare module "sap/ui/webc/main/Table" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:popinChange popinChange} to attached listeners.
      *
@@ -37013,7 +37013,7 @@ declare module "sap/ui/webc/main/Table" {
       mParameters?: Table$PopinChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:rowClick rowClick} to attached listeners.
      *
@@ -37026,7 +37026,7 @@ declare module "sap/ui/webc/main/Table" {
       mParameters?: Table$RowClickEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -37785,7 +37785,7 @@ declare module "sap/ui/webc/main/TableCell" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -37964,7 +37964,7 @@ declare module "sap/ui/webc/main/TableColumn" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -38317,7 +38317,7 @@ declare module "sap/ui/webc/main/TableGroupRow" {
 
   /**
    * @since 1.95.0
-   * Experimental (since 1.95.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.95.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -38450,7 +38450,7 @@ declare module "sap/ui/webc/main/TableRow" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -38743,7 +38743,7 @@ declare module "sap/ui/webc/main/TabSeparator" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.TabSeparator` represents a vertical line to separate tabs inside a `sap.ui.webc.main.TabContainer`.
    */
@@ -38844,7 +38844,7 @@ declare module "sap/ui/webc/main/TextArea" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -39058,7 +39058,7 @@ declare module "sap/ui/webc/main/TextArea" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -39071,7 +39071,7 @@ declare module "sap/ui/webc/main/TextArea" {
       mParameters?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -39747,7 +39747,7 @@ declare module "sap/ui/webc/main/TimePicker" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.TimePicker` component provides an input field with assigned sliders which
    * are opened on user action. The `sap.ui.webc.main.TimePicker` allows users to select a localized time
@@ -39988,7 +39988,7 @@ declare module "sap/ui/webc/main/TimePicker" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:change change} to attached listeners.
      *
@@ -40001,7 +40001,7 @@ declare module "sap/ui/webc/main/TimePicker" {
       mParameters?: TimePicker$ChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:input input} to attached listeners.
      *
@@ -40423,7 +40423,7 @@ declare module "sap/ui/webc/main/Title" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -40651,7 +40651,7 @@ declare module "sap/ui/webc/main/Toast" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -40959,7 +40959,7 @@ declare module "sap/ui/webc/main/ToggleButton" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -41110,7 +41110,7 @@ declare module "sap/ui/webc/main/ToggleButton" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:click click} to attached listeners.
      *
@@ -41603,7 +41603,7 @@ declare module "sap/ui/webc/main/Token" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview:
    *
@@ -41752,7 +41752,7 @@ declare module "sap/ui/webc/main/Token" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:select select} to attached listeners.
      *
@@ -41967,7 +41967,7 @@ declare module "sap/ui/webc/main/Tree" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.Tree` component provides a tree structure for displaying data in a hierarchy.
    *
@@ -42492,7 +42492,7 @@ declare module "sap/ui/webc/main/Tree" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemClick itemClick} to attached listeners.
      *
@@ -42508,7 +42508,7 @@ declare module "sap/ui/webc/main/Tree" {
       mParameters?: Tree$ItemClickEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemDelete itemDelete} to attached listeners.
      *
@@ -42521,7 +42521,7 @@ declare module "sap/ui/webc/main/Tree" {
       mParameters?: Tree$ItemDeleteEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemMouseout itemMouseout} to attached listeners.
      *
@@ -42534,7 +42534,7 @@ declare module "sap/ui/webc/main/Tree" {
       mParameters?: Tree$ItemMouseoutEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemMouseover itemMouseover} to attached listeners.
      *
@@ -42547,7 +42547,7 @@ declare module "sap/ui/webc/main/Tree" {
       mParameters?: Tree$ItemMouseoverEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:itemToggle itemToggle} to attached listeners.
      *
@@ -42563,7 +42563,7 @@ declare module "sap/ui/webc/main/Tree" {
       mParameters?: Tree$ItemToggleEventParameters
     ): boolean;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:selectionChange selectionChange} to attached listeners.
      *
@@ -43122,7 +43122,7 @@ declare module "sap/ui/webc/main/TreeItem" {
 
   /**
    * @since 1.92.0
-   * Experimental (since 1.92.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.92.0) - This control is experimental and its API might change significantly.
    *
    * Overview: The `sap.ui.webc.main.TreeItem` represents a node in a tree structure, shown as a `sap.ui.webc.main.List`.
    *
@@ -43286,7 +43286,7 @@ declare module "sap/ui/webc/main/TreeItem" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:detailClick detailClick} to attached listeners.
      *
@@ -43834,7 +43834,7 @@ declare module "sap/ui/webc/main/TreeItemCustom" {
 
   /**
    * @since 1.115.0
-   * Experimental (since 1.115.0) - This control is experimental and its API might change significantly.
+   * @experimental (since 1.115.0) - This control is experimental and its API might change significantly.
    *
    * The `sap.ui.webc.main.TreeItemCustom` represents a node in a tree structure, shown as a `sap.ui.webc.main.List`.
    *
@@ -44019,7 +44019,7 @@ declare module "sap/ui/webc/main/TreeItemCustom" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:detailClick detailClick} to attached listeners.
      *

--- a/types/openui5/sap.uxap.d.ts
+++ b/types/openui5/sap.uxap.d.ts
@@ -249,7 +249,7 @@ declare module "sap/uxap/AnchorBar" {
      */
     static getMetadata(): ElementMetadata;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This method is a hook for the RenderManager that gets called during the rendering of child Controls.
      * It allows to add, remove and update existing accessibility attributes (ARIA) of those controls.
@@ -598,7 +598,7 @@ declare module "sap/uxap/BlockBase" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Creates a view.
      *
@@ -641,7 +641,7 @@ declare module "sap/uxap/BlockBase" {
     ): this;
     /**
      * @since 1.72
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:viewInit viewInit} to attached listeners.
      *
@@ -2546,7 +2546,7 @@ declare module "sap/uxap/ObjectPageHeader" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:markChangesPress markChangesPress} to attached listeners.
      *
@@ -2559,7 +2559,7 @@ declare module "sap/uxap/ObjectPageHeader" {
       mParameters?: ObjectPageHeader$MarkChangesPressEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:markLockedPress markLockedPress} to attached listeners.
      *
@@ -2572,7 +2572,7 @@ declare module "sap/uxap/ObjectPageHeader" {
       mParameters?: ObjectPageHeader$MarkLockedPressEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:titleSelectorPress titleSelectorPress} to attached listeners.
      *
@@ -4855,7 +4855,7 @@ declare module "sap/uxap/ObjectPageLayout" {
       oListener?: object
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:editHeaderButtonPress editHeaderButtonPress} to attached listeners.
      *
@@ -4869,7 +4869,7 @@ declare module "sap/uxap/ObjectPageLayout" {
     ): this;
     /**
      * @since 1.93
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:headerContentPinnedStateChange headerContentPinnedStateChange} to attached
      * listeners.
@@ -4884,7 +4884,7 @@ declare module "sap/uxap/ObjectPageLayout" {
     ): this;
     /**
      * @since 1.40
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:navigate navigate} to attached listeners.
      *
@@ -4898,7 +4898,7 @@ declare module "sap/uxap/ObjectPageLayout" {
     ): this;
     /**
      * @since 1.73
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:sectionChange sectionChange} to attached listeners.
      *
@@ -4912,7 +4912,7 @@ declare module "sap/uxap/ObjectPageLayout" {
     ): this;
     /**
      * @since 1.77
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:subSectionVisibilityChange subSectionVisibilityChange} to attached listeners.
      *
@@ -4925,7 +4925,7 @@ declare module "sap/uxap/ObjectPageLayout" {
       mParameters?: ObjectPageLayout$SubSectionVisibilityChangeEventParameters
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Fires event {@link #event:toggleAnchorBar toggleAnchorBar} to attached listeners.
      *
@@ -5367,7 +5367,7 @@ declare module "sap/uxap/ObjectPageLayout" {
       iIndex: int
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * This triggers rerendering of itself and its children.
      */
@@ -6937,7 +6937,7 @@ declare module "sap/uxap/ObjectPageSectionBase" {
      */
     getImportance(): Importance | keyof typeof Importance;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Returns the control name text.
      *
@@ -7078,7 +7078,7 @@ declare module "sap/uxap/ObjectPageSectionBase" {
       bVisible?: boolean
     ): this;
     /**
-     * Protected:  Do not call from applications (only from related classes in the framework)
+     * @ui5-protected Do not call from applications (only from related classes in the framework)
      *
      * Performs the update of the invisible text label. This method is called for example when the section title
      * is changed.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).  → done as much as possible, as detailed in the [previous pull request for 1.90](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53680), some are unavoidable at this point
- [x] [Run \`npm test <package to test>\`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: → no specific URL about the changes, it's mostly updating the settings and a small type patch for release https://sdk.openui5.org/1.116.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. → no new JS version

***99% of the changes in this PR are related to defining two custom JSDoc tags we have been using all the time (but recently started breaking the linting) in .eslintrc.json and then re-enabling these comments in many occurrences across the sourcecode.***