### PR TITLE
[formidable] Add createDirsFromUploads option, fix type for Fields interface and Files interface

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -31,6 +31,7 @@ const options: Options = {
     minFileSize: 1,
     multiples: false,
     uploadDir: "/dir",
+    createDirsFromUploads: false,
     filter: (part) => {
         // $ExpectType Part
         part;
@@ -176,11 +177,11 @@ form.onPart = part => {
     form._handlePart(part);
 };
 
-http.createServer(req => {
+http.createServer(async req => {
     // $ExpectType IncomingMessage
     req;
 
-    form.parse(req, (err, fields, files) => {
+    form.parse(req, (err, fields, files) => { // testing with callback
         // $ExpectType any
         err;
         // $ExpectType Fields
@@ -188,13 +189,9 @@ http.createServer(req => {
         // $ExpectType Files
         files;
     });
-});
 
-http.createServer(req => {
     form.parse(req); // testing without callback
-});
 
-http.createServer(async req => {
     const [fields, files] = await form.parse(req); // testing with promise
     // $ExpectType Fields
     fields;

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -185,6 +185,13 @@ declare namespace formidable {
         multiples?: boolean | undefined;
 
         /**
+         * If true, makes direct folder uploads possible.
+         *
+         * @default false
+         */
+        createDirsFromUploads?: boolean;
+
+        /**
          * Use it to control newFilename. Must return a string. Will be joined with
          * options.uploadDir.
          *
@@ -198,10 +205,10 @@ declare namespace formidable {
     }
 
     interface Fields {
-        [field: string]: string | string[];
+        [field: string]: string[];
     }
     interface Files {
-        [file: string]: File | File[];
+        [file: string]: File[];
     }
 
     interface Part extends Stream {

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -189,7 +189,7 @@ declare namespace formidable {
          *
          * @default false
          */
-        createDirsFromUploads?: boolean;
+        createDirsFromUploads?: boolean | undefined;
 
         /**
          * Use it to control newFilename. Must return a string. Will be joined with


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test `formidable`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Discussion: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66218