### PR TITLE
google-apps-script blob contentType to be nullable

### DIFF
--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -22,13 +22,13 @@ declare namespace GoogleAppsScript {
       copyBlob(): Blob;
       getAs(contentType: string): Blob;
       getBytes(): Byte[];
-      getContentType(): string;
+      getContentType(): string | null;
       getDataAsString(): string;
       getDataAsString(charset: string): string;
       getName(): string | null;
       isGoogleType(): boolean;
       setBytes(data: Byte[]): Blob;
-      setContentType(contentType: string): Blob;
+      setContentType(contentType: string | null): Blob;
       setContentTypeFromExtension(): Blob;
       setDataFromString(string: string): Blob;
       setDataFromString(string: string, charset: string): Blob;

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -776,3 +776,15 @@ const sheetCellImage = () => {
     cellImage.getContentUrl();
     cellImage.getUrl();
 };
+
+// Blob test
+const blob = () => {
+    // $ExpectType Blob
+    const blob = Utilities.newBlob('content', 'type');
+    blob.setContentType(null);
+
+    // $ExpectType string
+    const contentType = blob.getContentType();
+
+    return contentType;
+};

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -780,7 +780,7 @@ const sheetCellImage = () => {
 // Blob test
 const blob = () => {
     // $ExpectType Blob
-    const blob = Utilities.newBlob('content', 'type');
+    const blob = Utilities.newBlob('content', 'application/json');
     blob.setContentType(null);
 
     // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
https://developers.google.com/apps-script/reference/base/blob#setcontenttypecontenttype
https://developers.google.com/apps-script/reference/base/blob#getcontenttype
String — The content type of this data, if known, or null.