### PR TITLE
Update index.d.ts

### DIFF
--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1389,12 +1389,12 @@ declare class UInt64 {
     xor(v: UInt64 | number | string): UInt64;
 
     /**
-     * Makes a new UInt64 whose value is `this` << `v`.
+     * Makes a new UInt64 whose value is `this` >> `v`.
      */
     shr(v: UInt64 | number | string): UInt64;
 
     /**
-     * Makes a new UInt64 whose value is `this` >> `v`.
+     * Makes a new UInt64 whose value is `this` << `v`.
      */
     shl(v: UInt64 | number | string): UInt64;
 


### PR DESCRIPTION
This commit addresses the documentation issue in the 'frida-gum' TypeScript typings related to the shift left (<<) and shift right (>>) operations. The previous documentation inaccurately described the behavior of these bitwise operations.

Shift Left (<<):
The documentation previously provided incorrect information about the shift left operation, which may have led to confusion for developers using it. The updated documentation now provides clear and accurate explanations of the shift left operation, ensuring developers have the correct understanding.

Shift Right (>>):
Similarly, the documentation for the shift right operation was incorrect, potentially causing misunderstandings about the expected behavior. The revised documentation now provides accurate details on the shift right operation, helping developers use it properly in their code.

By fixing these documentation issues, the 'frida-gum' TypeScript typings are now more reliable and will facilitate better development experiences for users.

Please review the changes to the documentation, and if you have any feedback or suggestions, feel free to let me know. Thank you! 🙌🙌

