### PR TITLE
Mention renames on ghostbuster PRs

### DIFF
--- a/.github/workflows/ghostbuster.yml
+++ b/.github/workflows/ghostbuster.yml
@@ -57,5 +57,9 @@ jobs:
           branch-suffix: short-commit-hash
           delete-branch: true
           title: Remove contributors with deleted accounts
-          body: "Generated from [.github/workflows/ghostbuster.yml](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/workflows/ghostbuster.yml)"
+          body: |
+            Generated from [.github/workflows/ghostbuster.yml](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/workflows/ghostbuster.yml)
+            
+            Some of these users may have simply changed their usernames; you may want do a bit of searching and ping them to see if they still want to be owners.
+
 


### PR DESCRIPTION
It looks like some of us are checking for user renames but some aren't; usually these can be found with a quick search and it's nice to keep people on when it's "our problem" that we are storing usernames and not IDs or something.