### PR TITLE
[sinon] static mock can get a string as name

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -775,7 +775,7 @@ declare namespace Sinon {
     }
 
     interface SinonMockStatic {
-        (): SinonExpectation;
+        (name?: string): SinonExpectation;
         /**
          * Creates a mock for the provided object.
          * Does not change the object, but returns a mock object to set expectations on the object’s methods.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -884,6 +884,22 @@ function testMock() {
     mock.verify();
 }
 
+function testMockStatic() {
+    const mock = sinon.mock();
+
+    mock.atLeast(2).atMost(5);
+    mock.restore();
+    mock.verify();
+}
+
+function testMockStaticNamed() {
+    const mock = sinon.mock('namedMock');
+
+    mock.atLeast(2).atMost(5);
+    mock.restore();
+    mock.verify();
+}
+
 function testAddBehavior() {
     sinon.addBehavior('returnsNum', (fake, n) => {
         fake.returns(n);


### PR DESCRIPTION
`sinon.mock()` code allows to pass a string to name the created mock, for easier troubleshooting: https://github.com/sinonjs/sinon/blob/main/lib/sinon/mock.js#L21-L23

This change add types for it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon/blob/main/lib/sinon/mock.js#L21-L23
- n/a If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.