### PR TITLE
[atlassian-connect-js] Fix some types and other improvements

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -24,6 +24,7 @@ AP.confluence.saveMacro({ foo: 'bar' }); // $ExpectType void
 AP.confluence.closeMacroEditor(); // $ExpectType void
 AP.confluence.getMacroBody(body => console.log(body)); // $ExpectType void
 AP.confluence.getMacroData(data => console.log(data)); // $ExpectType void
+AP.confluence.getMacroData<{ foo: string; bar: number }>(({ foo, bar }) => console.log(foo, bar)); // $ExpectType void
 AP.confluence.onMacroPropertyPanelEvent({ '{event-type}.{control-key}.{macro-key}.macro.property-panel': () => null }); // $ExpectType void
 AP.confluence.closeMacroPropertyPanel(); // $ExpectType void
 AP.confluence.getContentProperty('propertyKey', property => console.log(property)); // $ExpectType void

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -63,7 +63,21 @@ editComponent.cancelCallback(false); // $ExpectType void
 editComponent.cancelCallback(false, 'error'); // $ExpectType void
 
 AP.dialog.create({ key: 'key', size: 'small', customData: { data: 1 } }); // $ExpectType Dialog
+// $ExpectType Dialog
+AP.dialog.create({
+    key: 'my-module-key',
+    width: '500px',
+    height: '200px',
+    chrome: true,
+    buttons: [
+        {
+            text: 'my button',
+            identifier: 'my_unique_identifier',
+        },
+    ],
+});
 AP.dialog.close(); // $ExpectType void
+AP.dialog.close({ foo: 'bar' }); // $ExpectType void
 AP.dialog.getCustomData(data => console.log(data)); // $ExpectType void
 AP.dialog.getButton('submit'); // $ExpectType {} | DialogButton
 AP.dialog.disableCloseOnSubmit(); // $ExpectType void

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -95,6 +95,8 @@ AP.history.back(); // $ExpectType void
 AP.history.forward(); // $ExpectType void
 AP.history.go(-2); // $ExpectType void
 AP.history.getState(); // $ExpectType string
+AP.history.pushState(1); // $ExpectType void
+AP.history.pushState('page2'); // $ExpectType void
 AP.history.pushState({ state: 'state' }, 'title', 'https://example.com'); // $ExpectType void
 AP.history.replaceState('https://example.com'); // $ExpectType void
 

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -83,7 +83,9 @@ AP.events.offAll('name'); // $ExpectType void
 AP.events.offAllPublic('name'); // $ExpectType void
 AP.events.offAny((name, data) => console.log(name, data)); // $ExpectType void
 AP.events.offAnyPublic((name, data) => console.log(name, data)); // $ExpectType void
+AP.events.emit('name'); // $ExpectType void
 AP.events.emit('name', ['data']); // $ExpectType void
+AP.events.emitPublic('name'); // $ExpectType void
 AP.events.emitPublic('name', ['data']); // $ExpectType void
 
 const flag = AP.flag.create({ title: 'title', body: 'body', type: 'info', actions: { test: 'text' } }); // $ExpectType Flag

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -110,6 +110,8 @@ AP.jira.showJQLEditor(obj => console.log(obj.jql), {}); // $ExpectType void
 AP.jira.isNativeApp(isNative => console.log(isNative)); // $ExpectType void
 
 AP.navigator.getLocation(location => console.log(location)); // $ExpectType void
+AP.navigator.getLocation(location => console.log(location.target)); // $ExpectType void
+AP.navigator.getLocation(location => console.log(location.context)); // $ExpectType void
 AP.navigator.go('contentview', {}); // $ExpectType void
 AP.navigator.go('issue', {}); // $ExpectType void
 // $ExpectType void

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -203,7 +203,8 @@ declare namespace AP {
          *   alert(data);
          * });
          */
-        function getMacroData(callback: (data: object) => void): void;
+        // eslint-disable-next-line no-unnecessary-generics
+        function getMacroData<T extends object>(callback: (data: T) => void): void;
 
         /**
          * Get the body saved in the saveMacro method.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -523,12 +523,12 @@ declare namespace AP {
             /**
              * if size is not set, define the width as a percentage (append a % to the number) or pixels.
              */
-            width?: number | undefined;
+            width?: number | string | undefined;
 
             /**
              * if size is not set, define the height as a percentage (append a % to the number) or pixels.
              */
-            height?: number | undefined;
+            height?: number | string | undefined;
 
             /**
              * (optional) opens the dialog with heading and buttons.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -774,7 +774,7 @@ declare namespace AP {
          * @param name The name of event to emit
          * @param args 0 or more additional data arguments to deliver with the event
          */
-        function emit(name: string, args: string[]): void;
+        function emit(name: string, args?: string[]): void;
 
         /**
          * Emits a public event on this bus, firing listeners by name as well as all 'anyPublic' listeners.
@@ -785,7 +785,7 @@ declare namespace AP {
          * @param name The name of event to emit
          * @param args 0 or more additional data arguments to deliver with the event
          */
-        function emitPublic(name: string, args: string[]): void;
+        function emitPublic(name: string, args?: string[]): void;
     }
 
     /**

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -1233,6 +1233,19 @@ declare namespace AP {
              */
             absoluteUrl: string;
         }
+
+        interface NavigatorLocationContext {
+            /**
+             * The type of the page.
+             */
+            target: NavigatorTargetJira | NavigatorTargetConfluence;
+
+            /**
+             * Specific information that identifies the page.
+             */
+            context: Partial<NavigatorContext>;
+        }
+
         /**
          * Returns the context of the current page within the host application.
          *
@@ -1247,7 +1260,7 @@ declare namespace AP {
          * **contentedit** - the host application is currently editing a page, blog post or other content.
          * @param callback
          */
-        function getLocation(callback: (location: string) => void): void;
+        function getLocation(callback: (location: NavigatorLocationContext) => void): void;
 
         /**
          * Navigates the user from the current page to the specified page. This call navigates the host product, not the iframe content.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -865,7 +865,7 @@ declare namespace AP {
          * @param title
          * @param url URL to add to history
          */
-        function pushState(newState: object, title: string, url: string): void;
+        function pushState(newState: any, title?: string, url?: string): void;
 
         /**
          * Updates the current entry in the session history. Updates the location's anchor with the specified value but does not change the session history. Does not invoke popState callback.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/confluence/about-the-connect-javascript-api/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR contains the following improvements:
- **Fix: Fix the signature of the `AP.navigator.getLocation()` function.**
Indeed, the `location` argument passed to the callback is actually an `object` (not a `string`).
It contains two attributes: `target` and `context`.
See the example in the documentation: https://developer.atlassian.com/cloud/confluence/jsapi/navigator/#methods.
- **Fix: Allow emitting events without additional arguments.**
Indeed, we are allowed to emit events without providing additional arguments.
See the example in the documentation: https://developer.atlassian.com/cloud/confluence/jsapi/events/#basic-example.
- **Fix: Allow pushing any value to the history state.**
Indeed, we are allowed to push any value to the history state.
See the example in the documentation (providing a `string`): https://developer.atlassian.com/cloud/confluence/jsapi/history/#example.
I also tested by providing objects and numbers and it seems to work fine.
- **Fix: Allow using strings for the `width` and `height` attributes of a dialog.**
Indeed, we are allowed to provide strings for these fields in order to specify sizes in pixels (by suffixing the value with "px") or in percentages (by suffixing the value with "%").
See the example in the documentation: https://developer.atlassian.com/cloud/confluence/jsapi/dialog/#methods.
- **Feature: Allow using a generic type to properly type macro data.**
Indeed, the callback passed to the `AP.confluence.getMacroData()` function only accepts an `object` as an argument.
However, this means I can't type the data of my macros more precisely, even if I know the type of data they contain.
This means that I don't have autocompletion on the data of my macros and I can't use the destructuring syntax without generating errors.
I added a generic type to that function (which should extend `object`) to type macro data more precisely if the data type is known in advance.
Example:
```typescript
interface IMacroData {
    foo: string;
    bar: number;
}
AP.confluence.getMacroData<IMacroData>(({ foo, bar }) => console.log(foo, bar));
```

<br class="Apple-interchange-newline">
