### PR TITLE
[lodash] fix `WeakMap` when targeting es2023

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -41,5 +41,5 @@ declare global {
     // tslint:disable-next-line:no-empty-interface
     interface WeakSet<T> { }
     // tslint:disable-next-line:no-empty-interface
-    interface WeakMap<K extends object, V> { }
+    interface WeakMap<K extends WeakKey, V> { }
 }

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -31,15 +31,3 @@ declare namespace _ {
     // tslint:disable-next-line no-empty-interface (This will be augmented)
     interface LoDashStatic {}
 }
-
-// Backward compatibility with --target es5
-declare global {
-    // tslint:disable-next-line:no-empty-interface
-    interface Set<T> { }
-    // tslint:disable-next-line:no-empty-interface
-    interface Map<K, V> { }
-    // tslint:disable-next-line:no-empty-interface
-    interface WeakSet<T> { }
-    // tslint:disable-next-line:no-empty-interface
-    interface WeakMap<K extends WeakKey, V> { }
-}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [see "3. Symbols as WeakMap keys"](https://dev.to/jasmin/what-is-new-in-es2023-4bcm)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

fixes #66122