### PR TITLE
Fix braintree-web -> adjust type in verifyCard params

### DIFF
--- a/types/braintree-web/modules/three-d-secure.d.ts
+++ b/types/braintree-web/modules/three-d-secure.d.ts
@@ -122,7 +122,7 @@ export interface ThreeDSecureAdditionalInformation {
 
 export interface ThreeDSecureVerifyOptions {
     nonce: string;
-    amount: number;
+    amount: string;
     bin: string;
     challengeRequested?: boolean | undefined;
     exemptionRequested?: boolean | undefined;
@@ -214,7 +214,7 @@ export interface ThreeDSecure {
      *
      * threeDSecure.verifyCard({
      *   nonce: existingNonce,
-     *   amount: 123.45,
+     *   amount: '123.45',
      *   addFrame: function (err, iframe) {
      *     // Set up your UI and add the iframe.
      *     my3DSContainer = document.createElement('div');

--- a/types/braintree-web/test/node.ts
+++ b/types/braintree-web/test/node.ts
@@ -69,8 +69,8 @@ braintree.client.create(
                         nonce: existingNonce,
                         bin: testBin,
                     })
-                    .then(payload => {})
-                    .catch((err: braintree.BraintreeError) => {});
+                    .then(payload => { })
+                    .catch((err: braintree.BraintreeError) => { });
             });
 
         braintree.hostedFields.create(
@@ -601,7 +601,7 @@ braintree.client.create(
 );
 
 const existingNonce = 'fake-valid-nonce';
-const submitNonceToServer: (nonce: string) => void = (nonce: string) => {};
+const submitNonceToServer: (nonce: string) => void = (nonce: string) => { };
 
 braintree.client.create(
     {
@@ -641,7 +641,7 @@ braintree.client.create(
 braintree.threeDSecure.verifyCard(
     {
         nonce: existingNonce,
-        amount: 123.45, // $ExpectType number
+        amount: '123.45', // $ExpectType string
         bin: '1234',
         addFrame: (err, iframe) => {
             // Set up your UI and add the iframe.

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -55,8 +55,8 @@ braintree.client.create(
                         nonce: existingNonce,
                         bin: testBin,
                     })
-                    .then(payload => {})
-                    .catch((err: braintree.BraintreeError) => {});
+                    .then(payload => { })
+                    .catch((err: braintree.BraintreeError) => { });
             });
 
         clientInstance.request(
@@ -874,7 +874,7 @@ braintree.client.create(
 );
 
 const existingNonce = 'fake-valid-nonce';
-const submitNonceToServer: (nonce: string) => void = (nonce: string) => {};
+const submitNonceToServer: (nonce: string) => void = (nonce: string) => { };
 
 braintree.client.create(
     {
@@ -914,7 +914,7 @@ braintree.client.create(
 braintree.threeDSecure.verifyCard(
     {
         nonce: existingNonce,
-        amount: 123.45, // $ExpectType number
+        amount: '123.45', // $ExpectType string
         bin: '1234',
         addFrame: (err, iframe) => {
             // Set up your UI and add the iframe.
@@ -952,7 +952,7 @@ braintree.threeDSecure.verifyCard(
 braintree.threeDSecure.verifyCard(
     {
         nonce: existingNonce,
-        amount: 123.45, // $ExpectType number
+        amount: '123.45', // $ExpectType string
         bin: '1234',
     },
     (err: braintree.BraintreeError) => {


### PR DESCRIPTION
This Pull request fix wrong assign type.  Adjustment in type **amount** from `number` to be `string` in function **`verifyCard`**. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. 
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://braintree.github.io/braintree-web/current/ThreeDSecure.html#verifyCard>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
