### PR TITLE
[auth0-lock] added missing 'signUpFieldsStrictValidation' option

### DIFF
--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -166,6 +166,7 @@ interface Auth0LockConstructorOptions {
     socialButtonStyle?: "big" | "small" | undefined;
     theme?: Auth0LockThemeOptions | undefined;
     usernameStyle?: string | undefined;
+    signUpFieldsStrictValidation?: boolean | undefined;
     _enableImpersonation?: boolean | undefined;
     _enableIdPInitiatedLogin?: boolean | undefined;
 }


### PR DESCRIPTION
This PR adds a missing definition for `signUpFieldsStrictValidation` option that was added in `v11.27.0` (see [implementation](https://github.com/auth0/lock/blob/v11.27.0/src/engine/classic/sign_up_pane.jsx#L83)) and documented later in https://github.com/auth0/lock/pull/2016

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.