### PR TITLE
Add DNS type for Node perfhooks

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -31,7 +31,7 @@
  */
 declare module 'perf_hooks' {
     import { AsyncResource } from 'node:async_hooks';
-    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
+    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http' | 'dns';
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies

--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -30,7 +30,7 @@
  */
 declare module 'perf_hooks' {
     import { AsyncResource } from 'node:async_hooks';
-    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
+    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http' | 'dns';
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies

--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -30,7 +30,7 @@
  */
 declare module 'perf_hooks' {
     import { AsyncResource } from 'node:async_hooks';
-    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
+    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http' | 'dns';
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/perf_hooks.html#dns-dns-details
NOTE: It appears the type isn't listed correctly in the Node documentation but I've tested on Node v16, v18, and v20 and things work as expected.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.