### PR TITLE
fix: interface cannot be named

### DIFF
--- a/types/rdfjs__environment/Environment.d.ts
+++ b/types/rdfjs__environment/Environment.d.ts
@@ -1,4 +1,4 @@
-interface FactoryConstructor<F = {}> {
+export interface FactoryConstructor<F = {}> {
     new (...args: any[]): F;
 }
 

--- a/types/rdfjs__environment/rdfjs__environment-tests.ts
+++ b/types/rdfjs__environment/rdfjs__environment-tests.ts
@@ -1,5 +1,6 @@
 import { NamedNode, Stream } from '@rdfjs/types';
 import Environment from '@rdfjs/environment';
+import { FactoryConstructor } from '@rdfjs/environment/Environment.js';
 import FormatsFactory from '@rdfjs/environment/FormatsFactory.js';
 import NamespaceFactory from '@rdfjs/environment/NamespaceFactory.js';
 import TermMapSetFactory from '@rdfjs/environment/TermMapSetFactory.js';
@@ -91,3 +92,24 @@ const envOneFactoryInitOnly = new Environment([
 ]);
 
 envOneFactoryInitOnly.formats.import(envOneFactoryInitOnly.formats);
+
+// eslint-disable-next-line no-unnecessary-generics
+function customFactory<F extends FactoryConstructor>(...additionalFactories: F[]) {
+    return new Environment([
+        DataFactory,
+        ...additionalFactories,
+    ]);
+}
+
+function testCustomFactoryMethod() {
+    const env = customFactory(class Factory {
+        foo() {
+            return 'bar';
+        }
+    });
+
+    // $ExpectType BlankNode
+    const node = env.blankNode();
+    // $ExpectType string
+    const foo = env.foo();
+}


### PR DESCRIPTION
I need this to avoid downstream errors like

> error TS4058: Return type of exported function has or is using name 'FactoryConstructor' from external module "/node_modules/@types/rdfjs__environment/Environment" but cannot be named.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
