### PR TITLE
[crypto-ld] fixed return types of LDKeypair.signer() and LDKeypair.verifier() methods

### DIFF
--- a/types/crypto-ld/crypto-ld-tests.ts
+++ b/types/crypto-ld/crypto-ld-tests.ts
@@ -8,7 +8,7 @@ cryptoLdTests.generate({ type: '', controller: '' }).then(); // $ExpectType Prom
 cryptoLdTests.fromKeyDocument({ document: {}, checkContext: false, checkRevoked: false }).then(); // $ExpectType Promise<LDKeyPair>
 
 lDKeyPairTests.export({ publicKey: true, privateKey: true }); // $ExpectType object
-lDKeyPairTests.signer(); // $ExpectType { sign: () => void; }
+lDKeyPairTests.signer(); // $ExpectType { sign: ({ data }: { data: Uint8Array; }) => Promise<string | Uint8Array>; }
 lDKeyPairTests.fingerprint(); // $ExpectType string
 lDKeyPairTests.verifyFingerprint({ fingerprint: '' }); // $ExpectType { verified: boolean; }
-lDKeyPairTests.verifier(); // $ExpectType { verify: () => void; }
+lDKeyPairTests.verifier(); // $ExpectType { verify: ({ data, signature }: { data: Uint8Array; signature: Uint8Array; }) => Promise<boolean>; }

--- a/types/crypto-ld/index.d.ts
+++ b/types/crypto-ld/index.d.ts
@@ -60,7 +60,7 @@ export class LDKeyPair {
         verified: boolean;
     };
 
-    signer(): { sign: () => void };
+    signer(): { sign: ({data}: {data: Uint8Array}) => Promise<string | Uint8Array> };
 
-    verifier(): { verify: () => void };
+    verifier(): { verify: ({data, signature}: {data: Uint8Array, signature: Uint8Array}) => Promise<boolean> };
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes

Based on `crypto-ld` usage in @digitalbazaar's (original author of crypto-ld) [ed25519-verification-key-2020](https://github.com/digitalbazaar/ed25519-verification-key-2020) the return type of [signer.sign()](https://github.com/digitalbazaar/ed25519-verification-key-2020/blob/84f727ec01a8ce77f329955121077fde07b158e9/lib/Ed25519VerificationKey2020.js#L403) and [verifier.verify()](https://github.com/digitalbazaar/ed25519-verification-key-2020/blob/84f727ec01a8ce77f329955121077fde07b158e9/lib/Ed25519VerificationKey2020.js#L417) functions must not be `void`.
