### PR TITLE
Add missing type definitions `additional_tags`, `remove_tags` for UpdateManyModel

### DIFF
--- a/types/node-zendesk/index.d.ts
+++ b/types/node-zendesk/index.d.ts
@@ -622,6 +622,14 @@ export namespace Tickets {
     }
 
     /**
+     * @see {@link https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-many-tickets|Zendesk Tickets JSON Format}
+     */
+    interface UpdateManyModel extends UpdateModel {
+        additional_tags?: ReadonlyArray<string> | null | undefined;
+        remove_tags?: ReadonlyArray<string> | null | undefined;
+    }
+
+    /**
      * @see {@link https://developer.zendesk.com/rest_api/docs/support/tickets#json-format|Zendesk Tickets JSON Format}
      */
     interface ResponseModel extends AuditableModel {
@@ -720,7 +728,7 @@ export namespace Tickets {
     }
 
     interface UpdateManyPayload {
-        readonly tickets: ReadonlyArray<UpdateModel>;
+        readonly tickets: ReadonlyArray<UpdateManyModel>;
     }
 
     interface MergePayload {

--- a/types/node-zendesk/node-zendesk-tests.ts
+++ b/types/node-zendesk/node-zendesk-tests.ts
@@ -134,6 +134,10 @@ client.tickets.update(123, { ticket: {} }, zendeskCallback);
 client.tickets.update(123, { ticket: {} }).then(zendeskCallback);
 client.tickets.updateMany({ tickets: [{}] }, zendeskCallback);
 client.tickets.updateMany({ tickets: [{}] }).then(zendeskCallback);
+client.tickets.updateMany(
+    { tickets: [{additional_tags: ["foo", "bar"], remove_tags: ["baz", "qux"]}]},
+    zendeskCallback
+);
 client.tickets.delete(123, zendeskCallback);
 client.tickets.delete(123).then(zendeskCallback);
 client.tickets.deleteMany([123, 234], zendeskCallback);


### PR DESCRIPTION
Zendesk have 2 additional types supported in *UpdateManyPayload* that were not defined in this package.
As they do not apply to *UpdatePayload*, a new *UpdateManyModel* inheriting from *UpdateModel* was defined as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#updating-tag-lists
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

