### PR TITLE
fix(maxmsp): missing max messages

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -42,6 +42,83 @@ declare function outlet(outlet_number: number, ...arguments: any[]): void;
 declare function setinletassist(inlet_number: number, object: any): void;
 declare function setoutletassist(outlet_number: number, object: any): void;
 
+type MaxMessage =
+    | 'buildcollective'
+    | 'checkpreempt'
+    | 'clean'
+    | 'clearmaxwindow'
+    | 'closefile'
+    | 'crash'
+    | 'db.exportmetadata'
+    | 'db.importmetadata'
+    | 'db.reset'
+    | 'debug'
+    | 'disablevirtualmididestinations'
+    | 'disablevirtualmidisources'
+    | 'enablepathcache'
+    | 'externaleditor'
+    | 'externs'
+    | 'fileformat'
+    | 'fixwidthratio'
+    | 'getarch'
+    | 'getdefaultpatcherheight'
+    | 'getdefaultpatcherwidth'
+    | 'getenablepathcache'
+    | 'geteventinterval'
+    | 'getfixwidthratio'
+    | 'getpollthrottle'
+    | 'getqueuethrottle'
+    | 'getrefreshrate'
+    | 'getruntime'
+    | 'getslop'
+    | 'getsysqelemthrottle'
+    | 'getsystem'
+    | 'getversion'
+    | 'hidecursor'
+    | 'hidemenubar'
+    | 'htmlref'
+    | 'interval'
+    | 'launchbrowser'
+    | 'maxcharheightforsubpixelantialiasing'
+    | 'maxinwmenu'
+    | 'maxwindow'
+    | 'midilist'
+    | 'nativetextrendering'
+    | 'notypeinfo'
+    | 'objectfile'
+    | 'openfile'
+    | 'paths'
+    | 'preempt'
+    | 'pupdate'
+    | 'purgemididevices'
+    | 'quit'
+    | 'refresh'
+    | 'refreshrate'
+    | 'relaunchmax'
+    | 'runtime'
+    | 'sendinterval'
+    | 'sendapppath'
+    | 'setdefaultpatcherheight'
+    | 'setdefaultpatcherwidth'
+    | 'seteventinterval'
+    | 'setmixergbitmode'
+    | 'setmixerlatency'
+    | 'setmixerparallel'
+    | 'setmixerramptime'
+    | 'setmirrortoconsole'
+    | 'setsleep'
+    | 'setpollthrottle'
+    | 'setqueuethrottle'
+    | 'setslop'
+    | 'setsysqelemthrottle'
+    | 'showcursor'
+    | 'showmenubar'
+    | 'size'
+    | 'system'
+    | 'useexternaleditor'
+    | 'useslowbutcompletesearching'
+    | string;
+
 /**
  * The Buffer object in JavaScript is a companion to the buffer~ object you instantiate in Max patchers,
  * and provides the ability to access samples and metadata for the buffer~ object with the associated name.
@@ -857,6 +934,11 @@ declare class Max {
      * Displays the Max Window. If the Max window if not currently open, the window will be displayed. If the window is currently open, it will bring it to the front.
      */
     maxwindow(): void;
+
+    /**
+     * Sends a message to max
+     */
+    message(maxMessage: MaxMessage): void;
 
     /**
      * The word midi, followed by a variable-length message, allows messages to be sent to configure the system MIDI object.

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -161,6 +161,7 @@ testmax.showcursor();
 testmax.showmenubar();
 testmax.size();
 testmax.system('windows', 'my_message');
+testmax.message("hidecursor");
 testmax.useslowbutcompletesearching(1);
 
 // Create a new Maxobj


### PR DESCRIPTION
**Problem**
One can send messages to max
![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/6558089/ec08b026-37c0-4747-ba1b-5d86eb14968b) but types don't reflect that.

At runtime you can do the following but typescript will complain.
Those messages are documented [here](https://docs.cycling74.com/max7/vignettes/messages_to_max)


This pr adds types for it while still leaving a `string` as part of the type to allow messages that can have parameters e.g. `useslowbutcompletesearching`