### PR TITLE
feat: add `flags` type to `ember-feature-flags` Features service

### DIFF
--- a/types/ember-feature-flags/ember-feature-flags-tests.ts
+++ b/types/ember-feature-flags/ember-feature-flags-tests.ts
@@ -24,6 +24,7 @@ const setup = {
   'new-homepage': false
 };
 features.setup(setup); // $ExpectType void
+features.flags; // $ExpectType string[]
 withFeature('new-homepage'); // $ExpectType void
 enableFeature('new-homepage'); // $ExpectType void
 assertType<boolean>(features.get('someFeature'));

--- a/types/ember-feature-flags/index.d.ts
+++ b/types/ember-feature-flags/index.d.ts
@@ -14,4 +14,5 @@ export default interface Features extends Service {
     enable(feature: string): void;
     disable(feature: string): void;
     isEnabled(feature: string): boolean;
+    flags: string[];
 }

--- a/types/ember-feature-flags/index.d.ts
+++ b/types/ember-feature-flags/index.d.ts
@@ -14,5 +14,5 @@ export default interface Features extends Service {
     enable(feature: string): void;
     disable(feature: string): void;
     isEnabled(feature: string): boolean;
-    flags: string[];
+    readonly flags: string[];
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kategengler/ember-feature-flags/blob/702bc3560f3c44b42aae102fd6469ee4acd0e1c9/addon/services/features.js#L84-L88
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `flags` property is intended to be public as well. The README in the ember-feature-flags project mentions it