### PR TITLE
[@testing-library/jest-dom] Fix matchers type making the global expect unsafe

### DIFF
--- a/types/testing-library__jest-dom/matchers.d.ts
+++ b/types/testing-library__jest-dom/matchers.d.ts
@@ -1,5 +1,7 @@
+/// <reference types="jest" />
+
 declare namespace matchers {
-    interface TestingLibraryMatchers<E, R> extends Record<string, any> {
+    interface TestingLibraryMatchers<E, R> {
         /**
          * @deprecated
          * since v1.9.0
@@ -657,7 +659,11 @@ declare namespace matchers {
          */
         toHaveErrorMessage(text?: string | RegExp | E): R;
     }
+
+    // Needs to extend Record<string, any> to be accepted by expect.extend()
+    // as it requires a string index signature.
+    interface TestingLibraryMatchersExport extends Record<string, jest.CustomMatcher>, TestingLibraryMatchers<any, jest.CustomMatcherResult> {}
 }
 
-declare const matchers: matchers.TestingLibraryMatchers<any, void>;
+declare const matchers: matchers.TestingLibraryMatchersExport;
 export = matchers;

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-extend-matchers-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-extend-matchers-tests.ts
@@ -70,54 +70,5 @@ customExpect(element).toHaveErrorMessage('Invalid time: the time must be between
 customExpect(element).toHaveErrorMessage(/invalid time/i);
 customExpect(element).toHaveErrorMessage(expect.stringContaining('Invalid time'));
 
-customExpect(element).not.toBeInTheDOM();
-customExpect(element).not.toBeInTheDOM(document.body);
-customExpect(element).not.toBeInTheDocument();
-customExpect(element).not.toBeVisible();
-customExpect(element).not.toBeEmpty();
-customExpect(element).not.toBeEmptyDOMElement();
-customExpect(element).not.toBeDisabled();
-customExpect(element).not.toBeEnabled();
-customExpect(element).not.toBeInvalid();
-customExpect(element).not.toBeRequired();
-customExpect(element).not.toBeValid();
-customExpect(element).not.toContainElement(document.body);
-customExpect(element).not.toContainElement(null);
-customExpect(element).not.toContainHTML('body');
-customExpect(element).not.toHaveAttribute('attr');
-customExpect(element).not.toHaveAttribute('attr', true);
-customExpect(element).not.toHaveAttribute('attr', 'yes');
-customExpect(element).not.toHaveClass();
-customExpect(element).not.toHaveClass('cls1');
-customExpect(element).not.toHaveClass('cls1', 'cls2', 'cls3', 'cls4');
-customExpect(element).not.toHaveClass('cls1', { exact: true });
-customExpect(element).not.toHaveDisplayValue('str');
-customExpect(element).not.toHaveDisplayValue(['str1', 'str2']);
-customExpect(element).not.toHaveDisplayValue(/str/);
-customExpect(element).not.toHaveDisplayValue([/str1/, 'str2']);
-customExpect(element).not.toHaveFocus();
-customExpect(element).not.toHaveFormValues({ foo: 'bar', baz: 1 });
-customExpect(element).not.toHaveStyle('display: block');
-customExpect(element).not.toHaveTextContent('Text');
-customExpect(element).not.toHaveTextContent(/Text/);
-customExpect(element).not.toHaveTextContent('Text', { normalizeWhitespace: true });
-customExpect(element).not.toHaveTextContent(/Text/, { normalizeWhitespace: true });
-customExpect(element).not.toHaveValue();
-customExpect(element).not.toHaveValue('str');
-customExpect(element).not.toHaveValue(['str1', 'str2']);
-customExpect(element).not.toHaveValue(1);
-customExpect(element).not.toBeChecked();
-customExpect(element).not.toHaveDescription('some description');
-customExpect(element).not.toHaveDescription();
-customExpect(element).not.toHaveAccessibleDescription('some description');
-customExpect(element).not.toHaveAccessibleDescription();
-
-customExpect(element).not.toHaveAccessibleErrorMessage();
-customExpect(element).not.toHaveAccessibleErrorMessage('There is no date');
-customExpect(element).not.toHaveAccessibleErrorMessage(/everything is valid/i);
-
-customExpect(element).not.toHaveAccessibleName('a label');
-customExpect(element).not.toHaveAccessibleName();
-customExpect(element).not.toBePartiallyChecked();
-customExpect(element).not.toHaveErrorMessage();
-customExpect(element).not.toHaveErrorMessage('Pikachu!');
+// @ts-expect-error
+customExpect(element).nonExistentProperty();

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
@@ -100,3 +100,6 @@ expect(element).not.toHaveAccessibleName();
 expect(element).not.toBePartiallyChecked();
 expect(element).not.toHaveErrorMessage();
 expect(element).not.toHaveErrorMessage('Pikachu!');
+
+// @ts-expect-error
+expect(element).nonExistentProperty();


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64858
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
