### PR TITLE
mithril: Added SKIP property to the Route interface

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -108,6 +108,8 @@ declare namespace Mithril {
         param(name: string): string;
         /** Gets all route parameters. */
         param(): any;
+        /** Special value to SKIP current route */
+        SKIP: any;
     }
 
     interface RequestOptions<T> {

--- a/types/mithril/test/test-route.ts
+++ b/types/mithril/test/test-route.ts
@@ -123,6 +123,12 @@ m.route(document.body, '/', {
     // Can use other component types for routes
     test8: Component4,
     test9: component5,
+    // Can skip a route without property doesn't exist error
+    test10: {
+        onmatch(args, path) {
+            return m.route.SKIP;
+        }
+    }
 });
 
 m.route.prefix = '/app';


### PR DESCRIPTION
package: @types/mithril

This problem only happens when importing Mithril using ES6 syntax, the CommonJS syntax doesn't throw the error.

```js
// Doesn't throw error
const m = require('mithril')
m.route.SKIP

// Throws "Property 'SKIP' does not exist on type 'Route'."
import m from 'mithril'
```

In spite of the Mithril supporting the m.route.SKIP in JS and CommonJS, the SKIP property was missing its declaration inside the Route interface, throwing an error while using m.route.SKIP with ES6 and TypeScript.
![Type Error](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/34790144/1540336b-7405-4df3-8188-94a7ea8647a0)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[Mithril's Documentation](https://mithril.js.org/route.html#mrouteskip)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
