### PR TITLE
[node] Update types to v20.5.0

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -303,6 +303,11 @@ declare module 'child_process' {
          */
         kill(signal?: NodeJS.Signals | number): boolean;
         /**
+         * Calls {@link ChildProcess.kill} with `'SIGTERM'`.
+         * @since v20.5.0
+         */
+        [Symbol.dispose](): void;
+        /**
          * When an IPC channel has been established between the parent and child (
          * i.e. when using {@link fork}), the `subprocess.send()` method can
          * be used to send messages to the child process. When the child process is a

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -538,6 +538,11 @@ declare module 'dgram' {
         prependOnceListener(event: 'error', listener: (err: Error) => void): this;
         prependOnceListener(event: 'listening', listener: () => void): this;
         prependOnceListener(event: 'message', listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
+        /**
+         * Calls `socket.close()` and returns a promise that fulfills when the socket has closed.
+         * @since v20.5.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 }
 declare module 'node:dgram' {

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -339,6 +339,41 @@ declare module 'events' {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v20.5.0
+         * @experimental
+         * @return that removes the `abort` listener.
+         */
+        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        /**
          * This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
          *
          * Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -456,6 +456,11 @@ declare module 'fs/promises' {
          * @return Fulfills with `undefined` upon success.
          */
         close(): Promise<void>;
+        /**
+         * An alias for {@link FileHandle.close()}.
+         * @since v20.4.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     const constants: typeof fsConstants;
     /**

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -84,6 +84,28 @@ declare var AbortSignal: typeof globalThis extends {onmessage: any; AbortSignal:
     };
 //#endregion borrowed
 
+//#region Disposable
+interface SymbolConstructor {
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    readonly dispose: unique symbol;
+
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}
+//#endregion Disposable
+
 //#region ArrayLike.at()
 interface RelativeIndexable<T> {
     /**

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.4
+// Type definitions for non-npm package Node.js 20.5
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -639,6 +639,11 @@ declare module 'net' {
         prependOnceListener(event: 'error', listener: (err: Error) => void): this;
         prependOnceListener(event: 'listening', listener: () => void): this;
         prependOnceListener(event: 'drop', listener: (data?: DropArgument) => void): this;
+        /**
+         * Calls {@link Server.close()} and returns a promise that fulfills when the server has closed.
+         * @since v20.5.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     type IPVersion = 'ipv4' | 'ipv6';
     /**

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -477,6 +477,11 @@ declare module 'stream' {
         removeListener(event: 'resume', listener: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
         [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        /**
+         * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
+         * @since v20.4.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     import WritableOptions = internal.WritableOptions;
     class WritableBase extends Stream implements NodeJS.WritableStream {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -259,6 +259,16 @@ declare module 'node:test' {
      * If the test uses callbacks, the callback function is passed as an argument
      */
     type SuiteFn = (s: SuiteContext) => void | Promise<void>;
+    interface TestShard {
+        /**
+         * A positive integer between 1 and `<total>` that specifies the index of the shard to run.
+         */
+        index: number;
+        /**
+         * A positive integer that specifies the total number of shards to split the test files to.
+         */
+        total: number;
+    }
     interface RunOptions {
         /**
          * If a number is provided, then that many files would run in parallel.
@@ -301,9 +311,15 @@ declare module 'node:test' {
          */
         setup?: (root: Test) => void | Promise<void>;
         /**
-         * Whether to run in watch mode or not. Default: false.
+         * Whether to run in watch mode or not.
+         * @default false
          */
-        watch?: boolean;
+        watch?: boolean | undefined;
+        /**
+         * Running tests in a specific shard.
+         * @default undefined
+         */
+        shard?: TestShard | undefined;
     }
     class Test extends AsyncResource {
         concurrency: number;
@@ -1210,6 +1226,10 @@ declare module 'node:test' {
          * @since v20.4.0
          */
         runAll(): void;
+        /**
+         * Calls {@link MockTimers.reset()}.
+         */
+        [Symbol.dispose](): void;
     }
     export { test as default, run, test, describe, it, before, after, beforeEach, afterEach, mock, skip, only, todo };
 }

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -377,6 +377,7 @@ async function testPromisify() {
     _boolean = cp.kill();
     _boolean = cp.kill(9);
     _boolean = cp.kill("SIGTERM");
+    cp[Symbol.dispose]();
 
     _maybeNumber = cp.exitCode;
     _maybeSignal = cp.signalCode;

--- a/types/node/test/dgram.ts
+++ b/types/node/test/dgram.ts
@@ -18,6 +18,7 @@ import * as dns from 'node:dns';
     ds = ds.close();
     ds.setMulticastInterface("127.0.0.1");
     ds = dgram.createSocket({ type: "udp4", reuseAddr: true, recvBufferSize: 1000, sendBufferSize: 1000, lookup: dns.lookup });
+    ds[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -130,3 +130,16 @@ async function test() {
     const eventEmitter = new events.EventEmitter();
     events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
 }
+
+{
+    let disposable: Disposable | undefined;
+    try {
+        const signal = new AbortSignal();
+        signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+        disposable = events.addAbortListener(signal, (e) => {
+            console.log(e);
+        });
+    } finally {
+        disposable?.[Symbol.dispose]();
+    }
+}

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -35,6 +35,9 @@ import * as dns from 'node:dns';
         keepAliveTimeout: 100
     }, reqListener);
 
+    server.close();
+    server[Symbol.asyncDispose]();
+
     // test public props
     const maxHeadersCount: number | null = server.maxHeadersCount;
     const maxRequestsPerSocket: number | null = server.maxRequestsPerSocket;

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -351,6 +351,7 @@ import { Socket } from 'node:dgram';
 
     _socket.destroy();
     _server.close();
+    _server[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -521,6 +521,9 @@ function stream_readable_pipe_test() {
     r.close();
     z.close();
     rs.close();
+
+    rs.destroy();
+    rs[Symbol.asyncDispose]();
 }
 
 function stream_duplex_allowHalfOpen_test() {

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -22,7 +22,11 @@ run({
     inspectPort: () => 8081,
     testNamePatterns: ['executed'],
     setup: (root) => {},
-    watch: true
+    watch: true,
+    shard: {
+        index: 1,
+        total: 3,
+    },
 });
 
 // TestsStream should be a NodeJS.ReadableStream

--- a/types/node/test/timers.ts
+++ b/types/node/test/timers.ts
@@ -96,9 +96,12 @@ import * as timers from 'node:timers';
     function waitFor(options?: { timeout: number }) {
         const timerId = options && setTimeout(() => {}, options.timeout);
         clearTimeout(timerId);
+        timerId?.[Symbol.dispose]();
         const intervalId = options && setTimeout(() => {}, options.timeout);
         clearInterval(intervalId);
+        intervalId?.[Symbol.dispose]();
         const immediateId = options && setImmediate(() => {});
         clearImmediate(immediateId);
+        immediateId?.[Symbol.dispose]();
     }
 }

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -68,6 +68,11 @@ declare module 'timers' {
                  */
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
+                /**
+                 * Cancels the immediate. This is similar to calling `clearImmediate()`.
+                 * @since v20.5.0
+                 */
+                [Symbol.dispose](): void;
             }
             /**
              * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
@@ -114,6 +119,11 @@ declare module 'timers' {
                  */
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
+                /**
+                 * Cancels the timeout.
+                 * @since v20.5.0
+                 */
+                [Symbol.dispose](): void;
             }
         }
         /**
@@ -163,10 +173,10 @@ declare module 'timers' {
          * @param args Optional arguments to pass when the `callback` is called.
          * @return for use with {@link clearInterval}
          */
-        function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
+        function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
-        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timer;
+        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }

--- a/types/node/ts4.8/child_process.d.ts
+++ b/types/node/ts4.8/child_process.d.ts
@@ -303,6 +303,11 @@ declare module 'child_process' {
          */
         kill(signal?: NodeJS.Signals | number): boolean;
         /**
+         * Calls {@link ChildProcess.kill} with `'SIGTERM'`.
+         * @since v20.5.0
+         */
+        [Symbol.dispose](): void;
+        /**
          * When an IPC channel has been established between the parent and child (
          * i.e. when using {@link fork}), the `subprocess.send()` method can
          * be used to send messages to the child process. When the child process is a

--- a/types/node/ts4.8/dgram.d.ts
+++ b/types/node/ts4.8/dgram.d.ts
@@ -538,6 +538,11 @@ declare module 'dgram' {
         prependOnceListener(event: 'error', listener: (err: Error) => void): this;
         prependOnceListener(event: 'listening', listener: () => void): this;
         prependOnceListener(event: 'message', listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
+        /**
+         * Calls `socket.close()` and returns a promise that fulfills when the socket has closed.
+         * @since v20.5.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 }
 declare module 'node:dgram' {

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -339,6 +339,41 @@ declare module 'events' {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v20.5.0
+         * @experimental
+         * @return that removes the `abort` listener.
+         */
+        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        /**
          * This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
          *
          * Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no

--- a/types/node/ts4.8/fs/promises.d.ts
+++ b/types/node/ts4.8/fs/promises.d.ts
@@ -456,6 +456,11 @@ declare module 'fs/promises' {
          * @return Fulfills with `undefined` upon success.
          */
         close(): Promise<void>;
+        /**
+         * An alias for {@link FileHandle.close()}.
+         * @since v20.4.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     const constants: typeof fsConstants;
     /**

--- a/types/node/ts4.8/globals.d.ts
+++ b/types/node/ts4.8/globals.d.ts
@@ -84,6 +84,28 @@ declare var AbortSignal: typeof globalThis extends {onmessage: any; AbortSignal:
     };
 //#endregion borrowed
 
+//#region Disposable
+interface SymbolConstructor {
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    readonly dispose: unique symbol;
+
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}
+//#endregion Disposable
+
 //#region ArrayLike.at()
 interface RelativeIndexable<T> {
     /**

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -639,6 +639,11 @@ declare module 'net' {
         prependOnceListener(event: 'error', listener: (err: Error) => void): this;
         prependOnceListener(event: 'listening', listener: () => void): this;
         prependOnceListener(event: 'drop', listener: (data?: DropArgument) => void): this;
+        /**
+         * Calls {@link Server.close()} and returns a promise that fulfills when the server has closed.
+         * @since v20.5.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     type IPVersion = 'ipv4' | 'ipv6';
     /**

--- a/types/node/ts4.8/stream.d.ts
+++ b/types/node/ts4.8/stream.d.ts
@@ -34,6 +34,744 @@ declare module 'stream' {
         ): T;
         compose<T extends NodeJS.ReadableStream>(stream: T | ComposeFnParam | Iterable<T> | AsyncIterable<T>, options?: { signal: AbortSignal }): T;
     }
+    import Stream = internal.Stream;
+    import Readable = internal.Readable;
+    import ReadableOptions = internal.ReadableOptions;
+    class ReadableBase extends Stream implements NodeJS.ReadableStream {
+        /**
+         * A utility method for creating Readable Streams out of iterators.
+         */
+        static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+        /**
+         * Returns whether the stream has been read from or cancelled.
+         * @since v16.8.0
+         */
+        static isDisturbed(stream: Readable | NodeJS.ReadableStream): boolean;
+        /**
+         * Returns whether the stream was destroyed or errored before emitting `'end'`.
+         * @since v16.8.0
+         * @experimental
+         */
+        readonly readableAborted: boolean;
+        /**
+         * Is `true` if it is safe to call `readable.read()`, which means
+         * the stream has not been destroyed or emitted `'error'` or `'end'`.
+         * @since v11.4.0
+         */
+        readable: boolean;
+        /**
+         * Returns whether `'data'` has been emitted.
+         * @since v16.7.0, v14.18.0
+         * @experimental
+         */
+        readonly readableDidRead: boolean;
+        /**
+         * Getter for the property `encoding` of a given `Readable` stream. The `encoding`property can be set using the `readable.setEncoding()` method.
+         * @since v12.7.0
+         */
+        readonly readableEncoding: BufferEncoding | null;
+        /**
+         * Becomes `true` when `'end'` event is emitted.
+         * @since v12.9.0
+         */
+        readonly readableEnded: boolean;
+        /**
+         * This property reflects the current state of a `Readable` stream as described
+         * in the `Three states` section.
+         * @since v9.4.0
+         */
+        readonly readableFlowing: boolean | null;
+        /**
+         * Returns the value of `highWaterMark` passed when creating this `Readable`.
+         * @since v9.3.0
+         */
+        readonly readableHighWaterMark: number;
+        /**
+         * This property contains the number of bytes (or objects) in the queue
+         * ready to be read. The value provides introspection data regarding
+         * the status of the `highWaterMark`.
+         * @since v9.4.0
+         */
+        readonly readableLength: number;
+        /**
+         * Getter for the property `objectMode` of a given `Readable` stream.
+         * @since v12.3.0
+         */
+        readonly readableObjectMode: boolean;
+        /**
+         * Is `true` after `readable.destroy()` has been called.
+         * @since v8.0.0
+         */
+        destroyed: boolean;
+        /**
+         * Is `true` after `'close'` has been emitted.
+         * @since v18.0.0
+         */
+        readonly closed: boolean;
+        /**
+         * Returns error if the stream has been destroyed with an error.
+         * @since v18.0.0
+         */
+        readonly errored: Error | null;
+        constructor(opts?: ReadableOptions);
+        _construct?(callback: (error?: Error | null) => void): void;
+        _read(size: number): void;
+        /**
+         * The `readable.read()` method reads data out of the internal buffer and
+         * returns it. If no data is available to be read, `null` is returned. By default,
+         * the data is returned as a `Buffer` object unless an encoding has been
+         * specified using the `readable.setEncoding()` method or the stream is operating
+         * in object mode.
+         *
+         * The optional `size` argument specifies a specific number of bytes to read. If`size` bytes are not available to be read, `null` will be returned _unless_the stream has ended, in which
+         * case all of the data remaining in the internal
+         * buffer will be returned.
+         *
+         * If the `size` argument is not specified, all of the data contained in the
+         * internal buffer will be returned.
+         *
+         * The `size` argument must be less than or equal to 1 GiB.
+         *
+         * The `readable.read()` method should only be called on `Readable` streams
+         * operating in paused mode. In flowing mode, `readable.read()` is called
+         * automatically until the internal buffer is fully drained.
+         *
+         * ```js
+         * const readable = getReadableStreamSomehow();
+         *
+         * // 'readable' may be triggered multiple times as data is buffered in
+         * readable.on('readable', () => {
+         *   let chunk;
+         *   console.log('Stream is readable (new data received in buffer)');
+         *   // Use a loop to make sure we read all currently available data
+         *   while (null !== (chunk = readable.read())) {
+         *     console.log(`Read ${chunk.length} bytes of data...`);
+         *   }
+         * });
+         *
+         * // 'end' will be triggered once when there is no more data available
+         * readable.on('end', () => {
+         *   console.log('Reached end of stream.');
+         * });
+         * ```
+         *
+         * Each call to `readable.read()` returns a chunk of data, or `null`. The chunks
+         * are not concatenated. A `while` loop is necessary to consume all data
+         * currently in the buffer. When reading a large file `.read()` may return `null`,
+         * having consumed all buffered content so far, but there is still more data to
+         * come not yet buffered. In this case a new `'readable'` event will be emitted
+         * when there is more data in the buffer. Finally the `'end'` event will be
+         * emitted when there is no more data to come.
+         *
+         * Therefore to read a file's whole contents from a `readable`, it is necessary
+         * to collect chunks across multiple `'readable'` events:
+         *
+         * ```js
+         * const chunks = [];
+         *
+         * readable.on('readable', () => {
+         *   let chunk;
+         *   while (null !== (chunk = readable.read())) {
+         *     chunks.push(chunk);
+         *   }
+         * });
+         *
+         * readable.on('end', () => {
+         *   const content = chunks.join('');
+         * });
+         * ```
+         *
+         * A `Readable` stream in object mode will always return a single item from
+         * a call to `readable.read(size)`, regardless of the value of the`size` argument.
+         *
+         * If the `readable.read()` method returns a chunk of data, a `'data'` event will
+         * also be emitted.
+         *
+         * Calling {@link read} after the `'end'` event has
+         * been emitted will return `null`. No runtime error will be raised.
+         * @since v0.9.4
+         * @param size Optional argument to specify how much data to read.
+         */
+        read(size?: number): any;
+        /**
+         * The `readable.setEncoding()` method sets the character encoding for
+         * data read from the `Readable` stream.
+         *
+         * By default, no encoding is assigned and stream data will be returned as`Buffer` objects. Setting an encoding causes the stream data
+         * to be returned as strings of the specified encoding rather than as `Buffer`objects. For instance, calling `readable.setEncoding('utf8')` will cause the
+         * output data to be interpreted as UTF-8 data, and passed as strings. Calling`readable.setEncoding('hex')` will cause the data to be encoded in hexadecimal
+         * string format.
+         *
+         * The `Readable` stream will properly handle multi-byte characters delivered
+         * through the stream that would otherwise become improperly decoded if simply
+         * pulled from the stream as `Buffer` objects.
+         *
+         * ```js
+         * const readable = getReadableStreamSomehow();
+         * readable.setEncoding('utf8');
+         * readable.on('data', (chunk) => {
+         *   assert.equal(typeof chunk, 'string');
+         *   console.log('Got %d characters of string data:', chunk.length);
+         * });
+         * ```
+         * @since v0.9.4
+         * @param encoding The encoding to use.
+         */
+        setEncoding(encoding: BufferEncoding): this;
+        /**
+         * The `readable.pause()` method will cause a stream in flowing mode to stop
+         * emitting `'data'` events, switching out of flowing mode. Any data that
+         * becomes available will remain in the internal buffer.
+         *
+         * ```js
+         * const readable = getReadableStreamSomehow();
+         * readable.on('data', (chunk) => {
+         *   console.log(`Received ${chunk.length} bytes of data.`);
+         *   readable.pause();
+         *   console.log('There will be no additional data for 1 second.');
+         *   setTimeout(() => {
+         *     console.log('Now data will start flowing again.');
+         *     readable.resume();
+         *   }, 1000);
+         * });
+         * ```
+         *
+         * The `readable.pause()` method has no effect if there is a `'readable'`event listener.
+         * @since v0.9.4
+         */
+        pause(): this;
+        /**
+         * The `readable.resume()` method causes an explicitly paused `Readable` stream to
+         * resume emitting `'data'` events, switching the stream into flowing mode.
+         *
+         * The `readable.resume()` method can be used to fully consume the data from a
+         * stream without actually processing any of that data:
+         *
+         * ```js
+         * getReadableStreamSomehow()
+         *   .resume()
+         *   .on('end', () => {
+         *     console.log('Reached the end, but did not read anything.');
+         *   });
+         * ```
+         *
+         * The `readable.resume()` method has no effect if there is a `'readable'`event listener.
+         * @since v0.9.4
+         */
+        resume(): this;
+        /**
+         * The `readable.isPaused()` method returns the current operating state of the`Readable`. This is used primarily by the mechanism that underlies the`readable.pipe()` method. In most
+         * typical cases, there will be no reason to
+         * use this method directly.
+         *
+         * ```js
+         * const readable = new stream.Readable();
+         *
+         * readable.isPaused(); // === false
+         * readable.pause();
+         * readable.isPaused(); // === true
+         * readable.resume();
+         * readable.isPaused(); // === false
+         * ```
+         * @since v0.11.14
+         */
+        isPaused(): boolean;
+        /**
+         * The `readable.unpipe()` method detaches a `Writable` stream previously attached
+         * using the {@link pipe} method.
+         *
+         * If the `destination` is not specified, then _all_ pipes are detached.
+         *
+         * If the `destination` is specified, but no pipe is set up for it, then
+         * the method does nothing.
+         *
+         * ```js
+         * const fs = require('node:fs');
+         * const readable = getReadableStreamSomehow();
+         * const writable = fs.createWriteStream('file.txt');
+         * // All the data from readable goes into 'file.txt',
+         * // but only for the first second.
+         * readable.pipe(writable);
+         * setTimeout(() => {
+         *   console.log('Stop writing to file.txt.');
+         *   readable.unpipe(writable);
+         *   console.log('Manually close the file stream.');
+         *   writable.end();
+         * }, 1000);
+         * ```
+         * @since v0.9.4
+         * @param destination Optional specific stream to unpipe
+         */
+        unpipe(destination?: NodeJS.WritableStream): this;
+        /**
+         * Passing `chunk` as `null` signals the end of the stream (EOF) and behaves the
+         * same as `readable.push(null)`, after which no more data can be written. The EOF
+         * signal is put at the end of the buffer and any buffered data will still be
+         * flushed.
+         *
+         * The `readable.unshift()` method pushes a chunk of data back into the internal
+         * buffer. This is useful in certain situations where a stream is being consumed by
+         * code that needs to "un-consume" some amount of data that it has optimistically
+         * pulled out of the source, so that the data can be passed on to some other party.
+         *
+         * The `stream.unshift(chunk)` method cannot be called after the `'end'` event
+         * has been emitted or a runtime error will be thrown.
+         *
+         * Developers using `stream.unshift()` often should consider switching to
+         * use of a `Transform` stream instead. See the `API for stream implementers` section for more information.
+         *
+         * ```js
+         * // Pull off a header delimited by \n\n.
+         * // Use unshift() if we get too much.
+         * // Call the callback with (error, header, stream).
+         * const { StringDecoder } = require('node:string_decoder');
+         * function parseHeader(stream, callback) {
+         *   stream.on('error', callback);
+         *   stream.on('readable', onReadable);
+         *   const decoder = new StringDecoder('utf8');
+         *   let header = '';
+         *   function onReadable() {
+         *     let chunk;
+         *     while (null !== (chunk = stream.read())) {
+         *       const str = decoder.write(chunk);
+         *       if (str.includes('\n\n')) {
+         *         // Found the header boundary.
+         *         const split = str.split(/\n\n/);
+         *         header += split.shift();
+         *         const remaining = split.join('\n\n');
+         *         const buf = Buffer.from(remaining, 'utf8');
+         *         stream.removeListener('error', callback);
+         *         // Remove the 'readable' listener before unshifting.
+         *         stream.removeListener('readable', onReadable);
+         *         if (buf.length)
+         *           stream.unshift(buf);
+         *         // Now the body of the message can be read from the stream.
+         *         callback(null, header, stream);
+         *         return;
+         *       }
+         *       // Still reading the header.
+         *       header += str;
+         *     }
+         *   }
+         * }
+         * ```
+         *
+         * Unlike {@link push}, `stream.unshift(chunk)` will not
+         * end the reading process by resetting the internal reading state of the stream.
+         * This can cause unexpected results if `readable.unshift()` is called during a
+         * read (i.e. from within a {@link _read} implementation on a
+         * custom stream). Following the call to `readable.unshift()` with an immediate {@link push} will reset the reading state appropriately,
+         * however it is best to simply avoid calling `readable.unshift()` while in the
+         * process of performing a read.
+         * @since v0.9.11
+         * @param chunk Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode
+         * streams, `chunk` may be any JavaScript value.
+         * @param encoding Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`.
+         */
+        unshift(chunk: any, encoding?: BufferEncoding): void;
+        /**
+         * Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
+         * information.)
+         *
+         * When using an older Node.js library that emits `'data'` events and has a {@link pause} method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
+         * stream that uses
+         * the old stream as its data source.
+         *
+         * It will rarely be necessary to use `readable.wrap()` but the method has been
+         * provided as a convenience for interacting with older Node.js applications and
+         * libraries.
+         *
+         * ```js
+         * const { OldReader } = require('./old-api-module.js');
+         * const { Readable } = require('node:stream');
+         * const oreader = new OldReader();
+         * const myReader = new Readable().wrap(oreader);
+         *
+         * myReader.on('readable', () => {
+         *   myReader.read(); // etc.
+         * });
+         * ```
+         * @since v0.9.4
+         * @param stream An "old style" readable stream
+         */
+        wrap(stream: NodeJS.ReadableStream): this;
+        push(chunk: any, encoding?: BufferEncoding): boolean;
+        _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+        /**
+         * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the readable
+         * stream will release any internal resources and subsequent calls to `push()`will be ignored.
+         *
+         * Once `destroy()` has been called any further calls will be a no-op and no
+         * further errors except from `_destroy()` may be emitted as `'error'`.
+         *
+         * Implementors should not override this method, but instead implement `readable._destroy()`.
+         * @since v8.0.0
+         * @param error Error which will be passed as payload in `'error'` event
+         */
+        destroy(error?: Error): this;
+        /**
+         * Event emitter
+         * The defined events on documents including:
+         * 1. close
+         * 2. data
+         * 3. end
+         * 4. error
+         * 5. pause
+         * 6. readable
+         * 7. resume
+         */
+        addListener(event: 'close', listener: () => void): this;
+        addListener(event: 'data', listener: (chunk: any) => void): this;
+        addListener(event: 'end', listener: () => void): this;
+        addListener(event: 'error', listener: (err: Error) => void): this;
+        addListener(event: 'pause', listener: () => void): this;
+        addListener(event: 'readable', listener: () => void): this;
+        addListener(event: 'resume', listener: () => void): this;
+        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        emit(event: 'close'): boolean;
+        emit(event: 'data', chunk: any): boolean;
+        emit(event: 'end'): boolean;
+        emit(event: 'error', err: Error): boolean;
+        emit(event: 'pause'): boolean;
+        emit(event: 'readable'): boolean;
+        emit(event: 'resume'): boolean;
+        emit(event: string | symbol, ...args: any[]): boolean;
+        on(event: 'close', listener: () => void): this;
+        on(event: 'data', listener: (chunk: any) => void): this;
+        on(event: 'end', listener: () => void): this;
+        on(event: 'error', listener: (err: Error) => void): this;
+        on(event: 'pause', listener: () => void): this;
+        on(event: 'readable', listener: () => void): this;
+        on(event: 'resume', listener: () => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
+        once(event: 'close', listener: () => void): this;
+        once(event: 'data', listener: (chunk: any) => void): this;
+        once(event: 'end', listener: () => void): this;
+        once(event: 'error', listener: (err: Error) => void): this;
+        once(event: 'pause', listener: () => void): this;
+        once(event: 'readable', listener: () => void): this;
+        once(event: 'resume', listener: () => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
+        prependListener(event: 'close', listener: () => void): this;
+        prependListener(event: 'data', listener: (chunk: any) => void): this;
+        prependListener(event: 'end', listener: () => void): this;
+        prependListener(event: 'error', listener: (err: Error) => void): this;
+        prependListener(event: 'pause', listener: () => void): this;
+        prependListener(event: 'readable', listener: () => void): this;
+        prependListener(event: 'resume', listener: () => void): this;
+        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: 'close', listener: () => void): this;
+        prependOnceListener(event: 'data', listener: (chunk: any) => void): this;
+        prependOnceListener(event: 'end', listener: () => void): this;
+        prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+        prependOnceListener(event: 'pause', listener: () => void): this;
+        prependOnceListener(event: 'readable', listener: () => void): this;
+        prependOnceListener(event: 'resume', listener: () => void): this;
+        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        removeListener(event: 'close', listener: () => void): this;
+        removeListener(event: 'data', listener: (chunk: any) => void): this;
+        removeListener(event: 'end', listener: () => void): this;
+        removeListener(event: 'error', listener: (err: Error) => void): this;
+        removeListener(event: 'pause', listener: () => void): this;
+        removeListener(event: 'readable', listener: () => void): this;
+        removeListener(event: 'resume', listener: () => void): this;
+        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        /**
+         * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
+         * @since v20.4.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+    }
+    import WritableOptions = internal.WritableOptions;
+    class WritableBase extends Stream implements NodeJS.WritableStream {
+        /**
+         * Is `true` if it is safe to call `writable.write()`, which means
+         * the stream has not been destroyed, errored, or ended.
+         * @since v11.4.0
+         */
+        readonly writable: boolean;
+        /**
+         * Is `true` after `writable.end()` has been called. This property
+         * does not indicate whether the data has been flushed, for this use `writable.writableFinished` instead.
+         * @since v12.9.0
+         */
+        readonly writableEnded: boolean;
+        /**
+         * Is set to `true` immediately before the `'finish'` event is emitted.
+         * @since v12.6.0
+         */
+        readonly writableFinished: boolean;
+        /**
+         * Return the value of `highWaterMark` passed when creating this `Writable`.
+         * @since v9.3.0
+         */
+        readonly writableHighWaterMark: number;
+        /**
+         * This property contains the number of bytes (or objects) in the queue
+         * ready to be written. The value provides introspection data regarding
+         * the status of the `highWaterMark`.
+         * @since v9.4.0
+         */
+        readonly writableLength: number;
+        /**
+         * Getter for the property `objectMode` of a given `Writable` stream.
+         * @since v12.3.0
+         */
+        readonly writableObjectMode: boolean;
+        /**
+         * Number of times `writable.uncork()` needs to be
+         * called in order to fully uncork the stream.
+         * @since v13.2.0, v12.16.0
+         */
+        readonly writableCorked: number;
+        /**
+         * Is `true` after `writable.destroy()` has been called.
+         * @since v8.0.0
+         */
+        destroyed: boolean;
+        /**
+         * Is `true` after `'close'` has been emitted.
+         * @since v18.0.0
+         */
+        readonly closed: boolean;
+        /**
+         * Returns error if the stream has been destroyed with an error.
+         * @since v18.0.0
+         */
+        readonly errored: Error | null;
+        /**
+         * Is `true` if the stream's buffer has been full and stream will emit `'drain'`.
+         * @since v15.2.0, v14.17.0
+         */
+        readonly writableNeedDrain: boolean;
+        constructor(opts?: WritableOptions);
+        _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+        _writev?(
+            chunks: Array<{
+                chunk: any;
+                encoding: BufferEncoding;
+            }>,
+            callback: (error?: Error | null) => void
+        ): void;
+        _construct?(callback: (error?: Error | null) => void): void;
+        _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+        _final(callback: (error?: Error | null) => void): void;
+        /**
+         * The `writable.write()` method writes some data to the stream, and calls the
+         * supplied `callback` once the data has been fully handled. If an error
+         * occurs, the `callback` will be called with the error as its
+         * first argument. The `callback` is called asynchronously and before `'error'` is
+         * emitted.
+         *
+         * The return value is `true` if the internal buffer is less than the`highWaterMark` configured when the stream was created after admitting `chunk`.
+         * If `false` is returned, further attempts to write data to the stream should
+         * stop until the `'drain'` event is emitted.
+         *
+         * While a stream is not draining, calls to `write()` will buffer `chunk`, and
+         * return false. Once all currently buffered chunks are drained (accepted for
+         * delivery by the operating system), the `'drain'` event will be emitted.
+         * Once `write()` returns false, do not write more chunks
+         * until the `'drain'` event is emitted. While calling `write()` on a stream that
+         * is not draining is allowed, Node.js will buffer all written chunks until
+         * maximum memory usage occurs, at which point it will abort unconditionally.
+         * Even before it aborts, high memory usage will cause poor garbage collector
+         * performance and high RSS (which is not typically released back to the system,
+         * even after the memory is no longer required). Since TCP sockets may never
+         * drain if the remote peer does not read the data, writing a socket that is
+         * not draining may lead to a remotely exploitable vulnerability.
+         *
+         * Writing data while the stream is not draining is particularly
+         * problematic for a `Transform`, because the `Transform` streams are paused
+         * by default until they are piped or a `'data'` or `'readable'` event handler
+         * is added.
+         *
+         * If the data to be written can be generated or fetched on demand, it is
+         * recommended to encapsulate the logic into a `Readable` and use {@link pipe}. However, if calling `write()` is preferred, it is
+         * possible to respect backpressure and avoid memory issues using the `'drain'` event:
+         *
+         * ```js
+         * function write(data, cb) {
+         *   if (!stream.write(data)) {
+         *     stream.once('drain', cb);
+         *   } else {
+         *     process.nextTick(cb);
+         *   }
+         * }
+         *
+         * // Wait for cb to be called before doing any other write.
+         * write('hello', () => {
+         *   console.log('Write completed, do more writes now.');
+         * });
+         * ```
+         *
+         * A `Writable` stream in object mode will always ignore the `encoding` argument.
+         * @since v0.9.4
+         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
+         * JavaScript value other than `null`.
+         * @param [encoding='utf8'] The encoding, if `chunk` is a string.
+         * @param callback Callback for when this chunk of data is flushed.
+         * @return `false` if the stream wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
+         */
+        write(chunk: any, callback?: (error: Error | null | undefined) => void): boolean;
+        write(chunk: any, encoding: BufferEncoding, callback?: (error: Error | null | undefined) => void): boolean;
+        /**
+         * The `writable.setDefaultEncoding()` method sets the default `encoding` for a `Writable` stream.
+         * @since v0.11.15
+         * @param encoding The new default encoding
+         */
+        setDefaultEncoding(encoding: BufferEncoding): this;
+        /**
+         * Calling the `writable.end()` method signals that no more data will be written
+         * to the `Writable`. The optional `chunk` and `encoding` arguments allow one
+         * final additional chunk of data to be written immediately before closing the
+         * stream.
+         *
+         * Calling the {@link write} method after calling {@link end} will raise an error.
+         *
+         * ```js
+         * // Write 'hello, ' and then end with 'world!'.
+         * const fs = require('node:fs');
+         * const file = fs.createWriteStream('example.txt');
+         * file.write('hello, ');
+         * file.end('world!');
+         * // Writing more now is not allowed!
+         * ```
+         * @since v0.9.4
+         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
+         * JavaScript value other than `null`.
+         * @param encoding The encoding if `chunk` is a string
+         * @param callback Callback for when the stream is finished.
+         */
+        end(cb?: () => void): this;
+        end(chunk: any, cb?: () => void): this;
+        end(chunk: any, encoding: BufferEncoding, cb?: () => void): this;
+        /**
+         * The `writable.cork()` method forces all written data to be buffered in memory.
+         * The buffered data will be flushed when either the {@link uncork} or {@link end} methods are called.
+         *
+         * The primary intent of `writable.cork()` is to accommodate a situation in which
+         * several small chunks are written to the stream in rapid succession. Instead of
+         * immediately forwarding them to the underlying destination, `writable.cork()`buffers all the chunks until `writable.uncork()` is called, which will pass them
+         * all to `writable._writev()`, if present. This prevents a head-of-line blocking
+         * situation where data is being buffered while waiting for the first small chunk
+         * to be processed. However, use of `writable.cork()` without implementing`writable._writev()` may have an adverse effect on throughput.
+         *
+         * See also: `writable.uncork()`, `writable._writev()`.
+         * @since v0.11.2
+         */
+        cork(): void;
+        /**
+         * The `writable.uncork()` method flushes all data buffered since {@link cork} was called.
+         *
+         * When using `writable.cork()` and `writable.uncork()` to manage the buffering
+         * of writes to a stream, defer calls to `writable.uncork()` using`process.nextTick()`. Doing so allows batching of all`writable.write()` calls that occur within a given Node.js event
+         * loop phase.
+         *
+         * ```js
+         * stream.cork();
+         * stream.write('some ');
+         * stream.write('data ');
+         * process.nextTick(() => stream.uncork());
+         * ```
+         *
+         * If the `writable.cork()` method is called multiple times on a stream, the
+         * same number of calls to `writable.uncork()` must be called to flush the buffered
+         * data.
+         *
+         * ```js
+         * stream.cork();
+         * stream.write('some ');
+         * stream.cork();
+         * stream.write('data ');
+         * process.nextTick(() => {
+         *   stream.uncork();
+         *   // The data will not be flushed until uncork() is called a second time.
+         *   stream.uncork();
+         * });
+         * ```
+         *
+         * See also: `writable.cork()`.
+         * @since v0.11.2
+         */
+        uncork(): void;
+        /**
+         * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the writable
+         * stream has ended and subsequent calls to `write()` or `end()` will result in
+         * an `ERR_STREAM_DESTROYED` error.
+         * This is a destructive and immediate way to destroy a stream. Previous calls to`write()` may not have drained, and may trigger an `ERR_STREAM_DESTROYED` error.
+         * Use `end()` instead of destroy if data should flush before close, or wait for
+         * the `'drain'` event before destroying the stream.
+         *
+         * Once `destroy()` has been called any further calls will be a no-op and no
+         * further errors except from `_destroy()` may be emitted as `'error'`.
+         *
+         * Implementors should not override this method,
+         * but instead implement `writable._destroy()`.
+         * @since v8.0.0
+         * @param error Optional, an error to emit with `'error'` event.
+         */
+        destroy(error?: Error): this;
+        /**
+         * Event emitter
+         * The defined events on documents including:
+         * 1. close
+         * 2. drain
+         * 3. error
+         * 4. finish
+         * 5. pipe
+         * 6. unpipe
+         */
+        addListener(event: 'close', listener: () => void): this;
+        addListener(event: 'drain', listener: () => void): this;
+        addListener(event: 'error', listener: (err: Error) => void): this;
+        addListener(event: 'finish', listener: () => void): this;
+        addListener(event: 'pipe', listener: (src: Readable) => void): this;
+        addListener(event: 'unpipe', listener: (src: Readable) => void): this;
+        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        emit(event: 'close'): boolean;
+        emit(event: 'drain'): boolean;
+        emit(event: 'error', err: Error): boolean;
+        emit(event: 'finish'): boolean;
+        emit(event: 'pipe', src: Readable): boolean;
+        emit(event: 'unpipe', src: Readable): boolean;
+        emit(event: string | symbol, ...args: any[]): boolean;
+        on(event: 'close', listener: () => void): this;
+        on(event: 'drain', listener: () => void): this;
+        on(event: 'error', listener: (err: Error) => void): this;
+        on(event: 'finish', listener: () => void): this;
+        on(event: 'pipe', listener: (src: Readable) => void): this;
+        on(event: 'unpipe', listener: (src: Readable) => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
+        once(event: 'close', listener: () => void): this;
+        once(event: 'drain', listener: () => void): this;
+        once(event: 'error', listener: (err: Error) => void): this;
+        once(event: 'finish', listener: () => void): this;
+        once(event: 'pipe', listener: (src: Readable) => void): this;
+        once(event: 'unpipe', listener: (src: Readable) => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
+        prependListener(event: 'close', listener: () => void): this;
+        prependListener(event: 'drain', listener: () => void): this;
+        prependListener(event: 'error', listener: (err: Error) => void): this;
+        prependListener(event: 'finish', listener: () => void): this;
+        prependListener(event: 'pipe', listener: (src: Readable) => void): this;
+        prependListener(event: 'unpipe', listener: (src: Readable) => void): this;
+        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: 'close', listener: () => void): this;
+        prependOnceListener(event: 'drain', listener: () => void): this;
+        prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+        prependOnceListener(event: 'finish', listener: () => void): this;
+        prependOnceListener(event: 'pipe', listener: (src: Readable) => void): this;
+        prependOnceListener(event: 'unpipe', listener: (src: Readable) => void): this;
+        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        removeListener(event: 'close', listener: () => void): this;
+        removeListener(event: 'drain', listener: () => void): this;
+        removeListener(event: 'error', listener: (err: Error) => void): this;
+        removeListener(event: 'finish', listener: () => void): this;
+        removeListener(event: 'pipe', listener: (src: Readable) => void): this;
+        removeListener(event: 'unpipe', listener: (src: Readable) => void): this;
+        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    }
     namespace internal {
         class Stream extends internal {
             constructor(opts?: ReadableOptions);
@@ -53,11 +791,7 @@ declare module 'stream' {
         /**
          * @since v0.9.4
          */
-        class Readable extends Stream implements NodeJS.ReadableStream {
-            /**
-             * A utility method for creating Readable Streams out of iterators.
-             */
-            static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+        class Readable extends ReadableBase {
             /**
              * A utility method for creating a `Readable` from a web `ReadableStream`.
              * @since v17.0.0
@@ -65,446 +799,11 @@ declare module 'stream' {
              */
             static fromWeb(readableStream: streamWeb.ReadableStream, options?: Pick<ReadableOptions, 'encoding' | 'highWaterMark' | 'objectMode' | 'signal'>): Readable;
             /**
-             * Returns whether the stream has been read from or cancelled.
-             * @since v16.8.0
-             */
-            static isDisturbed(stream: Readable | NodeJS.ReadableStream): boolean;
-            /**
              * A utility method for creating a web `ReadableStream` from a `Readable`.
              * @since v17.0.0
              * @experimental
              */
             static toWeb(streamReadable: Readable): streamWeb.ReadableStream;
-            /**
-             * Returns whether the stream was destroyed or errored before emitting `'end'`.
-             * @since v16.8.0
-             * @experimental
-             */
-            readonly readableAborted: boolean;
-            /**
-             * Is `true` if it is safe to call `readable.read()`, which means
-             * the stream has not been destroyed or emitted `'error'` or `'end'`.
-             * @since v11.4.0
-             */
-            readable: boolean;
-            /**
-             * Returns whether `'data'` has been emitted.
-             * @since v16.7.0, v14.18.0
-             * @experimental
-             */
-            readonly readableDidRead: boolean;
-            /**
-             * Getter for the property `encoding` of a given `Readable` stream. The `encoding`property can be set using the `readable.setEncoding()` method.
-             * @since v12.7.0
-             */
-            readonly readableEncoding: BufferEncoding | null;
-            /**
-             * Becomes `true` when `'end'` event is emitted.
-             * @since v12.9.0
-             */
-            readonly readableEnded: boolean;
-            /**
-             * This property reflects the current state of a `Readable` stream as described
-             * in the `Three states` section.
-             * @since v9.4.0
-             */
-            readonly readableFlowing: boolean | null;
-            /**
-             * Returns the value of `highWaterMark` passed when creating this `Readable`.
-             * @since v9.3.0
-             */
-            readonly readableHighWaterMark: number;
-            /**
-             * This property contains the number of bytes (or objects) in the queue
-             * ready to be read. The value provides introspection data regarding
-             * the status of the `highWaterMark`.
-             * @since v9.4.0
-             */
-            readonly readableLength: number;
-            /**
-             * Getter for the property `objectMode` of a given `Readable` stream.
-             * @since v12.3.0
-             */
-            readonly readableObjectMode: boolean;
-            /**
-             * Is `true` after `readable.destroy()` has been called.
-             * @since v8.0.0
-             */
-            destroyed: boolean;
-            /**
-             * Is `true` after `'close'` has been emitted.
-             * @since v18.0.0
-             */
-            readonly closed: boolean;
-            /**
-             * Returns error if the stream has been destroyed with an error.
-             * @since v18.0.0
-             */
-            readonly errored: Error | null;
-            constructor(opts?: ReadableOptions);
-            _construct?(callback: (error?: Error | null) => void): void;
-            _read(size: number): void;
-            /**
-             * The `readable.read()` method reads data out of the internal buffer and
-             * returns it. If no data is available to be read, `null` is returned. By default,
-             * the data is returned as a `Buffer` object unless an encoding has been
-             * specified using the `readable.setEncoding()` method or the stream is operating
-             * in object mode.
-             *
-             * The optional `size` argument specifies a specific number of bytes to read. If`size` bytes are not available to be read, `null` will be returned _unless_the stream has ended, in which
-             * case all of the data remaining in the internal
-             * buffer will be returned.
-             *
-             * If the `size` argument is not specified, all of the data contained in the
-             * internal buffer will be returned.
-             *
-             * The `size` argument must be less than or equal to 1 GiB.
-             *
-             * The `readable.read()` method should only be called on `Readable` streams
-             * operating in paused mode. In flowing mode, `readable.read()` is called
-             * automatically until the internal buffer is fully drained.
-             *
-             * ```js
-             * const readable = getReadableStreamSomehow();
-             *
-             * // 'readable' may be triggered multiple times as data is buffered in
-             * readable.on('readable', () => {
-             *   let chunk;
-             *   console.log('Stream is readable (new data received in buffer)');
-             *   // Use a loop to make sure we read all currently available data
-             *   while (null !== (chunk = readable.read())) {
-             *     console.log(`Read ${chunk.length} bytes of data...`);
-             *   }
-             * });
-             *
-             * // 'end' will be triggered once when there is no more data available
-             * readable.on('end', () => {
-             *   console.log('Reached end of stream.');
-             * });
-             * ```
-             *
-             * Each call to `readable.read()` returns a chunk of data, or `null`. The chunks
-             * are not concatenated. A `while` loop is necessary to consume all data
-             * currently in the buffer. When reading a large file `.read()` may return `null`,
-             * having consumed all buffered content so far, but there is still more data to
-             * come not yet buffered. In this case a new `'readable'` event will be emitted
-             * when there is more data in the buffer. Finally the `'end'` event will be
-             * emitted when there is no more data to come.
-             *
-             * Therefore to read a file's whole contents from a `readable`, it is necessary
-             * to collect chunks across multiple `'readable'` events:
-             *
-             * ```js
-             * const chunks = [];
-             *
-             * readable.on('readable', () => {
-             *   let chunk;
-             *   while (null !== (chunk = readable.read())) {
-             *     chunks.push(chunk);
-             *   }
-             * });
-             *
-             * readable.on('end', () => {
-             *   const content = chunks.join('');
-             * });
-             * ```
-             *
-             * A `Readable` stream in object mode will always return a single item from
-             * a call to `readable.read(size)`, regardless of the value of the`size` argument.
-             *
-             * If the `readable.read()` method returns a chunk of data, a `'data'` event will
-             * also be emitted.
-             *
-             * Calling {@link read} after the `'end'` event has
-             * been emitted will return `null`. No runtime error will be raised.
-             * @since v0.9.4
-             * @param size Optional argument to specify how much data to read.
-             */
-            read(size?: number): any;
-            /**
-             * The `readable.setEncoding()` method sets the character encoding for
-             * data read from the `Readable` stream.
-             *
-             * By default, no encoding is assigned and stream data will be returned as`Buffer` objects. Setting an encoding causes the stream data
-             * to be returned as strings of the specified encoding rather than as `Buffer`objects. For instance, calling `readable.setEncoding('utf8')` will cause the
-             * output data to be interpreted as UTF-8 data, and passed as strings. Calling`readable.setEncoding('hex')` will cause the data to be encoded in hexadecimal
-             * string format.
-             *
-             * The `Readable` stream will properly handle multi-byte characters delivered
-             * through the stream that would otherwise become improperly decoded if simply
-             * pulled from the stream as `Buffer` objects.
-             *
-             * ```js
-             * const readable = getReadableStreamSomehow();
-             * readable.setEncoding('utf8');
-             * readable.on('data', (chunk) => {
-             *   assert.equal(typeof chunk, 'string');
-             *   console.log('Got %d characters of string data:', chunk.length);
-             * });
-             * ```
-             * @since v0.9.4
-             * @param encoding The encoding to use.
-             */
-            setEncoding(encoding: BufferEncoding): this;
-            /**
-             * The `readable.pause()` method will cause a stream in flowing mode to stop
-             * emitting `'data'` events, switching out of flowing mode. Any data that
-             * becomes available will remain in the internal buffer.
-             *
-             * ```js
-             * const readable = getReadableStreamSomehow();
-             * readable.on('data', (chunk) => {
-             *   console.log(`Received ${chunk.length} bytes of data.`);
-             *   readable.pause();
-             *   console.log('There will be no additional data for 1 second.');
-             *   setTimeout(() => {
-             *     console.log('Now data will start flowing again.');
-             *     readable.resume();
-             *   }, 1000);
-             * });
-             * ```
-             *
-             * The `readable.pause()` method has no effect if there is a `'readable'`event listener.
-             * @since v0.9.4
-             */
-            pause(): this;
-            /**
-             * The `readable.resume()` method causes an explicitly paused `Readable` stream to
-             * resume emitting `'data'` events, switching the stream into flowing mode.
-             *
-             * The `readable.resume()` method can be used to fully consume the data from a
-             * stream without actually processing any of that data:
-             *
-             * ```js
-             * getReadableStreamSomehow()
-             *   .resume()
-             *   .on('end', () => {
-             *     console.log('Reached the end, but did not read anything.');
-             *   });
-             * ```
-             *
-             * The `readable.resume()` method has no effect if there is a `'readable'`event listener.
-             * @since v0.9.4
-             */
-            resume(): this;
-            /**
-             * The `readable.isPaused()` method returns the current operating state of the`Readable`. This is used primarily by the mechanism that underlies the`readable.pipe()` method. In most
-             * typical cases, there will be no reason to
-             * use this method directly.
-             *
-             * ```js
-             * const readable = new stream.Readable();
-             *
-             * readable.isPaused(); // === false
-             * readable.pause();
-             * readable.isPaused(); // === true
-             * readable.resume();
-             * readable.isPaused(); // === false
-             * ```
-             * @since v0.11.14
-             */
-            isPaused(): boolean;
-            /**
-             * The `readable.unpipe()` method detaches a `Writable` stream previously attached
-             * using the {@link pipe} method.
-             *
-             * If the `destination` is not specified, then _all_ pipes are detached.
-             *
-             * If the `destination` is specified, but no pipe is set up for it, then
-             * the method does nothing.
-             *
-             * ```js
-             * const fs = require('node:fs');
-             * const readable = getReadableStreamSomehow();
-             * const writable = fs.createWriteStream('file.txt');
-             * // All the data from readable goes into 'file.txt',
-             * // but only for the first second.
-             * readable.pipe(writable);
-             * setTimeout(() => {
-             *   console.log('Stop writing to file.txt.');
-             *   readable.unpipe(writable);
-             *   console.log('Manually close the file stream.');
-             *   writable.end();
-             * }, 1000);
-             * ```
-             * @since v0.9.4
-             * @param destination Optional specific stream to unpipe
-             */
-            unpipe(destination?: NodeJS.WritableStream): this;
-            /**
-             * Passing `chunk` as `null` signals the end of the stream (EOF) and behaves the
-             * same as `readable.push(null)`, after which no more data can be written. The EOF
-             * signal is put at the end of the buffer and any buffered data will still be
-             * flushed.
-             *
-             * The `readable.unshift()` method pushes a chunk of data back into the internal
-             * buffer. This is useful in certain situations where a stream is being consumed by
-             * code that needs to "un-consume" some amount of data that it has optimistically
-             * pulled out of the source, so that the data can be passed on to some other party.
-             *
-             * The `stream.unshift(chunk)` method cannot be called after the `'end'` event
-             * has been emitted or a runtime error will be thrown.
-             *
-             * Developers using `stream.unshift()` often should consider switching to
-             * use of a `Transform` stream instead. See the `API for stream implementers` section for more information.
-             *
-             * ```js
-             * // Pull off a header delimited by \n\n.
-             * // Use unshift() if we get too much.
-             * // Call the callback with (error, header, stream).
-             * const { StringDecoder } = require('node:string_decoder');
-             * function parseHeader(stream, callback) {
-             *   stream.on('error', callback);
-             *   stream.on('readable', onReadable);
-             *   const decoder = new StringDecoder('utf8');
-             *   let header = '';
-             *   function onReadable() {
-             *     let chunk;
-             *     while (null !== (chunk = stream.read())) {
-             *       const str = decoder.write(chunk);
-             *       if (str.includes('\n\n')) {
-             *         // Found the header boundary.
-             *         const split = str.split(/\n\n/);
-             *         header += split.shift();
-             *         const remaining = split.join('\n\n');
-             *         const buf = Buffer.from(remaining, 'utf8');
-             *         stream.removeListener('error', callback);
-             *         // Remove the 'readable' listener before unshifting.
-             *         stream.removeListener('readable', onReadable);
-             *         if (buf.length)
-             *           stream.unshift(buf);
-             *         // Now the body of the message can be read from the stream.
-             *         callback(null, header, stream);
-             *         return;
-             *       }
-             *       // Still reading the header.
-             *       header += str;
-             *     }
-             *   }
-             * }
-             * ```
-             *
-             * Unlike {@link push}, `stream.unshift(chunk)` will not
-             * end the reading process by resetting the internal reading state of the stream.
-             * This can cause unexpected results if `readable.unshift()` is called during a
-             * read (i.e. from within a {@link _read} implementation on a
-             * custom stream). Following the call to `readable.unshift()` with an immediate {@link push} will reset the reading state appropriately,
-             * however it is best to simply avoid calling `readable.unshift()` while in the
-             * process of performing a read.
-             * @since v0.9.11
-             * @param chunk Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode
-             * streams, `chunk` may be any JavaScript value.
-             * @param encoding Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`.
-             */
-            unshift(chunk: any, encoding?: BufferEncoding): void;
-            /**
-             * Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
-             * information.)
-             *
-             * When using an older Node.js library that emits `'data'` events and has a {@link pause} method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
-             * stream that uses
-             * the old stream as its data source.
-             *
-             * It will rarely be necessary to use `readable.wrap()` but the method has been
-             * provided as a convenience for interacting with older Node.js applications and
-             * libraries.
-             *
-             * ```js
-             * const { OldReader } = require('./old-api-module.js');
-             * const { Readable } = require('node:stream');
-             * const oreader = new OldReader();
-             * const myReader = new Readable().wrap(oreader);
-             *
-             * myReader.on('readable', () => {
-             *   myReader.read(); // etc.
-             * });
-             * ```
-             * @since v0.9.4
-             * @param stream An "old style" readable stream
-             */
-            wrap(stream: NodeJS.ReadableStream): this;
-            push(chunk: any, encoding?: BufferEncoding): boolean;
-            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
-            /**
-             * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the readable
-             * stream will release any internal resources and subsequent calls to `push()`will be ignored.
-             *
-             * Once `destroy()` has been called any further calls will be a no-op and no
-             * further errors except from `_destroy()` may be emitted as `'error'`.
-             *
-             * Implementors should not override this method, but instead implement `readable._destroy()`.
-             * @since v8.0.0
-             * @param error Error which will be passed as payload in `'error'` event
-             */
-            destroy(error?: Error): this;
-            /**
-             * Event emitter
-             * The defined events on documents including:
-             * 1. close
-             * 2. data
-             * 3. end
-             * 4. error
-             * 5. pause
-             * 6. readable
-             * 7. resume
-             */
-            addListener(event: 'close', listener: () => void): this;
-            addListener(event: 'data', listener: (chunk: any) => void): this;
-            addListener(event: 'end', listener: () => void): this;
-            addListener(event: 'error', listener: (err: Error) => void): this;
-            addListener(event: 'pause', listener: () => void): this;
-            addListener(event: 'readable', listener: () => void): this;
-            addListener(event: 'resume', listener: () => void): this;
-            addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            emit(event: 'close'): boolean;
-            emit(event: 'data', chunk: any): boolean;
-            emit(event: 'end'): boolean;
-            emit(event: 'error', err: Error): boolean;
-            emit(event: 'pause'): boolean;
-            emit(event: 'readable'): boolean;
-            emit(event: 'resume'): boolean;
-            emit(event: string | symbol, ...args: any[]): boolean;
-            on(event: 'close', listener: () => void): this;
-            on(event: 'data', listener: (chunk: any) => void): this;
-            on(event: 'end', listener: () => void): this;
-            on(event: 'error', listener: (err: Error) => void): this;
-            on(event: 'pause', listener: () => void): this;
-            on(event: 'readable', listener: () => void): this;
-            on(event: 'resume', listener: () => void): this;
-            on(event: string | symbol, listener: (...args: any[]) => void): this;
-            once(event: 'close', listener: () => void): this;
-            once(event: 'data', listener: (chunk: any) => void): this;
-            once(event: 'end', listener: () => void): this;
-            once(event: 'error', listener: (err: Error) => void): this;
-            once(event: 'pause', listener: () => void): this;
-            once(event: 'readable', listener: () => void): this;
-            once(event: 'resume', listener: () => void): this;
-            once(event: string | symbol, listener: (...args: any[]) => void): this;
-            prependListener(event: 'close', listener: () => void): this;
-            prependListener(event: 'data', listener: (chunk: any) => void): this;
-            prependListener(event: 'end', listener: () => void): this;
-            prependListener(event: 'error', listener: (err: Error) => void): this;
-            prependListener(event: 'pause', listener: () => void): this;
-            prependListener(event: 'readable', listener: () => void): this;
-            prependListener(event: 'resume', listener: () => void): this;
-            prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            prependOnceListener(event: 'close', listener: () => void): this;
-            prependOnceListener(event: 'data', listener: (chunk: any) => void): this;
-            prependOnceListener(event: 'end', listener: () => void): this;
-            prependOnceListener(event: 'error', listener: (err: Error) => void): this;
-            prependOnceListener(event: 'pause', listener: () => void): this;
-            prependOnceListener(event: 'readable', listener: () => void): this;
-            prependOnceListener(event: 'resume', listener: () => void): this;
-            prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            removeListener(event: 'close', listener: () => void): this;
-            removeListener(event: 'data', listener: (chunk: any) => void): this;
-            removeListener(event: 'end', listener: () => void): this;
-            removeListener(event: 'error', listener: (err: Error) => void): this;
-            removeListener(event: 'pause', listener: () => void): this;
-            removeListener(event: 'readable', listener: () => void): this;
-            removeListener(event: 'resume', listener: () => void): this;
-            removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<any>;
         }
         interface WritableOptions extends StreamOptions<Writable> {
             decodeStrings?: boolean | undefined;
@@ -523,7 +822,7 @@ declare module 'stream' {
         /**
          * @since v0.9.4
          */
-        class Writable extends Stream implements NodeJS.WritableStream {
+        class Writable extends WritableBase {
             /**
              * A utility method for creating a `Writable` from a web `WritableStream`.
              * @since v17.0.0
@@ -536,292 +835,6 @@ declare module 'stream' {
              * @experimental
              */
             static toWeb(streamWritable: Writable): streamWeb.WritableStream;
-            /**
-             * Is `true` if it is safe to call `writable.write()`, which means
-             * the stream has not been destroyed, errored, or ended.
-             * @since v11.4.0
-             */
-            readonly writable: boolean;
-            /**
-             * Is `true` after `writable.end()` has been called. This property
-             * does not indicate whether the data has been flushed, for this use `writable.writableFinished` instead.
-             * @since v12.9.0
-             */
-            readonly writableEnded: boolean;
-            /**
-             * Is set to `true` immediately before the `'finish'` event is emitted.
-             * @since v12.6.0
-             */
-            readonly writableFinished: boolean;
-            /**
-             * Return the value of `highWaterMark` passed when creating this `Writable`.
-             * @since v9.3.0
-             */
-            readonly writableHighWaterMark: number;
-            /**
-             * This property contains the number of bytes (or objects) in the queue
-             * ready to be written. The value provides introspection data regarding
-             * the status of the `highWaterMark`.
-             * @since v9.4.0
-             */
-            readonly writableLength: number;
-            /**
-             * Getter for the property `objectMode` of a given `Writable` stream.
-             * @since v12.3.0
-             */
-            readonly writableObjectMode: boolean;
-            /**
-             * Number of times `writable.uncork()` needs to be
-             * called in order to fully uncork the stream.
-             * @since v13.2.0, v12.16.0
-             */
-            readonly writableCorked: number;
-            /**
-             * Is `true` after `writable.destroy()` has been called.
-             * @since v8.0.0
-             */
-            destroyed: boolean;
-            /**
-             * Is `true` after `'close'` has been emitted.
-             * @since v18.0.0
-             */
-            readonly closed: boolean;
-            /**
-             * Returns error if the stream has been destroyed with an error.
-             * @since v18.0.0
-             */
-            readonly errored: Error | null;
-            /**
-             * Is `true` if the stream's buffer has been full and stream will emit `'drain'`.
-             * @since v15.2.0, v14.17.0
-             */
-            readonly writableNeedDrain: boolean;
-            constructor(opts?: WritableOptions);
-            _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
-            _writev?(
-                chunks: Array<{
-                    chunk: any;
-                    encoding: BufferEncoding;
-                }>,
-                callback: (error?: Error | null) => void
-            ): void;
-            _construct?(callback: (error?: Error | null) => void): void;
-            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
-            _final(callback: (error?: Error | null) => void): void;
-            /**
-             * The `writable.write()` method writes some data to the stream, and calls the
-             * supplied `callback` once the data has been fully handled. If an error
-             * occurs, the `callback` will be called with the error as its
-             * first argument. The `callback` is called asynchronously and before `'error'` is
-             * emitted.
-             *
-             * The return value is `true` if the internal buffer is less than the`highWaterMark` configured when the stream was created after admitting `chunk`.
-             * If `false` is returned, further attempts to write data to the stream should
-             * stop until the `'drain'` event is emitted.
-             *
-             * While a stream is not draining, calls to `write()` will buffer `chunk`, and
-             * return false. Once all currently buffered chunks are drained (accepted for
-             * delivery by the operating system), the `'drain'` event will be emitted.
-             * Once `write()` returns false, do not write more chunks
-             * until the `'drain'` event is emitted. While calling `write()` on a stream that
-             * is not draining is allowed, Node.js will buffer all written chunks until
-             * maximum memory usage occurs, at which point it will abort unconditionally.
-             * Even before it aborts, high memory usage will cause poor garbage collector
-             * performance and high RSS (which is not typically released back to the system,
-             * even after the memory is no longer required). Since TCP sockets may never
-             * drain if the remote peer does not read the data, writing a socket that is
-             * not draining may lead to a remotely exploitable vulnerability.
-             *
-             * Writing data while the stream is not draining is particularly
-             * problematic for a `Transform`, because the `Transform` streams are paused
-             * by default until they are piped or a `'data'` or `'readable'` event handler
-             * is added.
-             *
-             * If the data to be written can be generated or fetched on demand, it is
-             * recommended to encapsulate the logic into a `Readable` and use {@link pipe}. However, if calling `write()` is preferred, it is
-             * possible to respect backpressure and avoid memory issues using the `'drain'` event:
-             *
-             * ```js
-             * function write(data, cb) {
-             *   if (!stream.write(data)) {
-             *     stream.once('drain', cb);
-             *   } else {
-             *     process.nextTick(cb);
-             *   }
-             * }
-             *
-             * // Wait for cb to be called before doing any other write.
-             * write('hello', () => {
-             *   console.log('Write completed, do more writes now.');
-             * });
-             * ```
-             *
-             * A `Writable` stream in object mode will always ignore the `encoding` argument.
-             * @since v0.9.4
-             * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
-             * JavaScript value other than `null`.
-             * @param [encoding='utf8'] The encoding, if `chunk` is a string.
-             * @param callback Callback for when this chunk of data is flushed.
-             * @return `false` if the stream wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
-             */
-            write(chunk: any, callback?: (error: Error | null | undefined) => void): boolean;
-            write(chunk: any, encoding: BufferEncoding, callback?: (error: Error | null | undefined) => void): boolean;
-            /**
-             * The `writable.setDefaultEncoding()` method sets the default `encoding` for a `Writable` stream.
-             * @since v0.11.15
-             * @param encoding The new default encoding
-             */
-            setDefaultEncoding(encoding: BufferEncoding): this;
-            /**
-             * Calling the `writable.end()` method signals that no more data will be written
-             * to the `Writable`. The optional `chunk` and `encoding` arguments allow one
-             * final additional chunk of data to be written immediately before closing the
-             * stream.
-             *
-             * Calling the {@link write} method after calling {@link end} will raise an error.
-             *
-             * ```js
-             * // Write 'hello, ' and then end with 'world!'.
-             * const fs = require('node:fs');
-             * const file = fs.createWriteStream('example.txt');
-             * file.write('hello, ');
-             * file.end('world!');
-             * // Writing more now is not allowed!
-             * ```
-             * @since v0.9.4
-             * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
-             * JavaScript value other than `null`.
-             * @param encoding The encoding if `chunk` is a string
-             * @param callback Callback for when the stream is finished.
-             */
-            end(cb?: () => void): this;
-            end(chunk: any, cb?: () => void): this;
-            end(chunk: any, encoding: BufferEncoding, cb?: () => void): this;
-            /**
-             * The `writable.cork()` method forces all written data to be buffered in memory.
-             * The buffered data will be flushed when either the {@link uncork} or {@link end} methods are called.
-             *
-             * The primary intent of `writable.cork()` is to accommodate a situation in which
-             * several small chunks are written to the stream in rapid succession. Instead of
-             * immediately forwarding them to the underlying destination, `writable.cork()`buffers all the chunks until `writable.uncork()` is called, which will pass them
-             * all to `writable._writev()`, if present. This prevents a head-of-line blocking
-             * situation where data is being buffered while waiting for the first small chunk
-             * to be processed. However, use of `writable.cork()` without implementing`writable._writev()` may have an adverse effect on throughput.
-             *
-             * See also: `writable.uncork()`, `writable._writev()`.
-             * @since v0.11.2
-             */
-            cork(): void;
-            /**
-             * The `writable.uncork()` method flushes all data buffered since {@link cork} was called.
-             *
-             * When using `writable.cork()` and `writable.uncork()` to manage the buffering
-             * of writes to a stream, defer calls to `writable.uncork()` using`process.nextTick()`. Doing so allows batching of all`writable.write()` calls that occur within a given Node.js event
-             * loop phase.
-             *
-             * ```js
-             * stream.cork();
-             * stream.write('some ');
-             * stream.write('data ');
-             * process.nextTick(() => stream.uncork());
-             * ```
-             *
-             * If the `writable.cork()` method is called multiple times on a stream, the
-             * same number of calls to `writable.uncork()` must be called to flush the buffered
-             * data.
-             *
-             * ```js
-             * stream.cork();
-             * stream.write('some ');
-             * stream.cork();
-             * stream.write('data ');
-             * process.nextTick(() => {
-             *   stream.uncork();
-             *   // The data will not be flushed until uncork() is called a second time.
-             *   stream.uncork();
-             * });
-             * ```
-             *
-             * See also: `writable.cork()`.
-             * @since v0.11.2
-             */
-            uncork(): void;
-            /**
-             * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the writable
-             * stream has ended and subsequent calls to `write()` or `end()` will result in
-             * an `ERR_STREAM_DESTROYED` error.
-             * This is a destructive and immediate way to destroy a stream. Previous calls to`write()` may not have drained, and may trigger an `ERR_STREAM_DESTROYED` error.
-             * Use `end()` instead of destroy if data should flush before close, or wait for
-             * the `'drain'` event before destroying the stream.
-             *
-             * Once `destroy()` has been called any further calls will be a no-op and no
-             * further errors except from `_destroy()` may be emitted as `'error'`.
-             *
-             * Implementors should not override this method,
-             * but instead implement `writable._destroy()`.
-             * @since v8.0.0
-             * @param error Optional, an error to emit with `'error'` event.
-             */
-            destroy(error?: Error): this;
-            /**
-             * Event emitter
-             * The defined events on documents including:
-             * 1. close
-             * 2. drain
-             * 3. error
-             * 4. finish
-             * 5. pipe
-             * 6. unpipe
-             */
-            addListener(event: 'close', listener: () => void): this;
-            addListener(event: 'drain', listener: () => void): this;
-            addListener(event: 'error', listener: (err: Error) => void): this;
-            addListener(event: 'finish', listener: () => void): this;
-            addListener(event: 'pipe', listener: (src: Readable) => void): this;
-            addListener(event: 'unpipe', listener: (src: Readable) => void): this;
-            addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            emit(event: 'close'): boolean;
-            emit(event: 'drain'): boolean;
-            emit(event: 'error', err: Error): boolean;
-            emit(event: 'finish'): boolean;
-            emit(event: 'pipe', src: Readable): boolean;
-            emit(event: 'unpipe', src: Readable): boolean;
-            emit(event: string | symbol, ...args: any[]): boolean;
-            on(event: 'close', listener: () => void): this;
-            on(event: 'drain', listener: () => void): this;
-            on(event: 'error', listener: (err: Error) => void): this;
-            on(event: 'finish', listener: () => void): this;
-            on(event: 'pipe', listener: (src: Readable) => void): this;
-            on(event: 'unpipe', listener: (src: Readable) => void): this;
-            on(event: string | symbol, listener: (...args: any[]) => void): this;
-            once(event: 'close', listener: () => void): this;
-            once(event: 'drain', listener: () => void): this;
-            once(event: 'error', listener: (err: Error) => void): this;
-            once(event: 'finish', listener: () => void): this;
-            once(event: 'pipe', listener: (src: Readable) => void): this;
-            once(event: 'unpipe', listener: (src: Readable) => void): this;
-            once(event: string | symbol, listener: (...args: any[]) => void): this;
-            prependListener(event: 'close', listener: () => void): this;
-            prependListener(event: 'drain', listener: () => void): this;
-            prependListener(event: 'error', listener: (err: Error) => void): this;
-            prependListener(event: 'finish', listener: () => void): this;
-            prependListener(event: 'pipe', listener: (src: Readable) => void): this;
-            prependListener(event: 'unpipe', listener: (src: Readable) => void): this;
-            prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            prependOnceListener(event: 'close', listener: () => void): this;
-            prependOnceListener(event: 'drain', listener: () => void): this;
-            prependOnceListener(event: 'error', listener: (err: Error) => void): this;
-            prependOnceListener(event: 'finish', listener: () => void): this;
-            prependOnceListener(event: 'pipe', listener: (src: Readable) => void): this;
-            prependOnceListener(event: 'unpipe', listener: (src: Readable) => void): this;
-            prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            removeListener(event: 'close', listener: () => void): this;
-            removeListener(event: 'drain', listener: () => void): this;
-            removeListener(event: 'error', listener: (err: Error) => void): this;
-            removeListener(event: 'finish', listener: () => void): this;
-            removeListener(event: 'pipe', listener: (src: Readable) => void): this;
-            removeListener(event: 'unpipe', listener: (src: Readable) => void): this;
-            removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
         }
         interface DuplexOptions extends ReadableOptions, WritableOptions {
             allowHalfOpen?: boolean | undefined;
@@ -854,7 +867,7 @@ declare module 'stream' {
          * * `crypto streams`
          * @since v0.9.4
          */
-        class Duplex extends Readable implements Writable {
+        class Duplex extends ReadableBase implements WritableBase {
             readonly writable: boolean;
             readonly writableEnded: boolean;
             readonly writableFinished: boolean;
@@ -916,6 +929,27 @@ declare module 'stream' {
             end(chunk: any, encoding?: BufferEncoding, cb?: () => void): this;
             cork(): void;
             uncork(): void;
+            /**
+             * A utility method for creating a web `ReadableStream` and `WritableStream` from a `Duplex`.
+             * @since v17.0.0
+             * @experimental
+             */
+            static toWeb(streamDuplex: Duplex): {
+                readable: streamWeb.ReadableStream;
+                writable: streamWeb.WritableStream;
+            };
+            /**
+             * A utility method for creating a `Duplex` from a web `ReadableStream` and `WritableStream`.
+             * @since v17.0.0
+             * @experimental
+             */
+            static fromWeb(
+                duplexStream: {
+                    readable: streamWeb.ReadableStream;
+                    writable: streamWeb.WritableStream;
+                },
+                options?: Pick<DuplexOptions, 'allowHalfOpen' | 'decodeStrings' | 'encoding' | 'highWaterMark' | 'objectMode' | 'signal'>
+            ): Duplex;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -162,33 +162,33 @@ declare module 'node:test' {
      * @param [fn='A no-op function'] The function under suite declaring all subtests and subsuites. The first argument to this function is a {@link SuiteContext} object.
      * @return Immediately fulfilled with `undefined`.
      */
-    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-    function describe(name?: string, fn?: SuiteFn): void;
-    function describe(options?: TestOptions, fn?: SuiteFn): void;
-    function describe(fn?: SuiteFn): void;
+    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(name?: string, fn?: SuiteFn): Promise<void>;
+    function describe(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(fn?: SuiteFn): Promise<void>;
     namespace describe {
         /**
          * Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
          */
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function skip(name?: string, fn?: SuiteFn): void;
-        function skip(options?: TestOptions, fn?: SuiteFn): void;
-        function skip(fn?: SuiteFn): void;
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(name?: string, fn?: SuiteFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(fn?: SuiteFn): Promise<void>;
         /**
          * Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
          */
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function todo(name?: string, fn?: SuiteFn): void;
-        function todo(options?: TestOptions, fn?: SuiteFn): void;
-        function todo(fn?: SuiteFn): void;
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(name?: string, fn?: SuiteFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(fn?: SuiteFn): Promise<void>;
         /**
          * Shorthand for marking a suite as `only`, same as `describe([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function only(name?: string, fn?: SuiteFn): void;
-        function only(options?: TestOptions, fn?: SuiteFn): void;
-        function only(fn?: SuiteFn): void;
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(name?: string, fn?: SuiteFn): Promise<void>;
+        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(fn?: SuiteFn): Promise<void>;
     }
     /**
      * Shorthand for `test()`.
@@ -196,69 +196,79 @@ declare module 'node:test' {
      * The `it()` function is imported from the `node:test` module.
      * @since v18.6.0, v16.17.0
      */
-    function it(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function it(name?: string, fn?: TestFn): void;
-    function it(options?: TestOptions, fn?: TestFn): void;
-    function it(fn?: TestFn): void;
+    function it(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(name?: string, fn?: TestFn): Promise<void>;
+    function it(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(fn?: TestFn): Promise<void>;
     namespace it {
         /**
          * Shorthand for skipping a test, same as `it([name], { skip: true }[, fn])`.
          */
-        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function skip(name?: string, fn?: TestFn): void;
-        function skip(options?: TestOptions, fn?: TestFn): void;
-        function skip(fn?: TestFn): void;
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(name?: string, fn?: TestFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(fn?: TestFn): Promise<void>;
         /**
          * Shorthand for marking a test as `TODO`, same as `it([name], { todo: true }[, fn])`.
          */
-        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function todo(name?: string, fn?: TestFn): void;
-        function todo(options?: TestOptions, fn?: TestFn): void;
-        function todo(fn?: TestFn): void;
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(name?: string, fn?: TestFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(fn?: TestFn): Promise<void>;
         /**
          * Shorthand for marking a test as `only`, same as `it([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function only(name?: string, fn?: TestFn): void;
-        function only(options?: TestOptions, fn?: TestFn): void;
-        function only(fn?: TestFn): void;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(name?: string, fn?: TestFn): Promise<void>;
+        function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(fn?: TestFn): Promise<void>;
     }
     /**
      * Shorthand for skipping a test, same as `test([name], { skip: true }[, fn])`.
      * @since v20.2.0
      */
-    function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function skip(name?: string, fn?: TestFn): void;
-    function skip(options?: TestOptions, fn?: TestFn): void;
-    function skip(fn?: TestFn): void;
+    function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(name?: string, fn?: TestFn): Promise<void>;
+    function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function skip(fn?: TestFn): Promise<void>;
     /**
      * Shorthand for marking a test as `TODO`, same as `test([name], { todo: true }[, fn])`.
      * @since v20.2.0
      */
-    function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function todo(name?: string, fn?: TestFn): void;
-    function todo(options?: TestOptions, fn?: TestFn): void;
-    function todo(fn?: TestFn): void;
+    function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(name?: string, fn?: TestFn): Promise<void>;
+    function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function todo(fn?: TestFn): Promise<void>;
     /**
      * Shorthand for marking a test as `only`, same as `test([name], { only: true }[, fn])`.
      * @since v20.2.0
      */
-    function only(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function only(name?: string, fn?: TestFn): void;
-    function only(options?: TestOptions, fn?: TestFn): void;
-    function only(fn?: TestFn): void;
+    function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(name?: string, fn?: TestFn): Promise<void>;
+    function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function only(fn?: TestFn): Promise<void>;
     /**
      * The type of a function under test. The first argument to this function is a
      * {@link TestContext} object. If the test uses callbacks, the callback function is passed as
      * the second argument.
      */
-    type TestFn = (t: TestContext, done: (result?: any) => void) => any;
+    type TestFn = (t: TestContext, done: (result?: any) => void) => void | Promise<void>;
     /**
      * The type of a function under Suite.
      * If the test uses callbacks, the callback function is passed as an argument
      */
-    type SuiteFn = (done: (result?: any) => void) => void;
+    type SuiteFn = (s: SuiteContext) => void | Promise<void>;
+    interface TestShard {
+        /**
+         * A positive integer between 1 and `<total>` that specifies the index of the shard to run.
+         */
+        index: number;
+        /**
+         * A positive integer that specifies the total number of shards to split the test files to.
+         */
+        total: number;
+    }
     interface RunOptions {
         /**
          * If a number is provided, then that many files would run in parallel.
@@ -301,9 +311,15 @@ declare module 'node:test' {
          */
         setup?: (root: unknown) => void | Promise<void>;
         /**
-         * Whether to run in watch mode or not. Default: false.
+         * Whether to run in watch mode or not.
+         * @default false
          */
-        watch?: boolean;
+        watch?: boolean | undefined;
+        /**
+         * Running tests in a specific shard.
+         * @default undefined
+         */
+        shard?: TestShard | undefined;
     }
     class Test extends AsyncResource {
         concurrency: number;
@@ -503,6 +519,24 @@ declare module 'node:test' {
          * Each test provides its own MockTracker instance.
          */
         readonly mock: MockTracker;
+    }
+    /**
+     * An instance of `SuiteContext` is passed to each suite function in order to
+     * interact with the test runner. However, the `SuiteContext` constructor is not
+     * exposed as part of the API.
+     * @since v18.7.0, v16.17.0
+     */
+    class SuiteContext {
+        /**
+         * The name of the suite.
+         * @since v18.8.0, v16.18.0
+         */
+        readonly name: string;
+        /**
+         * Can be used to abort test subtasks when the test has been aborted.
+         * @since v18.7.0, v16.17.0
+         */
+        readonly signal: AbortSignal;
     }
     interface TestOptions {
         /**
@@ -1192,6 +1226,10 @@ declare module 'node:test' {
          * @since v20.4.0
          */
         runAll(): void;
+        /**
+         * Calls {@link MockTimers.reset()}.
+         */
+        [Symbol.dispose](): void;
     }
     export { test as default, run, test, describe, it, before, after, beforeEach, afterEach, mock, skip, only, todo };
 }

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -22,7 +22,11 @@ run({
     inspectPort: () => 8081,
     testNamePatterns: ['executed'],
     setup: (root) => {},
-    watch: true
+    watch: true,
+    shard: {
+        index: 1,
+        total: 3,
+    },
 });
 
 // TestsStream should be a NodeJS.ReadableStream
@@ -31,6 +35,16 @@ run().pipe(process.stdout);
 test('foo', t => {
     // $ExpectType TestContext
     t;
+});
+
+test('foo', (t) => {
+    // $ExpectType Promise<void>
+    t.test();
+});
+
+test('foo', async (t) => {
+    // $ExpectType void
+    await t.test();
 });
 
 test('blank options', {});
@@ -125,6 +139,26 @@ test.only('only', () => {});
 describe('foo', () => {
     it('it', () => {});
 });
+
+describe('foo', () => {
+    const d = describe();
+    // $ExpectType Promise<void>
+    d;
+});
+
+describe('foo', async () => {
+    const d = describe();
+    // $ExpectType Promise<void>
+    d;
+    // $ExpectType void
+    await d;
+});
+
+{
+    const ret = describe();
+    // $ExpectType Promise<void>
+    ret;
+}
 
 describe('blank options', {});
 it('blank options', {});
@@ -256,11 +290,11 @@ it.only('only shorthand', {
 });
 
 // Test callback mode
-describe(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
+describe(s => {
+    // $ExpectType SuiteContext
+    s;
+    // $ExpectType string
+    s.name;
 });
 
 // Test callback mode

--- a/types/node/ts4.8/timers.d.ts
+++ b/types/node/ts4.8/timers.d.ts
@@ -68,6 +68,11 @@ declare module 'timers' {
                  */
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
+                /**
+                 * Cancels the immediate. This is similar to calling `clearImmediate()`.
+                 * @since v20.5.0
+                 */
+                [Symbol.dispose](): void;
             }
             /**
              * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
@@ -114,6 +119,11 @@ declare module 'timers' {
                  */
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
+                /**
+                 * Cancels the timeout.
+                 * @since v20.5.0
+                 */
+                [Symbol.dispose](): void;
             }
         }
         /**
@@ -163,10 +173,10 @@ declare module 'timers' {
          * @param args Optional arguments to pass when the `callback` is called.
          * @return for use with {@link clearInterval}
          */
-        function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
+        function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
-        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timer;
+        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -143,6 +143,7 @@ declare class _Readable implements _IReadable {
     eventNames(): Array<string | symbol>;
 
     [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+    [Symbol.asyncDispose](): never;
 
     // static ReadableState: _Readable.ReadableState;
     _readableState: _Readable.ReadableState;
@@ -237,6 +238,7 @@ declare namespace _Readable {
 
         _undestroy(): void;
         [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        [Symbol.asyncDispose](): never;
         // end-Readable
 
         constructor(options?: DuplexOptions);


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.5.0

- events: allow safely adding listener to abortSignal
- test_runner: add shards support

Also:
- some classes became Disposable or AsyncDisposable
- fix return type in `setInterval`
