### PR TITLE
[ua-parser-js] add support for upcoming version 2.0

### DIFF
--- a/types/ua-parser-js/v2/index.d.ts
+++ b/types/ua-parser-js/v2/index.d.ts
@@ -1,0 +1,211 @@
+// Type definitions for ua-parser-js 0.7
+// Project: https://github.com/faisalman/ua-parser-js
+// Definitions by: Viktor Miroshnikov <https://github.com/superduper>
+//                 Lucas Woo <https://github.com/legendecas>
+//                 Pablo Rodríguez <https://github.com/MeLlamoPablo>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace UAParser {
+    // tslint:disable:interface-name backward compatible exclusion
+
+    interface IBrowser {
+        /**
+         * Possible values :
+         * Amaya, Android Browser, Arora, Avant, Baidu, Blazer, Bolt, Camino, Chimera, Chrome,
+         * Chromium, Comodo Dragon, Conkeror, Dillo, Dolphin, Doris, Edge, Epiphany, Fennec,
+         * Firebird, Firefox, Flock, GoBrowser, iCab, ICE Browser, IceApe, IceCat, IceDragon,
+         * Iceweasel, IE [Mobile], Iron, Jasmine, K-Meleon, Konqueror, Kindle, Links,
+         * Lunascape, Lynx, Maemo, Maxthon, Midori, Minimo, MIUI Browser, [Mobile] Safari,
+         * Mosaic, Mozilla, Netfront, Netscape, NetSurf, Nokia, OmniWeb, Opera [Mini/Mobi/Tablet],
+         * Phoenix, Polaris, QQBrowser, RockMelt, Silk, Skyfire, SeaMonkey, SlimBrowser, Swiftfox,
+         * Tizen, UCBrowser, Vivaldi, w3m, Yandex
+         *
+         */
+        name: string | undefined;
+
+        /**
+         * Determined dynamically
+         */
+        version: string | undefined;
+
+        /**
+         * Determined dynamically
+         * @deprecated
+         */
+        major: string | undefined;
+    }
+
+    interface IDevice {
+        /**
+         * Determined dynamically
+         */
+        model: string | undefined;
+
+        /**
+         * Possible type:
+         * console, mobile, tablet, smarttv, wearable, embedded
+         */
+        type: string | undefined;
+
+        /**
+         * Possible vendor:
+         * Acer, Alcatel, Amazon, Apple, Archos, Asus, BenQ, BlackBerry, Dell, GeeksPhone,
+         * Google, HP, HTC, Huawei, Jolla, Lenovo, LG, Meizu, Microsoft, Motorola, Nexian,
+         * Nintendo, Nokia, Nvidia, Ouya, Palm, Panasonic, Polytron, RIM, Samsung, Sharp,
+         * Siemens, Sony-Ericsson, Sprint, Xbox, ZTE
+         */
+        vendor: string | undefined;
+    }
+
+    interface IEngine {
+        /**
+         * Possible name:
+         * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
+         * Tasman, Trident, w3m, WebKit
+         */
+        name: string | undefined;
+        /**
+         * Determined dynamically
+         */
+        version: string | undefined;
+    }
+
+    interface IOS {
+        /**
+         * Possible 'os.name'
+         * AIX, Amiga OS, Android, Arch, Bada, BeOS, BlackBerry, CentOS, Chromium OS, Contiki,
+         * Fedora, Firefox OS, FreeBSD, Debian, DragonFly, Gentoo, GNU, Haiku, Hurd, iOS,
+         * Joli, Linpus, Linux, Mac OS, Mageia, Mandriva, MeeGo, Minix, Mint, Morph OS, NetBSD,
+         * Nintendo, OpenBSD, OpenVMS, OS/2, Palm, PCLinuxOS, Plan9, Playstation, QNX, RedHat,
+         * RIM Tablet OS, RISC OS, Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen,
+         * Ubuntu, UNIX, VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk
+         */
+        name: string | undefined;
+        /**
+         * Determined dynamically
+         */
+        version: string | undefined;
+    }
+
+    interface ICPU {
+        /**
+         * Possible architecture:
+         *  68k, amd64, arm, arm64, avr, ia32, ia64, irix, irix64, mips, mips64, pa-risc,
+         *  ppc, sparc, sparc64
+         */
+        architecture: string | undefined;
+    }
+
+    interface IResult {
+        ua: string;
+        browser: IBrowser;
+        device: IDevice;
+        engine: IEngine;
+        os: IOS;
+        cpu: ICPU;
+    }
+
+    interface BROWSER {
+        NAME: "name";
+        /**
+         * @deprecated
+         */
+        MAJOR: "major";
+        VERSION: "version";
+    }
+
+    interface CPU {
+        ARCHITECTURE: "architecture";
+    }
+
+    interface DEVICE {
+        MODEL: "model";
+        VENDOR: "vendor";
+        TYPE: "type";
+        CONSOLE: "console";
+        MOBILE: "mobile";
+        SMARTTV: "smarttv";
+        TABLET: "tablet";
+        WEARABLE: "wearable";
+        EMBEDDED: "embedded";
+    }
+
+    interface ENGINE {
+        NAME: "name";
+        VERSION: "version";
+    }
+
+    interface OS {
+        NAME: "name";
+        VERSION: "version";
+    }
+
+    interface UAParserInstance {
+        /**
+         *  Returns browser information
+         */
+        getBrowser(): IBrowser;
+
+        /**
+         *  Returns OS information
+         */
+        getOS(): IOS;
+
+        /**
+         *  Returns browsers engine information
+         */
+        getEngine(): IEngine;
+
+        /**
+         *  Returns device information
+         */
+        getDevice(): IDevice;
+
+        /**
+         *  Returns parsed CPU information
+         */
+        getCPU(): ICPU;
+
+        /**
+         *  Returns UA string of current instance
+         */
+        getUA(): string;
+
+        /**
+         *  Set & parse UA string
+         */
+        setUA(uastring: string): UAParserInstance;
+
+        /**
+         *  Returns parse result
+         */
+        getResult(): IResult;
+    }
+}
+
+type UAParser = UAParser.UAParserInstance;
+
+declare const UAParser: {
+    VERSION: string;
+    BROWSER: UAParser.BROWSER;
+    CPU: UAParser.CPU;
+    DEVICE: UAParser.DEVICE;
+    ENGINE: UAParser.ENGINE;
+    OS: UAParser.OS;
+
+    /**
+     * Create a new parser with UA prepopulated and extensions extended
+     */
+    new (uastring?: string, extensions?: Record<string, unknown>): UAParser.UAParserInstance;
+    new (extensions?: Record<string, unknown>): UAParser.UAParserInstance;
+    (uastring?: string, extensions?: Record<string, unknown>): UAParser.IResult;
+    (extensions?: Record<string, unknown>): UAParser.IResult;
+
+    // alias for older syntax
+    UAParser: typeof UAParser;
+};
+
+export as namespace UAParser;
+export = UAParser;

--- a/types/ua-parser-js/v2/index.d.ts
+++ b/types/ua-parser-js/v2/index.d.ts
@@ -1,16 +1,24 @@
-// Type definitions for ua-parser-js 0.7
+// Type definitions for ua-parser-js 2.0
 // Project: https://github.com/faisalman/ua-parser-js
 // Definitions by: Viktor Miroshnikov <https://github.com/superduper>
 //                 Lucas Woo <https://github.com/legendecas>
 //                 Pablo Rodríguez <https://github.com/MeLlamoPablo>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Faisal Salman <https://github.com/faisalman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace UAParser {
     // tslint:disable:interface-name backward compatible exclusion
 
-    interface IBrowser {
+    interface IData {
+        is(val: string): boolean;
+        toString(): string;
+        withClientHints(): PromiseLike<IData> | IData;
+        withFeatureCheck(): IData;
+    }
+
+    interface IBrowser extends IData {
         /**
          * Possible values :
          * Amaya, Android Browser, Arora, Avant, Baidu, Blazer, Bolt, Camino, Chimera, Chrome,
@@ -37,7 +45,7 @@ declare namespace UAParser {
         major: string | undefined;
     }
 
-    interface IDevice {
+    interface IDevice extends IData {
         /**
          * Determined dynamically
          */
@@ -59,7 +67,7 @@ declare namespace UAParser {
         vendor: string | undefined;
     }
 
-    interface IEngine {
+    interface IEngine extends IData {
         /**
          * Possible name:
          * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
@@ -72,7 +80,7 @@ declare namespace UAParser {
         version: string | undefined;
     }
 
-    interface IOS {
+    interface IOS extends IData {
         /**
          * Possible 'os.name'
          * AIX, Amiga OS, Android, Arch, Bada, BeOS, BlackBerry, CentOS, Chromium OS, Contiki,
@@ -89,7 +97,7 @@ declare namespace UAParser {
         version: string | undefined;
     }
 
-    interface ICPU {
+    interface ICPU extends IData {
         /**
          * Possible architecture:
          *  68k, amd64, arm, arm64, avr, ia32, ia64, irix, irix64, mips, mips64, pa-risc,
@@ -98,7 +106,7 @@ declare namespace UAParser {
         architecture: string | undefined;
     }
 
-    interface IResult {
+    interface IResult extends IData {
         ua: string;
         browser: IBrowser;
         device: IDevice;
@@ -198,10 +206,12 @@ declare const UAParser: {
     /**
      * Create a new parser with UA prepopulated and extensions extended
      */
-    new (uastring?: string, extensions?: Record<string, unknown>): UAParser.UAParserInstance;
-    new (extensions?: Record<string, unknown>): UAParser.UAParserInstance;
-    (uastring?: string, extensions?: Record<string, unknown>): UAParser.IResult;
-    (extensions?: Record<string, unknown>): UAParser.IResult;
+    new (uastring?: string, extensions?: Record<string, unknown>, headers?: Record<string, string>): UAParser.UAParserInstance;
+    new (extensions?: Record<string, unknown>, headers?: Record<string, string>): UAParser.UAParserInstance;
+    new (headers?: Record<string, string>): UAParser.UAParserInstance;
+    (uastring?: string, extensions?: Record<string, unknown>, headers?: Record<string, string>): UAParser.IResult;
+    (extensions?: Record<string, unknown>, headers?: Record<string, string>): UAParser.IResult;
+    (headers?: Record<string, string>): UAParser.IResult;
 
     // alias for older syntax
     UAParser: typeof UAParser;

--- a/types/ua-parser-js/v2/tsconfig.json
+++ b/types/ua-parser-js/v2/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ua-parser-js-tests.ts"
+    ]
+}

--- a/types/ua-parser-js/v2/tsconfig.json
+++ b/types/ua-parser-js/v2/tsconfig.json
@@ -8,10 +8,13 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
+        "paths": {
+          "ua-parser-js": [ "ua-parser-js/v2" ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/ua-parser-js/v2/tslint.json
+++ b/types/ua-parser-js/v2/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json"
+}

--- a/types/ua-parser-js/v2/ua-parser-js-tests.ts
+++ b/types/ua-parser-js/v2/ua-parser-js-tests.ts
@@ -75,3 +75,29 @@ interface Foo extends UAParser {
 }
 
 const method: Foo["getBrowser"] = parser.getBrowser;
+
+// test new API v2.0
+
+parser.getCPU().is('ia32'); // $ExpectType boolean
+parser.getCPU().toString(); // $ExpectType string
+parser.getCPU().withClientHints(); // $ExpectType IData | PromiseLike<IData>
+parser.getCPU().withFeatureCheck(); // $ExpectType IData
+
+const extensions = {
+    browser : ownBrowser
+};
+const headers = {
+    'user-agent' : 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36',
+    'sec-ch-ua-mobile' : '?1',
+    'sec-ch-ua-model' : 'Galaxy S3 Marketing',
+    'sec-ch-ua-platform' : 'Android'
+};
+
+UAParser(); // $ExpectType IResult
+UAParser(uaString); // $ExpectType IResult
+UAParser(extensions); // $ExpectType IResult
+UAParser(headers); // $ExpectType IResult
+UAParser(uaString, extensions); // $ExpectType IResult
+UAParser(uaString, headers); // $ExpectType IResult
+UAParser(extensions, headers); // $ExpectType IResult
+UAParser(uaString, extensions, headers); // $ExpectType IResult

--- a/types/ua-parser-js/v2/ua-parser-js-tests.ts
+++ b/types/ua-parser-js/v2/ua-parser-js-tests.ts
@@ -1,0 +1,77 @@
+import UAParser = require("ua-parser-js");
+// tslint:disable-next-line:no-duplicate-imports testing imports
+import { UAParser as UAParserAlias } from "ua-parser-js";
+// tslint:disable-next-line:no-duplicate-imports testing imports
+import { IBrowser, ICPU, IDevice, IEngine, IOS, IResult, BROWSER, CPU, DEVICE, ENGINE, OS } from "ua-parser-js";
+
+const ua = "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6";
+new UAParser(); // $ExpectType UAParserInstance
+const parser = new UAParser(ua); // $ExpectType UAParserInstance
+const result = parser.getResult(); // $ExpectType IResult
+
+// create via call instead of new
+UAParser(); // $ExpectType IResult
+UAParser(ua); // $ExpectType IResult
+
+parser.getUA(); // $ExpectType string
+parser.setUA("foo"); // $ExpectType UAParserInstance
+
+result.ua; // $ExpectType string
+
+// browser
+result.browser.name; // $ExpectType string | undefined
+result.browser.version; // $ExpectType string | undefined
+parser.getBrowser().name; // $ExpectType string | undefined
+parser.getBrowser().version; // $ExpectType string | undefined
+
+// device
+result.device.model; // $ExpectType string | undefined
+result.device.type; // $ExpectType string | undefined
+result.device.vendor; // $ExpectType string | undefined
+
+parser.getDevice().model; // $ExpectType string | undefined
+parser.getDevice().type; // $ExpectType string | undefined
+parser.getDevice().vendor; // $ExpectType string | undefined
+
+// Engine
+result.engine.name; // $ExpectType string | undefined
+result.engine.version; // $ExpectType string | undefined
+parser.getEngine().name; // $ExpectType string | undefined
+parser.getEngine().version; // $ExpectType string | undefined
+
+// OS
+result.os.name; // $ExpectType string | undefined
+result.os.version; // $ExpectType string | undefined
+parser.getOS().name; // $ExpectType string | undefined
+parser.getOS().version; // $ExpectType string | undefined
+
+// CPU
+result.cpu.architecture; // $ExpectType string | undefined
+parser.getCPU().architecture; // $ExpectType string | undefined
+
+// Extensions
+const uaString = "ownbrowser/1.3";
+const ownBrowser = [[/(ownbrowser)\/([\w\.]+)/i], [UAParser.BROWSER.NAME, UAParser.BROWSER.VERSION]];
+new UAParser({ browser: ownBrowser }); // $ExpectType UAParserInstance
+new UAParser(uaString, { browser: ownBrowser }); // $ExpectType UAParserInstance
+UAParser({ browser: ownBrowser }); // $ExpectType IResult
+UAParser(uaString, { browser: ownBrowser }); // $ExpectType IResult
+
+// alias
+new UAParserAlias(uaString, { browser: ownBrowser }); // $ExpectType UAParserInstance
+UAParserAlias(uaString, { browser: ownBrowser }); // $ExpectType IResult
+
+// static fields
+UAParser.VERSION; // $ExpectType string
+UAParser.BROWSER; // $ExpectType BROWSER
+UAParser.CPU; // $ExpectType CPU
+UAParser.DEVICE; // $ExpectType DEVICE
+UAParser.ENGINE; // $ExpectType ENGINE
+UAParser.OS; // $ExpectType OS
+
+// test UAParser interface export
+interface Foo extends UAParser {
+    a: string;
+}
+
+const method: Foo["getBrowser"] = parser.getBrowser;


### PR DESCRIPTION
This update brings support for those who wanted to try the upcoming version of `ua-parser-js` (still in [alpha](https://www.npmjs.com/package/ua-parser-js/v/2.0.0-alpha.2?activeTab=versions))

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://faisalman.github.io/ua-parser-js-docs/v2/](https://faisalman.github.io/ua-parser-js-docs/v2/)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.