### PR TITLE
[@types/use-global-hook] Updated types for the latest release of 0.3.0

### DIFF
--- a/types/use-global-hook/index.d.ts
+++ b/types/use-global-hook/index.d.ts
@@ -38,7 +38,6 @@ type UseGlobal<S, A> = (() => [S, A]) &
 // The option property also has an initializer function type for backward compatibility with 0.1.2
 // see https://github.com/andregardi/use-global-hook/pull/51/files#diff-5330e30faa98f2945d75901849861a10R4
 export default function useStore<S, A>(
-    React: ReactInterface,
     inititalState: S,
     actions: object,
     options?: Options<S, A> | InitializerFunction<S, A>,

--- a/types/use-global-hook/index.d.ts
+++ b/types/use-global-hook/index.d.ts
@@ -3,16 +3,10 @@
 // Definitions by: James Hong <https://github.com/ojameso>
 //                 Jeremy Powers <https://github.com/wutname1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 4.5
 
 import Immer from 'immer';
 
-// Use an interface so that different versions of React can be used
-interface ReactInterface {
-    useEffect: (...args: any[]) => any;
-    useState: (...args: any[]) => any;
-    useMemo: (...args: any[]) => any;
-}
 // to ignore strict-export-declare-modifiers error
 export {};
 

--- a/types/use-global-hook/index.d.ts
+++ b/types/use-global-hook/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for use-global-hook 0.1
+// Type definitions for use-global-hook 0.3
 // Project: https://github.com/andregardi/use-global-hook#readme
 // Definitions by: James Hong <https://github.com/ojameso>
+//                 Jeremy Powers <https://github.com/wutname1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 

--- a/types/use-global-hook/tslint.json
+++ b/types/use-global-hook/tslint.json
@@ -1,6 +1,6 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "npm-naming": [true,{"mode":"code","errors":[["NoDefaultExport",false]]}]
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/use-global-hook/tslint.json
+++ b/types/use-global-hook/tslint.json
@@ -1,6 +1,6 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false], ["NoDefaultExport", false]]}]
     }
 }

--- a/types/use-global-hook/tslint.json
+++ b/types/use-global-hook/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NoDefaultExport",false]]}]
+    }
+}

--- a/types/use-global-hook/use-global-hook-tests.ts
+++ b/types/use-global-hook/use-global-hook-tests.ts
@@ -26,7 +26,7 @@ const options: Options<stateType, associatedActionsType> = {
 };
 
 // with options
-const store = useStore<stateType, associatedActionsType>(React, { value: '' }, {}, options);
+const store = useStore<stateType, associatedActionsType>({ value: '' }, {}, options);
 
 // default
 store(); // $ExpectType [stateType, associatedActionsType]
@@ -53,12 +53,12 @@ store<string, setFunc>(
 );
 
 // without options
-useStore<stateType, associatedActionsType>(React, { value: '' }, {});
-useStore<stateType, associatedActionsType>(React, { value: '' }, {}, {});
+useStore<stateType, associatedActionsType>({ value: '' }, {});
+useStore<stateType, associatedActionsType>({ value: '' }, {}, {});
 
 // with options
-useStore<stateType, associatedActionsType>(React, { value: '' }, {}, { Immer });
-useStore<stateType, associatedActionsType>(React, { value: '' }, {}, { initializer });
+useStore<stateType, associatedActionsType>({ value: '' }, {}, { Immer });
+useStore<stateType, associatedActionsType>({ value: '' }, {}, { initializer });
 
 // with initializer (backward compatibility with 0.1.2)
-useStore<stateType, associatedActionsType>(React, { value: '' }, {}, initializer);
+useStore<stateType, associatedActionsType>({ value: '' }, {}, initializer);

--- a/types/use-global-hook/use-global-hook-tests.ts
+++ b/types/use-global-hook/use-global-hook-tests.ts
@@ -1,6 +1,5 @@
 import useStore, { Store, InitializerFunction, Options } from 'use-global-hook';
 import Immer from 'immer';
-import React = require('react');
 
 interface stateType {
     value: string;


### PR DESCRIPTION
The latest release of use-global-hook does not need React passed to it. Due to this change the primary function (useStore) has changed from taking 4 parameters with 1 being optional tos 3 parameters with 1 optional.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PR #70](https://github.com/use-global-hook/use-global-hook/pull/70) - [Release 0.3.0](https://github.com/use-global-hook/use-global-hook/releases/tag/v0.3.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
