### PR TITLE
Added HEAP64/HEAPU64 types for emscripten

### DIFF
--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -80,6 +80,8 @@ interface EmscriptenModule {
     HEAPU32: Uint32Array;
     HEAPF32: Float32Array;
     HEAPF64: Float64Array;
+    HEAP64: BigInt64Array;
+    HEAPU64: BigUint64Array;
 
     TOTAL_STACK: number;
     TOTAL_MEMORY: number;

--- a/types/emscripten/tsconfig.json
+++ b/types/emscripten/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "lib": [
             "es6",
+            "es2020",
             "dom"
         ],
         "noImplicitAny": true,


### PR DESCRIPTION
The change adds exported HEAP64/HEAPU64 arrays when WASM_BIGINT is enabled, here is the source code
https://github.com/emscripten-core/emscripten/blob/bec42dac7873903d09d713963e34020c22a8bd2d/src/preamble.js#L152