### PR TITLE
[howler] fix: add missing exports, remove incorrect export and remove private `Sound`

### DIFF
--- a/types/howler/howler-tests.ts
+++ b/types/howler/howler-tests.ts
@@ -1,3 +1,5 @@
+import './test/globals';
+
 import { Howl, Howler } from 'howler';
 
 // Set global volume

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -29,7 +29,7 @@ export interface PannerAttributes {
 }
 
 export interface Sound {
-    (howl: Howl): this;
+    new(howl: Howl): this;
 }
 
 export interface HowlListeners {

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -289,6 +289,7 @@ import { Howl as _Howl, HowlerGlobal as _HowlerGlobal } from '.';
 export { Howler };
 
 declare global {
+    // tslint:disable:no-empty-interface
     interface Howl extends _Howl {}
     interface HowlerGlobal extends _HowlerGlobal {}
     var Howl: typeof _Howl;

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -170,130 +170,128 @@ export interface HowlOptions extends HowlListeners {
         | undefined;
 }
 
-// typescript 4.4 compat
-type _HowlerGlobal = HowlerGlobal;
-export { Howl, Howler, _HowlerGlobal as HowlerGlobal };
+export class Howl {
+    constructor(options: HowlOptions);
+
+    play(spriteOrId?: string | number): number; // .play() is not chainable; the other methods are
+    pause(id?: number): this;
+    stop(id?: number): this;
+
+    mute(): boolean;
+    mute(muted: boolean, id?: number): this;
+
+    volume(): number;
+    volume(idOrSetVolume: number): this | number;
+    volume(volume: number, id: number): this;
+
+    fade(from: number, to: number, duration: number, id?: number): this;
+
+    rate(id?: number): number;
+    rate(rate: number, id?: number): this;
+
+    seek(id?: number): number;
+    seek(seek: number, id?: number): this;
+
+    loop(id?: number): boolean;
+    loop(loop: boolean, id?: number): this;
+
+    playing(id?: number): boolean;
+    duration(id?: number): number;
+    state(): 'unloaded' | 'loading' | 'loaded';
+    load(): this;
+    unload(): null;
+
+    on(event: 'load', callback: () => void, id?: number): this;
+    on(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
+    on(
+        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+        callback: HowlCallback,
+        id?: number,
+    ): this;
+    on(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
+
+    once(event: 'load', callback: () => void, id?: number): this;
+    once(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
+    once(
+        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+        callback: HowlCallback,
+        id?: number,
+    ): this;
+    once(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
+
+    off(event: 'load', callback?: () => void, id?: number): this;
+    off(event: 'loaderror' | 'playerror', callback?: HowlErrorCallback, id?: number): this;
+    off(
+        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+        callback?: HowlCallback,
+        id?: number,
+    ): this;
+    // off() also supports passing id as second argument: internally it is type checked and treated as an id if it is a number
+    off(
+        event:
+            | 'load'
+            | 'loaderror'
+            | 'playerror'
+            | 'play'
+            | 'end'
+            | 'pause'
+            | 'stop'
+            | 'mute'
+            | 'volume'
+            | 'rate'
+            | 'seek'
+            | 'fade'
+            | 'unlock',
+        id: number,
+    ): this;
+    off(event?: string, callback?: HowlCallback | HowlErrorCallback, id?: number): this;
+
+    stereo(): number;
+    stereo(pan: number, id?: number): number | this;
+
+    pos(): SpatialPosition;
+    pos(x: number, y?: number, z?: number, id?: number): this;
+
+    orientation(): SpatialOrientation;
+    orientation(x: number, y?: number, z?: number, id?: number): this;
+
+    pannerAttr(id?: number): PannerAttributes;
+    pannerAttr(options: PannerAttributes, id?: number): this;
+}
+
+export class HowlerGlobal {
+    mute(muted: boolean): this;
+    stop(): this;
+
+    volume(): number;
+    volume(volume: number): this;
+
+    codecs(ext: string): boolean;
+    unload(): this;
+    usingWebAudio: boolean;
+    html5PoolSize: number;
+    noAudio: boolean;
+    autoUnlock: boolean;
+    autoSuspend: boolean;
+    ctx: AudioContext;
+    masterGain: GainNode;
+
+    stereo(pan: number): this;
+
+    pos(): SpatialPosition;
+    pos(x: number, y?: number, z?: number): this;
+
+    orientation(): SpatialOrientation;
+    orientation(x: number, y?: number, z?: number, xUp?: number, yUp?: number, zUp?: number): this;
+}
+
+import { Howl as _Howl, HowlerGlobal as _HowlerGlobal } from 'howler';
+export { Howler };
 
 declare global {
-    class Howl {
-        constructor(options: HowlOptions);
-
-        play(spriteOrId?: string | number): number; // .play() is not chainable; the other methods are
-        pause(id?: number): this;
-        stop(id?: number): this;
-
-        mute(): boolean;
-        mute(muted: boolean, id?: number): this;
-
-        volume(): number;
-        volume(idOrSetVolume: number): this | number;
-        volume(volume: number, id: number): this;
-
-        fade(from: number, to: number, duration: number, id?: number): this;
-
-        rate(id?: number): number;
-        rate(rate: number, id?: number): this;
-
-        seek(id?: number): number;
-        seek(seek: number, id?: number): this;
-
-        loop(id?: number): boolean;
-        loop(loop: boolean, id?: number): this;
-
-        playing(id?: number): boolean;
-        duration(id?: number): number;
-        state(): 'unloaded' | 'loading' | 'loaded';
-        load(): this;
-        unload(): null;
-
-        on(event: 'load', callback: () => void, id?: number): this;
-        on(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
-        on(
-            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-            callback: HowlCallback,
-            id?: number,
-        ): this;
-        on(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
-
-        once(event: 'load', callback: () => void, id?: number): this;
-        once(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
-        once(
-            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-            callback: HowlCallback,
-            id?: number,
-        ): this;
-        once(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
-
-        off(event: 'load', callback?: () => void, id?: number): this;
-        off(event: 'loaderror' | 'playerror', callback?: HowlErrorCallback, id?: number): this;
-        off(
-            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-            callback?: HowlCallback,
-            id?: number,
-        ): this;
-        // off() also supports passing id as second argument: internally it is type checked and treated as an id if it is a number
-        off(
-            event:
-                | 'load'
-                | 'loaderror'
-                | 'playerror'
-                | 'play'
-                | 'end'
-                | 'pause'
-                | 'stop'
-                | 'mute'
-                | 'volume'
-                | 'rate'
-                | 'seek'
-                | 'fade'
-                | 'unlock',
-            id: number,
-        ): this;
-        off(event?: string, callback?: HowlCallback | HowlErrorCallback, id?: number): this;
-
-        stereo(): number;
-        stereo(pan: number, id?: number): number | this;
-
-        pos(): SpatialPosition;
-        pos(x: number, y?: number, z?: number, id?: number): this;
-
-        orientation(): SpatialOrientation;
-        orientation(x: number, y?: number, z?: number, id?: number): this;
-
-        pannerAttr(id?: number): PannerAttributes;
-        pannerAttr(options: PannerAttributes, id?: number): this;
-    }
-
-    class HowlerGlobal {
-        mute(muted: boolean): this;
-        stop(): this;
-
-        volume(): number;
-        volume(volume: number): this;
-
-        codecs(ext: string): boolean;
-        unload(): this;
-        usingWebAudio: boolean;
-        html5PoolSize: number;
-        noAudio: boolean;
-        autoUnlock: boolean;
-        autoSuspend: boolean;
-        ctx: AudioContext;
-        masterGain: GainNode;
-
-        stereo(pan: number): this;
-
-        pos(): SpatialPosition;
-        pos(x: number, y?: number, z?: number): this;
-
-        orientation(): SpatialOrientation;
-        orientation(x: number, y?: number, z?: number, xUp?: number, yUp?: number, zUp?: number): this;
-    }
-    const Howler: HowlerGlobal;
-
-    interface Window {
-        Howl: typeof Howl;
-        HowlerGlobal: typeof HowlerGlobal;
-        Howler: typeof Howler;
-    }
+    interface Howl extends _Howl {}
+    interface HowlerGlobal extends _HowlerGlobal {}
+    var Howl: typeof _Howl;
+    var HowlerGlobal: typeof _HowlerGlobal;
+    var Howler: HowlerGlobal;
 }

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -180,96 +180,100 @@ export interface HowlOptions extends HowlListeners {
         | undefined;
 }
 
-export class Howl {
-    constructor(options: HowlOptions);
-
-    play(spriteOrId?: string | number): number; // .play() is not chainable; the other methods are
-    pause(id?: number): this;
-    stop(id?: number): this;
-
-    mute(): boolean;
-    mute(muted: boolean, id?: number): this;
-
-    volume(): number;
-    volume(idOrSetVolume: number): this | number;
-    volume(volume: number, id: number): this;
-
-    fade(from: number, to: number, duration: number, id?: number): this;
-
-    rate(id?: number): number;
-    rate(rate: number, id?: number): this;
-
-    seek(id?: number): number;
-    seek(seek: number, id?: number): this;
-
-    loop(id?: number): boolean;
-    loop(loop: boolean, id?: number): this;
-
-    playing(id?: number): boolean;
-    duration(id?: number): number;
-    state(): 'unloaded' | 'loading' | 'loaded';
-    load(): this;
-    unload(): null;
-
-    on(event: 'load', callback: () => void, id?: number): this;
-    on(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
-    on(
-        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-        callback: HowlCallback,
-        id?: number,
-    ): this;
-    on(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
-
-    once(event: 'load', callback: () => void, id?: number): this;
-    once(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
-    once(
-        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-        callback: HowlCallback,
-        id?: number,
-    ): this;
-    once(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
-
-    off(event: 'load', callback?: () => void, id?: number): this;
-    off(event: 'loaderror' | 'playerror', callback?: HowlErrorCallback, id?: number): this;
-    off(
-        event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
-        callback?: HowlCallback,
-        id?: number,
-    ): this;
-    // off() also supports passing id as second argument: internally it is type checked and treated as an id if it is a number
-    off(
-        event:
-            | 'load'
-            | 'loaderror'
-            | 'playerror'
-            | 'play'
-            | 'end'
-            | 'pause'
-            | 'stop'
-            | 'mute'
-            | 'volume'
-            | 'rate'
-            | 'seek'
-            | 'fade'
-            | 'unlock',
-        id: number,
-    ): this;
-    off(event?: string, callback?: HowlCallback | HowlErrorCallback, id?: number): this;
-
-    stereo(): number;
-    stereo(pan: number, id?: number): number | this;
-
-    pos(): SpatialPosition;
-    pos(x: number, y?: number, z?: number, id?: number): this;
-
-    orientation(): SpatialOrientation;
-    orientation(x: number, y?: number, z?: number, id?: number): this;
-
-    pannerAttr(id?: number): PannerAttributes;
-    pannerAttr(options: PannerAttributes, id?: number): this;
-}
+// typescript 4.4 compat
+type _HowlerGlobal = HowlerGlobal;
+export { Howl, Howler, _HowlerGlobal as HowlerGlobal };
 
 declare global {
+    class Howl {
+        constructor(options: HowlOptions);
+
+        play(spriteOrId?: string | number): number; // .play() is not chainable; the other methods are
+        pause(id?: number): this;
+        stop(id?: number): this;
+
+        mute(): boolean;
+        mute(muted: boolean, id?: number): this;
+
+        volume(): number;
+        volume(idOrSetVolume: number): this | number;
+        volume(volume: number, id: number): this;
+
+        fade(from: number, to: number, duration: number, id?: number): this;
+
+        rate(id?: number): number;
+        rate(rate: number, id?: number): this;
+
+        seek(id?: number): number;
+        seek(seek: number, id?: number): this;
+
+        loop(id?: number): boolean;
+        loop(loop: boolean, id?: number): this;
+
+        playing(id?: number): boolean;
+        duration(id?: number): number;
+        state(): 'unloaded' | 'loading' | 'loaded';
+        load(): this;
+        unload(): null;
+
+        on(event: 'load', callback: () => void, id?: number): this;
+        on(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
+        on(
+            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+            callback: HowlCallback,
+            id?: number,
+        ): this;
+        on(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
+
+        once(event: 'load', callback: () => void, id?: number): this;
+        once(event: 'loaderror' | 'playerror', callback: HowlErrorCallback, id?: number): this;
+        once(
+            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+            callback: HowlCallback,
+            id?: number,
+        ): this;
+        once(event: string, callback: HowlCallback | HowlErrorCallback, id?: number): this;
+
+        off(event: 'load', callback?: () => void, id?: number): this;
+        off(event: 'loaderror' | 'playerror', callback?: HowlErrorCallback, id?: number): this;
+        off(
+            event: 'play' | 'end' | 'pause' | 'stop' | 'mute' | 'volume' | 'rate' | 'seek' | 'fade' | 'unlock',
+            callback?: HowlCallback,
+            id?: number,
+        ): this;
+        // off() also supports passing id as second argument: internally it is type checked and treated as an id if it is a number
+        off(
+            event:
+                | 'load'
+                | 'loaderror'
+                | 'playerror'
+                | 'play'
+                | 'end'
+                | 'pause'
+                | 'stop'
+                | 'mute'
+                | 'volume'
+                | 'rate'
+                | 'seek'
+                | 'fade'
+                | 'unlock',
+            id: number,
+        ): this;
+        off(event?: string, callback?: HowlCallback | HowlErrorCallback, id?: number): this;
+
+        stereo(): number;
+        stereo(pan: number, id?: number): number | this;
+
+        pos(): SpatialPosition;
+        pos(x: number, y?: number, z?: number, id?: number): this;
+
+        orientation(): SpatialOrientation;
+        orientation(x: number, y?: number, z?: number, id?: number): this;
+
+        pannerAttr(id?: number): PannerAttributes;
+        pannerAttr(options: PannerAttributes, id?: number): this;
+    }
+
     class HowlerGlobal {
         mute(muted: boolean): this;
         stop(): this;
@@ -296,6 +300,10 @@ declare global {
         orientation(x: number, y?: number, z?: number, xUp?: number, yUp?: number, zUp?: number): this;
     }
     const Howler: HowlerGlobal;
-}
 
-export const Howler: HowlerGlobal;
+    interface Window {
+        Howl: typeof Howl;
+        HowlerGlobal: typeof HowlerGlobal;
+        Howler: typeof Howler;
+    }
+}

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -28,10 +28,6 @@ export interface PannerAttributes {
     rolloffFactor?: number;
 }
 
-export interface Sound {
-    new(howl: Howl): this;
-}
-
 export interface HowlListeners {
     /** Fires when the sound has been stopped. The first parameter is the ID of the sound. */
     onstop?: HowlCallback | undefined;

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -259,7 +259,7 @@ export class Howl {
     pannerAttr(options: PannerAttributes, id?: number): this;
 }
 
-export class HowlerGlobal {
+export interface HowlerGlobal {
     mute(muted: boolean): this;
     stop(): this;
 
@@ -293,6 +293,9 @@ declare global {
     interface Howl extends _Howl {}
     interface HowlerGlobal extends _HowlerGlobal {}
     var Howl: typeof _Howl;
-    var HowlerGlobal: typeof _HowlerGlobal;
+    var HowlerGlobal: {
+        prototype: _HowlerGlobal;
+        new (): _HowlerGlobal;
+    };
     var Howler: HowlerGlobal;
 }

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -285,7 +285,7 @@ export class HowlerGlobal {
     orientation(x: number, y?: number, z?: number, xUp?: number, yUp?: number, zUp?: number): this;
 }
 
-import { Howl as _Howl, HowlerGlobal as _HowlerGlobal } from 'howler';
+import { Howl as _Howl, HowlerGlobal as _HowlerGlobal } from '.';
 export { Howler };
 
 declare global {

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -13,12 +13,6 @@ export type HowlErrorCallback = (soundId: number, error: unknown) => void;
 export type SpatialOrientation = [number, number, number];
 export type SpatialPosition = [number, number, number];
 
-export enum State {
-    Unloaded = 'unloaded',
-    Loading = 'loading',
-    Loaded = 'loaded',
-}
-
 export interface SoundSpriteDefinitions {
     [name: string]: [number, number] | [number, number, boolean];
 }

--- a/types/howler/test/globals.ts
+++ b/types/howler/test/globals.ts
@@ -1,0 +1,12 @@
+new globalThis.Howl({ src: 'sound.mp3' });
+new this.Howl({ src: 'sound.mp3' });
+new window.Howl({ src: 'sound.mp3' });
+new Howl({ src: 'sound.mp3' });
+
+globalThis.Howler.volume(0.8);
+this.Howler.volume(0.8);
+window.Howler.volume(0.8);
+Howler.volume(0.8);
+
+let a: Howl = new globalThis.Howl({ src: 'sound.mp3' });
+let b: HowlerGlobal = globalThis.Howler;

--- a/types/howler/tslint.json
+++ b/types/howler/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "space-before-function-paren": false,
         "only-arrow-functions": false,
-        "object-literal-shorthand": false,
-        "no-empty-interface": false
+        "object-literal-shorthand": false
     }
 }

--- a/types/howler/tslint.json
+++ b/types/howler/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "space-before-function-paren": false,
         "only-arrow-functions": false,
-        "object-literal-shorthand": false
+        "object-literal-shorthand": false,
+        "no-empty-interface": false
     }
 }


### PR DESCRIPTION
Changes:
- The global `Howl` class has been added to global and window.
- The global `Howler` object has been added to window.
- The global `HowlerGlobal` class has been added to window.
- The enum `State` has been removed, it was never exported in howler.js.
- The type `Sound` has been removed, howler.js' `Sound` class only exists for private members.
- The types `Howl` and `HowlerGlobal` has been added to global.

From source:
https://github.com/goldfire/howler.js/blob/9610df82fb93467d62f25a7b1682d534923dc963/src/howler.core.js#L2576-L2585