### PR TITLE
[plotly.js] add layout type for PlotlyHTMLElement

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -314,6 +314,7 @@ export interface PlotlyHTMLElement extends HTMLElement {
     ): void;
     removeAllListeners: (handler: string) => void;
     data: Data[];
+    layout: Layout;
 }
 
 export interface ToImgopts {

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -932,6 +932,8 @@ function rand() {
     myPlot.removeAllListeners('plotly_restyle');
 
     myPlot.data; // $ExpectType Data[]
+
+    myPlot.layout; // $ExpectType Layout
 })();
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65953. PlotlyHTMLElement has a `layout` property, as per [docs](https://plotly.com/javascript/plotlyjs-function-reference/#:~:text=After%20plotting%2C%20the%20data%20or%20layout%20can%20always%20be%20retrieved%20from%20the%20%3Cdiv%3E%20element%20in%20which%20the%20plot%20was%20drawn%3A):

> After plotting, the `data` or `layout` can always be retrieved from the `<div>` element in which the plot was drawn

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/javascript/plotlyjs-function-reference/#plotlynewplot
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.