### PR TITLE
[node] adds "type" to test runner event details

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1223,6 +1223,11 @@ interface TestFail {
          * The error thrown by the test.
          */
         error: Error;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 20.0.0, 19.9.0, 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.
@@ -1258,6 +1263,11 @@ interface TestPass {
          * The duration of the test in milliseconds.
          */
         duration_ms: number;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 20.0.0, 19.9.0, 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -668,14 +668,15 @@ class TestReporter extends Transform {
             case 'test:fail':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
                     ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:pass':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
+                    ${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:plan':

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -1205,6 +1205,11 @@ interface TestFail {
          * The error thrown by the test.
          */
         error: Error;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 20.0.0, 19.9.0, 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.
@@ -1240,6 +1245,11 @@ interface TestPass {
          * The duration of the test in milliseconds.
          */
         duration_ms: number;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 20.0.0, 19.9.0, 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -638,14 +638,15 @@ class TestReporter extends Transform {
             case 'test:fail':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
                     ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:pass':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
+                    ${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:plan':

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -742,6 +742,11 @@ interface TestFail {
          * The error thrown by the test.
          */
         error: Error;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.
@@ -777,6 +782,11 @@ interface TestPass {
          * The duration of the test in milliseconds.
          */
         duration_ms: number;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -548,14 +548,15 @@ class TestReporter extends Transform {
             case 'test:fail':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
                     ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:pass':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
+                    ${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:plan':

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -742,6 +742,11 @@ interface TestFail {
          * The error thrown by the test.
          */
         error: Error;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.
@@ -777,6 +782,11 @@ interface TestPass {
          * The duration of the test in milliseconds.
          */
         duration_ms: number;
+        /**
+         * The type of the test, used to denote whether this is a suite.
+         * @since 18.17.0
+         */
+        type?: 'suite';
     };
     /**
      * The test name.

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -548,14 +548,15 @@ class TestReporter extends Transform {
             case 'test:fail':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
                     ${event.data.details.error}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:pass':
                 callback(
                     null,
-                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
+                    `${event.data.name}/${event.data.details.duration_ms}/${event.data.details.type}/
+                    ${event.data.nesting}/${event.data.testNumber}/${event.data.todo}/${event.data.skip}/${event.data.file}`,
                 );
                 break;
             case 'test:plan':


### PR DESCRIPTION
In [version 20.0.0 (and backported to 19.9.0 and 18.7.0)](https://github.com/nodejs/node/pull/47094) the test runner started reporting on whether a test was a suite. This was exposed to reporters in the `details` object of a `test:pass` or `test:fail` event but this hasn't been documented. This adds the `type` property to both event's `details` object.

This isn't currently documented in Node, but [I have opened a PR for it here](https://github.com/nodejs/node/pull/49014).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
