### PR TITLE
[node] Fix http2.ClientHttp2Stream.session typing

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -156,7 +156,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/ts4.8/http2.d.ts
+++ b/types/node/ts4.8/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/ts4.8/test/http2.ts
+++ b/types/node/ts4.8/test/http2.ts
@@ -156,7 +156,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -80,7 +80,7 @@ declare module 'http2' {
         readonly sentHeaders: OutgoingHttpHeaders;
         readonly sentInfoHeaders?: OutgoingHttpHeaders[] | undefined;
         readonly sentTrailers?: OutgoingHttpHeaders | undefined;
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         readonly state: StreamState;
 
         close(code?: number, callback?: () => void): void;

--- a/types/node/v14/test/http2.ts
+++ b/types/node/v14/test/http2.ts
@@ -155,7 +155,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v14/ts4.8/http2.d.ts
+++ b/types/node/v14/ts4.8/http2.d.ts
@@ -80,7 +80,7 @@ declare module 'http2' {
         readonly sentHeaders: OutgoingHttpHeaders;
         readonly sentInfoHeaders?: OutgoingHttpHeaders[] | undefined;
         readonly sentTrailers?: OutgoingHttpHeaders | undefined;
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         readonly state: StreamState;
 
         close(code?: number, callback?: () => void): void;

--- a/types/node/v14/ts4.8/test/http2.ts
+++ b/types/node/v14/ts4.8/test/http2.ts
@@ -155,7 +155,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/v16/test/http2.ts
+++ b/types/node/v16/test/http2.ts
@@ -155,7 +155,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v16/ts4.8/http2.d.ts
+++ b/types/node/v16/ts4.8/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/v16/ts4.8/test/http2.ts
+++ b/types/node/v16/ts4.8/test/http2.ts
@@ -155,7 +155,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v18/http2.d.ts
+++ b/types/node/v18/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/v18/test/http2.ts
+++ b/types/node/v18/test/http2.ts
@@ -156,7 +156,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};

--- a/types/node/v18/ts4.8/http2.d.ts
+++ b/types/node/v18/ts4.8/http2.d.ts
@@ -128,7 +128,7 @@ declare module 'http2' {
          * value will be `undefined` after the `Http2Stream` instance is destroyed.
          * @since v8.4.0
          */
-        readonly session: Http2Session;
+        readonly session: Http2Session | undefined;
         /**
          * Provides miscellaneous information about the current state of the`Http2Stream`.
          *

--- a/types/node/v18/ts4.8/test/http2.ts
+++ b/types/node/v18/ts4.8/test/http2.ts
@@ -156,7 +156,7 @@ import { URL } from 'node:url';
         silent: true
     });
 
-    const sesh: Http2Session = http2Stream.session;
+    const sesh: Http2Session | undefined = http2Stream.session;
 
     http2Stream.setTimeout(100, () => {});
     const trailers: OutgoingHttpHeaders = {};


### PR DESCRIPTION
For `http.Http2Stream`, @types/node declares:

```ts
/**
 * A reference to the `Http2Session` instance that owns this `Http2Stream`. The
 * value will be `undefined` after the `Http2Stream` instance is destroyed.
 * @since v8.4.0
 */
 readonly session: Http2Session;
```

The JSDoc block matches the [current documentation](https://nodejs.org/api/http2.html#http2streamsession), and the [documentation for v8.x](https://nodejs.org/docs/latest-v8.x/api/http2.html#http2_http2stream_session) - both say that the property can be `undefined`.

To match the documentation, this changes the type to `readonly session: Http2Session | undefined` for all versions. 

It is possible that this breaks users, but without the fix, it is easy for bugs to slip in that would otherwise be caught by the compiler, see https://github.com/bufbuild/connect-es/issues/725 for example.

