### PR TITLE
@types/k6 Fix runtime error when grcp Stream experimental

### DIFF
--- a/types/k6/experimental/grpc.d.ts
+++ b/types/k6/experimental/grpc.d.ts
@@ -81,22 +81,21 @@ declare namespace grpc {
      * StreamEvent describes the possible events that can be emitted
      * by a gRPC stream.
      */
-    enum StreamEvent {
+    type StreamEvent =
         /**
          * Event fired when data has been received from the server.
          */
-        Data = 'data',
+        | 'data'
 
         /**
          * Event fired when a stream has been closed due to an error.
          */
-        Error = 'error',
+        | 'error'
 
         /**
          * Event fired when the stream closes.
          */
-        End = 'end',
-    }
+        | 'end';
 
     /**
      * Stream allows you to use streaming RPCs.

--- a/types/k6/test/experimental/grpc.ts
+++ b/types/k6/test/experimental/grpc.ts
@@ -40,7 +40,7 @@ client.invoke('main.RouteGuide/UpdateFeature', req, params_with_string_timeout);
 
 const stream = new grpc.Stream(client, 'main.RouteGuide/GetFeature', params);
 
-stream.on(grpc.StreamEvent.Data, (data) => {
+stream.on('data', data => {
     data; // $ExpectType object | GrpcError | undefined
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://k6.io/docs/javascript-api/k6-experimental/grpc/stream/stream-on/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
