### PR TITLE
`react-router-bootstrap`: Add `search` and `hash` to LinkContainerProps.to

### DIFF
--- a/types/react-router-bootstrap/lib/LinkContainer.d.ts
+++ b/types/react-router-bootstrap/lib/LinkContainer.d.ts
@@ -5,13 +5,21 @@ interface LinkContainerProps {
     children: ReactNode;
     onClick?: MouseEventHandler<HTMLElement>;
     replace?: boolean;
-    to: string | { pathname: string };
+    to: To;
     state?: object;
     className?: string;
     activeClassName?: string;
     style?: CSSProperties;
     activeStyle?: CSSProperties;
     isActive?: ((match: any, location: any) => boolean) | boolean;
+}
+
+type To = string | Partial<Path>;
+
+interface Path {
+  pathname: string;
+  search: string;
+  hash: string;
 }
 
 type LinkContainer = ComponentClass<LinkContainerProps>;

--- a/types/react-router-bootstrap/react-router-bootstrap-tests.tsx
+++ b/types/react-router-bootstrap/react-router-bootstrap-tests.tsx
@@ -14,6 +14,9 @@ export class ReactRouterBootstrapTest extends Component {
             <div style={style}>
 
                 <div style={style}>
+                    <LinkContainer to={{ search: 'page=2' }}>
+                      <Button>Link</Button>
+                    </LinkContainer>
                     <LinkContainer to="/page" onClick={(_ev: MouseEvent) => {}} style={{color: 'red'}}>
                       <Button>Link</Button>
                     </LinkContainer>


### PR DESCRIPTION
Description: Mirror the type definition of [`To`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/router/history.ts#L103) and [`Path`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/router/history.ts#L35-L50) from react-router, which this property is passed directly to as the first argument of [`NavigateFunction`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/react-router/lib/hooks.tsx#L151)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`link`](https://reactrouter.com/en/main/components/link), [`To`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/router/history.ts#L103), [`Path`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/router/history.ts#L35-L50), [`NavigateFunction`](https://github.com/remix-run/react-router/blob/868e5157bbb72fb77f827f264a2b7f6f6106147d/packages/react-router/lib/hooks.tsx#L151) and [the js usage](https://github.com/react-bootstrap/react-router-bootstrap/blob/6d3325e9e03fd3750a7e23fb3f9beeb928ab9af6/src/LinkContainer.js#L51)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
