### PR TITLE
Add minexponent to plotly chart types

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -709,6 +709,10 @@ export interface Axis {
      */
     exponentformat: 'none' | 'e' | 'E' | 'power' | 'SI' | 'B';
     /**
+     * Hide SI prefix for 10^n if |n| is below this number. This only has an effect when `tickformat` is "SI" or "B".
+     */
+    minexponent: number
+    /**
      * 'If `true`, even 4-digit integers are separated
      */
     separatethousands: boolean;
@@ -1515,6 +1519,7 @@ export interface ColorBar {
     separatethousands: boolean;
     exponentformat: 'none' | 'e' | 'E' | 'power' | 'SI' | 'B';
     showexponent: 'all' | 'first' | 'last' | 'none';
+    minexponent: number;
     title: string;
     titlefont: Font;
     titleside: 'right' | 'top' | 'bottom';

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -711,7 +711,7 @@ export interface Axis {
     /**
      * Hide SI prefix for 10^n if |n| is below this number. This only has an effect when `tickformat` is "SI" or "B".
      */
-    minexponent: number
+    minexponent: number;
     /**
      * 'If `true`, even 4-digit integers are separated
      */


### PR DESCRIPTION
minexponent is explained in

https://plotly.com/javascript/reference/layout/yaxis/#layout-yaxis-minexponent

and given form in https://github.com/plotly/plotly.js/blob/bb4a1f7966344dd6080d7e11bf40729a86370016/src/plots/ternary/layout_attributes.js#L37 (to name a place)

but missing in @types/plotly.js

I ran this and it seems to be working, with a y-axis of:

```
[ 0, 0.0002, 0.0004, 0.0008, 0.0016, 0.0032, 0.0064 ]
```

the following axis is drawn with `minexponent: 2`
![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/3583395/822a409a-9daf-4272-9f15-2984146e3b22)

with minexponent unspecified however:
![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/3583395/21b6a7c9-0e2e-4781-a31b-4ae24bc58ec5)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
