### PR TITLE
fix(js-beautify): add inline_custom_elements option

### DIFF
--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for js_beautify 1.13
+// Type definitions for js_beautify 1.14
 // Project: https://github.com/beautify-web/js-beautify/
 // Definitions by: Hans Windhoff <https://github.com/hansrwindhoff>
 //                 Gavin Rehkemper <https://github.com/gavinr/>
@@ -61,6 +61,7 @@ declare namespace js_beautify {
         content_unformatted?: string[] | undefined;
         unformatted_content_delimiter?: string | undefined;
         indent_scripts?: 'normal' | 'keep' | 'separate' | undefined;
+        inline_custom_elements?: boolean | undefined;
     }
 
     interface CSSBeautifyOptions extends CoreBeautifyOptions {

--- a/types/js-beautify/js-beautify-tests.ts
+++ b/types/js-beautify/js-beautify-tests.ts
@@ -51,6 +51,7 @@ const HTMLoptions: js_beautify.HTMLBeautifyOptions = {
     wrap_attributes: 'auto',
     wrap_attributes_indent_size: 4,
     end_with_newline: false,
+    inline_custom_elements: true
 };
 
 const CSSoptions: js_beautify.CSSBeautifyOptions = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  js-beautify v1.14.9 introduced a new option to inlien custom elements, see https://github.com/beautify-web/js-beautify/commit/bcc42130c14362f90a5816309cd3f7efb5c2727b
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
