### PR TITLE
Mapbox-GL: update Marker with missing occludedOpacity option

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1866,6 +1866,10 @@ declare namespace mapboxgl {
         getPitchAlignment(): Alignment;
 
         setPitchAlignment(alignment: Alignment): this;
+
+        getOccludedOpacity(): number;
+
+        setOccludedOpacity(opacity: number): this;
     }
 
     type Alignment = 'map' | 'viewport' | 'auto';
@@ -1918,6 +1922,11 @@ declare namespace mapboxgl {
          * The default scale (1) corresponds to a height of `41px` and a width of `27px`.
          */
         scale?: number | undefined;
+
+        /**
+         * The opacity of a marker that's occluded by 3D terrain. Number between 0 and 1.
+         */
+        occludedOpacity?: number | undefined;
     }
 
     type EventedListener = (object?: Object) => any;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -713,6 +713,7 @@ let marker = new mapboxgl.Marker(undefined, {
     rotationAlignment: 'map',
     pitchAlignment: 'viewport',
     scale: 5.5,
+    occludedOpacity: 0.5
 })
     .setLngLat([-50, 50])
     .setPitchAlignment('map')
@@ -728,6 +729,12 @@ marker.getRotation();
 
 // $ExpectType Alignment
 marker.getRotationAlignment();
+
+// $ExpectType number
+marker.getOccludedOpacity();
+
+// $ExpectType Marker
+marker.setOccludedOpacity(1);
 
 marker.remove();
 


### PR DESCRIPTION
in version 2.11.0 Marker component was updated to have `occludedOpacity` option this PR add it to the types.
CHANGELOG: https://github.com/mapbox/mapbox-gl-js/blob/main/CHANGELOG.md#2110

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/api/markers/#marker
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
