### PR TITLE
[@types/react] add `PropsWithRequiredChildren` and `PropsWithOptionalChildren` utility types

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -834,6 +834,10 @@ declare namespace React {
 
     type PropsWithChildren<P = unknown> = P & { children?: ReactNode | undefined };
 
+    type PropsWithRequiredChildren<P = unknown> = P & { children: ReactNode };
+
+    type PropsWithOptionalChildren<P = unknown> = PropsWithChildren<P>;
+
     /**
      * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
      * or ComponentPropsWithoutRef when refs are not supported.

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -82,6 +82,20 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
 // @ts-expect-error
 <ComponentWithChildren3 bar="42"></ComponentWithChildren3>;
 
+const ComponentWithRequiredChildren: React.FunctionComponent<React.PropsWithRequiredChildren> = ({children}) => {
+    return <div>{children}</div>;
+};
+// @ts-expect-error
+<ComponentWithRequiredChildren></ComponentWithRequiredChildren>;
+<ComponentWithRequiredChildren>Hello World</ComponentWithRequiredChildren>;
+
+const ComponentWithOptionalChildren: React.FunctionComponent<React.PropsWithOptionalChildren> = ({children}) => {
+    if (!children) return null;
+    return <div>{children}</div>;
+};
+<ComponentWithOptionalChildren></ComponentWithOptionalChildren>;
+<ComponentWithOptionalChildren>Hello World</ComponentWithOptionalChildren>;
+
 // svg sanity check
 <svg suppressHydrationWarning viewBox="0 0 1000 1000">
     <g>


### PR DESCRIPTION
Following the discussion ([66150](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66150)), I propose to add 2 more utility types.

```typescript
type PropsWithRequiredChildren<P = unknown> = P & { children: ReactNode };

type PropsWithOptionalChildren<P = unknown> = PropsWithChildren<P>;
```