### PR TITLE
[react-datepicker] fix missing renderMonthContent type

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 4.11
+// Type definitions for react-datepicker 4.15
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 //                 Greg Smith <https://github.com/smrq>

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -157,7 +157,7 @@ export interface ReactDatePickerProps<
     readOnly?: boolean | undefined;
     renderCustomHeader?(params: ReactDatePickerCustomHeaderProps): React.ReactNode;
     renderDayContents?(dayOfMonth: number, date?: Date): React.ReactNode;
-    renderMonthContent?(monthIndex: number, shortMonthText: number, fullMonthText: number): React.ReactNode;
+    renderMonthContent?(monthIndex: number, shortMonthText: string, fullMonthText: string): React.ReactNode;
     required?: boolean | undefined;
     scrollableMonthYearDropdown?: boolean | undefined;
     scrollableYearDropdown?: boolean | undefined;

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -157,6 +157,7 @@ export interface ReactDatePickerProps<
     readOnly?: boolean | undefined;
     renderCustomHeader?(params: ReactDatePickerCustomHeaderProps): React.ReactNode;
     renderDayContents?(dayOfMonth: number, date?: Date): React.ReactNode;
+    renderMonthContent?(monthIndex: number, shortMonthText: number, fullMonthText: number): React.ReactNode;
     required?: boolean | undefined;
     scrollableMonthYearDropdown?: boolean | undefined;
     scrollableYearDropdown?: boolean | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -61,7 +61,7 @@ const topLogger: Modifier<'topLogger'> = {
     filterTime={date => true}
     fixedHeight
     forceShowMonthNavigation
-    formatWeekDay={(day) => day[0]}
+    formatWeekDay={day => day[0]}
     formatWeekNumber={date => 0}
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""
@@ -151,6 +151,7 @@ const topLogger: Modifier<'topLogger'> = {
         nextYearButtonDisabled,
     }) => <div />}
     renderDayContents={(dayOfMonth, date) => <div />}
+    renderMonthContent={(monthIndex, shortMonth, longMonth) => <div />}
     required
     scrollableMonthYearDropdown
     scrollableYearDropdown

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -61,7 +61,7 @@ const topLogger: Modifier<'topLogger'> = {
     filterTime={date => true}
     fixedHeight
     forceShowMonthNavigation
-    formatWeekDay={day => day[0]}
+    formatWeekDay={(day) => day[0]}
     formatWeekNumber={date => 0}
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/blob/main/src/month.jsx#L628
