### PR TITLE
[postcss-font-variant] Add types for postcss-font-variant

### DIFF
--- a/types/postcss-font-variant/index.d.ts
+++ b/types/postcss-font-variant/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for postcss-font-variant 5.0
+// Project: https://github.com/postcss/postcss-font-variant#readme
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { PluginCreator } from 'postcss';
+
+declare var _export: PluginCreator<never>;
+
+export = _export;

--- a/types/postcss-font-variant/package.json
+++ b/types/postcss-font-variant/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.1.0"
+    }
+}

--- a/types/postcss-font-variant/postcss-font-variant-tests.ts
+++ b/types/postcss-font-variant/postcss-font-variant-tests.ts
@@ -1,0 +1,4 @@
+import fontVariant = require('postcss-font-variant');
+import postcss = require('postcss');
+
+postcss().use(fontVariant());

--- a/types/postcss-font-variant/tsconfig.json
+++ b/types/postcss-font-variant/tsconfig.json
@@ -1,23 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6", "ES2018.Promise"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "postcss-font-variant-tests.ts"
-    ]
+    "files": ["index.d.ts", "postcss-font-variant-tests.ts"]
 }

--- a/types/postcss-font-variant/tsconfig.json
+++ b/types/postcss-font-variant/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-font-variant-tests.ts"
+    ]
+}

--- a/types/postcss-font-variant/tslint.json
+++ b/types/postcss-font-variant/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package postcss-font-variant (<https://www.npmjs.com/package/postcss-font-variant>)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
