### PR TITLE
ibm_db: Rename poolsize to poolSize

### DIFF
--- a/types/ibm_db/ibm_db-tests.ts
+++ b/types/ibm_db/ibm_db-tests.ts
@@ -38,6 +38,7 @@ ibmdb.open("DATABASE=<dbname>;HOSTNAME=<myhost>;UID=db2user;PWD=password;PORT=<d
 /** ibmdb.Pool */
 async function testPool() {
   const pool = new ibmdb.Pool();
+  pool.poolSize; // $ExpectType number
   const conn = await pool.open("DATABASE=<dbname>;HOSTNAME=<myhost>;UID=db2user;PWD=password;PORT=<dbport>;PROTOCOL=TCPIP");
   conn.query('select 1 from sysibm.sysdummy1', (err, data) => {
       if (err) return false;

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -220,7 +220,7 @@ export class Pool implements PoolOptions {
     index: number;
     availablePool: object;
     usedPool: object;
-    poolsize: number;
+    poolSize: number;
     odbc: ODBC;
     constructor(options?: PoolOptions);
     open(connStr: string): Promise<Database>;


### PR DESCRIPTION
The variable is spelled using camelCase as shown in the code [here](https://github.com/ibmdb/node-ibm_db/blob/master/lib/odbc.js#L2543).