### PR TITLE
[react-datepicker] fix missing renderYearContent & renderQuarterContent type

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -158,8 +158,8 @@ export interface ReactDatePickerProps<
     renderCustomHeader?(params: ReactDatePickerCustomHeaderProps): React.ReactNode;
     renderDayContents?(dayOfMonth: number, date?: Date): React.ReactNode;
     renderMonthContent?(monthIndex: number, shortMonthText: string, fullMonthText: string): React.ReactNode;
-    renderQuarterContent: (quarter: string, shortQuarter?: string): React.ReactNode;
-    renderYearContent: (year: number): React.ReactNode;
+    renderQuarterContent?(quarter: string, shortQuarter?: string): React.ReactNode;
+    renderYearContent?(year: number): React.ReactNode;
     required?: boolean | undefined;
     scrollableMonthYearDropdown?: boolean | undefined;
     scrollableYearDropdown?: boolean | undefined;

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 4.15
+// Type definitions for react-datepicker 4.16
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 //                 Greg Smith <https://github.com/smrq>
@@ -158,6 +158,8 @@ export interface ReactDatePickerProps<
     renderCustomHeader?(params: ReactDatePickerCustomHeaderProps): React.ReactNode;
     renderDayContents?(dayOfMonth: number, date?: Date): React.ReactNode;
     renderMonthContent?(monthIndex: number, shortMonthText: string, fullMonthText: string): React.ReactNode;
+    renderQuarterContent: (quarter: string, shortQuarter?: string): React.ReactNode;
+    renderYearContent: (year: number): React.ReactNode;
     required?: boolean | undefined;
     scrollableMonthYearDropdown?: boolean | undefined;
     scrollableYearDropdown?: boolean | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -152,7 +152,7 @@ const topLogger: Modifier<'topLogger'> = {
     }) => <div />}
     renderDayContents={(dayOfMonth, date) => <div />}
     renderMonthContent={(monthIndex, shortMonth, longMonth) => <div />}
-    renderQuarterContent={(quarter: string, shortQuarter?: string) => <div />}
+    renderQuarterContent={(quarter, shortQuarter) => <div />}
     renderYearContent={(year) => <div />}
     required
     scrollableMonthYearDropdown

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -66,7 +66,7 @@ const topLogger: Modifier<'topLogger'> = {
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""
     includeDates={[new Date()]}
-    includeDateIntervals={[{ startf: new Date(), end: new Date() }]}
+    includeDateIntervals={[{ start: new Date(), end: new Date() }]}
     includeTimes={[new Date()]}
     injectTimes={[new Date()]}
     inline

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -66,7 +66,7 @@ const topLogger: Modifier<'topLogger'> = {
     highlightDates={[{ someClassName: [new Date()] }]}
     id=""
     includeDates={[new Date()]}
-    includeDateIntervals={[{ start: new Date(), end: new Date() }]}
+    includeDateIntervals={[{ startf: new Date(), end: new Date() }]}
     includeTimes={[new Date()]}
     injectTimes={[new Date()]}
     inline
@@ -152,6 +152,8 @@ const topLogger: Modifier<'topLogger'> = {
     }) => <div />}
     renderDayContents={(dayOfMonth, date) => <div />}
     renderMonthContent={(monthIndex, shortMonth, longMonth) => <div />}
+    renderQuarterContent={(quarter: string, shortQuarter?: string) => <div />}
+    renderYearContent={(year) => <div />}
     required
     scrollableMonthYearDropdown
     scrollableYearDropdown


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Hacker0x01/react-datepicker/blob/main/src/calendar.jsx#L196>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
