### PR TITLE
Fix function name typo on tabulator-tables - refreshFilters to refreshFilter

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -9,24 +9,24 @@
 
 export interface Options
     extends OptionsGeneral,
-        OptionsMenu,
-        OptionsHistory,
-        OptionsLocale,
-        OptionsDownload,
-        OptionsColumns,
-        OptionsRows,
-        OptionsData,
-        OptionsSorting,
-        OptionsFiltering,
-        OptionsRowGrouping,
-        OptionsPagination,
-        OptionsPersistentConfiguration,
-        OptionsClipboard,
-        OptionsDataTree,
-        OptionsCell,
-        OptionsCells,
-        OptionsDebug,
-        OptionsHTML {}
+    OptionsMenu,
+    OptionsHistory,
+    OptionsLocale,
+    OptionsDownload,
+    OptionsColumns,
+    OptionsRows,
+    OptionsData,
+    OptionsSorting,
+    OptionsFiltering,
+    OptionsRowGrouping,
+    OptionsPagination,
+    OptionsPersistentConfiguration,
+    OptionsClipboard,
+    OptionsDataTree,
+    OptionsCell,
+    OptionsCells,
+    OptionsDebug,
+    OptionsHTML { }
 
 export interface OptionsDebug {
     invalidOptionWarning?: boolean;
@@ -49,8 +49,8 @@ export interface OptionsDebug {
 export interface OptionsCells extends CellCallbacks {
     /** The validationFailed event is triggered when the value entered into a cell during an edit fails to pass validation. */
     validationFailed?:
-        | ((cell: CellComponent, value: any, validators: Validator[] | StandardValidatorType[]) => void)
-        | undefined;
+    | ((cell: CellComponent, value: any, validators: Validator[] | StandardValidatorType[]) => void)
+    | undefined;
 }
 
 export interface OptionsDataTree {
@@ -154,15 +154,15 @@ export interface OptionsClipboard {
 
     /** When copying to clipboard you may want to apply a different group header from the one usually used in the table. You can now do this using the groupHeaderClipboard table option, which takes the same inputs as the standard groupHeader property. */
     groupHeaderClipboard?:
-        | ((value: any, count: number, data: any, group: GroupComponent) => string)
-        | Array<(value: any, count: number, data: any) => string>
-        | undefined;
+    | ((value: any, count: number, data: any, group: GroupComponent) => string)
+    | Array<(value: any, count: number, data: any) => string>
+    | undefined;
 
     /** When the getHtml function is called you may want to apply a different group header from the one usually used in the table. You can now do this using the groupHeaderHtmlOutput table option, which takes the same inputs as the standard groupHeader property. */
     groupHeaderHtmlOutput?:
-        | ((value: any, count: number, data: any, group: GroupComponent) => string)
-        | Array<(value: any, count: number, data: any) => string>
-        | undefined;
+    | ((value: any, count: number, data: any, group: GroupComponent) => string)
+    | Array<(value: any, count: number, data: any) => string>
+    | undefined;
 }
 
 export interface OptionsPersistentConfiguration {
@@ -282,15 +282,15 @@ export interface OptionsPagination {
      * The function must return the contents of the counter, either the text value of the counter, valid HTML or a DOM node
      */
     paginationCounter?:
-        | 'rows'
-        | 'pages'
-        | ((
-              pageSize: number,
-              currentRow: number,
-              currentPage: number,
-              totalRows: number,
-              totalPages: number,
-          ) => string | HTMLElement);
+    | 'rows'
+    | 'pages'
+    | ((
+        pageSize: number,
+        currentRow: number,
+        currentPage: number,
+        totalRows: number,
+        totalPages: number,
+    ) => string | HTMLElement);
 
     /**
      * By default the counter will be displayed in the left of the table footer. If you would like it displayed in another element pass a DOM node or a CSS selector for that element.
@@ -319,15 +319,15 @@ export interface OptionsRowGrouping {
 
     /** You can use the setGroupHeader function to change the header generation function for each group. This function has one argument and takes the same values as passed to the groupHeader setup option. */
     groupHeader?:
-        | ((value: any, count: number, data: any, group: GroupComponent) => string)
-        | Array<(value: any, count: number, data: any) => string>
-        | undefined;
+    | ((value: any, count: number, data: any, group: GroupComponent) => string)
+    | Array<(value: any, count: number, data: any) => string>
+    | undefined;
 
     /** When printing you may want to apply a different group header from the one usually used in the table. You can now do this using the groupHeaderPrint table option, which takes the same inputs as the standard groupHeader property. */
     groupHeaderPrint?:
-        | ((value: any, count: number, data: any, group: GroupComponent) => string)
-        | Array<(value: any, count: number, data: any) => string>
-        | undefined;
+    | ((value: any, count: number, data: any, group: GroupComponent) => string)
+    | Array<(value: any, count: number, data: any) => string>
+    | undefined;
 
     /**
      * You can set the default open state of groups using the groupStartOpen property* * This can take one of three possible values:
@@ -596,10 +596,10 @@ export interface OptionsRows {
      * You can also pass a callback to the movableRowsSender option for custom sender functionality
      */
     movableRowsSender?:
-        | false
-        | 'delete'
-        | ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => any)
-        | undefined;
+    | false
+    | 'delete'
+    | ((fromRow: RowComponent, toRow: RowComponent, toTable: Tabulator) => any)
+    | undefined;
 
     /**
      * The movableRowsReceiver option should be set on the receiving tables, and sets the action that should be taken when the row is dropped into the table.
@@ -611,12 +611,12 @@ export interface OptionsRows {
      * - replace - replaces the row it is dropped on with the sent row
      */
     movableRowsReceiver?:
-        | 'insert'
-        | 'add'
-        | 'update'
-        | 'replace'
-        | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => any)
-        | undefined;
+    | 'insert'
+    | 'add'
+    | 'update'
+    | 'replace'
+    | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => any)
+    | undefined;
     movableRowsConnectedElements?: string | HTMLElement | undefined;
 
     /** When a row is dropped on element from from the movableRowsConnectedElements option the movableRowsElementDrop callback will be triggered. You can use this callback to trigger any changes as a result of the drop */
@@ -669,8 +669,8 @@ export interface OptionsRows {
 
     /** The movableRowsReceivedFailed callback is triggered on a receiving table when a row receiver has returned false. */
     movableRowsReceivedFailed?:
-        | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void)
-        | undefined;
+    | ((fromRow: RowComponent, toRow: RowComponent, fromTable: Tabulator) => void)
+    | undefined;
 
     /** The movableRowsReceivingStop callback is triggered on a receiving table after a row has been dropped and any senders and receivers have been handled. */
     movableRowsReceivingStop?: ((fromTable: Tabulator) => void) | undefined;
@@ -751,10 +751,10 @@ export interface OptionsColumns {
     /** If you set the autoColumns option to true, every time data is loaded into the table through the data option or through the setData function, Tabulator will examine the first row of the data and build columns to match that data. */
     autoColumns?: boolean | undefined;
     autoColumnsDefinitions?:
-        | ((columnDefinitions?: ColumnDefinition[]) => ColumnDefinition[])
-        | ColumnDefinition[]
-        | Record<string, Partial<ColumnDefinition>>
-        | undefined;
+    | ((columnDefinitions?: ColumnDefinition[]) => ColumnDefinition[])
+    | ColumnDefinition[]
+    | Record<string, Partial<ColumnDefinition>>
+    | undefined;
 
     /** By default Tabulator will use the fitData layout mode, which will resize the tables columns to fit the data held in each column, unless you specify a width or minWidth in the column constructor. If the width of all columns exceeds the width of the containing element, a scroll bar will appear. */
     layout?: 'fitData' | 'fitColumns' | 'fitDataFill' | 'fitDataStretch' | 'fitDataTable' | undefined;
@@ -1019,7 +1019,7 @@ export interface MenuSeparator {
 
 export type DownloadType = 'csv' | 'json' | 'xlsx' | 'pdf' | 'html';
 
-export interface DownloadOptions extends DownloadCSV, DownloadXLXS, DownloadPDF, DownloadHTML {}
+export interface DownloadOptions extends DownloadCSV, DownloadXLXS, DownloadPDF, DownloadHTML { }
 
 export interface DownloadCSV {
     /** By default CSV files are created using a comma (,) delimiter. If you need to change this for any reason the you can pass the options object with a delimiter property to the download function which will then use this delimiter instead of the comma. */
@@ -1114,9 +1114,9 @@ export interface OptionsHTML {
     printFormatter?: ((tableHolderElement: any, tableElement: any) => any) | undefined;
 
     groupHeaderDownload?:
-        | ((value: any, count: number, data: any, group: GroupComponent) => string)
-        | Array<(value: any, count: number, data: any) => string>
-        | undefined;
+    | ((value: any, count: number, data: any, group: GroupComponent) => string)
+    | Array<(value: any, count: number, data: any) => string>
+    | undefined;
 }
 
 export type StandardStringParam = string | HTMLElement | (() => string | HTMLElement);
@@ -1229,25 +1229,25 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
      * You can pass an optional additional property with sorter, sorterParams that should contain an object with additional information for configuring the sorter
      */
     sorter?:
-        | 'string'
-        | 'number'
-        | 'alphanum'
-        | 'boolean'
-        | 'exists'
-        | 'date'
-        | 'time'
-        | 'datetime'
-        | 'array'
-        | ((
-              a: any,
-              b: any,
-              aRow: RowComponent,
-              bRow: RowComponent,
-              column: ColumnComponent,
-              dir: SortDirection,
-              sorterParams: {},
-          ) => number)
-        | undefined;
+    | 'string'
+    | 'number'
+    | 'alphanum'
+    | 'boolean'
+    | 'exists'
+    | 'date'
+    | 'time'
+    | 'datetime'
+    | 'array'
+    | ((
+        a: any,
+        b: any,
+        aRow: RowComponent,
+        bRow: RowComponent,
+        column: ColumnComponent,
+        dir: SortDirection,
+        sorterParams: {},
+    ) => number)
+    | undefined;
 
     /** If you want to dynamically generate the sorterParams at the time the sort is called you can pass a function into the property that should return the params object. */
     sorterParams?: ColumnDefinitionSorterParams | ColumnSorterParamLookupFunction | undefined;
@@ -1435,9 +1435,9 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
      * If you want to specify the type of filter used you can pass it to the headerFilterFunc option in the column definition object. This will take any of the standard filters outlined above or a custom function
      */
     headerFilterFunc?:
-        | FilterType
-        | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean)
-        | undefined;
+    | FilterType
+    | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean)
+    | undefined;
 
     /** additional parameters object passed to the headerFilterFunc function. */
     headerFilterFuncParams?: any;
@@ -1476,8 +1476,8 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
 
     /** Popups work in a similar way to menus, but instead of only displaying lists of menu items they allow you to fill them with any custom content you like, text, input elements, forms, anything you fancy. */
     cellPopup?:
-        | string
-        | ((e: MouseEvent, component: RowComponent | CellComponent | ColumnComponent, onRendered: () => any) => any);
+    | string
+    | ((e: MouseEvent, component: RowComponent | CellComponent | ColumnComponent, onRendered: () => any) => any);
 
     /** When copying to the clipboard you may want to apply a different formatter from the one usually used to format the cell, you can do this using the formatterClipboard column definition option. You can use the formatterClipboardParams to pass in any additional params to the formatter. */
     formatterClipboard?: Formatter | false | undefined;
@@ -1596,12 +1596,12 @@ export type CustomAccessor = (
 export type CustomAccessorParams =
     | {}
     | ((
-          value: any,
-          data: any,
-          type: 'data' | 'download' | 'clipboard',
-          column?: ColumnComponent,
-          row?: RowComponent,
-      ) => any);
+        value: any,
+        data: any,
+        type: 'data' | 'download' | 'clipboard',
+        column?: ColumnComponent,
+        row?: RowComponent,
+    ) => any);
 
 export type ColumnCalc =
     | 'avg'
@@ -1664,12 +1664,12 @@ export type Editor =
     | 'time'
     | 'datetime'
     | ((
-          cell: CellComponent,
-          onRendered: EmptyCallback,
-          success: ValueBooleanCallback,
-          cancel: ValueVoidCallback,
-          editorParams: {},
-      ) => HTMLElement | false);
+        cell: CellComponent,
+        onRendered: EmptyCallback,
+        success: ValueBooleanCallback,
+        cancel: ValueVoidCallback,
+        editorParams: {},
+    ) => HTMLElement | false);
 
 export type EditorParams =
     | NumberParams
@@ -2883,7 +2883,7 @@ declare class Tabulator {
     setGroupValues: (data: GroupValuesArg) => void;
 
     /** You can now trigger a refresh of the current filters using the refreshFilter function. This function will cause the current filters to be run again and applied to the table data. */
-    refreshFilters: () => void;
+    refreshFilter: () => void;
 
     /** The clearHistory function can be used to clear out the current table interaction history. */
     clearHistory: () => void;
@@ -2895,43 +2895,43 @@ declare class Module {
     static moduleName: string;
     constructor(table: Tabulator);
 }
-declare class AccessorModule {}
-declare class AjaxModule {}
-declare class ClipboardModule {}
-declare class ColumnCalcsModule {}
-declare class DataTreeModule {}
-declare class DownloadModule {}
-declare class EditModule {}
-declare class ExportModule {}
-declare class FilterModule {}
-declare class FormatModule {}
-declare class FrozenColumnsModule {}
-declare class FrozenRowsModule {}
-declare class GroupRowsModule {}
-declare class HistoryModule {}
-declare class HtmlTableImportModule {}
-declare class InteractionModule {}
-declare class KeybindingsModule {}
-declare class MenuModule {}
-declare class MoveColumnsModule {}
-declare class MoveRowsModule {}
-declare class MutatorModule {}
-declare class PageModule {}
-declare class PersistenceModule {}
-declare class PopupModule {}
-declare class PrintModule {}
-declare class PseudoRow {}
-declare class ReactiveDataModule {}
-declare class Renderer {}
-declare class ResizeColumnsModule {}
-declare class ResizeRowsModule {}
-declare class ResizeTableModule {}
-declare class ResponsiveLayoutModule {}
-declare class SelectRowModule {}
-declare class SortModule {}
-declare class TabulatorFull extends Tabulator {}
-declare class TooltipModule {}
-declare class ValidateModule {}
+declare class AccessorModule { }
+declare class AjaxModule { }
+declare class ClipboardModule { }
+declare class ColumnCalcsModule { }
+declare class DataTreeModule { }
+declare class DownloadModule { }
+declare class EditModule { }
+declare class ExportModule { }
+declare class FilterModule { }
+declare class FormatModule { }
+declare class FrozenColumnsModule { }
+declare class FrozenRowsModule { }
+declare class GroupRowsModule { }
+declare class HistoryModule { }
+declare class HtmlTableImportModule { }
+declare class InteractionModule { }
+declare class KeybindingsModule { }
+declare class MenuModule { }
+declare class MoveColumnsModule { }
+declare class MoveRowsModule { }
+declare class MutatorModule { }
+declare class PageModule { }
+declare class PersistenceModule { }
+declare class PopupModule { }
+declare class PrintModule { }
+declare class PseudoRow { }
+declare class ReactiveDataModule { }
+declare class Renderer { }
+declare class ResizeColumnsModule { }
+declare class ResizeRowsModule { }
+declare class ResizeTableModule { }
+declare class ResponsiveLayoutModule { }
+declare class SelectRowModule { }
+declare class SortModule { }
+declare class TabulatorFull extends Tabulator { }
+declare class TooltipModule { }
+declare class ValidateModule { }
 
 export {
     Module,

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -169,7 +169,7 @@ colDef.formatterParams = {
 };
 // Custom Formatter
 colDef.formatter = (cell: CellComponent, formatterParams: {}, onRendered) => {
-    onRendered = () => {};
+    onRendered = () => { };
     return '';
 };
 
@@ -530,7 +530,7 @@ colDef.editorParams = { search: true };
 table.getHtml('all', true, { columnCalcs: true });
 
 table.download('pdf', 'data.pdf', {
-    documentProcessing: doc => {},
+    documentProcessing: doc => { },
 });
 
 table.download('pdf', 'data.pdf', {
@@ -668,9 +668,9 @@ table.restoreRedraw();
 table.getRows('visible');
 table.deleteRow([15, 7, 9]);
 
-table.addColumn({} as ColumnDefinition).then(() => {});
+table.addColumn({} as ColumnDefinition).then(() => { });
 
-table.deleteColumn('name').then(() => {});
+table.deleteColumn('name').then(() => { });
 
 table
     .updateColumnDefinition('age', { title: 'Updated Title', frozen: true })
@@ -693,8 +693,8 @@ table.download('xlsx', 'data.xlsx', {
 });
 
 table = new Tabulator('#example-table', {
-    scrollVertical: () => {},
-    scrollHorizontal: () => {},
+    scrollVertical: () => { },
+    scrollHorizontal: () => { },
 });
 
 // 4.6 updates
@@ -773,8 +773,8 @@ table = new Tabulator('#example-table', {
     printRowRange: () => {
         return [];
     },
-    rowFormatterPrint: row => {},
-    rowFormatterHtmlOutput: row => {},
+    rowFormatterPrint: row => { },
+    rowFormatterHtmlOutput: row => { },
     headerFilterLiveFilterDelay: 600,
     columns: [
         {
@@ -804,7 +804,7 @@ columns.forEach(col => col.getDefinition());
 // 4.7 updates
 
 table = new Tabulator('#example-table', {
-    movableRowsElementDrop: (e, element, row) => {},
+    movableRowsElementDrop: (e, element, row) => { },
     downloadRowRange: 'selected',
     layout: 'fitDataTable',
     validationMode: 'highlight',
@@ -918,7 +918,7 @@ table = new Tabulator('#example-table', {
     dataTreeFilter: false,
     dataTreeSort: false,
     groupUpdateOnCellEdit: true,
-    dataChanged: data => {},
+    dataChanged: data => { },
 });
 
 table.setGroupValues([['male', 'female', 'smizmar']]);
@@ -984,7 +984,7 @@ colDef.formatterParams = {
     urlSuffix: '.png',
 };
 
-table.refreshFilters();
+table.refreshFilter();
 table.clearHistory();
 
 colDef.maxWidth = 300;
@@ -994,7 +994,7 @@ colDef.maxWidth = false;
 Tabulator.defaultOptions.movableRows = true;
 Tabulator.extendModule('format', 'formatters', {});
 
-class CustomRenderer extends Renderer {}
+class CustomRenderer extends Renderer { }
 
 table = new Tabulator('#test', {
     renderVertical: 'virtual',
@@ -1030,23 +1030,23 @@ table = new Tabulator('#test', {
     debugEventsInternal: false,
 });
 
-const dataProcessedEvent = () => {};
+const dataProcessedEvent = () => { };
 
 table.on('dataLoading', dataProcessedEvent);
-table.on('dataLoaded', () => {});
-table.on('dataLoadError', () => {});
-table.on('dataProcessing', () => {});
-table.on('dataProcessed', () => {});
-table.on('rowMoving', () => {});
-table.on('rowMoveCancelled', row => {});
-table.on('rowSelectionChanged', (selectedData, selectedRows) => {});
+table.on('dataLoaded', () => { });
+table.on('dataLoadError', () => { });
+table.on('dataProcessing', () => { });
+table.on('dataProcessed', () => { });
+table.on('rowMoving', () => { });
+table.on('rowMoveCancelled', row => { });
+table.on('rowSelectionChanged', (selectedData, selectedRows) => { });
 table.off('dataProcessed');
 table.off('dataProcessed', dataProcessedEvent);
-table.off('rowMoving', () => {});
-table.on('cellClick', () => {});
-table.on('scrollHorizontal', (left, leftDir) => {});
-table.on('scrollVertical', (top, topDir) => {});
-table.on('pageSizeChanged', pageSize => {});
+table.off('rowMoving', () => { });
+table.on('cellClick', () => { });
+table.on('scrollHorizontal', (left, leftDir) => { });
+table.on('scrollVertical', (top, topDir) => { });
+table.on('pageSizeChanged', pageSize => { });
 table = Tabulator.findTable('#example-table')[0];
 table = TabulatorFull.findTable('#example-table')[0];
 
@@ -1058,7 +1058,7 @@ class CustomModule extends Module {
         super(table);
     }
 
-    initialize() {}
+    initialize() { }
 }
 
 CustomModule.moduleName = 'custom';
@@ -1224,20 +1224,20 @@ table = new Tabulator('#test', {
             dblClickPopup: 'Im a Popup',
             headerDblClickPopup: 'Im a Popup',
             headerWordWrap: true,
-            headerMouseUp: (e, column) => {},
+            headerMouseUp: (e, column) => { },
         },
     ],
 });
 
-table.on('cellMouseDown', (e, cell) => {});
+table.on('cellMouseDown', (e, cell) => { });
 
 // Testing popup event and menu event
-table.on('popupClosed', component => {});
-table.on('popupOpen', component => {});
-table.on('menuOpened', component => {});
-table.on('menuClosed', component => {});
-table.on('TooltipOpened', component => {});
-table.on('TooltipClosed', component => {});
+table.on('popupClosed', component => { });
+table.on('popupOpen', component => { });
+table.on('menuOpened', component => { });
+table.on('menuClosed', component => { });
+table.on('TooltipOpened', component => { });
+table.on('TooltipClosed', component => { });
 
 column.popup('test', 'bottom');
 


### PR DESCRIPTION
This Pull request fix typo on type refreshFilters. the correct name is `refreshFilter`. 
issue from [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/65802) 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. 
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://tabulator.info/docs/5.5/filter#main-contents>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
