### PR TITLE
mithril: reorder overloads of m for more specific errors

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -43,17 +43,17 @@ declare namespace Mithril {
 
     interface Hyperscript {
         /** Creates a virtual element (Vnode). */
+        (selector: string, ...children: Children[]): Vnode<any, any>;
+        /** Creates a virtual element (Vnode). */
+        <Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
+        /** Creates a virtual element (Vnode). */
+        (selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
+        /** Creates a virtual element (Vnode). */
         <Attrs, State>(
             component: ComponentTypes<Attrs, State>,
             attributes: Attrs & CommonAttributes<Attrs, State>,
             ...args: Children[]
         ): Vnode<Attrs, State>;
-        /** Creates a virtual element (Vnode). */
-        (selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
-        /** Creates a virtual element (Vnode). */
-        <Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
-        /** Creates a virtual element (Vnode). */
-        (selector: string, ...children: Children[]): Vnode<any, any>;
         /** Creates a fragment virtual element (Vnode). */
         fragment(attrs: CommonAttributes<any, any> & { [key: string]: any }, children: ChildArrayOrPrimitive): Vnode<any, any>;
         /** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */


### PR DESCRIPTION
package: @types/mithril

Reverse the order of the overloads on the m function defined in the Hyperscript interface

this improves the quality and detail of typescript errors. If no overloads match the definition of a component, (because say it's missing a required attribute) instead of telling you what attribute is missing or is of the wrong type, it would pick the last overload that allows the second argument to be a string instead of the attributes and just say the the passed in argument doesn't match the string type.

By reversing the definitions it gives an error on the specific attribute that's mistyped.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
