### PR TITLE
webrtc: typo: RTCRt(c->p)Capabilities

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -208,12 +208,6 @@ interface RTCRtpContributingSource {
     readonly voiceActivityFlag?: boolean | undefined;
 }
 
-// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcapabilities
-interface RTCRtcCapabilities {
-    codecs: RTCRtpCodecCapability[];
-    headerExtensions: RTCRtpHeaderExtensionCapability[];
-}
-
 // https://www.w3.org/TR/webrtc/#dom-rtcrtpsender
 interface RTCRtpSender {
     //readonly track?: MediaStreamTrack;


### PR DESCRIPTION
Not entirely sure what the procedure is for fixing a typo like this. `npm test webrtc` seemed to complete successfully but also I can't see any tests for it in the first place.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] (not needed) [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcapabilities
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
