### PR TITLE
Undeprecate Global React JSX Namespace

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3220,9 +3220,6 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
             : P;
 
 declare global {
-    /**
-     * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
-     */
     namespace JSX {
         // We don't just alias React.ElementType because React.ElementType
         // historically does more than we need it to.


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464 (landed in semver patch release `@types/react@18.2.6`) scopes the JSX namespace as `React.JSX` to avoid collisions with multiple libraries working in the JSX namespace.

This change also deprecated the existing JSX namespace, so existing usages of `JSX.Element`, etc are flagged in-editor.

<img width="686" alt="Screenshot 2023-07-25 at 14 11 59" src="https://github.com/facebook/react-native/assets/4661784/531a4f88-8090-43aa-86d6-4af595d4cb5d"> 

This has a pretty drastic effect of making many (most?) non-anonymous function components, with an explicit return type, now fire deprecation warnings.

In DefinitelyTyped itself, the hundreds of packages using `JSX.Element` outside of the direct React typings were not updated. TypeScript's [own documentation](https://www.typescriptlang.org/docs/handbook/jsx.html) also still suggests using `JSX.Element`. This is echoed by a platitude of existing documentation, and googling for `React.JSX.Element` will just bring up information about `JSX.Element`.

Due to the very widespread usage of the deprecated namespace, and disconnect with existing code, documentation, and resources, this change removes the `@deprecated` annotation. I think there might still be a possible path to discouraging usage, but there needs to be a lot of legwork to get there in a way which isn't disruptive.
