### PR TITLE
fix(maxmsp): mgraphics size missing

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -1683,6 +1683,11 @@ declare class MGraphics {
     autofill: number;
 
     /**
+     * Array of two values width and height of the jsui object in the maxpat
+     */
+    size: [number, number];
+
+    /**
      * The init routine is the first thing that an mgraphics-based Javascript program needs to call. It initializes the library, sets up the internal mgraphics variables and prepares the jsui object
      * for drawing.
      */

--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package maxmsp 1.0
 // Project: https://docs.cycling74.com/max8/vignettes/javascript_usage_topic
 // Definitions by: TomW <https://github.com/twhiston>
+//                 FrancescElies <https://github.com/FrancescElies>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions originally created by: ErnstHot <https://github.com/ErnstHot>
 // Documentation is property of Cycling '74 and published with permission.

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -331,8 +331,12 @@ myMGraphics.autosketch = 1;
 myMGraphics.relative_coords = 1;
 myMGraphics.autofill = 1;
 
+let width = 0;
+let height = 0;
+
 myMGraphics.init();
 myMGraphics.redraw();
+[width, height] = myMGraphics.size;
 myMGraphics.copy_path();
 myMGraphics.append_path('pathToAppend');
 myMGraphics.close_path();
@@ -360,7 +364,7 @@ myMGraphics.text_path('Hello');
 const fontExtents = myMGraphics.font_extents();
 post(fontExtents);
 const textMeasure = myMGraphics.text_measure("my-string");
-const [width, height] = textMeasure;
+[width, height] = textMeasure;
 post(textMeasure);
 const fontlist = myMGraphics.getfontlist();
 post(fontlist);


### PR DESCRIPTION
mgraphics size is missing.

Size represent the dimensions of a jsuiobject.
![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/6558089/26ef2e9c-b461-43f6-b178-eb4f8c86420a)


Sadly size I couldn't find it in the max docs but at runtime it's definitely there.