### PR TITLE
Fix k6 browser type definitions

### DIFF
--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1333,7 +1333,7 @@ export class JSHandle<T = any> {
      * @param args The arguments to pass to the page function.
      * @returns The return value of `pageFunction`.
      */
-    evaluate<R, Arg>(pageFunction: PageFunction<R, Arg>, ...args: any): any;
+    evaluate<R, Arg>(pageFunction: PageFunction<Arg, R>, arg?: Arg): R;
 
     /**
      * Evaluates the page function and returns a `JSHandle`.
@@ -1343,7 +1343,7 @@ export class JSHandle<T = any> {
      * @param args The arguments to pass to the page function.
      * @returns A JSHandle of the return value of `pageFunction`.
      */
-    evaluateHandle<R, Arg>(pageFunction: PageFunction<R, Arg>, ...args: any): JSHandle<R>;
+    evaluateHandle<R, Arg>(pageFunction: PageFunction<Arg, R>, arg?: Arg): JSHandle<R>;
 
     /**
      * Fethes a map with own property names of of the `JSHandle` with their values as

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -152,7 +152,7 @@ export type MouseMultiClickOptions = MouseClickOptions & {
     clickCount?: number;
 };
 
- export interface MouseDownUpOptions {
+export interface MouseDownUpOptions {
     /**
      * The mouse button to use during the action.
      * Defaults to `left`.

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1,5 +1,3 @@
-export {};
-
 /**
  * Represents event-specific properties. Refer to the events documentation for
  * the lists of initial properties:
@@ -11,11 +9,11 @@ export {};
  * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
  * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
  */
-type EvaluationArgument = object;
+export type EvaluationArgument = object;
 
-type PageFunction<Arg, R> = string | ((arg: Unboxed<Arg>) => R);
+export type PageFunction<Arg, R> = string | ((arg: Unboxed<Arg>) => R);
 
-type Unboxed<Arg> = Arg extends [infer A0, infer A1]
+export type Unboxed<Arg> = Arg extends [infer A0, infer A1]
     ? [Unboxed<A0>, Unboxed<A1>]
     : Arg extends [infer A0, infer A1, infer A2]
     ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>]
@@ -27,7 +25,7 @@ type Unboxed<Arg> = Arg extends [infer A0, infer A1]
     ? { [Key in keyof Arg]: Unboxed<Arg[Key]> }
     : Arg;
 
-interface SelectOptionsObject {
+export interface SelectOptionsObject {
     /**
      * Matches by `option.value`.
      */
@@ -44,7 +42,7 @@ interface SelectOptionsObject {
     index?: number;
 }
 
-type ResourceType =
+export type ResourceType =
     | 'document'
     | 'stylesheet'
     | 'image'
@@ -58,13 +56,13 @@ type ResourceType =
     | 'websocket'
     | 'manifest'
     | 'other';
-type MouseButton = 'left' | 'right' | 'middle';
-type KeyboardModifier = 'Alt' | 'Control' | 'Meta' | 'Shift';
-type ElementState = 'attached' | 'detached' | 'visible' | 'hidden';
-type InputElementState = ElementState | 'enabled' | 'disabled' | 'editable';
-type LifecycleEvent = 'load' | 'domcontentloaded' | 'networkidle';
+export type MouseButton = 'left' | 'right' | 'middle';
+export type KeyboardModifier = 'Alt' | 'Control' | 'Meta' | 'Shift';
+export type ElementState = 'attached' | 'detached' | 'visible' | 'hidden';
+export type InputElementState = ElementState | 'enabled' | 'disabled' | 'editable';
+export type LifecycleEvent = 'load' | 'domcontentloaded' | 'networkidle';
 
-interface TimeoutOptions {
+export interface TimeoutOptions {
     /**
      * Maximum time in milliseconds. Pass 0 to disable the timeout. Default is overridden by the setDefaultTimeout option on `BrowserContext` or `Page`.
      * Defaults to 30000.
@@ -72,7 +70,7 @@ interface TimeoutOptions {
     timeout?: number;
 }
 
-interface StrictnessOptions {
+export interface StrictnessOptions {
     /**
      * When `true`, the call requires selector to resolve to a single element.
      * If given selector resolves to more than one element, the call throws
@@ -81,14 +79,14 @@ interface StrictnessOptions {
     strict?: boolean;
 }
 
-interface EventSequenceOptions {
+export interface EventSequenceOptions {
     /**
      * Delay between events in milliseconds. Defaults to 0.
      */
     delay?: number;
 }
 
-type ElementHandleOptions = {
+export type ElementHandleOptions = {
     /**
      * Setting this to `true` will bypass the actionability checks (visible,
      * stable, enabled). Defaults to `false`.
@@ -102,7 +100,7 @@ type ElementHandleOptions = {
     noWaitAfter?: boolean;
 } & TimeoutOptions;
 
-type ElementHandlePointerOptions = ElementHandleOptions & {
+export type ElementHandlePointerOptions = ElementHandleOptions & {
     /**
      * Setting this to `true` will perform the actionability checks without
      * performing the action. Useful to wait until the element is ready for the
@@ -111,7 +109,7 @@ type ElementHandlePointerOptions = ElementHandleOptions & {
     trial?: boolean;
 };
 
-type ElementClickOptions = ElementHandlePointerOptions & {
+export type ElementClickOptions = ElementHandlePointerOptions & {
     /**
      * A point to use relative to the top left corner of the element. If not supplied,
      * a visible point of the element is used.
@@ -119,7 +117,7 @@ type ElementClickOptions = ElementHandlePointerOptions & {
     position?: { x: number; y: number };
 };
 
-interface KeyboardModifierOptions {
+export interface KeyboardModifierOptions {
     /**
      * `Alt`, `Control`, `Meta` or `Shift` modifiers keys pressed during the action.
      * If not specified, currently pressed modifiers are used.
@@ -127,7 +125,7 @@ interface KeyboardModifierOptions {
     modifiers?: KeyboardModifier[];
 }
 
-type KeyboardPressOptions = {
+export type KeyboardPressOptions = {
     /**
      * If set to `true` and a navigation occurs from performing this action, it
      * will not wait for it to complete. Defaults to `false`.
@@ -136,9 +134,9 @@ type KeyboardPressOptions = {
 } & EventSequenceOptions &
     TimeoutOptions;
 
-type MouseMoveOptions = ElementClickOptions & KeyboardModifierOptions;
+export type MouseMoveOptions = ElementClickOptions & KeyboardModifierOptions;
 
-type MouseClickOptions = {
+export type MouseClickOptions = {
     /**
      * The mouse button to use during the action.
      * Defaults to `left`.
@@ -146,7 +144,7 @@ type MouseClickOptions = {
     button?: MouseButton;
 } & EventSequenceOptions;
 
-type MouseMultiClickOptions = MouseClickOptions & {
+export type MouseMultiClickOptions = MouseClickOptions & {
     /**
      * The number of times the action is performed.
      * Defaults to 1.
@@ -154,7 +152,7 @@ type MouseMultiClickOptions = MouseClickOptions & {
     clickCount?: number;
 };
 
-interface MouseDownUpOptions {
+export interface MouseDownUpOptions {
     /**
      * The mouse button to use during the action.
      * Defaults to `left`.
@@ -167,7 +165,7 @@ interface MouseDownUpOptions {
     clickCount?: number;
 }
 
-type ContentLoadOptions = {
+export type ContentLoadOptions = {
     /**
      * When to consider operation succeeded, defaults to `load`. Events can be
      * either:
@@ -183,14 +181,14 @@ type ContentLoadOptions = {
     waitUntil?: LifecycleEvent;
 } & TimeoutOptions;
 
-type NavigationOptions = {
+export type NavigationOptions = {
     /**
      * Referer header value.
      */
     referer?: string;
 } & ContentLoadOptions;
 
-interface ResourceTiming {
+export interface ResourceTiming {
     /**
      * Request start time in milliseconds elapsed since January 1, 1970 00:00:00 UTC
      */
@@ -250,7 +248,7 @@ interface ResourceTiming {
     responseEnd: number;
 }
 
-interface SecurityDetailsObject {
+export interface SecurityDetailsObject {
     /**
      * Common Name component of the Issuer field. The value is extracted from the
      * certificate. This should only be used for informational purposes.
@@ -287,7 +285,7 @@ interface SecurityDetailsObject {
     sanList?: string[];
 }
 
-interface Rect {
+export interface Rect {
     /**
      * The x coordinate of the element in pixels.
      * (0, 0) is the top left corner of the viewport.
@@ -311,9 +309,9 @@ interface Rect {
     height: number;
 }
 
-type ImageFormat = 'jpeg' | 'png';
+export type ImageFormat = 'jpeg' | 'png';
 
-interface ScreenshotOptions {
+export interface ScreenshotOptions {
     /**
      * The file path to save the image to. The screenshot type will be inferred from file extension.
      */
@@ -345,9 +343,9 @@ interface ScreenshotOptions {
  * - `mutation` - use a mutation observer
  * - `interval` - use a polling interval
  */
-type PollingMethod = 'raf' | 'mutation' | 'interval';
+export type PollingMethod = 'raf' | 'mutation' | 'interval';
 
-interface PollingOptions {
+export interface PollingOptions {
     /**
      * Polling method to use.
      * @default 'raf'
@@ -360,7 +358,7 @@ interface PollingOptions {
     interval?: number;
 }
 
-interface ElementStateFilter {
+export interface ElementStateFilter {
     /**
      * The element state to filter for.
      * @default 'visible'
@@ -372,15 +370,15 @@ interface ElementStateFilter {
  * BrowserPermissions defines all the possible permissions that can be granted
  * to the browser application.
  */
-type BrowserPermissions = 'geolocation' | 'midi' | 'midi-sysex' |
-                          'notifications' | 'camera' |
-                          'microphone' | 'background-sync' |
-                          'ambient-light-sensor' | 'accelerometer' |
-                          'gyroscope' | 'magnetometer' |
-                          'accessibility-events' | 'clipboard-read' |
-                          'clipboard-write' | 'payment-handler';
+export type BrowserPermissions = 'geolocation' | 'midi' | 'midi-sysex' |
+                                  'notifications' | 'camera' |
+                                  'microphone' | 'background-sync' |
+                                  'ambient-light-sensor' | 'accelerometer' |
+                                  'gyroscope' | 'magnetometer' |
+                                  'accessibility-events' | 'clipboard-read' |
+                                  'clipboard-write' | 'payment-handler';
 
-interface NewBrowserContextOptions {
+export interface NewBrowserContextOptions {
     /**
      * Setting this to `true` will bypass a page's Content-Security-Policy.
      * Defaults to `false`.
@@ -540,7 +538,7 @@ export const browser: Browser;
 /**
  * `Browser` represents the main web browser instance.
  */
-interface Browser {
+export interface Browser {
     /**
      * Returns the current `BrowserContext`. There is a 1-to-1 mapping between
      * `Browser` and `BrowserContext`. If no `BrowserContext` has been
@@ -592,7 +590,7 @@ interface Browser {
  * `BrowserContext` provides a way to operate multiple independent sessions, with
  * separate pages, cache, and cookies.
  */
-interface BrowserContext {
+export interface BrowserContext {
     /**
      * Returns the `Browser` instance that this `BrowserContext` belongs to.
      */
@@ -770,7 +768,7 @@ interface BrowserContext {
 /**
  * ElementHandle represents an in-page DOM element.
  */
-interface ElementHandle extends JSHandle {
+export interface ElementHandle extends JSHandle {
     /**
      * Finds an element matching the specified selector in the `ElementHandle`'s subtree.
      * @param selector A selector to query element for.
@@ -966,7 +964,7 @@ interface ElementHandle extends JSHandle {
 /**
  * Frame represents the frame within a page. A page is made up of hierarchy of frames.
  */
-interface Frame {
+export interface Frame {
     /**
      * Finds an element matching the specified selector within the `Frame`.
      * @param selector A selector to query element for.
@@ -1313,7 +1311,7 @@ interface Frame {
 /**
  * JSHandle represents an in-page JavaScript object.
  */
-interface JSHandle<T = any> {
+export interface JSHandle<T = any> {
     /**
      * Returns either `null` or the object handle itself, if the object handle is
      * an instance of `ElementHandle`.
@@ -1362,7 +1360,7 @@ interface JSHandle<T = any> {
 /**
  * Keyboard provides an API for managing a virtual keyboard.
  */
-interface Keyboard {
+export interface Keyboard {
     /**
      * Sends a key down message to a session target.
      * A superset of the key values can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values).
@@ -1413,7 +1411,7 @@ interface Keyboard {
  * - Makes it easier to work with dynamic web pages and SPAs built with Svelte,
  * React, Vue, etc.
  */
-interface Locator {
+export interface Locator {
     /**
      * Mouse click on the chosen element.
      * @param options Options to use.
@@ -1587,7 +1585,7 @@ interface Locator {
 /**
  * Mouse provides an API for managing a virtual mouse.
  */
-interface Mouse {
+export interface Mouse {
     /**
      * Shortcut for `mouse.move(x, y)`, `mouse.down()`, `mouse.up()`.
      * @param x The x position.
@@ -1630,7 +1628,7 @@ interface Mouse {
  * Page provides methods to interact with a single tab in a running web browser
  * instance. One instance of the browser can have many page instances.
  */
-interface Page {
+export interface Page {
     /**
      * Activates the browser tab so that it comes into focus and actions can be
      * performed against it.
@@ -3134,7 +3132,7 @@ interface Page {
 /**
  * Request represents requests which are sent by a page.
  */
-interface Request {
+export interface Request {
     /**
      * An object with HTTP headers associated with the request. All header names are
      * lower-case.
@@ -3232,7 +3230,7 @@ interface Request {
 /**
  * Response represents responses which are received by page.
  */
-interface Response {
+export interface Response {
     /**
      * An object with HTTP headers associated with the response. All header names are
      * lower-case.
@@ -3346,7 +3344,7 @@ interface Response {
  * operates in main-frame CSS pixels relative to the top-left corner of the
  * viewport.
  */
-interface Touchscreen {
+export interface Touchscreen {
     /**
      * Taps on the specified position (`x`,`y`), which internally dispatches a `touchstart` and `touchend` event.
      * @param x The x position.
@@ -3358,7 +3356,7 @@ interface Touchscreen {
 /**
  * The Worker represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
  */
-interface Worker {
+export interface Worker {
     /**
      * Get the URL of the web worker.
      * @return The URL of the web worker.

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1,3 +1,5 @@
+export {};
+
 /**
  * Represents event-specific properties. Refer to the events documentation for
  * the lists of initial properties:
@@ -530,10 +532,15 @@ export interface NewBrowserContextOptions {
 }
 
 /**
- * The `Browser` class is the entry point for all your tests, it interacts
- * with the actual web browser via Chrome DevTools Protocol (CDP).
+ * The `browser` named export is the entry point for all your tests,
+ * it interacts with the actual web browser via Chrome DevTools Protocol (CDP).
  */
-export class Browser {
+export const browser: Browser;
+
+/**
+ * `Browser` represents the main web browser instance.
+ */
+interface Browser {
     /**
      * Returns the current `BrowserContext`. There is a 1-to-1 mapping between
      * `Browser` and `BrowserContext`. If no `BrowserContext` has been

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -11,11 +11,11 @@ export {};
  * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
  * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
  */
-export type EvaluationArgument = object;
+type EvaluationArgument = object;
 
-export type PageFunction<Arg, R> = string | ((arg: Unboxed<Arg>) => R);
+type PageFunction<Arg, R> = string | ((arg: Unboxed<Arg>) => R);
 
-export type Unboxed<Arg> = Arg extends [infer A0, infer A1]
+type Unboxed<Arg> = Arg extends [infer A0, infer A1]
     ? [Unboxed<A0>, Unboxed<A1>]
     : Arg extends [infer A0, infer A1, infer A2]
     ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>]
@@ -27,7 +27,7 @@ export type Unboxed<Arg> = Arg extends [infer A0, infer A1]
     ? { [Key in keyof Arg]: Unboxed<Arg[Key]> }
     : Arg;
 
-export interface SelectOptionsObject {
+interface SelectOptionsObject {
     /**
      * Matches by `option.value`.
      */
@@ -44,7 +44,7 @@ export interface SelectOptionsObject {
     index?: number;
 }
 
-export type ResourceType =
+type ResourceType =
     | 'document'
     | 'stylesheet'
     | 'image'
@@ -58,13 +58,13 @@ export type ResourceType =
     | 'websocket'
     | 'manifest'
     | 'other';
-export type MouseButton = 'left' | 'right' | 'middle';
-export type KeyboardModifier = 'Alt' | 'Control' | 'Meta' | 'Shift';
-export type ElementState = 'attached' | 'detached' | 'visible' | 'hidden';
-export type InputElementState = ElementState | 'enabled' | 'disabled' | 'editable';
-export type LifecycleEvent = 'load' | 'domcontentloaded' | 'networkidle';
+type MouseButton = 'left' | 'right' | 'middle';
+type KeyboardModifier = 'Alt' | 'Control' | 'Meta' | 'Shift';
+type ElementState = 'attached' | 'detached' | 'visible' | 'hidden';
+type InputElementState = ElementState | 'enabled' | 'disabled' | 'editable';
+type LifecycleEvent = 'load' | 'domcontentloaded' | 'networkidle';
 
-export interface TimeoutOptions {
+interface TimeoutOptions {
     /**
      * Maximum time in milliseconds. Pass 0 to disable the timeout. Default is overridden by the setDefaultTimeout option on `BrowserContext` or `Page`.
      * Defaults to 30000.
@@ -72,7 +72,7 @@ export interface TimeoutOptions {
     timeout?: number;
 }
 
-export interface StrictnessOptions {
+interface StrictnessOptions {
     /**
      * When `true`, the call requires selector to resolve to a single element.
      * If given selector resolves to more than one element, the call throws
@@ -81,14 +81,14 @@ export interface StrictnessOptions {
     strict?: boolean;
 }
 
-export interface EventSequenceOptions {
+interface EventSequenceOptions {
     /**
      * Delay between events in milliseconds. Defaults to 0.
      */
     delay?: number;
 }
 
-export type ElementHandleOptions = {
+type ElementHandleOptions = {
     /**
      * Setting this to `true` will bypass the actionability checks (visible,
      * stable, enabled). Defaults to `false`.
@@ -102,7 +102,7 @@ export type ElementHandleOptions = {
     noWaitAfter?: boolean;
 } & TimeoutOptions;
 
-export type ElementHandlePointerOptions = ElementHandleOptions & {
+type ElementHandlePointerOptions = ElementHandleOptions & {
     /**
      * Setting this to `true` will perform the actionability checks without
      * performing the action. Useful to wait until the element is ready for the
@@ -111,7 +111,7 @@ export type ElementHandlePointerOptions = ElementHandleOptions & {
     trial?: boolean;
 };
 
-export type ElementClickOptions = ElementHandlePointerOptions & {
+type ElementClickOptions = ElementHandlePointerOptions & {
     /**
      * A point to use relative to the top left corner of the element. If not supplied,
      * a visible point of the element is used.
@@ -119,7 +119,7 @@ export type ElementClickOptions = ElementHandlePointerOptions & {
     position?: { x: number; y: number };
 };
 
-export interface KeyboardModifierOptions {
+interface KeyboardModifierOptions {
     /**
      * `Alt`, `Control`, `Meta` or `Shift` modifiers keys pressed during the action.
      * If not specified, currently pressed modifiers are used.
@@ -127,7 +127,7 @@ export interface KeyboardModifierOptions {
     modifiers?: KeyboardModifier[];
 }
 
-export type KeyboardPressOptions = {
+type KeyboardPressOptions = {
     /**
      * If set to `true` and a navigation occurs from performing this action, it
      * will not wait for it to complete. Defaults to `false`.
@@ -136,9 +136,9 @@ export type KeyboardPressOptions = {
 } & EventSequenceOptions &
     TimeoutOptions;
 
-export type MouseMoveOptions = ElementClickOptions & KeyboardModifierOptions;
+type MouseMoveOptions = ElementClickOptions & KeyboardModifierOptions;
 
-export type MouseClickOptions = {
+type MouseClickOptions = {
     /**
      * The mouse button to use during the action.
      * Defaults to `left`.
@@ -146,7 +146,7 @@ export type MouseClickOptions = {
     button?: MouseButton;
 } & EventSequenceOptions;
 
-export type MouseMultiClickOptions = MouseClickOptions & {
+type MouseMultiClickOptions = MouseClickOptions & {
     /**
      * The number of times the action is performed.
      * Defaults to 1.
@@ -154,7 +154,7 @@ export type MouseMultiClickOptions = MouseClickOptions & {
     clickCount?: number;
 };
 
-export interface MouseDownUpOptions {
+interface MouseDownUpOptions {
     /**
      * The mouse button to use during the action.
      * Defaults to `left`.
@@ -167,7 +167,7 @@ export interface MouseDownUpOptions {
     clickCount?: number;
 }
 
-export type ContentLoadOptions = {
+type ContentLoadOptions = {
     /**
      * When to consider operation succeeded, defaults to `load`. Events can be
      * either:
@@ -183,14 +183,14 @@ export type ContentLoadOptions = {
     waitUntil?: LifecycleEvent;
 } & TimeoutOptions;
 
-export type NavigationOptions = {
+type NavigationOptions = {
     /**
      * Referer header value.
      */
     referer?: string;
 } & ContentLoadOptions;
 
-export interface ResourceTiming {
+interface ResourceTiming {
     /**
      * Request start time in milliseconds elapsed since January 1, 1970 00:00:00 UTC
      */
@@ -250,7 +250,7 @@ export interface ResourceTiming {
     responseEnd: number;
 }
 
-export interface SecurityDetailsObject {
+interface SecurityDetailsObject {
     /**
      * Common Name component of the Issuer field. The value is extracted from the
      * certificate. This should only be used for informational purposes.
@@ -287,7 +287,7 @@ export interface SecurityDetailsObject {
     sanList?: string[];
 }
 
-export interface Rect {
+interface Rect {
     /**
      * The x coordinate of the element in pixels.
      * (0, 0) is the top left corner of the viewport.
@@ -311,9 +311,9 @@ export interface Rect {
     height: number;
 }
 
-export type ImageFormat = 'jpeg' | 'png';
+type ImageFormat = 'jpeg' | 'png';
 
-export interface ScreenshotOptions {
+interface ScreenshotOptions {
     /**
      * The file path to save the image to. The screenshot type will be inferred from file extension.
      */
@@ -345,9 +345,9 @@ export interface ScreenshotOptions {
  * - `mutation` - use a mutation observer
  * - `interval` - use a polling interval
  */
-export type PollingMethod = 'raf' | 'mutation' | 'interval';
+type PollingMethod = 'raf' | 'mutation' | 'interval';
 
-export interface PollingOptions {
+interface PollingOptions {
     /**
      * Polling method to use.
      * @default 'raf'
@@ -360,7 +360,7 @@ export interface PollingOptions {
     interval?: number;
 }
 
-export interface ElementStateFilter {
+interface ElementStateFilter {
     /**
      * The element state to filter for.
      * @default 'visible'
@@ -372,15 +372,15 @@ export interface ElementStateFilter {
  * BrowserPermissions defines all the possible permissions that can be granted
  * to the browser application.
  */
-export type BrowserPermissions = 'geolocation' | 'midi' | 'midi-sysex' |
-                                  'notifications' | 'camera' |
-                                  'microphone' | 'background-sync' |
-                                  'ambient-light-sensor' | 'accelerometer' |
-                                  'gyroscope' | 'magnetometer' |
-                                  'accessibility-events' | 'clipboard-read' |
-                                  'clipboard-write' | 'payment-handler';
+type BrowserPermissions = 'geolocation' | 'midi' | 'midi-sysex' |
+                          'notifications' | 'camera' |
+                          'microphone' | 'background-sync' |
+                          'ambient-light-sensor' | 'accelerometer' |
+                          'gyroscope' | 'magnetometer' |
+                          'accessibility-events' | 'clipboard-read' |
+                          'clipboard-write' | 'payment-handler';
 
-export interface NewBrowserContextOptions {
+interface NewBrowserContextOptions {
     /**
      * Setting this to `true` will bypass a page's Content-Security-Policy.
      * Defaults to `false`.
@@ -592,7 +592,7 @@ interface Browser {
  * `BrowserContext` provides a way to operate multiple independent sessions, with
  * separate pages, cache, and cookies.
  */
-export class BrowserContext {
+interface BrowserContext {
     /**
      * Returns the `Browser` instance that this `BrowserContext` belongs to.
      */
@@ -770,7 +770,7 @@ export class BrowserContext {
 /**
  * ElementHandle represents an in-page DOM element.
  */
-export class ElementHandle extends JSHandle {
+interface ElementHandle extends JSHandle {
     /**
      * Finds an element matching the specified selector in the `ElementHandle`'s subtree.
      * @param selector A selector to query element for.
@@ -966,7 +966,7 @@ export class ElementHandle extends JSHandle {
 /**
  * Frame represents the frame within a page. A page is made up of hierarchy of frames.
  */
-export class Frame {
+interface Frame {
     /**
      * Finds an element matching the specified selector within the `Frame`.
      * @param selector A selector to query element for.
@@ -1313,7 +1313,7 @@ export class Frame {
 /**
  * JSHandle represents an in-page JavaScript object.
  */
-export class JSHandle<T = any> {
+interface JSHandle<T = any> {
     /**
      * Returns either `null` or the object handle itself, if the object handle is
      * an instance of `ElementHandle`.
@@ -1362,7 +1362,7 @@ export class JSHandle<T = any> {
 /**
  * Keyboard provides an API for managing a virtual keyboard.
  */
-export class Keyboard {
+interface Keyboard {
     /**
      * Sends a key down message to a session target.
      * A superset of the key values can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values).
@@ -1413,7 +1413,7 @@ export class Keyboard {
  * - Makes it easier to work with dynamic web pages and SPAs built with Svelte,
  * React, Vue, etc.
  */
-export class Locator {
+interface Locator {
     /**
      * Mouse click on the chosen element.
      * @param options Options to use.
@@ -1587,7 +1587,7 @@ export class Locator {
 /**
  * Mouse provides an API for managing a virtual mouse.
  */
-export class Mouse {
+interface Mouse {
     /**
      * Shortcut for `mouse.move(x, y)`, `mouse.down()`, `mouse.up()`.
      * @param x The x position.
@@ -1630,7 +1630,7 @@ export class Mouse {
  * Page provides methods to interact with a single tab in a running web browser
  * instance. One instance of the browser can have many page instances.
  */
-export class Page {
+interface Page {
     /**
      * Activates the browser tab so that it comes into focus and actions can be
      * performed against it.
@@ -3132,9 +3132,9 @@ export class Page {
 }
 
 /**
- * Request class represents requests which are sent by a page.
+ * Request represents requests which are sent by a page.
  */
-export class Request {
+interface Request {
     /**
      * An object with HTTP headers associated with the request. All header names are
      * lower-case.
@@ -3230,9 +3230,9 @@ export class Request {
 }
 
 /**
- * Response class represents responses which are received by page.
+ * Response represents responses which are received by page.
  */
-export class Response {
+interface Response {
     /**
      * An object with HTTP headers associated with the response. All header names are
      * lower-case.
@@ -3346,7 +3346,7 @@ export class Response {
  * operates in main-frame CSS pixels relative to the top-left corner of the
  * viewport.
  */
-export class Touchscreen {
+interface Touchscreen {
     /**
      * Taps on the specified position (`x`,`y`), which internally dispatches a `touchstart` and `touchend` event.
      * @param x The x position.
@@ -3356,9 +3356,9 @@ export class Touchscreen {
 }
 
 /**
- * The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
+ * The Worker represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
  */
-export class Worker {
+interface Worker {
     /**
      * Get the URL of the web worker.
      * @return The URL of the web worker.

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -1,19 +1,9 @@
 import {
-    ElementState,
-    ImageFormat,
-    InputElementState,
-    LifecycleEvent,
-    Page,
-    Request,
-    Response,
-    ElementHandle,
     browser,
-    BrowserContext,
 } from 'k6/experimental/browser';
 
 const url = 'http://example.com';
 const selector = 'a[href="http://example.com"]';
-const elementHandle = new ElementHandle();
 
 //
 // browser tests
@@ -125,7 +115,7 @@ browser.version();
 //
 // Create a browserContext
 //
-const browserContext = new BrowserContext();
+const browserContext = browser.newContext();
 
 // $ExpectType Browser
 browserContext.browser();
@@ -160,12 +150,12 @@ browserContext.setGeolocation({ latitude: 0, longitude: 0, accuracy: 1 });
 // $ExpectType void
 browserContext.setOffline(true);
 // $ExpectType Page | null
-browserContext.waitForEvent('', { predicate: (page: Page | null) => true, timeout: 30000 });
+browserContext.waitForEvent('', { predicate: () => true, timeout: 30000 });
 
 //
 // Create a page
 //
-const page = new Page();
+const page = browser.newPage();
 
 // $ExpectType void
 page.bringToFront();
@@ -544,7 +534,7 @@ page.screenshot({ path: 'image.jpeg' });
 page.screenshot({ quality: 50 });
 for (const format of ['png', 'jpeg']) {
     // $ExpectType ArrayBuffer
-    page.screenshot({ type: format as ImageFormat });
+    page.screenshot({ type: format as any });
 }
 
 // @ts-expect-error
@@ -554,7 +544,7 @@ page.selectOption(selector);
 // $ExpectType string[]
 page.selectOption(selector, 'option');
 // $ExpectType string[]
-page.selectOption(selector, elementHandle);
+page.selectOption(selector, page.waitForSelector(selector));
 // $ExpectType string[]
 page.selectOption(selector, { value: '' });
 // $ExpectType string[]
@@ -564,7 +554,7 @@ page.selectOption(selector, { index: 0 });
 // $ExpectType string[]
 page.selectOption(selector, ['option', 'option2']);
 // $ExpectType string[]
-page.selectOption(selector, [elementHandle, elementHandle]);
+page.selectOption(selector, [page.waitForSelector(selector), page.waitForSelector(selector)]);
 // $ExpectType string[]
 page.selectOption(selector, [{ value: '' }, { label: '' }]);
 // $ExpectType string[]
@@ -1094,7 +1084,7 @@ locator.dispatchEvent('click', { buttons: 2 & 4 }, { strict: true });
 locator.waitFor();
 for (const state of ['attached', 'detached', 'visible', 'hidden']) {
     // $ExpectType void
-    locator.waitFor({ state: state as ElementState });
+    locator.waitFor({ state: state as any });
 }
 // $ExpectType void
 locator.waitFor({ timeout: 10000 });
@@ -1159,109 +1149,111 @@ jsHandle.jsonValue();
 //
 // Request
 //
-const request = new Request();
+const request = page.goto(url).then(r => r?.request());
 
-// $ExpectType Record<string, string>
-request.allHeaders();
+// $ExpectType Promise<Record<string, string> | undefined>
+request.then(r => r?.allHeaders());
 
-// $ExpectType Frame
-request.frame();
+// $ExpectType Promise<Frame | undefined>
+request.then(r => r?.frame());
 
-// $ExpectType Record<string, string>
-request.headers();
+// $ExpectType Promise<Record<string, string> | undefined>
+request.then(r => r?.headers());
 
-// $ExpectType { name: string; value: string; }[]
-request.headersArray();
+// $ExpectType Promise<{ name: string; value: string; }[] | undefined>
+request.then(r => r?.headersArray());
 
 // @ts-expect-error
-request.headerValue();
-// $ExpectType string | null
-request.headerValue('content-type');
+request.then(r => r?.headerValue());
+// $ExpectType Promise<string | null | undefined>
+request.then(r => r?.headerValue('content-type'));
 
-// $ExpectType boolean
-request.isNavigationRequest();
+// $ExpectType Promise<boolean | undefined>
+request.then(r => r?.isNavigationRequest());
 
-// $ExpectType string
-request.method();
+// $ExpectType Promise<string | undefined>
+request.then(r => r?.method());
 
-// $ExpectType string
-request.postData();
+// $ExpectType Promise<string | undefined>
+request.then(r => r?.postData());
 
-// $ExpectType ArrayBuffer | null
-request.postDataBuffer();
+// $ExpectType Promise<ArrayBuffer | null | undefined>
+request.then(r => r?.postDataBuffer());
 
-// $ExpectType ResourceType
-request.resourceType();
+// $ExpectType Promise<"document" | "stylesheet" | "image" | "media" | "font" | "script" | "texttrack" | "xhr" | "fetch" | "eventsource" | "websocket" | "manifest" | "other" | undefined>
+request.then(r => r?.resourceType());
 
-// $ExpectType Response | null
-request.response();
+// $ExpectType Promise<Response | null | undefined>
+request.then(r => r?.response());
 
-// $ExpectType { body: number; headers: number; }
-request.size();
+// $ExpectType Promise<{ body: number; headers: number; } | undefined>
+request.then(r => r?.size());
 
-// $ExpectType ResourceTiming
-request.timing();
+// $ExpectType Promise<ResourceTiming | undefined>
+request.then(r => r?.timing());
 
 //
 // Response
 //
-const response = new Response();
+const response = page.goto(url);
 
-// $ExpectType Record<string, string>
-response.allHeaders();
+// $ExpectType Promise<Record<string, string> | undefined>
+response.then(r => r?.allHeaders());
 
-// $ExpectType ArrayBuffer
-response.body();
+// $ExpectType Promise<ArrayBuffer | undefined>
+response.then(r => r?.body());
 
-// $ExpectType Frame
-response.frame();
+// $ExpectType Promise<Frame | undefined>
+response.then(r => r?.frame());
 
-// $ExpectType Record<string, string>
-response.headers();
+// $ExpectType Promise<Record<string, string> | undefined>
+response.then(r => r?.headers());
 
-// $ExpectType { name: string; value: string; }[]
-response.headersArray();
-
-// @ts-expect-error
-response.headerValue();
-// $ExpectType string | null
-response.headerValue('content-type');
+// $ExpectType Promise<{ name: string; value: string; }[] | undefined>
+response.then(r => r?.headersArray());
 
 // @ts-expect-error
-response.headerValues();
-// $ExpectType string[]
-response.headerValues('content-type');
+response.then(r => r?.headerValue());
+// $ExpectType Promise<string | null | undefined>
+response.then(r => r?.headerValue('content-type'));
 
-// $ExpectType any
-response.json();
+// @ts-expect-error
+response.then(r => r?.headerValues());
+// $ExpectType Promise<string[] | undefined>
+response.then(r => r?.headerValues('content-type'));
 
-// $ExpectType boolean
-response.ok();
+// $ExpectType Promise<any>
+response.then(r => r?.json());
 
-// $ExpectType Request
-response.request();
+// $ExpectType Promise<boolean | undefined>
+response.then(r => r?.ok());
 
-// $ExpectType SecurityDetailsObject | null
-response.securityDetails();
+// $ExpectType Promise<Request | undefined>
+response.then(r => r?.request());
 
-// $ExpectType { ipAddress: string; port: number; } | null
-response.serverAddr();
+// $ExpectType Promise<SecurityDetailsObject | null | undefined>
+response.then(r => r?.securityDetails());
 
-// $ExpectType number
-response.status();
+// $ExpectType Promise<{ ipAddress: string; port: number; } | null | undefined>
+response.then(r => r?.serverAddr());
 
-// $ExpectType string
-response.statusText();
+// $ExpectType Promise<number | undefined>
+response.then(r => r?.status());
 
-// $ExpectType { body: number; headers: number; }
-response.size();
+// $ExpectType Promise<string | undefined>
+response.then(r => r?.statusText());
 
-// $ExpectType string
-response.url();
+// $ExpectType Promise<{ body: number; headers: number; } | undefined>
+response.then(r => r?.size());
+
+// $ExpectType Promise<string | undefined>
+response.then(r => r?.url());
 
 //
 // ElementHandle
 //
+
+const elementHandle = page.$(selector);
 
 // @ts-expect-error
 elementHandle.$();
@@ -1364,7 +1356,7 @@ elementHandle.screenshot({ omitBackground: true });
 elementHandle.screenshot({ quality: 100 });
 for (const format of ['png', 'jpeg']) {
     // $ExpectType ArrayBuffer
-    elementHandle.screenshot({ type: format as ImageFormat });
+    elementHandle.screenshot({ type: format as any });
 }
 
 // $ExpectType void
@@ -1456,7 +1448,7 @@ elementHandle.uncheck({ strict: true });
 elementHandle.waitForElementState();
 for (const state of ['visible', 'hidden', 'stable', 'enabled', 'disabled', 'editable', 'disabled']) {
     // $ExpectType void
-    elementHandle.waitForElementState(state as InputElementState);
+    elementHandle.waitForElementState(state as any);
 }
 // $ExpectType void
 elementHandle.waitForElementState('visible', { timeout: 10000 });
@@ -1655,9 +1647,9 @@ frame.selectOption('select', 'value');
 // $ExpectType string[]
 frame.selectOption('select', ['value1', 'value2']);
 // $ExpectType string[]
-frame.selectOption('select', new ElementHandle());
+frame.selectOption('select', elementHandle);
 // $ExpectType string[]
-frame.selectOption('select', [new ElementHandle(), new ElementHandle()]);
+frame.selectOption('select', [elementHandle, elementHandle]);
 // $ExpectType string[]
 frame.selectOption('select', { value: 'value', index: 1, label: 'label' });
 // $ExpectType string[]
@@ -1745,7 +1737,7 @@ frame.goto('https://example.com');
 frame.goto('https://example.com', { timeout: 10000 });
 for (const state of ['load', 'domcontentloaded', 'networkidle']) {
     // $ExpectType Promise<Response | null>
-    frame.goto('https://example.com', { waitUntil: state as LifecycleEvent });
+    frame.goto('https://example.com', { waitUntil: state as any });
 }
 // $ExpectType Promise<Response | null>
 frame.goto('https://example.com', { referer: 'https://example.com' });
@@ -1758,7 +1750,7 @@ frame.setContent('<div>content</div>');
 frame.setContent('<div>content</div>', { timeout: 10000 });
 for (const state of ['load', 'domcontentloaded', 'networkidle']) {
     // $ExpectType void
-    frame.setContent('<div>content</div>', { waitUntil: state as LifecycleEvent });
+    frame.setContent('<div>content</div>', { waitUntil: state as any });
 }
 
 // $ExpectType string
@@ -1899,7 +1891,7 @@ frame.waitForFunction((a: number) => a === 1, {}, 1);
 frame.waitForLoadState();
 for (const state of ['load', 'domcontentloaded', 'networkidle']) {
     // $ExpectType void
-    frame.waitForLoadState(state as LifecycleEvent);
+    frame.waitForLoadState(state as any);
 }
 // $ExpectType void
 frame.waitForLoadState('domcontentloaded', { timeout: 10000 });
@@ -1919,7 +1911,7 @@ frame.waitForSelector('div');
 frame.waitForSelector('div', { timeout: 10000 });
 for (const state of ['attached', 'detached', 'visible', 'hidden']) {
     // $ExpectType ElementHandle
-    frame.waitForSelector('div', { state: state as ElementState });
+    frame.waitForSelector('div', { state: state as any });
 }
 
 // @ts-expect-error

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -7,7 +7,7 @@ import {
     Request,
     Response,
     ElementHandle,
-    Browser,
+    browser,
     BrowserContext,
 } from 'k6/experimental/browser';
 
@@ -16,9 +16,8 @@ const selector = 'a[href="http://example.com"]';
 const elementHandle = new ElementHandle();
 
 //
-// Create a browser
+// browser tests
 //
-const browser = new Browser();
 
 // $ExpectType BrowserContext
 browser.context();


### PR DESCRIPTION
When testing the type definitions for the k6 browser module, we found that the type definitions didn't correctly reflect the usage. This change fixes this issue and ensures that the `browser` type is the entry point for working with the browser module.

Previously this is how the type definitions were defined (which is incorrect):

```js
import { Browser, Page, BrowserContext } from 'k6/experimental/browser'
...
    const browser = new Browser();
```

1. xk6-browser only export `browser`, not even `Browser`.
2. `browser` a type that we should be able to work with directly without having to new up an instance of one.

The aim of this PR is to correctly reflect the implementation of the k6 browser module (xk6-browser) APIs so that it works like so:

```js
import { browser } from 'k6/experimental/browser'
...
    const page = browser.newPage();
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
