### PR TITLE
[electron-progressbar] fix callback type for method `on`

### DIFF
--- a/types/electron-progressbar/electron-progressbar-tests.ts
+++ b/types/electron-progressbar/electron-progressbar-tests.ts
@@ -18,7 +18,7 @@ progressBar.on('progress', () => {
     progressBar.detail = 'progress called 1st time without values';
 });
 
-progressBar.on('progress', (value: any) => {
+progressBar.on('progress', (value: number) => {
     progressBar.detail += ` and 2nd time with value ${value}`;
 });
 

--- a/types/electron-progressbar/electron-progressbar-tests.ts
+++ b/types/electron-progressbar/electron-progressbar-tests.ts
@@ -6,11 +6,20 @@ const progressBar = new ProgressBar({
         webPreferences: {
             nodeIntegration: false
         }
-    }
+    },
+    indeterminate: false
 });
-
-progressBar.value = 10;
 
 progressBar.on('ready', () => {
     return;
 });
+
+progressBar.on('progress', () => {
+    progressBar.detail = 'progress called 1st time without values`
+});
+
+progressBar.on('progress', (value) => {
+    progressBar.detail += ` and 2nd time with value ${value}"`
+});
+
+progressBar.value = 10;

--- a/types/electron-progressbar/electron-progressbar-tests.ts
+++ b/types/electron-progressbar/electron-progressbar-tests.ts
@@ -15,11 +15,11 @@ progressBar.on('ready', () => {
 });
 
 progressBar.on('progress', () => {
-    progressBar.detail = 'progress called 1st time without values'
+    progressBar.detail = 'progress called 1st time without values';
 });
 
-progressBar.on('progress', (value: number) => {
-    progressBar.detail += ` and 2nd time with value ${value}"`
+progressBar.on('progress', (value: any) => {
+    progressBar.detail += ` and 2nd time with value ${value}`;
 });
 
 progressBar.value = 10;

--- a/types/electron-progressbar/electron-progressbar-tests.ts
+++ b/types/electron-progressbar/electron-progressbar-tests.ts
@@ -15,7 +15,7 @@ progressBar.on('ready', () => {
 });
 
 progressBar.on('progress', () => {
-    progressBar.detail = 'progress called 1st time without values`
+    progressBar.detail = 'progress called 1st time without values'
 });
 
 progressBar.on('progress', (value) => {

--- a/types/electron-progressbar/electron-progressbar-tests.ts
+++ b/types/electron-progressbar/electron-progressbar-tests.ts
@@ -18,7 +18,7 @@ progressBar.on('progress', () => {
     progressBar.detail = 'progress called 1st time without values'
 });
 
-progressBar.on('progress', (value) => {
+progressBar.on('progress', (value: number) => {
     progressBar.detail += ` and 2nd time with value ${value}"`
 });
 

--- a/types/electron-progressbar/index.d.ts
+++ b/types/electron-progressbar/index.d.ts
@@ -11,6 +11,7 @@ declare class ProgressBar {
     getOptions(): ProgressBarOptions;
 
     on(eventName: 'ready' | 'progress' | 'completed' | 'aborted', listener: () => void): this;
+    on(eventName: 'progress' | 'completed' | 'aborted', listener: (value: number) => void): this;
 
     setCompleted(): void;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/AndersonMamede/electron-progressbar/blob/ef8805439c993b0d5f12d9019967866e6c9a73a6/source/index.js#L68-L73)>>

## Description 
The method `on` needs an overloading, because with the esclusion of the `ready` event, the callback can accept also a `number` param.

Please note that, as it was for the previuos commit, the tests are not automated tests. (To test Electron you would need to install WebdriverIO, or Selenium, or Microsoft Playwrigh). In any case the module "electron-progressbar" don't implement any tests: https://github.com/AndersonMamede/electron-progressbar/blob/ef8805439c993b0d5f12d9019967866e6c9a73a6/package.json


