### PR TITLE
fix(object-hash): add missing hash option algorithm allowed values

### DIFF
--- a/types/object-hash/index.d.ts
+++ b/types/object-hash/index.d.ts
@@ -48,11 +48,48 @@ declare namespace objectHash {
         write?(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
     }
 
+    type HashName =
+        | 'md4'
+        | 'md4WithRSAEncryption'
+        | 'md5'
+        | 'md5WithRSAEncryption'
+        | 'ripemd'
+        | 'ripemd160'
+        | 'ripemd160WithRSA'
+        | 'rmd160'
+        | 'rsa-md4'
+        | 'rsa-md5'
+        | 'rsa-ripemd160'
+        | 'rsa-sha1'
+        | 'rsa-sha1-2'
+        | 'rsa-sha224'
+        | 'rsa-sha256'
+        | 'rsa-sha3-224'
+        | 'rsa-sha3-256'
+        | 'rsa-sha3-384'
+        | 'rsa-sha3-512'
+        | 'rsa-sha384'
+        | 'rsa-sha512'
+        | 'sha1'
+        | 'sha1WithRSAEncryption'
+        | 'sha224'
+        | 'sha224WithRSAEncryption'
+        | 'sha256'
+        | 'sha256WithRSAEncryption'
+        | 'sha3-224'
+        | 'sha3-256'
+        | 'sha3-384'
+        | 'sha3-512'
+        | 'sha384'
+        | 'sha384WithRSAEncryption'
+        | 'sha512'
+        | 'sha512WithRSAEncryption';
+
     interface BaseOptions {
         /**
          * @default 'sha1'
          */
-        algorithm?: 'sha1' | 'md5' | 'passthrough' | undefined;
+        algorithm?: HashName | 'passthrough' | undefined;
 
         excludeKeys?: ((key: string) => boolean) | undefined;
         /**

--- a/types/object-hash/object-hash-tests.ts
+++ b/types/object-hash/object-hash-tests.ts
@@ -31,6 +31,7 @@ hash([1, '2', 3, true]); // $ExpectType string
 hash(['1', '1', '3']); // $ExpectType string
 hash([{ objectInArray: true }]); // $ExpectType string
 hash(obj, options); // $ExpectType string
+hash(obj, { ...options, algorithm: 'sha256' }); // $ExpectType string
 hash(obj, { ...options, encoding: 'buffer' }); // $ExpectType Buffer
 hash({ name: 'Peter', stapler: false, friends: ['Joanna', 'Michael', 'Samir'] }); // $ExpectType string
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Here[ the doc](https://github.com/puleos/object-hash#hashvalue-options) says :

> This supports the algorithms returned by crypto.getHashes(). Note that the default of SHA-1 is not considered secure, 

wich can be verified [here](https://github.com/puleos/object-hash/blob/1045a05d42c2077f7b380617d0f3d32c851234dd/index.js#L57)


- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
