### PR TITLE
[docker-modem] Fix stream types

### DIFF
--- a/types/docker-modem/docker-modem-tests.ts
+++ b/types/docker-modem/docker-modem-tests.ts
@@ -61,10 +61,10 @@ modem.dial({ path: '/path', abortSignal: abortController.signal }, (err, result)
     // NOOP;
 });
 
-modem.demuxStream(new Stream(), process.stdout, process.stderr);
+modem.demuxStream(new Stream.Readable(), process.stdout, process.stderr);
 
 modem.followProgress(
-    new Stream(),
+    new Stream.Readable(),
     (error, result) => {
         // NOOP;
     },

--- a/types/docker-modem/index.d.ts
+++ b/types/docker-modem/index.d.ts
@@ -8,7 +8,7 @@
 import { ConnectConfig } from 'ssh2';
 import { ClientRequest, IncomingMessage, OutgoingHttpHeaders, RequestOptions, Agent } from 'http';
 import { Socket } from 'net';
-import { Duplex, DuplexOptions, Stream } from 'stream';
+import { Duplex, DuplexOptions } from 'stream';
 
 declare namespace DockerModem {
     class HttpDuplex extends Duplex {
@@ -87,10 +87,10 @@ declare class DockerModem {
 
     dial(options: DockerModem.DialOptions, callback?: DockerModem.RequestCallback): void;
 
-    demuxStream(stream: Stream, stdout: NodeJS.WritableStream, stderr: NodeJS.WritableStream): void;
+    demuxStream(stream: NodeJS.ReadableStream, stdout: NodeJS.WritableStream, stderr: NodeJS.WritableStream): void;
 
     followProgress(
-        stream: Stream,
+        stream: NodeJS.ReadableStream,
         onFinished: (error: Error | null, result: any[]) => void,
         onProgress?: (obj: any) => void,
     ): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/apocas/docker-modem/blob/2fbe36af3792670d231e6afbe07087ebcd5b8c75/lib/modem.js#L387
  - https://github.com/apocas/docker-modem/blob/2fbe36af3792670d231e6afbe07087ebcd5b8c75/lib/modem.js#L429
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Additional context

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65929 appears to have broken the typings; I'm not sure if that linked PR is wrong, or if the typings were originally incorrect. See this TypeScript Playground example: https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAEQgYwNYFMpwGZQiOAIgBMUM9j1CBuAWACgHkIA7AZ3lLUzgF44W6AO6IymABQBKOo3rN28MAFc2ACwCSIAIYBzdHwHDR3KADpNu9OK7lTICJRAAaIqEsBaFlpBVpDJqwccBxQ6N4GWkJawIoqGtp6pspqUjIMNph2DuggptgQADYFEEIACng6oWxs4v6ydQ30cMEwod5ODM3imFCSfAB8cADenc1wAPTjcAByAPKzpaMAvh1NcOIQSjDKMH28gyNrzZMz84trKwx+9EA

<img width="760" alt="Screenshot 2023-08-01 at 12 32 33" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/1476544/394d2c55-0197-4728-ba74-59ad03fa679b">
