### PR TITLE
fix(luxon): `twoDigitCutoffYear` option added to settings

### DIFF
--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -41,7 +41,7 @@ export class Settings {
      * The default output calendar to create DateTimes with. Does not affect existing instances.
      */
     static defaultOutputCalendar: string;
-    
+
     /**
      * The cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
      */

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -41,6 +41,11 @@ export class Settings {
      * The default output calendar to create DateTimes with. Does not affect existing instances.
      */
     static defaultOutputCalendar: string;
+    
+    /**
+     * The cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
+     */
+    static twoDigitCutoffYear: number;
 
     /**
      * Whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -319,6 +319,11 @@ Settings.defaultZone = 'America/Los_Angeles';
 Settings.defaultZone = Settings.defaultZone;
 Settings.defaultZone; // $ExpectType Zone
 
+Settings.twoDigitCutoffYear;
+Settings.twoDigitCutoffYear = 42;
+// @ts-expect-error
+Settings.twoDigitCutoffYear = '123';
+
 // The following tests were coped from the docs
 // http://moment.github.io/luxon/docs/manual/
 


### PR DESCRIPTION
The only option that for some reason is not present in the types described.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/api-docs/index.html#settings
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.