### PR TITLE
fix(treeverse): correct `leave` definition

### DIFF
--- a/types/treeverse/index.d.ts
+++ b/types/treeverse/index.d.ts
@@ -55,14 +55,11 @@ export interface DepthOptions<Node, Value, Children extends Node[] | Promise<Nod
      * If the tree is acyclic, then leave() will have been called on all of them.
      * If it has cycles, then the children may not have been left yet.
      *
-     * @param node The original node
-     * @param children A list of the child nodes that have been visited (and potentially left) already.
+     * @param node The value of the original node
+     * @param children is an array of child node visit results. If the graph is cyclic, then some children may have been visited but not left.
      * @returns A reduced value, or nothing to leave it as is
      */
-    leave?: (
-        node: Node,
-        children: Node[],
-    ) => Children extends Promise<any> ? Promise<Value | undefined> | Value | undefined : Value | undefined;
+    leave?: (node: Value, children: Value[]) => Children extends Promise<any> ? Promise<Value> | Value : Value;
 }
 
 /**

--- a/types/treeverse/treeverse-tests.ts
+++ b/types/treeverse/treeverse-tests.ts
@@ -64,15 +64,16 @@ interface Node {
     // $ExpectType number
     depth({
         tree: nodeA,
-        leave: (node, children) => node.id + children.length,
+        leave: (node: number, children) => node + children.length,
         getChildren: (node, value) => node.nodes.slice(value),
+        visit: node => node.id,
     });
 
     // Promised traversal with `leave`
     // $ExpectType Promise<number>
     depth({
         tree: nodeA,
-        leave: async (node, children) => node.id + children.length,
+        leave: async (node: number, children) => node + children.length,
         getChildren: async (node, value) => node.nodes.slice(value),
     });
 
@@ -120,5 +121,13 @@ interface Node {
         getChildren: node => node.nodes,
         // @ts-expect-error -- `getChildren` is not a Promise
         leave: async node => node.id.toString(),
+    });
+
+    depth({
+        tree: nodeA,
+        leave: (node: number, children) => node + children.length,
+        getChildren: (node, value) => node.nodes.slice(value),
+        // @ts-expect-error -- Should be a number
+        visit: node => node.id.toString(),
     });
 })();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: _See below_
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The parameters of the `leave` function were wrong.

As written at the description of `leave` in the library's home page:
>  `children` is an array of child node visit **results**.
