### PR TITLE
[node] Adds test:enqueue, test:dequeue and test:watch:drained to test reporter events

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1218,7 +1218,7 @@ interface TestFail {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
         /**
          * The error thrown by the test.
          */
@@ -1257,7 +1257,7 @@ interface TestPass {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
     };
     /**
      * The test name.
@@ -1379,5 +1379,5 @@ declare module 'node:test/reporters' {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, tap, Spec as spec };
+    export { dot, tap, Spec as spec, TestEvent };
 }

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1332,6 +1332,34 @@ interface TestStdout {
      */
     message: string;
 }
+interface TestEnqueue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
+interface TestDequeue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
 
 /**
  * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
@@ -1360,7 +1388,10 @@ declare module 'node:test/reporters' {
         | { type: 'test:plan', data: TestPlan }
         | { type: 'test:start', data: TestStart }
         | { type: 'test:stderr', data: TestStderr }
-        | { type: 'test:stdout', data: TestStdout };
+        | { type: 'test:stdout', data: TestStdout }
+        | { type: 'test:enqueue', data: TestEnqueue }
+        | { type: 'test:dequeue', data: TestDequeue }
+        | { type: 'test:watch:drained' };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
     /**

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -690,6 +690,16 @@ class TestReporter extends Transform {
             case 'test:stdout':
                 callback(null, `${event.data.message}/${event.data.file}`);
                 break;
+            case 'test:enqueue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:dequeue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:watch:drained':
+                // event doesn't have any data
+                callback(null);
+                break;
             default:
                 callback(null);
         }

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1,5 +1,6 @@
 import { describe, it, run, test, before, beforeEach, after, afterEach, skip, todo, only } from 'node:test';
-import { dot, spec, tap } from 'node:test/reporters';
+import { dot, spec, tap, TestEvent } from 'node:test/reporters';
+import { Transform, TransformOptions, TransformCallback } from 'node:stream';
 
 // run without options
 // $ExpectType TestsStream
@@ -654,3 +655,43 @@ describe('Mock Timers Test Suite', () => {
         t.mock.timers.tick(1000);
     });
 });
+
+class TestReporter extends Transform {
+    constructor(options: TransformOptions) {
+        super(options);
+    }
+    _transform(event: TestEvent, _encoding: BufferEncoding, callback: TransformCallback): void {
+        switch (event.type) {
+            case 'test:diagnostic':
+                callback(null, `${event.data.message}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:fail':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/
+                    ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:pass':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:plan':
+                callback(null, `${event.data.count}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:start':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:stderr':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            case 'test:stdout':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            default:
+                callback(null);
+        }
+    }
+}

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -1200,7 +1200,7 @@ interface TestFail {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
         /**
          * The error thrown by the test.
          */
@@ -1239,7 +1239,7 @@ interface TestPass {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
     };
     /**
      * The test name.
@@ -1361,5 +1361,5 @@ declare module 'node:test/reporters' {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, tap, Spec as spec };
+    export { dot, tap, Spec as spec, TestEvent };
 }

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -1314,6 +1314,34 @@ interface TestStdout {
      */
     message: string;
 }
+interface TestEnqueue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
+interface TestDequeue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
 
 /**
  * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
@@ -1342,7 +1370,10 @@ declare module 'node:test/reporters' {
         | { type: 'test:plan', data: TestPlan }
         | { type: 'test:start', data: TestStart }
         | { type: 'test:stderr', data: TestStderr }
-        | { type: 'test:stdout', data: TestStdout };
+        | { type: 'test:stdout', data: TestStdout }
+        | { type: 'test:enqueue', data: TestEnqueue }
+        | { type: 'test:dequeue', data: TestDequeue }
+        | { type: 'test:watch:drained' };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
     /**

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -1,5 +1,6 @@
 import { describe, it, run, test, before, beforeEach, after, afterEach, skip, todo, only } from 'node:test';
-import { dot, spec, tap } from 'node:test/reporters';
+import { dot, spec, tap, TestEvent } from 'node:test/reporters';
+import { Transform, TransformOptions, TransformCallback } from 'node:stream';
 
 // run without options
 // $ExpectType TestsStream
@@ -624,3 +625,43 @@ describe('Mock Timers Test Suite', () => {
         t.mock.timers.tick(1000);
     });
 });
+
+class TestReporter extends Transform {
+    constructor(options: TransformOptions) {
+        super(options);
+    }
+    _transform(event: TestEvent, _encoding: BufferEncoding, callback: TransformCallback): void {
+        switch (event.type) {
+            case 'test:diagnostic':
+                callback(null, `${event.data.message}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:fail':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/
+                    ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:pass':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:plan':
+                callback(null, `${event.data.count}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:start':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:stderr':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            case 'test:stdout':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            default:
+                callback(null);
+        }
+    }
+}

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -660,6 +660,16 @@ class TestReporter extends Transform {
             case 'test:stdout':
                 callback(null, `${event.data.message}/${event.data.file}`);
                 break;
+            case 'test:enqueue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:dequeue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:watch:drained':
+                // event doesn't have any data
+                callback(null);
+                break;
             default:
                 callback(null);
         }

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -851,6 +851,34 @@ interface TestStdout {
      */
     message: string;
 }
+interface TestEnqueue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
+interface TestDequeue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
 
 /**
  * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
@@ -879,7 +907,10 @@ declare module 'node:test/reporters' {
         | { type: 'test:plan', data: TestPlan }
         | { type: 'test:start', data: TestStart }
         | { type: 'test:stderr', data: TestStderr }
-        | { type: 'test:stdout', data: TestStdout };
+        | { type: 'test:stdout', data: TestStdout }
+        | { type: 'test:enqueue'; data: TestEnqueue }
+        | { type: 'test:dequeue'; data: TestDequeue }
+        | { type: 'test:watch:drained' };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
     /**

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -737,7 +737,7 @@ interface TestFail {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
         /**
          * The error thrown by the test.
          */
@@ -776,7 +776,7 @@ interface TestPass {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
     };
     /**
      * The test name.
@@ -898,5 +898,5 @@ declare module 'node:test/reporters' {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, tap, Spec as spec };
+    export { dot, tap, Spec as spec, TestEvent };
 }

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -1,4 +1,6 @@
 import { describe, it, run, test, before, beforeEach, after, afterEach } from 'node:test';
+import { Transform, TransformOptions, TransformCallback } from 'node:stream';
+import { TestEvent } from 'node:test/reporters';
 
 // run without options
 // $ExpectType TestsStream
@@ -533,3 +535,43 @@ test('mocks a setter', (t) => {
         call.this;
     }
 });
+
+class TestReporter extends Transform {
+    constructor(options: TransformOptions) {
+        super(options);
+    }
+    _transform(event: TestEvent, _encoding: BufferEncoding, callback: TransformCallback): void {
+        switch (event.type) {
+            case 'test:diagnostic':
+                callback(null, `${event.data.message}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:fail':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/
+                    ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:pass':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:plan':
+                callback(null, `${event.data.count}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:start':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:stderr':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            case 'test:stdout':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            default:
+                callback(null);
+        }
+    }
+}

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -570,6 +570,16 @@ class TestReporter extends Transform {
             case 'test:stdout':
                 callback(null, `${event.data.message}/${event.data.file}`);
                 break;
+            case 'test:enqueue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:dequeue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:watch:drained':
+                // event doesn't have any data
+                callback(null);
+                break;
             default:
                 callback(null);
         }

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -851,6 +851,34 @@ interface TestStdout {
      */
     message: string;
 }
+interface TestEnqueue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
+interface TestDequeue {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The path of the test file, undefined if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
 
 /**
  * The `node:test/reporters` module exposes the builtin-reporters for `node:test`.
@@ -879,7 +907,10 @@ declare module 'node:test/reporters' {
         | { type: 'test:plan', data: TestPlan }
         | { type: 'test:start', data: TestStart }
         | { type: 'test:stderr', data: TestStderr }
-        | { type: 'test:stdout', data: TestStdout };
+        | { type: 'test:stdout', data: TestStdout }
+        | { type: 'test:enqueue'; data: TestEnqueue }
+        | { type: 'test:dequeue'; data: TestDequeue }
+        | { type: 'test:watch:drained' };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
     /**

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -737,7 +737,7 @@ interface TestFail {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
         /**
          * The error thrown by the test.
          */
@@ -776,7 +776,7 @@ interface TestPass {
         /**
          * The duration of the test in milliseconds.
          */
-        duration: number;
+        duration_ms: number;
     };
     /**
      * The test name.
@@ -898,5 +898,5 @@ declare module 'node:test/reporters' {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, tap, Spec as spec };
+    export { dot, tap, Spec as spec, TestEvent };
 }

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -1,4 +1,6 @@
 import { describe, it, run, test, before, beforeEach, after, afterEach } from 'node:test';
+import { Transform, TransformCallback, TransformOptions } from 'node:stream';
+import { TestEvent } from 'node:test/reporters';
 
 // run without options
 // $ExpectType TestsStream
@@ -533,3 +535,43 @@ test('mocks a setter', (t) => {
         call.this;
     }
 });
+
+class TestReporter extends Transform {
+    constructor(options: TransformOptions) {
+        super(options);
+    }
+    _transform(event: TestEvent, _encoding: BufferEncoding, callback: TransformCallback): void {
+        switch (event.type) {
+            case 'test:diagnostic':
+                callback(null, `${event.data.message}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:fail':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/
+                    ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:pass':
+                callback(
+                    null,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                );
+                break;
+            case 'test:plan':
+                callback(null, `${event.data.count}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:start':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:stderr':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            case 'test:stdout':
+                callback(null, `${event.data.message}/${event.data.file}`);
+                break;
+            default:
+                callback(null);
+        }
+    }
+}

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -570,6 +570,16 @@ class TestReporter extends Transform {
             case 'test:stdout':
                 callback(null, `${event.data.message}/${event.data.file}`);
                 break;
+            case 'test:enqueue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:dequeue':
+                callback(null, `${event.data.name}/${event.data.nesting}/${event.data.file}`);
+                break;
+            case 'test:watch:drained':
+                // event doesn't have any data
+                callback(null);
+                break;
             default:
                 callback(null);
         }


### PR DESCRIPTION
New events have been added to the Node test runner's reporter stream.

This PR depends on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66255 and will only be 2 commits once 66255 is merged.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Addition of enqueue and dequeue: https://github.com/nodejs/node/pull/48428 (landed in Node 20.4, backported to 18.7)
  - Addition of watch:drained: https://github.com/nodejs/node/pull/48259 (landed in Node 20.3, backported to 18.7)
