### PR TITLE
fix(spritesmith): image result is Transform for processImages and Buffer for run

### DIFF
--- a/types/spritesmith/index.d.ts
+++ b/types/spritesmith/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Zenoo <https://github.com/Zenoo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ReadableStream } from 'stream/web';
+import { Transform } from 'stream';
 import { BufferFile } from 'vinyl';
 
 declare class Spritesmith {
@@ -53,7 +53,7 @@ declare namespace Spritesmith {
     }
 
     interface SpritesmithResult {
-        image: ReadableStream;
+        image: Transform;
         coordinates: Record<string, { x: number; y: number; width: number; height: number }>;
         properties: { width: number; height: number };
     }

--- a/types/spritesmith/index.d.ts
+++ b/types/spritesmith/index.d.ts
@@ -9,20 +9,20 @@ import { BufferFile } from 'vinyl';
 declare class Spritesmith {
     constructor(params?: Spritesmith.SpritesmithParams);
     static run(
-        params: Spritesmith.SpritesmithParams & Spritesmith.SpritesmithProcessImagesOptions & {
-            src: Spritesmith.SpritesmithCreateImagesSrc;
-        },
-        callback: (
-            err: Error | null,
-            result: Spritesmith.SpritesmithResult & {
-                image: Buffer;
-            }
-        ) => void): void;
-    createImages(src: Spritesmith.SpritesmithCreateImagesSrc, callback: (err: Error | null, images: Spritesmith.SpritesmithImage[]) => void): void;
+        params: Spritesmith.SpritesmithParams &
+            Spritesmith.SpritesmithProcessImagesOptions & {
+                src: Spritesmith.SpritesmithCreateImagesSrc;
+            },
+        callback: (err: Error | null, result: Spritesmith.SpritesmithResult) => void,
+    ): void;
+    createImages(
+        src: Spritesmith.SpritesmithCreateImagesSrc,
+        callback: (err: Error | null, images: Spritesmith.SpritesmithImage[]) => void,
+    ): void;
     processImages(
         images: Spritesmith.SpritesmithImage[],
-        options?: Spritesmith.SpritesmithProcessImagesOptions
-    ): Spritesmith.SpritesmithResult;
+        options?: Spritesmith.SpritesmithProcessImagesOptions,
+    ): Spritesmith.SpritesmithResult<Transform>;
 }
 
 declare namespace Spritesmith {
@@ -52,8 +52,8 @@ declare namespace Spritesmith {
         };
     }
 
-    interface SpritesmithResult {
-        image: Transform;
+    interface SpritesmithResult<Image extends Buffer | Transform = Buffer> {
+        image: Image;
         coordinates: Record<string, { x: number; y: number; width: number; height: number }>;
         properties: { width: number; height: number };
     }

--- a/types/spritesmith/spritesmith-tests.ts
+++ b/types/spritesmith/spritesmith-tests.ts
@@ -1,10 +1,12 @@
 import { SpritesmithResult } from 'spritesmith';
 import Spritesmith = require('spritesmith');
+import { Transform } from 'stream';
 
 // Generate our spritesheet
 const sprites = ['fork.png', 'github.png', 'twitter.png'];
 // $ExpectType void
 Spritesmith.run({ src: sprites }, function handleResult(err, result) {
+    // $ExpectType Buffer
     result.image; // Buffer representation of image
     result.coordinates; // Object mapping filename to {x, y, width, height} of image
     result.properties; // Object with metadata about spritesheet {width, height}
@@ -18,8 +20,8 @@ spritesmith.createImages(sprites, function handleImages(err, images) {
     images[0].height; // Height of image
 
     // Create our result
-    // $ExpectType SpritesmithResult
-    const result: SpritesmithResult = spritesmith.processImages(images);
+    const result: SpritesmithResult<Transform> = spritesmith.processImages(images);
+    // $ExpectType Transform
     result.image; // Readable stream outputting image
     result.coordinates; // Object mapping filename to {x, y, width, height} of image
     result.properties; // Object with metadata about spritesheet {width, height}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [the Transform created in `processImages`](https://github.com/twolfson/spritesmith/blob/master/src/smith.js#L127) vs [the buffer created in `run`](https://github.com/twolfson/spritesmith/blob/master/src/smith.js#L86)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

CC @twolfson and @Zenoo 