### PR TITLE
[consumer-data-standards] ran dprint fmt

### DIFF
--- a/types/consumer-data-standards/admin/index.d.ts
+++ b/types/consumer-data-standards/admin/index.d.ts
@@ -4,15 +4,15 @@
  * Percentage availability of the CDR platform over time
  */
 export interface AvailabilityMetrics {
-  /**
-   * Percentage availability of the CDR platform so far for the current calendar month. 0.0 means 0%. 1.0 means 100%.
-   */
-  currentMonth?: number | null;
-  /**
-   * Percentage availability of the CDR platform for previous calendar months. The first element indicates the last month and so on. A maximum of twelve entries is required if available. 0.0 means 0%. 1.0 means 100%.
-   */
-  previousMonths?: number[] | null;
-  [k: string]: unknown;
+    /**
+     * Percentage availability of the CDR platform so far for the current calendar month. 0.0 means 0%. 1.0 means 100%.
+     */
+    currentMonth?: number | null;
+    /**
+     * Percentage availability of the CDR platform for previous calendar months. The first element indicates the last month and so on. A maximum of twelve entries is required if available. 0.0 means 0%. 1.0 means 100%.
+     */
+    previousMonths?: number[] | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
 
@@ -20,145 +20,145 @@ export interface AvailabilityMetrics {
  * Average response time in seconds, at millisecond resolution, within each performance tier
  */
 export interface AverageResponseMetricsV2 {
-  /**
-   * Average response time for the high priority tier
-   */
-  highPriority: {
     /**
-     * Average response time for current day
+     * Average response time for the high priority tier
      */
-    currentDay?: number | null;
-    /**
-     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Average response time for the large payload tier
-   */
-  largePayload: {
-    /**
-     * Average response time for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Average response time for the large payload tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-   */
-  largeSecondary?: {
-    /**
-     * Average response time as measured for the primary data holder
-     */
-    primary: {
-      /**
-       * Average response time for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
+    highPriority: {
+        /**
+         * Average response time for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
     };
     /**
-     * Average response time as measured for the secondary data holder
+     * Average response time for the large payload tier
      */
-    secondary: {
-      /**
-       * Average response time for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Average response time for the low priority tier
-   */
-  lowPriority: {
-    /**
-     * Average response time for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Average response time for the secondary tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-   */
-  secondary?: {
-    /**
-     * Average response time as measured for the primary data holder
-     */
-    primary: {
-      /**
-       * Average response time for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
+    largePayload: {
+        /**
+         * Average response time for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
     };
     /**
-     * Average response time as measured for the secondary data holder
+     * Average response time for the large payload tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
      */
-    secondary: {
-      /**
-       * Average response time for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
+    largeSecondary?: {
+        /**
+         * Average response time as measured for the primary data holder
+         */
+        primary: {
+            /**
+             * Average response time for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Average response time as measured for the secondary data holder
+         */
+        secondary: {
+            /**
+             * Average response time for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Average response time for the low priority tier
+     */
+    lowPriority: {
+        /**
+         * Average response time for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Average response time for the secondary tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+     */
+    secondary?: {
+        /**
+         * Average response time as measured for the primary data holder
+         */
+        primary: {
+            /**
+             * Average response time for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Average response time as measured for the secondary data holder
+         */
+        secondary: {
+            /**
+             * Average response time for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Average response time for the unattended tier
+     */
+    unattended: {
+        /**
+         * Average response time for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Average response time for the unauthenticated tier
+     */
+    unauthenticated: {
+        /**
+         * Average response time for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
     };
     [k: string]: unknown;
-  } | null;
-  /**
-   * Average response time for the unattended tier
-   */
-  unattended: {
-    /**
-     * Average response time for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Average response time for the unauthenticated tier
-   */
-  unauthenticated: {
-    /**
-     * Average response time for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
 
@@ -166,15 +166,15 @@ export interface AverageResponseMetricsV2 {
  * Transactions per second over time
  */
 export interface AverageTPSMetrics {
-  /**
-   * Average TPS for current day
-   */
-  currentDay?: number | null;
-  /**
-   * Average TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-   */
-  previousDays?: number[] | null;
-  [k: string]: unknown;
+    /**
+     * Average TPS for current day
+     */
+    currentDay?: number | null;
+    /**
+     * Average TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+     */
+    previousDays?: number[] | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
 
@@ -182,701 +182,6 @@ export interface AverageTPSMetrics {
  * Number of calls resulting in error due to server execution over time
  */
 export interface ErrorMetrics {
-  /**
-   * Number of errors for current day
-   */
-  currentDay?: number | null;
-  /**
-   * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-   */
-  previousDays?: number[] | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Number of API calls in each performance tier over time
- */
-export interface InvocationMetricsV2 {
-  /**
-   * API call counts for the high priority tier
-   */
-  highPriority: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * API call counts for the large payload tier
-   */
-  largePayload: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * API call counts for the large Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-   */
-  largeSecondary?: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * API call counts for the low priority tier
-   */
-  lowPriority: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * API call counts for the Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-   */
-  secondary?: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * API call counts for the unattended tier
-   */
-  unattended: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * API call counts for the unauthenticated tier
-   */
-  unauthenticated: {
-    /**
-     * API call counts for current day
-     */
-    currentDay?: number | null;
-    /**
-     * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-export interface Links {
-  /**
-   * Fully qualified link to this API call
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-export interface Meta {
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Additional data for customised error codes
- */
-export interface MetaError {
-  /**
-   * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-   */
-  urn?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Maximum record transactions per second over time
- */
-export interface PeakTPSMetrics {
-  /**
-   * Peak TPS for current day
-   */
-  currentDay?: number | null;
-  /**
-   * Peak TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-   */
-  previousDays?: number[] | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Percentage of calls within the performance thresholds
- */
-export interface PerformanceMetrics {
-  /**
-   * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%
-   */
-  currentDay?: number | null;
-  /**
-   * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%
-   */
-  previousDays?: number[] | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Number of calls rejected due to traffic thresholds over time
- */
-export interface RejectionMetricsV2 {
-  /**
-   * Rejection counts for all authenticated end points
-   */
-  authenticated: {
-    /**
-     * Number of calls rejected for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Rejection counts for all unauthenticated end points
-   */
-  unauthenticated: {
-    /**
-     * Number of calls rejected for current day
-     */
-    currentDay?: number | null;
-    /**
-     * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-     */
-    previousDays?: number[] | null;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-export interface RequestMetaDataUpdate {
-  data: {
-    /**
-     * The action to take for the meta data. At the moment the only option is REFRESH which requires the data holder to call the ACCC to refresh meta data as soon as practicable
-     */
-    action: "REFRESH";
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-export interface ResponseMetricsListV3 {
-  data: {
-    /**
-     * Percentage availability of the CDR platform over time
-     */
-    availability: {
-      /**
-       * Percentage availability of the CDR platform so far for the current calendar month. 0.0 means 0%. 1.0 means 100%.
-       */
-      currentMonth?: number | null;
-      /**
-       * Percentage availability of the CDR platform for previous calendar months. The first element indicates the last month and so on. A maximum of twelve entries is required if available. 0.0 means 0%. 1.0 means 100%.
-       */
-      previousMonths?: number[] | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Average response time in seconds, at millisecond resolution, within each performance tier
-     */
-    averageResponse: {
-      /**
-       * Average response time for the high priority tier
-       */
-      highPriority: {
-        /**
-         * Average response time for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Average response time for the large payload tier
-       */
-      largePayload: {
-        /**
-         * Average response time for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Average response time for the large payload tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-       */
-      largeSecondary?: {
-        /**
-         * Average response time as measured for the primary data holder
-         */
-        primary: {
-          /**
-           * Average response time for current day
-           */
-          currentDay?: number | null;
-          /**
-           * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-           */
-          previousDays?: number[] | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Average response time as measured for the secondary data holder
-         */
-        secondary: {
-          /**
-           * Average response time for current day
-           */
-          currentDay?: number | null;
-          /**
-           * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-           */
-          previousDays?: number[] | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      } | null;
-      /**
-       * Average response time for the low priority tier
-       */
-      lowPriority: {
-        /**
-         * Average response time for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Average response time for the secondary tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-       */
-      secondary?: {
-        /**
-         * Average response time as measured for the primary data holder
-         */
-        primary: {
-          /**
-           * Average response time for current day
-           */
-          currentDay?: number | null;
-          /**
-           * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-           */
-          previousDays?: number[] | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Average response time as measured for the secondary data holder
-         */
-        secondary: {
-          /**
-           * Average response time for current day
-           */
-          currentDay?: number | null;
-          /**
-           * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-           */
-          previousDays?: number[] | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      } | null;
-      /**
-       * Average response time for the unattended tier
-       */
-      unattended: {
-        /**
-         * Average response time for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Average response time for the unauthenticated tier
-       */
-      unauthenticated: {
-        /**
-         * Average response time for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Transactions per second over time
-     */
-    averageTps: {
-      /**
-       * Average TPS for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Average TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Number of customers with active authorisations at the time of the call
-     */
-    customerCount: number;
-    /**
-     * Number of calls resulting in error due to server execution over time
-     */
-    errors: {
-      /**
-       * Number of errors for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Number of API calls in each performance tier over time
-     */
-    invocations: {
-      /**
-       * API call counts for the high priority tier
-       */
-      highPriority: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * API call counts for the large payload tier
-       */
-      largePayload: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * API call counts for the large Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-       */
-      largeSecondary?: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      } | null;
-      /**
-       * API call counts for the low priority tier
-       */
-      lowPriority: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * API call counts for the Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-       */
-      secondary?: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      } | null;
-      /**
-       * API call counts for the unattended tier
-       */
-      unattended: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * API call counts for the unauthenticated tier
-       */
-      unauthenticated: {
-        /**
-         * API call counts for current day
-         */
-        currentDay?: number | null;
-        /**
-         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Maximum record transactions per second over time
-     */
-    peakTps: {
-      /**
-       * Peak TPS for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Peak TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Percentage of calls within the performance thresholds
-     */
-    performance: {
-      /**
-       * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%
-       */
-      currentDay?: number | null;
-      /**
-       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Number of Data Recipient Software Products with active authorisations at the time of the call
-     */
-    recipientCount: number;
-    /**
-     * Number of calls rejected due to traffic thresholds over time
-     */
-    rejections: {
-      /**
-       * Rejection counts for all authenticated end points
-       */
-      authenticated: {
-        /**
-         * Number of calls rejected for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Rejection counts for all unauthenticated end points
-       */
-      unauthenticated: {
-        /**
-         * Number of calls rejected for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * The date and time that the metrics in this payload were requested.
-     */
-    requestTime: string;
-    /**
-     * Errors and rejections received by the primary data holder from the secondary data holder.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
-     */
-    secondaryHolder?: {
-      /**
-       * Number of calls resulting in error due to server execution over time
-       */
-      errors: {
-        /**
-         * Number of errors for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Number of calls rejected due to traffic thresholds over time
-       */
-      rejections: {
-        /**
-         * Number of rejections for current day
-         */
-        currentDay?: number | null;
-        /**
-         * Number of rejections for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-         */
-        previousDays?: number[] | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Session counts over time. Note that a session is defined as the provisioning of an Access Token.
-     */
-    sessionCount: {
-      /**
-       * Session count for current day
-       */
-      currentDay?: number | null;
-      /**
-       * Session count for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-       */
-      previousDays?: number[] | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link to this API call
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
-/**
- * Errors and rejections received by the primary data holder from the secondary data holder.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
- */
-export interface SecondaryHolderMetrics {
-  /**
-   * Number of calls resulting in error due to server execution over time
-   */
-  errors: {
     /**
      * Number of errors for current day
      */
@@ -886,22 +191,717 @@ export interface SecondaryHolderMetrics {
      */
     previousDays?: number[] | null;
     [k: string]: unknown;
-  };
-  /**
-   * Number of calls resulting in a rejection due to server execution over time
-   */
-  rejections: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Number of API calls in each performance tier over time
+ */
+export interface InvocationMetricsV2 {
     /**
-     * Number of rejections for current day
+     * API call counts for the high priority tier
+     */
+    highPriority: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * API call counts for the large payload tier
+     */
+    largePayload: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * API call counts for the large Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+     */
+    largeSecondary?: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * API call counts for the low priority tier
+     */
+    lowPriority: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * API call counts for the Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+     */
+    secondary?: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * API call counts for the unattended tier
+     */
+    unattended: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * API call counts for the unauthenticated tier
+     */
+    unauthenticated: {
+        /**
+         * API call counts for current day
+         */
+        currentDay?: number | null;
+        /**
+         * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+export interface Links {
+    /**
+     * Fully qualified link to this API call
+     */
+    self: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+export interface Meta {
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Additional data for customised error codes
+ */
+export interface MetaError {
+    /**
+     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+     */
+    urn?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Maximum record transactions per second over time
+ */
+export interface PeakTPSMetrics {
+    /**
+     * Peak TPS for current day
      */
     currentDay?: number | null;
     /**
-     * Number of rejections for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+     * Peak TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
      */
     previousDays?: number[] | null;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Percentage of calls within the performance thresholds
+ */
+export interface PerformanceMetrics {
+    /**
+     * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%
+     */
+    currentDay?: number | null;
+    /**
+     * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%
+     */
+    previousDays?: number[] | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Number of calls rejected due to traffic thresholds over time
+ */
+export interface RejectionMetricsV2 {
+    /**
+     * Rejection counts for all authenticated end points
+     */
+    authenticated: {
+        /**
+         * Number of calls rejected for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Rejection counts for all unauthenticated end points
+     */
+    unauthenticated: {
+        /**
+         * Number of calls rejected for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+export interface RequestMetaDataUpdate {
+    data: {
+        /**
+         * The action to take for the meta data. At the moment the only option is REFRESH which requires the data holder to call the ACCC to refresh meta data as soon as practicable
+         */
+        action: 'REFRESH';
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+export interface ResponseErrorListV2 {
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+export interface ResponseMetricsListV3 {
+    data: {
+        /**
+         * Percentage availability of the CDR platform over time
+         */
+        availability: {
+            /**
+             * Percentage availability of the CDR platform so far for the current calendar month. 0.0 means 0%. 1.0 means 100%.
+             */
+            currentMonth?: number | null;
+            /**
+             * Percentage availability of the CDR platform for previous calendar months. The first element indicates the last month and so on. A maximum of twelve entries is required if available. 0.0 means 0%. 1.0 means 100%.
+             */
+            previousMonths?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Average response time in seconds, at millisecond resolution, within each performance tier
+         */
+        averageResponse: {
+            /**
+             * Average response time for the high priority tier
+             */
+            highPriority: {
+                /**
+                 * Average response time for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Average response time for the large payload tier
+             */
+            largePayload: {
+                /**
+                 * Average response time for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Average response time for the large payload tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+             */
+            largeSecondary?: {
+                /**
+                 * Average response time as measured for the primary data holder
+                 */
+                primary: {
+                    /**
+                     * Average response time for current day
+                     */
+                    currentDay?: number | null;
+                    /**
+                     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                     */
+                    previousDays?: number[] | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Average response time as measured for the secondary data holder
+                 */
+                secondary: {
+                    /**
+                     * Average response time for current day
+                     */
+                    currentDay?: number | null;
+                    /**
+                     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                     */
+                    previousDays?: number[] | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Average response time for the low priority tier
+             */
+            lowPriority: {
+                /**
+                 * Average response time for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Average response time for the secondary tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+             */
+            secondary?: {
+                /**
+                 * Average response time as measured for the primary data holder
+                 */
+                primary: {
+                    /**
+                     * Average response time for current day
+                     */
+                    currentDay?: number | null;
+                    /**
+                     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                     */
+                    previousDays?: number[] | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Average response time as measured for the secondary data holder
+                 */
+                secondary: {
+                    /**
+                     * Average response time for current day
+                     */
+                    currentDay?: number | null;
+                    /**
+                     * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                     */
+                    previousDays?: number[] | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Average response time for the unattended tier
+             */
+            unattended: {
+                /**
+                 * Average response time for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Average response time for the unauthenticated tier
+             */
+            unauthenticated: {
+                /**
+                 * Average response time for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Average response time for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Transactions per second over time
+         */
+        averageTps: {
+            /**
+             * Average TPS for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Average TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Number of customers with active authorisations at the time of the call
+         */
+        customerCount: number;
+        /**
+         * Number of calls resulting in error due to server execution over time
+         */
+        errors: {
+            /**
+             * Number of errors for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Number of API calls in each performance tier over time
+         */
+        invocations: {
+            /**
+             * API call counts for the high priority tier
+             */
+            highPriority: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * API call counts for the large payload tier
+             */
+            largePayload: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * API call counts for the large Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+             */
+            largeSecondary?: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * API call counts for the low priority tier
+             */
+            lowPriority: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * API call counts for the Shared Responsibility Data Requests tier.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+             */
+            secondary?: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * API call counts for the unattended tier
+             */
+            unattended: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * API call counts for the unauthenticated tier
+             */
+            unauthenticated: {
+                /**
+                 * API call counts for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * API call counts for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Maximum record transactions per second over time
+         */
+        peakTps: {
+            /**
+             * Peak TPS for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Peak TPS for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Percentage of calls within the performance thresholds
+         */
+        performance: {
+            /**
+             * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%
+             */
+            currentDay?: number | null;
+            /**
+             * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Number of Data Recipient Software Products with active authorisations at the time of the call
+         */
+        recipientCount: number;
+        /**
+         * Number of calls rejected due to traffic thresholds over time
+         */
+        rejections: {
+            /**
+             * Rejection counts for all authenticated end points
+             */
+            authenticated: {
+                /**
+                 * Number of calls rejected for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Rejection counts for all unauthenticated end points
+             */
+            unauthenticated: {
+                /**
+                 * Number of calls rejected for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Number of calls rejected for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available.
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * The date and time that the metrics in this payload were requested.
+         */
+        requestTime: string;
+        /**
+         * Errors and rejections received by the primary data holder from the secondary data holder.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+         */
+        secondaryHolder?: {
+            /**
+             * Number of calls resulting in error due to server execution over time
+             */
+            errors: {
+                /**
+                 * Number of errors for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Number of calls rejected due to traffic thresholds over time
+             */
+            rejections: {
+                /**
+                 * Number of rejections for current day
+                 */
+                currentDay?: number | null;
+                /**
+                 * Number of rejections for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+                 */
+                previousDays?: number[] | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Session counts over time. Note that a session is defined as the provisioning of an Access Token.
+         */
+        sessionCount: {
+            /**
+             * Session count for current day
+             */
+            currentDay?: number | null;
+            /**
+             * Session count for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+             */
+            previousDays?: number[] | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Errors and rejections received by the primary data holder from the secondary data holder.  Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
+ */
+export interface SecondaryHolderMetrics {
+    /**
+     * Number of calls resulting in error due to server execution over time
+     */
+    errors: {
+        /**
+         * Number of errors for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Number of errors for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Number of calls resulting in a rejection due to server execution over time
+     */
+    rejections: {
+        /**
+         * Number of rejections for current day
+         */
+        currentDay?: number | null;
+        /**
+         * Number of rejections for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+         */
+        previousDays?: number[] | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
 
@@ -909,13 +909,13 @@ export interface SecondaryHolderMetrics {
  * Session counts over time. Note that a session is defined as the provisioning of an Access Token.
  */
 export interface SessionCountMetrics {
-  /**
-   * Session count for current day
-   */
-  currentDay?: number | null;
-  /**
-   * Session count for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
-   */
-  previousDays?: number[] | null;
-  [k: string]: unknown;
+    /**
+     * Session count for current day
+     */
+    currentDay?: number | null;
+    /**
+     * Session count for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available
+     */
+    previousDays?: number[] | null;
+    [k: string]: unknown;
 }

--- a/types/consumer-data-standards/banking/index.d.ts
+++ b/types/consumer-data-standards/banking/index.d.ts
@@ -1,99 +1,951 @@
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingAccount {
-  /**
-   * A unique ID of the account adhering to the standards for ID permanence
-   */
-  accountId: string;
-  /**
-   * Date that the account was created (if known)
-   */
-  creationDate?: string | null;
-  /**
-   * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-   */
-  displayName: string;
-  /**
-   * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-   */
-  isOwned?: boolean | null;
-  /**
-   * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-   */
-  maskedNumber: string;
-  /**
-   * A customer supplied nick name for the account
-   */
-  nickname?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  /**
-   * The category to which a product or account belongs. See [here](#product-categories) for more details
-   */
-  productCategory:
-    | "BUSINESS_LOANS"
-    | "CRED_AND_CHRG_CARDS"
-    | "LEASES"
-    | "MARGIN_LOANS"
-    | "OVERDRAFTS"
-    | "PERS_LOANS"
-    | "REGULATED_TRUST_ACCOUNTS"
-    | "RESIDENTIAL_MORTGAGES"
-    | "TERM_DEPOSITS"
-    | "TRADE_FINANCE"
-    | "TRANS_AND_SAVINGS_ACCOUNTS"
-    | "TRAVEL_CARDS";
-  /**
-   * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-   */
-  productName: string;
-  [k: string]: unknown;
+    /**
+     * A unique ID of the account adhering to the standards for ID permanence
+     */
+    accountId: string;
+    /**
+     * Date that the account was created (if known)
+     */
+    creationDate?: string | null;
+    /**
+     * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+     */
+    displayName: string;
+    /**
+     * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+     */
+    isOwned?: boolean | null;
+    /**
+     * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+     */
+    maskedNumber: string;
+    /**
+     * A customer supplied nick name for the account
+     */
+    nickname?: string | null;
+    /**
+     * Open or closed status for the account. If not present then OPEN is assumed
+     */
+    openStatus?: ('CLOSED' | 'OPEN') | null;
+    /**
+     * The category to which a product or account belongs. See [here](#product-categories) for more details
+     */
+    productCategory:
+        | 'BUSINESS_LOANS'
+        | 'CRED_AND_CHRG_CARDS'
+        | 'LEASES'
+        | 'MARGIN_LOANS'
+        | 'OVERDRAFTS'
+        | 'PERS_LOANS'
+        | 'REGULATED_TRUST_ACCOUNTS'
+        | 'RESIDENTIAL_MORTGAGES'
+        | 'TERM_DEPOSITS'
+        | 'TRADE_FINANCE'
+        | 'TRANS_AND_SAVINGS_ACCOUNTS'
+        | 'TRAVEL_CARDS';
+    /**
+     * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+     */
+    productName: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingAccountDetailV2 extends BankingAccount {
-  /**
-   * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-   */
-  bsb?: string;
-  /**
-   * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-   */
-  accountNumber?: string;
-  /**
-   * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
-   */
-  bundleName?: string;
-  /**
-   * The type of structure to present account specific fields.
-   */
-  specificAccountUType?: "creditCard" | "loan" | "termDeposit";
-  termDeposit?: {
     /**
-     * The lodgement date of the original deposit
+     * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
      */
-    lodgementDate: string;
+    bsb?: string;
     /**
-     * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+     * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
      */
-    maturityAmount?: string | null;
+    accountNumber?: string;
     /**
-     * If absent assumes AUD
+     * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
      */
-    maturityCurrency?: string | null;
+    bundleName?: string;
     /**
-     * Maturity date for the term deposit
+     * The type of structure to present account specific fields.
      */
-    maturityDate: string;
+    specificAccountUType?: 'creditCard' | 'loan' | 'termDeposit';
+    termDeposit?: {
+        /**
+         * The lodgement date of the original deposit
+         */
+        lodgementDate: string;
+        /**
+         * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+         */
+        maturityAmount?: string | null;
+        /**
+         * If absent assumes AUD
+         */
+        maturityCurrency?: string | null;
+        /**
+         * Maturity date for the term deposit
+         */
+        maturityDate: string;
+        /**
+         * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+         */
+        maturityInstructions: 'HOLD_ON_MATURITY' | 'PAID_OUT_AT_MATURITY' | 'ROLLED_OVER';
+        [k: string]: unknown;
+    }[];
+    creditCard?: {
+        /**
+         * The minimum payment amount due for the next card payment
+         */
+        minPaymentAmount: string;
+        /**
+         * If absent assumes AUD
+         */
+        paymentCurrency?: string | null;
+        /**
+         * The amount due for the next card payment
+         */
+        paymentDueAmount: string;
+        /**
+         * Date that the next payment for the card is due
+         */
+        paymentDueDate: string;
+        [k: string]: unknown;
+    };
+    loan?: {
+        /**
+         * Date that the loan is due to be repaid in full
+         */
+        loanEndDate?: string | null;
+        /**
+         * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+         */
+        maxRedraw?: string | null;
+        /**
+         * If absent assumes AUD
+         */
+        maxRedrawCurrency?: string | null;
+        /**
+         * Minimum amount of next instalment
+         */
+        minInstalmentAmount?: string | null;
+        /**
+         * If absent assumes AUD
+         */
+        minInstalmentCurrency?: string | null;
+        /**
+         * Minimum redraw amount
+         */
+        minRedraw?: string | null;
+        /**
+         * If absent assumes AUD
+         */
+        minRedrawCurrency?: string | null;
+        /**
+         * Next date that an instalment is required
+         */
+        nextInstalmentDate?: string | null;
+        /**
+         * Set to true if one or more offset accounts are configured for this loan account
+         */
+        offsetAccountEnabled?: boolean | null;
+        /**
+         * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
+         */
+        offsetAccountIds?: string[] | null;
+        /**
+         * Optional original loan value
+         */
+        originalLoanAmount?: string | null;
+        /**
+         * If absent assumes AUD
+         */
+        originalLoanCurrency?: string | null;
+        /**
+         * Optional original start date for the loan
+         */
+        originalStartDate?: string | null;
+        /**
+         * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        repaymentFrequency?: string | null;
+        /**
+         * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+         */
+        repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+        [k: string]: unknown;
+    };
     /**
-     * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+     * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
      */
-    maturityInstructions: "HOLD_ON_MATURITY" | "PAID_OUT_AT_MATURITY" | "ROLLED_OVER";
+    depositRate?: string;
+    /**
+     * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+     */
+    lendingRate?: string;
+    /**
+     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+     */
+    depositRates?: {
+        /**
+         * Display text providing more information on the rate
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this rate
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        applicationFrequency?: string | null;
+        /**
+         * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        calculationFrequency?: string | null;
+        /**
+         * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+         */
+        depositRateType:
+            | 'BONUS'
+            | 'BUNDLE_BONUS'
+            | 'FIXED'
+            | 'FLOATING'
+            | 'INTRODUCTORY'
+            | 'MARKET_LINKED'
+            | 'VARIABLE';
+        /**
+         * The rate to be applied
+         */
+        rate: string;
+        /**
+         * Rate tiers applicable for this rate
+         */
+        tiers?:
+            | {
+                /**
+                 * Display text providing more information on the rate tier.
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this rate tier
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Defines a condition for the applicability of a tiered rate
+                 */
+                applicabilityConditions?: {
+                    /**
+                     * Display text providing more information on the condition
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this condition
+                     */
+                    additionalInfoUri?: string | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                 */
+                maximumValue?: number | null;
+                /**
+                 * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                 */
+                minimumValue: number;
+                /**
+                 * A display name for the tier
+                 */
+                name: string;
+                /**
+                 * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                 */
+                rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                /**
+                 * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                 */
+                unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    }[];
+    /**
+     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+     */
+    lendingRates?: {
+        /**
+         * Display text providing more information on the rate.
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this rate
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        applicationFrequency?: string | null;
+        /**
+         * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        calculationFrequency?: string | null;
+        /**
+         * A comparison rate equivalent for this rate
+         */
+        comparisonRate?: string | null;
+        /**
+         * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+         */
+        interestPaymentDue?: ('IN_ADVANCE' | 'IN_ARREARS') | null;
+        /**
+         * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+         */
+        lendingRateType:
+            | 'BUNDLE_DISCOUNT_FIXED'
+            | 'BUNDLE_DISCOUNT_VARIABLE'
+            | 'CASH_ADVANCE'
+            | 'DISCOUNT'
+            | 'FIXED'
+            | 'FLOATING'
+            | 'INTRODUCTORY'
+            | 'MARKET_LINKED'
+            | 'PENALTY'
+            | 'PURCHASE'
+            | 'VARIABLE';
+        /**
+         * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+         */
+        loanPurpose?: ('INVESTMENT' | 'OWNER_OCCUPIED') | null;
+        /**
+         * The rate to be applied
+         */
+        rate: string;
+        /**
+         * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+         */
+        repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+        /**
+         * Rate tiers applicable for this rate
+         */
+        tiers?:
+            | {
+                /**
+                 * Display text providing more information on the rate tier.
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this rate tier
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Defines a condition for the applicability of a tiered rate
+                 */
+                applicabilityConditions?: {
+                    /**
+                     * Display text providing more information on the condition
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this condition
+                     */
+                    additionalInfoUri?: string | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                 */
+                maximumValue?: number | null;
+                /**
+                 * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                 */
+                minimumValue: number;
+                /**
+                 * A display name for the tier
+                 */
+                name: string;
+                /**
+                 * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                 */
+                rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                /**
+                 * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                 */
+                unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    }[];
+    /**
+     * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+     */
+    features?: ({
+        /**
+         * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this feature
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The type of feature described
+         */
+        featureType:
+            | 'ADDITIONAL_CARDS'
+            | 'BALANCE_TRANSFERS'
+            | 'BILL_PAYMENT'
+            | 'BONUS_REWARDS'
+            | 'CARD_ACCESS'
+            | 'CASHBACK_OFFER'
+            | 'COMPLEMENTARY_PRODUCT_DISCOUNTS'
+            | 'DIGITAL_BANKING'
+            | 'DIGITAL_WALLET'
+            | 'DONATE_INTEREST'
+            | 'EXTRA_REPAYMENTS'
+            | 'FRAUD_PROTECTION'
+            | 'FREE_TXNS'
+            | 'FREE_TXNS_ALLOWANCE'
+            | 'GUARANTOR'
+            | 'INSURANCE'
+            | 'INSTALMENT_PLAN'
+            | 'INTEREST_FREE'
+            | 'INTEREST_FREE_TRANSFERS'
+            | 'LOYALTY_PROGRAM'
+            | 'NOTIFICATIONS'
+            | 'NPP_ENABLED'
+            | 'NPP_PAYID'
+            | 'OFFSET'
+            | 'OTHER'
+            | 'OVERDRAFT'
+            | 'REDRAW'
+            | 'RELATIONSHIP_MANAGEMENT'
+            | 'UNLIMITED_TXNS';
+        [k: string]: unknown;
+    } & {
+        /**
+         * True if the feature is already activated and false if the feature is available for activation. Defaults to true if absent. (note this is an additional field appended to the feature object defined in the Product Reference payload)
+         */
+        isActivated?: boolean;
+        [k: string]: unknown;
+    })[];
+    /**
+     * Fees and charges applicable to the account based on the equivalent structure in Product Reference
+     */
+    fees?: {
+        /**
+         * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        accrualFrequency?: string | null;
+        /**
+         * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        accruedRate?: string | null;
+        /**
+         * Display text providing more information on the fee
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this fee
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        amount?: string | null;
+        /**
+         * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+         */
+        balanceRate?: string | null;
+        /**
+         * The currency the fee will be charged in. Assumes AUD if absent
+         */
+        currency?: string | null;
+        /**
+         * An optional list of discounts to this fee that may be available
+         */
+        discounts?:
+            | {
+                /**
+                 * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                accruedRate?: string | null;
+                /**
+                 * Display text providing more information on the discount
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this discount
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+                 */
+                additionalValue?: string | null;
+                /**
+                 * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+                 */
+                amount?: string | null;
+                /**
+                 * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                balanceRate?: string | null;
+                /**
+                 * Description of the discount
+                 */
+                description: string;
+                /**
+                 * The type of discount. See the next section for an overview of valid values and their meaning
+                 */
+                discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+                /**
+                 * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+                 */
+                eligibility?:
+                    | {
+                        /**
+                         * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this eligibility constraint
+                         */
+                        additionalInfoUri?: string | null;
+                        /**
+                         * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                         */
+                        additionalValue?: string | null;
+                        /**
+                         * The type of the specific eligibility constraint for a discount
+                         */
+                        discountEligibilityType:
+                            | 'BUSINESS'
+                            | 'EMPLOYMENT_STATUS'
+                            | 'INTRODUCTORY'
+                            | 'MAX_AGE'
+                            | 'MIN_AGE'
+                            | 'MIN_INCOME'
+                            | 'MIN_TURNOVER'
+                            | 'NATURAL_PERSON'
+                            | 'OTHER'
+                            | 'PENSION_RECIPIENT'
+                            | 'RESIDENCY_STATUS'
+                            | 'STAFF'
+                            | 'STUDENT';
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                feeRate?: string | null;
+                /**
+                 * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+                 */
+                transactionRate?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The type of fee
+         */
+        feeType:
+            | 'DEPOSIT'
+            | 'EVENT'
+            | 'EXIT'
+            | 'PAYMENT'
+            | 'PERIODIC'
+            | 'PURCHASE'
+            | 'TRANSACTION'
+            | 'UPFRONT'
+            | 'VARIABLE'
+            | 'WITHDRAWAL';
+        /**
+         * Name of the fee
+         */
+        name: string;
+        /**
+         * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        transactionRate?: string | null;
+        [k: string]: unknown;
+    }[];
+    /**
+     * The addresses for the account to be used for correspondence
+     */
+    addresses?: {
+        /**
+         * The type of address object present
+         */
+        addressUType: 'paf' | 'simple';
+        /**
+         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+         */
+        paf?: {
+            /**
+             * Building/Property name 1
+             */
+            buildingName1?: string | null;
+            /**
+             * Building/Property name 2
+             */
+            buildingName2?: string | null;
+            /**
+             * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+             */
+            dpid?: string | null;
+            /**
+             * Unit number (including suffix, if applicable)
+             */
+            flatUnitNumber?: string | null;
+            /**
+             * Type of flat or unit for the address
+             */
+            flatUnitType?: string | null;
+            /**
+             * Floor or level number (including alpha characters)
+             */
+            floorLevelNumber?: string | null;
+            /**
+             * Type of floor or level for the address
+             */
+            floorLevelType?: string | null;
+            /**
+             * Full name of locality
+             */
+            localityName: string;
+            /**
+             * Allotment number for the address
+             */
+            lotNumber?: string | null;
+            /**
+             * Postal delivery number if the address is a postal delivery type
+             */
+            postalDeliveryNumber?: number | null;
+            /**
+             * Postal delivery number prefix related to the postal delivery number
+             */
+            postalDeliveryNumberPrefix?: string | null;
+            /**
+             * Postal delivery number suffix related to the postal delivery number
+             */
+            postalDeliveryNumberSuffix?: string | null;
+            /**
+             * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+             */
+            postalDeliveryType?: string | null;
+            /**
+             * Postcode for the locality
+             */
+            postcode: string;
+            /**
+             * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            /**
+             * The name of the street
+             */
+            streetName?: string | null;
+            /**
+             * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetSuffix?: string | null;
+            /**
+             * The street type. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetType?: string | null;
+            /**
+             * Thoroughfare number for a property (first number in a property ranged address)
+             */
+            thoroughfareNumber1?: number | null;
+            /**
+             * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+             */
+            thoroughfareNumber1Suffix?: string | null;
+            /**
+             * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+             */
+            thoroughfareNumber2?: number | null;
+            /**
+             * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+             */
+            thoroughfareNumber2Suffix?: string | null;
+            [k: string]: unknown;
+        };
+        simple?: {
+            /**
+             * First line of the standard address object
+             */
+            addressLine1: string;
+            /**
+             * Second line of the standard address object
+             */
+            addressLine2?: string | null;
+            /**
+             * Third line of the standard address object
+             */
+            addressLine3?: string | null;
+            /**
+             * Name of the city or locality
+             */
+            city: string;
+            /**
+             * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+             */
+            country?: string | null;
+            /**
+             * Name of the individual or business formatted for inclusion in an address used for physical mail
+             */
+            mailingName?: string | null;
+            /**
+             * Mandatory for Australian addresses
+             */
+            postcode?: string | null;
+            /**
+             * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  creditCard?: {
+}
+
+/* This structure is used in the BankingAccountDetailV3.features property */
+export interface accV3DetailFeatureObj extends BankingProductFeatureV2 {
+    isActivated?: boolean;
+}
+
+export interface BankingAccountDetailV3 extends BankingAccountV2 {
+    /**
+     * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+     */
+    bsb?: string;
+    /**
+     * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+     */
+    accountNumber?: string;
+    /**
+     * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
+     */
+    bundleName?: string;
+    /**
+     * The type of structure to present account specific fields.
+     */
+    specificAccountUType?: 'creditCard' | 'loan' | 'termDeposit';
+    termDeposit?: BankingTermDepositAccount[];
+    creditCard?: BankingCreditCardAccount;
+    loan?: BankingLoanAccountV2;
+    /**
+     * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
+     */
+    depositRate?: string;
+    /**
+     * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+     */
+    lendingRate?: string;
+    /**
+     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+     */
+    depositRates?: BankingProductDepositRate[];
+    /**
+     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+     */
+    lendingRates?: BankingProductLendingRateV2[];
+    /**
+     * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+     */
+    features?: accV3DetailFeatureObj[];
+    /**
+     * Fees and charges applicable to the account based on the equivalent structure in Product Reference
+     */
+    fees?: BankingProductFee[];
+    /**
+     * The addresses for the account to be used for correspondence
+     */
+    addresses?: CommonPhysicalAddress[];
+
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingAccountV2 {
+    /**
+     * A unique ID of the account adhering to the standards for ID permanence
+     */
+    accountId: string;
+    /**
+     * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+     */
+    accountOwnership: 'UNKNOWN' | 'ONE_PARTY' | 'TWO_PARTY' | 'MANY_PARTY' | 'OTHER';
+    /**
+     * Date that the account was created (if known)
+     */
+    creationDate?: string | null;
+    /**
+     * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+     */
+    displayName: string;
+    /**
+     * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+     */
+    isOwned?: boolean | null;
+    /**
+     * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+     */
+    maskedNumber: string;
+    /**
+     * A customer supplied nick name for the account
+     */
+    nickname?: string | null;
+    /**
+     * Open or closed status for the account. If not present then OPEN is assumed
+     */
+    openStatus?: ('CLOSED' | 'OPEN') | null;
+    /**
+     * The category to which a product or account belongs. See [here](#product-categories) for more details
+     */
+    productCategory:
+        | 'BUSINESS_LOANS'
+        | 'CRED_AND_CHRG_CARDS'
+        | 'LEASES'
+        | 'MARGIN_LOANS'
+        | 'OVERDRAFTS'
+        | 'PERS_LOANS'
+        | 'REGULATED_TRUST_ACCOUNTS'
+        | 'RESIDENTIAL_MORTGAGES'
+        | 'TERM_DEPOSITS'
+        | 'TRADE_FINANCE'
+        | 'TRANS_AND_SAVINGS_ACCOUNTS'
+        | 'TRAVEL_CARDS';
+    /**
+     * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+     */
+    productName: string;
+    [k: string]: unknown;
+}
+
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingAuthorisedEntity {
+    /**
+     * Australian Business Number for the authorised entity
+     */
+    abn?: string | null;
+    /**
+     * Australian Company Number for the authorised entity
+     */
+    acn?: string | null;
+    /**
+     * Australian Registered Body Number for the authorised entity
+     */
+    arbn?: string | null;
+    /**
+     * Description of the authorised entity derived from previously executed direct debits
+     */
+    description?: string | null;
+    /**
+     * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+     */
+    financialInstitution?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingBalance {
+    /**
+     * A unique ID of the account adhering to the standards for ID permanence
+     */
+    accountId: string;
+    /**
+     * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+     */
+    amortisedLimit?: string | null;
+    /**
+     * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+     */
+    availableBalance: string;
+    /**
+     * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+     */
+    creditLimit?: string | null;
+    /**
+     * The currency for the balance amounts. If absent assumed to be AUD
+     */
+    currency?: string | null;
+    /**
+     * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+     */
+    currentBalance: string;
+    /**
+     * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+     */
+    purses?:
+        | {
+            /**
+             * The balance available for this additional currency purse
+             */
+            amount: string;
+            /**
+             * The currency for the purse
+             */
+            currency?: string | null;
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingBalancePurse {
+    /**
+     * The balance available for this additional currency purse
+     */
+    amount: string;
+    /**
+     * The currency for the purse
+     */
+    currency?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingBillerPayee {
+    /**
+     * BPAY Biller Code of the Biller
+     */
+    billerCode: string;
+    /**
+     * Name of the Biller
+     */
+    billerName: string;
+    /**
+     * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+     */
+    crn?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingCreditCardAccount {
     /**
      * The minimum payment amount due for the next card payment
      */
@@ -111,8 +963,226 @@ export interface BankingAccountDetailV2 extends BankingAccount {
      */
     paymentDueDate: string;
     [k: string]: unknown;
-  };
-  loan?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDigitalWalletPayee {
+    /**
+     * The identifier of the digital wallet (dependent on type)
+     */
+    identifier: string;
+    /**
+     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+     */
+    name: string;
+    /**
+     * The provider of the digital wallet
+     */
+    provider: 'PAYPAL_AU' | 'OTHER';
+    /**
+     * The type of the digital wallet identifier
+     */
+    type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDirectDebit {
+    /**
+     * A unique ID of the account adhering to the standards for ID permanence.
+     */
+    accountId: string;
+    authorisedEntity: {
+        /**
+         * Australian Business Number for the authorised entity
+         */
+        abn?: string | null;
+        /**
+         * Australian Company Number for the authorised entity
+         */
+        acn?: string | null;
+        /**
+         * Australian Registered Body Number for the authorised entity
+         */
+        arbn?: string | null;
+        /**
+         * Description of the authorised entity derived from previously executed direct debits
+         */
+        description?: string | null;
+        /**
+         * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+         */
+        financialInstitution?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * The amount of the last debit executed under this authorisation
+     */
+    lastDebitAmount?: string | null;
+    /**
+     * The date and time of the last debit executed under this authorisation
+     */
+    lastDebitDateTime?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDomesticPayee {
+    account?: {
+        /**
+         * Name of the account to pay to
+         */
+        accountName?: string | null;
+        /**
+         * Number of the account to pay to
+         */
+        accountNumber: string;
+        /**
+         * BSB of the account to pay to
+         */
+        bsb: string;
+        [k: string]: unknown;
+    };
+    card?: {
+        /**
+         * Name of the account to pay to
+         */
+        cardNumber: string;
+        [k: string]: unknown;
+    };
+    payId?: {
+        /**
+         * The identifier of the PayID (dependent on type)
+         */
+        identifier: string;
+        /**
+         * The name assigned to the PayID by the owner of the PayID
+         */
+        name?: string | null;
+        /**
+         * The type of the PayID
+         */
+        type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+        [k: string]: unknown;
+    };
+    /**
+     * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
+     */
+    payeeAccountUType: 'account' | 'card' | 'payId';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDomesticPayeeAccount {
+    /**
+     * Name of the account to pay to
+     */
+    accountName?: string | null;
+    /**
+     * Number of the account to pay to
+     */
+    accountNumber: string;
+    /**
+     * BSB of the account to pay to
+     */
+    bsb: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDomesticPayeeCard {
+    /**
+     * Name of the account to pay to
+     */
+    cardNumber: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingDomesticPayeePayId {
+    /**
+     * The identifier of the PayID (dependent on type)
+     */
+    identifier: string;
+    /**
+     * The name assigned to the PayID by the owner of the PayID
+     */
+    name?: string | null;
+    /**
+     * The type of the PayID
+     */
+    type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingInternationalPayee {
+    bankDetails: {
+        /**
+         * Account Targeted for payment
+         */
+        accountNumber: string;
+        bankAddress?: {
+            /**
+             * Address of the recipient Bank
+             */
+            address: string;
+            /**
+             * Name of the recipient Bank
+             */
+            name: string;
+            [k: string]: unknown;
+        } | null;
+        /**
+         * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+         */
+        beneficiaryBankBIC?: string | null;
+        /**
+         * Number for the Clearing House Interbank Payments System
+         */
+        chipNumber?: string | null;
+        /**
+         * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+         */
+        country: string;
+        /**
+         * Number for Fedwire payment (Federal Reserve Wire Network)
+         */
+        fedWireNumber?: string | null;
+        /**
+         * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+         */
+        legalEntityIdentifier?: string | null;
+        /**
+         * International bank routing number
+         */
+        routingNumber?: string | null;
+        /**
+         * Sort code used for account identification in some jurisdictions
+         */
+        sortCode?: string | null;
+        [k: string]: unknown;
+    };
+    beneficiaryDetails: {
+        /**
+         * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+         */
+        country: string;
+        /**
+         * Response message for the payment
+         */
+        message?: string | null;
+        /**
+         * Name of the beneficiary
+         */
+        name?: string | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingLoanAccountV2 {
     /**
      * Date that the loan is due to be repaid in full
      */
@@ -172,1247 +1242,184 @@ export interface BankingAccountDetailV2 extends BankingAccount {
     /**
      * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
      */
-    repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
+    repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
     [k: string]: unknown;
-  };
-  /**
-   * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
-   */
-  depositRate?: string;
-  /**
-   * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
-   */
-  lendingRate?: string;
-  /**
-   * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-   */
-  depositRates?: {
-    /**
-     * Display text providing more information on the rate
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this rate
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    applicationFrequency?: string | null;
-    /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    calculationFrequency?: string | null;
-    /**
-     * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
-     */
-    depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
-    /**
-     * The rate to be applied
-     */
-    rate: string;
-    /**
-     * Rate tiers applicable for this rate
-     */
-    tiers?:
-      | {
-          /**
-           * Display text providing more information on the rate tier.
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this rate tier
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Defines a condition for the applicability of a tiered rate
-           */
-          applicabilityConditions?: {
-            /**
-             * Display text providing more information on the condition
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this condition
-             */
-            additionalInfoUri?: string | null;
-            [k: string]: unknown;
-          };
-          /**
-           * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-           */
-          maximumValue?: number | null;
-          /**
-           * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-           */
-          minimumValue: number;
-          /**
-           * A display name for the tier
-           */
-          name: string;
-          /**
-           * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-           */
-          rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-          /**
-           * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-           */
-          unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-          [k: string]: unknown;
-        }[]
-      | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-   */
-  lendingRates?: {
-    /**
-     * Display text providing more information on the rate.
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this rate
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    applicationFrequency?: string | null;
-    /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    calculationFrequency?: string | null;
-    /**
-     * A comparison rate equivalent for this rate
-     */
-    comparisonRate?: string | null;
-    /**
-     * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
-     */
-    interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
-    /**
-     * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
-     */
-    lendingRateType:
-      | "BUNDLE_DISCOUNT_FIXED"
-      | "BUNDLE_DISCOUNT_VARIABLE"
-      | "CASH_ADVANCE"
-      | "DISCOUNT"
-      | "FIXED"
-      | "FLOATING"
-      | "INTRODUCTORY"
-      | "MARKET_LINKED"
-      | "PENALTY"
-      | "PURCHASE"
-      | "VARIABLE";
-    /**
-     * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
-     */
-    loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
-    /**
-     * The rate to be applied
-     */
-    rate: string;
-    /**
-     * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
-     */
-    repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-    /**
-     * Rate tiers applicable for this rate
-     */
-    tiers?:
-      | {
-          /**
-           * Display text providing more information on the rate tier.
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this rate tier
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Defines a condition for the applicability of a tiered rate
-           */
-          applicabilityConditions?: {
-            /**
-             * Display text providing more information on the condition
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this condition
-             */
-            additionalInfoUri?: string | null;
-            [k: string]: unknown;
-          };
-          /**
-           * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-           */
-          maximumValue?: number | null;
-          /**
-           * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-           */
-          minimumValue: number;
-          /**
-           * A display name for the tier
-           */
-          name: string;
-          /**
-           * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-           */
-          rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-          /**
-           * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-           */
-          unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-          [k: string]: unknown;
-        }[]
-      | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
-   */
-  features?: ({
-    /**
-     * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this feature
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The type of feature described
-     */
-    featureType:
-      | "ADDITIONAL_CARDS"
-      | "BALANCE_TRANSFERS"
-      | "BILL_PAYMENT"
-      | "BONUS_REWARDS"
-      | "CARD_ACCESS"
-      | "CASHBACK_OFFER"
-      | "COMPLEMENTARY_PRODUCT_DISCOUNTS"
-      | "DIGITAL_BANKING"
-      | "DIGITAL_WALLET"
-      | "DONATE_INTEREST"
-      | "EXTRA_REPAYMENTS"
-      | "FRAUD_PROTECTION"
-      | "FREE_TXNS"
-      | "FREE_TXNS_ALLOWANCE"
-      | "GUARANTOR"
-      | "INSURANCE"
-      | "INSTALMENT_PLAN"
-      | "INTEREST_FREE"
-      | "INTEREST_FREE_TRANSFERS"
-      | "LOYALTY_PROGRAM"
-      | "NOTIFICATIONS"
-      | "NPP_ENABLED"
-      | "NPP_PAYID"
-      | "OFFSET"
-      | "OTHER"
-      | "OVERDRAFT"
-      | "REDRAW"
-      | "RELATIONSHIP_MANAGEMENT"
-      | "UNLIMITED_TXNS";
-    [k: string]: unknown;
-  } & {
-    /**
-     * True if the feature is already activated and false if the feature is available for activation. Defaults to true if absent. (note this is an additional field appended to the feature object defined in the Product Reference payload)
-     */
-    isActivated?: boolean;
-    [k: string]: unknown;
-  })[];
-  /**
-   * Fees and charges applicable to the account based on the equivalent structure in Product Reference
-   */
-  fees?: {
-    /**
-     * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    accrualFrequency?: string | null;
-    /**
-     * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    accruedRate?: string | null;
-    /**
-     * Display text providing more information on the fee
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this fee
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    amount?: string | null;
-    /**
-     * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
-     */
-    balanceRate?: string | null;
-    /**
-     * The currency the fee will be charged in. Assumes AUD if absent
-     */
-    currency?: string | null;
-    /**
-     * An optional list of discounts to this fee that may be available
-     */
-    discounts?:
-      | {
-          /**
-           * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          accruedRate?: string | null;
-          /**
-           * Display text providing more information on the discount
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this discount
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-           */
-          additionalValue?: string | null;
-          /**
-           * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-           */
-          amount?: string | null;
-          /**
-           * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          balanceRate?: string | null;
-          /**
-           * Description of the discount
-           */
-          description: string;
-          /**
-           * The type of discount. See the next section for an overview of valid values and their meaning
-           */
-          discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-          /**
-           * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-           */
-          eligibility?:
-            | {
-                /**
-                 * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                 */
-                additionalInfo?: string | null;
-                /**
-                 * Link to a web page with more information on this eligibility constraint
-                 */
-                additionalInfoUri?: string | null;
-                /**
-                 * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                 */
-                additionalValue?: string | null;
-                /**
-                 * The type of the specific eligibility constraint for a discount
-                 */
-                discountEligibilityType:
-                  | "BUSINESS"
-                  | "EMPLOYMENT_STATUS"
-                  | "INTRODUCTORY"
-                  | "MAX_AGE"
-                  | "MIN_AGE"
-                  | "MIN_INCOME"
-                  | "MIN_TURNOVER"
-                  | "NATURAL_PERSON"
-                  | "OTHER"
-                  | "PENSION_RECIPIENT"
-                  | "RESIDENCY_STATUS"
-                  | "STAFF"
-                  | "STUDENT";
-                [k: string]: unknown;
-              }[]
-            | null;
-          /**
-           * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          feeRate?: string | null;
-          /**
-           * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-           */
-          transactionRate?: string | null;
-          [k: string]: unknown;
-        }[]
-      | null;
-    /**
-     * The type of fee
-     */
-    feeType:
-      | "DEPOSIT"
-      | "EVENT"
-      | "EXIT"
-      | "PAYMENT"
-      | "PERIODIC"
-      | "PURCHASE"
-      | "TRANSACTION"
-      | "UPFRONT"
-      | "VARIABLE"
-      | "WITHDRAWAL";
-    /**
-     * Name of the fee
-     */
-    name: string;
-    /**
-     * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    transactionRate?: string | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * The addresses for the account to be used for correspondence
-   */
-  addresses?: {
-    /**
-     * The type of address object present
-     */
-    addressUType: "paf" | "simple";
-    /**
-     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-     */
-    paf?: {
-      /**
-       * Building/Property name 1
-       */
-      buildingName1?: string | null;
-      /**
-       * Building/Property name 2
-       */
-      buildingName2?: string | null;
-      /**
-       * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-       */
-      dpid?: string | null;
-      /**
-       * Unit number (including suffix, if applicable)
-       */
-      flatUnitNumber?: string | null;
-      /**
-       * Type of flat or unit for the address
-       */
-      flatUnitType?: string | null;
-      /**
-       * Floor or level number (including alpha characters)
-       */
-      floorLevelNumber?: string | null;
-      /**
-       * Type of floor or level for the address
-       */
-      floorLevelType?: string | null;
-      /**
-       * Full name of locality
-       */
-      localityName: string;
-      /**
-       * Allotment number for the address
-       */
-      lotNumber?: string | null;
-      /**
-       * Postal delivery number if the address is a postal delivery type
-       */
-      postalDeliveryNumber?: number | null;
-      /**
-       * Postal delivery number prefix related to the postal delivery number
-       */
-      postalDeliveryNumberPrefix?: string | null;
-      /**
-       * Postal delivery number suffix related to the postal delivery number
-       */
-      postalDeliveryNumberSuffix?: string | null;
-      /**
-       * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-       */
-      postalDeliveryType?: string | null;
-      /**
-       * Postcode for the locality
-       */
-      postcode: string;
-      /**
-       * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      /**
-       * The name of the street
-       */
-      streetName?: string | null;
-      /**
-       * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetSuffix?: string | null;
-      /**
-       * The street type. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetType?: string | null;
-      /**
-       * Thoroughfare number for a property (first number in a property ranged address)
-       */
-      thoroughfareNumber1?: number | null;
-      /**
-       * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-       */
-      thoroughfareNumber1Suffix?: string | null;
-      /**
-       * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-       */
-      thoroughfareNumber2?: number | null;
-      /**
-       * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-       */
-      thoroughfareNumber2Suffix?: string | null;
-      [k: string]: unknown;
-    };
-    simple?: {
-      /**
-       * First line of the standard address object
-       */
-      addressLine1: string;
-      /**
-       * Second line of the standard address object
-       */
-      addressLine2?: string | null;
-      /**
-       * Third line of the standard address object
-       */
-      addressLine3?: string | null;
-      /**
-       * Name of the city or locality
-       */
-      city: string;
-      /**
-       * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-       */
-      country?: string | null;
-      /**
-       * Name of the individual or business formatted for inclusion in an address used for physical mail
-       */
-      mailingName?: string | null;
-      /**
-       * Mandatory for Australian addresses
-       */
-      postcode?: string | null;
-      /**
-       * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-
-/* This structure is used in the BankingAccountDetailV3.features property */
-export interface accV3DetailFeatureObj extends BankingProductFeatureV2 {
-   isActivated?: boolean;
-}
-
-export interface BankingAccountDetailV3 extends BankingAccountV2 {
-  /**
-   * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-   */
-  bsb?: string;
-  /**
-   * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-   */
-  accountNumber?: string;
-  /**
-   * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
-   */
-  bundleName?: string;
-  /**
-   * The type of structure to present account specific fields.
-   */
-  specificAccountUType?: "creditCard" | "loan" | "termDeposit";
-  termDeposit?: BankingTermDepositAccount[];
-  creditCard?: BankingCreditCardAccount;
-  loan?: BankingLoanAccountV2;
-  /**
-   * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
-   */
-  depositRate?: string;
-  /**
-   * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
-   */
-  lendingRate?: string;
-  /**
-   * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-   */
-  depositRates?: BankingProductDepositRate[];
-  /**
-   * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-   */
-  lendingRates?: BankingProductLendingRateV2[];
-  /**
-   * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
-   */
-  features?: accV3DetailFeatureObj[];
-  /**
-   * Fees and charges applicable to the account based on the equivalent structure in Product Reference
-   */
-  fees?: BankingProductFee[];
-  /**
-   * The addresses for the account to be used for correspondence
-   */
-  addresses?: CommonPhysicalAddress[];
-
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingAccountV2 {
-  /**
-   * A unique ID of the account adhering to the standards for ID permanence
-   */
-  accountId: string;
-  /**
-   * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
-   */
-  accountOwnership: "UNKNOWN" | "ONE_PARTY" | "TWO_PARTY" | "MANY_PARTY" | "OTHER";
-  /**
-   * Date that the account was created (if known)
-   */
-  creationDate?: string | null;
-  /**
-   * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-   */
-  displayName: string;
-  /**
-   * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-   */
-  isOwned?: boolean | null;
-  /**
-   * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-   */
-  maskedNumber: string;
-  /**
-   * A customer supplied nick name for the account
-   */
-  nickname?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  /**
-   * The category to which a product or account belongs. See [here](#product-categories) for more details
-   */
-  productCategory:
-    | "BUSINESS_LOANS"
-    | "CRED_AND_CHRG_CARDS"
-    | "LEASES"
-    | "MARGIN_LOANS"
-    | "OVERDRAFTS"
-    | "PERS_LOANS"
-    | "REGULATED_TRUST_ACCOUNTS"
-    | "RESIDENTIAL_MORTGAGES"
-    | "TERM_DEPOSITS"
-    | "TRADE_FINANCE"
-    | "TRANS_AND_SAVINGS_ACCOUNTS"
-    | "TRAVEL_CARDS";
-  /**
-   * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-   */
-  productName: string;
-  [k: string]: unknown;
-}
-
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingAuthorisedEntity {
-  /**
-   * Australian Business Number for the authorised entity
-   */
-  abn?: string | null;
-  /**
-   * Australian Company Number for the authorised entity
-   */
-  acn?: string | null;
-  /**
-   * Australian Registered Body Number for the authorised entity
-   */
-  arbn?: string | null;
-  /**
-   * Description of the authorised entity derived from previously executed direct debits
-   */
-  description?: string | null;
-  /**
-   * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
-   */
-  financialInstitution?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingBalance {
-  /**
-   * A unique ID of the account adhering to the standards for ID permanence
-   */
-  accountId: string;
-  /**
-   * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
-   */
-  amortisedLimit?: string | null;
-  /**
-   * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
-   */
-  availableBalance: string;
-  /**
-   * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
-   */
-  creditLimit?: string | null;
-  /**
-   * The currency for the balance amounts. If absent assumed to be AUD
-   */
-  currency?: string | null;
-  /**
-   * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
-   */
-  currentBalance: string;
-  /**
-   * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
-   */
-  purses?:
-    | {
-        /**
-         * The balance available for this additional currency purse
-         */
-        amount: string;
-        /**
-         * The currency for the purse
-         */
-        currency?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingBalancePurse {
-  /**
-   * The balance available for this additional currency purse
-   */
-  amount: string;
-  /**
-   * The currency for the purse
-   */
-  currency?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingBillerPayee {
-  /**
-   * BPAY Biller Code of the Biller
-   */
-  billerCode: string;
-  /**
-   * Name of the Biller
-   */
-  billerName: string;
-  /**
-   * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-   */
-  crn?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingCreditCardAccount {
-  /**
-   * The minimum payment amount due for the next card payment
-   */
-  minPaymentAmount: string;
-  /**
-   * If absent assumes AUD
-   */
-  paymentCurrency?: string | null;
-  /**
-   * The amount due for the next card payment
-   */
-  paymentDueAmount: string;
-  /**
-   * Date that the next payment for the card is due
-   */
-  paymentDueDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDigitalWalletPayee {
-  /**
-   * The identifier of the digital wallet (dependent on type)
-   */
-  identifier: string;
-  /**
-   * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-   */
-  name: string;
-  /**
-   * The provider of the digital wallet
-   */
-  provider: "PAYPAL_AU" | "OTHER";
-  /**
-   * The type of the digital wallet identifier
-   */
-  type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDirectDebit {
-  /**
-   * A unique ID of the account adhering to the standards for ID permanence.
-   */
-  accountId: string;
-  authorisedEntity: {
-    /**
-     * Australian Business Number for the authorised entity
-     */
-    abn?: string | null;
-    /**
-     * Australian Company Number for the authorised entity
-     */
-    acn?: string | null;
-    /**
-     * Australian Registered Body Number for the authorised entity
-     */
-    arbn?: string | null;
-    /**
-     * Description of the authorised entity derived from previously executed direct debits
-     */
-    description?: string | null;
-    /**
-     * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
-     */
-    financialInstitution?: string | null;
-    [k: string]: unknown;
-  };
-  /**
-   * The amount of the last debit executed under this authorisation
-   */
-  lastDebitAmount?: string | null;
-  /**
-   * The date and time of the last debit executed under this authorisation
-   */
-  lastDebitDateTime?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDomesticPayee {
-  account?: {
-    /**
-     * Name of the account to pay to
-     */
-    accountName?: string | null;
-    /**
-     * Number of the account to pay to
-     */
-    accountNumber: string;
-    /**
-     * BSB of the account to pay to
-     */
-    bsb: string;
-    [k: string]: unknown;
-  };
-  card?: {
-    /**
-     * Name of the account to pay to
-     */
-    cardNumber: string;
-    [k: string]: unknown;
-  };
-  payId?: {
-    /**
-     * The identifier of the PayID (dependent on type)
-     */
-    identifier: string;
-    /**
-     * The name assigned to the PayID by the owner of the PayID
-     */
-    name?: string | null;
-    /**
-     * The type of the PayID
-     */
-    type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-    [k: string]: unknown;
-  };
-  /**
-   * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
-   */
-  payeeAccountUType: "account" | "card" | "payId";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDomesticPayeeAccount {
-  /**
-   * Name of the account to pay to
-   */
-  accountName?: string | null;
-  /**
-   * Number of the account to pay to
-   */
-  accountNumber: string;
-  /**
-   * BSB of the account to pay to
-   */
-  bsb: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDomesticPayeeCard {
-  /**
-   * Name of the account to pay to
-   */
-  cardNumber: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingDomesticPayeePayId {
-  /**
-   * The identifier of the PayID (dependent on type)
-   */
-  identifier: string;
-  /**
-   * The name assigned to the PayID by the owner of the PayID
-   */
-  name?: string | null;
-  /**
-   * The type of the PayID
-   */
-  type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingInternationalPayee {
-  bankDetails: {
-    /**
-     * Account Targeted for payment
-     */
-    accountNumber: string;
-    bankAddress?: {
-      /**
-       * Address of the recipient Bank
-       */
-      address: string;
-      /**
-       * Name of the recipient Bank
-       */
-      name: string;
-      [k: string]: unknown;
-    } | null;
-    /**
-     * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-     */
-    beneficiaryBankBIC?: string | null;
-    /**
-     * Number for the Clearing House Interbank Payments System
-     */
-    chipNumber?: string | null;
-    /**
-     * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-     */
-    country: string;
-    /**
-     * Number for Fedwire payment (Federal Reserve Wire Network)
-     */
-    fedWireNumber?: string | null;
-    /**
-     * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-     */
-    legalEntityIdentifier?: string | null;
-    /**
-     * International bank routing number
-     */
-    routingNumber?: string | null;
-    /**
-     * Sort code used for account identification in some jurisdictions
-     */
-    sortCode?: string | null;
-    [k: string]: unknown;
-  };
-  beneficiaryDetails: {
-    /**
-     * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-     */
-    country: string;
-    /**
-     * Response message for the payment
-     */
-    message?: string | null;
-    /**
-     * Name of the beneficiary
-     */
-    name?: string | null;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingLoanAccountV2 {
-  /**
-   * Date that the loan is due to be repaid in full
-   */
-  loanEndDate?: string | null;
-  /**
-   * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
-   */
-  maxRedraw?: string | null;
-  /**
-   * If absent assumes AUD
-   */
-  maxRedrawCurrency?: string | null;
-  /**
-   * Minimum amount of next instalment
-   */
-  minInstalmentAmount?: string | null;
-  /**
-   * If absent assumes AUD
-   */
-  minInstalmentCurrency?: string | null;
-  /**
-   * Minimum redraw amount
-   */
-  minRedraw?: string | null;
-  /**
-   * If absent assumes AUD
-   */
-  minRedrawCurrency?: string | null;
-  /**
-   * Next date that an instalment is required
-   */
-  nextInstalmentDate?: string | null;
-  /**
-   * Set to true if one or more offset accounts are configured for this loan account
-   */
-  offsetAccountEnabled?: boolean | null;
-  /**
-   * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
-   */
-  offsetAccountIds?: string[] | null;
-  /**
-   * Optional original loan value
-   */
-  originalLoanAmount?: string | null;
-  /**
-   * If absent assumes AUD
-   */
-  originalLoanCurrency?: string | null;
-  /**
-   * Optional original start date for the loan
-   */
-  originalStartDate?: string | null;
-  /**
-   * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  repaymentFrequency?: string | null;
-  /**
-   * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
-   */
-  repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
-  /**
-   * Type of object included that describes the payee in detail
-   */
-  payeeUType: "biller" | "digitalWallet" | "domestic" | "international";
-  biller?: {
     /**
-     * BPAY Biller Code of the Biller
+     * Type of object included that describes the payee in detail
      */
-    billerCode: string;
-    /**
-     * Name of the Biller
-     */
-    billerName: string;
-    /**
-     * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-     */
-    crn?: string | null;
-    [k: string]: unknown;
-  };
-  domestic?: {
-    account?: {
-      /**
-       * Name of the account to pay to
-       */
-      accountName?: string | null;
-      /**
-       * Number of the account to pay to
-       */
-      accountNumber: string;
-      /**
-       * BSB of the account to pay to
-       */
-      bsb: string;
-      [k: string]: unknown;
-    };
-    card?: {
-      /**
-       * Name of the account to pay to
-       */
-      cardNumber: string;
-      [k: string]: unknown;
-    };
-    payId?: {
-      /**
-       * The identifier of the PayID (dependent on type)
-       */
-      identifier: string;
-      /**
-       * The name assigned to the PayID by the owner of the PayID
-       */
-      name?: string | null;
-      /**
-       * The type of the PayID
-       */
-      type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-      [k: string]: unknown;
-    };
-    /**
-     * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
-     */
-    payeeAccountUType: "account" | "card" | "payId";
-    [k: string]: unknown;
-  };
-  digitalWallet?: {
-    /**
-     * The identifier of the digital wallet (dependent on type)
-     */
-    identifier: string;
-    /**
-     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-     */
-    name: string;
-    /**
-     * The provider of the digital wallet
-     */
-    provider: "PAYPAL_AU" | "OTHER";
-    /**
-     * The type of the digital wallet identifier
-     */
-    type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-    [k: string]: unknown;
-  };
-  international?: {
-    bankDetails: {
-      /**
-       * Account Targeted for payment
-       */
-      accountNumber: string;
-      bankAddress?: {
+    payeeUType: 'biller' | 'digitalWallet' | 'domestic' | 'international';
+    biller?: {
         /**
-         * Address of the recipient Bank
+         * BPAY Biller Code of the Biller
          */
-        address: string;
+        billerCode: string;
         /**
-         * Name of the recipient Bank
+         * Name of the Biller
+         */
+        billerName: string;
+        /**
+         * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+         */
+        crn?: string | null;
+        [k: string]: unknown;
+    };
+    domestic?: {
+        account?: {
+            /**
+             * Name of the account to pay to
+             */
+            accountName?: string | null;
+            /**
+             * Number of the account to pay to
+             */
+            accountNumber: string;
+            /**
+             * BSB of the account to pay to
+             */
+            bsb: string;
+            [k: string]: unknown;
+        };
+        card?: {
+            /**
+             * Name of the account to pay to
+             */
+            cardNumber: string;
+            [k: string]: unknown;
+        };
+        payId?: {
+            /**
+             * The identifier of the PayID (dependent on type)
+             */
+            identifier: string;
+            /**
+             * The name assigned to the PayID by the owner of the PayID
+             */
+            name?: string | null;
+            /**
+             * The type of the PayID
+             */
+            type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+            [k: string]: unknown;
+        };
+        /**
+         * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
+         */
+        payeeAccountUType: 'account' | 'card' | 'payId';
+        [k: string]: unknown;
+    };
+    digitalWallet?: {
+        /**
+         * The identifier of the digital wallet (dependent on type)
+         */
+        identifier: string;
+        /**
+         * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
          */
         name: string;
+        /**
+         * The provider of the digital wallet
+         */
+        provider: 'PAYPAL_AU' | 'OTHER';
+        /**
+         * The type of the digital wallet identifier
+         */
+        type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
         [k: string]: unknown;
-      } | null;
-      /**
-       * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-       */
-      beneficiaryBankBIC?: string | null;
-      /**
-       * Number for the Clearing House Interbank Payments System
-       */
-      chipNumber?: string | null;
-      /**
-       * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-       */
-      country: string;
-      /**
-       * Number for Fedwire payment (Federal Reserve Wire Network)
-       */
-      fedWireNumber?: string | null;
-      /**
-       * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-       */
-      legalEntityIdentifier?: string | null;
-      /**
-       * International bank routing number
-       */
-      routingNumber?: string | null;
-      /**
-       * Sort code used for account identification in some jurisdictions
-       */
-      sortCode?: string | null;
-      [k: string]: unknown;
     };
-    beneficiaryDetails: {
-      /**
-       * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-       */
-      country: string;
-      /**
-       * Response message for the payment
-       */
-      message?: string | null;
-      /**
-       * Name of the beneficiary
-       */
-      name?: string | null;
-      [k: string]: unknown;
+    international?: {
+        bankDetails: {
+            /**
+             * Account Targeted for payment
+             */
+            accountNumber: string;
+            bankAddress?: {
+                /**
+                 * Address of the recipient Bank
+                 */
+                address: string;
+                /**
+                 * Name of the recipient Bank
+                 */
+                name: string;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+             */
+            beneficiaryBankBIC?: string | null;
+            /**
+             * Number for the Clearing House Interbank Payments System
+             */
+            chipNumber?: string | null;
+            /**
+             * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+             */
+            country: string;
+            /**
+             * Number for Fedwire payment (Federal Reserve Wire Network)
+             */
+            fedWireNumber?: string | null;
+            /**
+             * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+             */
+            legalEntityIdentifier?: string | null;
+            /**
+             * International bank routing number
+             */
+            routingNumber?: string | null;
+            /**
+             * Sort code used for account identification in some jurisdictions
+             */
+            sortCode?: string | null;
+            [k: string]: unknown;
+        };
+        beneficiaryDetails: {
+            /**
+             * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+             */
+            country: string;
+            /**
+             * Response message for the payment
+             */
+            message?: string | null;
+            /**
+             * Name of the beneficiary
+             */
+            name?: string | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingPayeeV2 {
-  /**
-   * The date the payee was created by the customer
-   */
-  creationDate?: string | null;
-  /**
-   * A description of the payee provided by the customer
-   */
-  description?: string | null;
-  /**
-   * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
-   */
-  nickname: string;
-  /**
-   * ID of the payee adhering to the rules of ID permanence
-   */
-  payeeId: string;
-  /**
-   * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
-   */
-  type: "BILLER" | "DIGITAL_WALLET" | "DOMESTIC" | "INTERNATIONAL";
-  [k: string]: unknown;
+    /**
+     * The date the payee was created by the customer
+     */
+    creationDate?: string | null;
+    /**
+     * A description of the payee provided by the customer
+     */
+    description?: string | null;
+    /**
+     * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
+     */
+    nickname: string;
+    /**
+     * ID of the payee adhering to the rules of ID permanence
+     */
+    payeeId: string;
+    /**
+     * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
+     */
+    type: 'BILLER' | 'DIGITAL_WALLET' | 'DOMESTIC' | 'INTERNATIONAL';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
@@ -1420,1352 +1427,86 @@ export interface BankingPayeeV2 {
  * Object that contains links to additional information on specific topics
  */
 export interface BankingProductAdditionalInformationV2 {
-  /**
-   * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
-   */
-  additionalBundleUris?:
-    | {
-        /**
-         * The URI describing the additional information
-         */
-        additionalInfoUri: string;
-        /**
-         * Display text providing more information about the document URI
-         */
-        description?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
-   */
-  additionalEligibilityUris?:
-    | {
-        /**
-         * The URI describing the additional information
-         */
-        additionalInfoUri: string;
-        /**
-         * Display text providing more information about the document URI
-         */
-        description?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
-   */
-  additionalFeesAndPricingUris?:
-    | {
-        /**
-         * The URI describing the additional information
-         */
-        additionalInfoUri: string;
-        /**
-         * Display text providing more information about the document URI
-         */
-        description?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
-   */
-  additionalOverviewUris?:
-    | {
-        /**
-         * The URI describing the additional information
-         */
-        additionalInfoUri: string;
-        /**
-         * Display text providing more information about the document URI
-         */
-        description?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
-   */
-  additionalTermsUris?:
-    | {
-        /**
-         * The URI describing the additional information
-         */
-        additionalInfoUri: string;
-        /**
-         * Display text providing more information about the document URI
-         */
-        description?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
-   */
-  bundleUri?: string | null;
-  /**
-   * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
-   */
-  eligibilityUri?: string | null;
-  /**
-   * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
-   */
-  feesAndPricingUri?: string | null;
-  /**
-   * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
-   */
-  overviewUri?: string | null;
-  /**
-   * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
-   */
-  termsUri?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductAdditionalInformationV2AdditionalInformationUris {
-  /**
-   * The URI describing the additional information
-   */
-  additionalInfoUri: string;
-  /**
-   * Display text providing more information about the document URI
-   */
-  description?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductBundle {
-  /**
-   * Display text providing more information on the bundle
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on the bundle criteria and benefits
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Description of the bundle
-   */
-  description: string;
-  /**
-   * Name of the bundle
-   */
-  name: string;
-  /**
-   * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
-   */
-  productIds?: string[] | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * The category to which a product or account belongs. See [here](#product-categories) for more details
- */
-export type BankingProductCategory =
-  | "BUSINESS_LOANS"
-  | "CRED_AND_CHRG_CARDS"
-  | "LEASES"
-  | "MARGIN_LOANS"
-  | "OVERDRAFTS"
-  | "PERS_LOANS"
-  | "REGULATED_TRUST_ACCOUNTS"
-  | "RESIDENTIAL_MORTGAGES"
-  | "TERM_DEPOSITS"
-  | "TRADE_FINANCE"
-  | "TRANS_AND_SAVINGS_ACCOUNTS"
-  | "TRAVEL_CARDS";
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductConstraint {
-  /**
-   * Display text providing more information the constraint
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on the constraint
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The type of constraint described.  See the next section for an overview of valid values and their meaning
-   */
-  constraintType: "MAX_BALANCE" | "MAX_LIMIT" | "MIN_BALANCE" | "MIN_LIMIT" | "OPENING_BALANCE";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductDepositRate {
-  /**
-   * Display text providing more information on the rate
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this rate
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  applicationFrequency?: string | null;
-  /**
-   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  calculationFrequency?: string | null;
-  /**
-   * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
-   */
-  depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
-  /**
-   * The rate to be applied
-   */
-  rate: string;
-  /**
-   * Rate tiers applicable for this rate
-   */
-  tiers?:
-    | {
-        /**
-         * Display text providing more information on the rate tier.
-         */
-        additionalInfo?: string | null;
-        /**
-         * Link to a web page with more information on this rate tier
-         */
-        additionalInfoUri?: string | null;
-        /**
-         * Defines a condition for the applicability of a tiered rate
-         */
-        applicabilityConditions?: {
-          /**
-           * Display text providing more information on the condition
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this condition
-           */
-          additionalInfoUri?: string | null;
-          [k: string]: unknown;
-        };
-        /**
-         * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-         */
-        maximumValue?: number | null;
-        /**
-         * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-         */
-        minimumValue: number;
-        /**
-         * A display name for the tier
-         */
-        name: string;
-        /**
-         * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-         */
-        rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-        /**
-         * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-         */
-        unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductDetailV4 extends BankingProductV4 {
-  /**
-   * An array of bundles that this product participates in.  Each bundle is described by free form information but also by a list of product IDs of the other products that are included in the bundle.  It is assumed that the current product is included in the bundle also
-   */
-  bundles?: {
-    /**
-     * Display text providing more information on the bundle
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on the bundle criteria and benefits
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Description of the bundle
-     */
-    description: string;
-    /**
-     * Name of the bundle
-     */
-    name: string;
-    /**
-     * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
-     */
-    productIds?: string[] | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Array of features available for the product
-   */
-  features?: {
-    /**
-     * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this feature
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The type of feature described
-     */
-    featureType:
-      | "ADDITIONAL_CARDS"
-      | "BALANCE_TRANSFERS"
-      | "BILL_PAYMENT"
-      | "BONUS_REWARDS"
-      | "CARD_ACCESS"
-      | "CASHBACK_OFFER"
-      | "COMPLEMENTARY_PRODUCT_DISCOUNTS"
-      | "DIGITAL_BANKING"
-      | "DIGITAL_WALLET"
-      | "DONATE_INTEREST"
-      | "EXTRA_REPAYMENTS"
-      | "FRAUD_PROTECTION"
-      | "FREE_TXNS"
-      | "FREE_TXNS_ALLOWANCE"
-      | "GUARANTOR"
-      | "INSURANCE"
-      | "INSTALMENT_PLAN"
-      | "INTEREST_FREE"
-      | "INTEREST_FREE_TRANSFERS"
-      | "LOYALTY_PROGRAM"
-      | "NOTIFICATIONS"
-      | "NPP_ENABLED"
-      | "NPP_PAYID"
-      | "OFFSET"
-      | "OTHER"
-      | "OVERDRAFT"
-      | "REDRAW"
-      | "RELATIONSHIP_MANAGEMENT"
-      | "UNLIMITED_TXNS";
-    [k: string]: unknown;
-  }[];
-  /**
-   * Constraints on the application for or operation of the product such as minimum balances or limit thresholds
-   */
-  constraints?: {
-    /**
-     * Display text providing more information the constraint
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on the constraint
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The type of constraint described.  See the next section for an overview of valid values and their meaning
-     */
-    constraintType: "MAX_BALANCE" | "MAX_LIMIT" | "MIN_BALANCE" | "MIN_LIMIT" | "OPENING_BALANCE";
-    [k: string]: unknown;
-  }[];
-  /**
-   * Eligibility criteria for the product
-   */
-  eligibility?: {
-    /**
-     * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this eligibility criteria
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
-     */
-    eligibilityType:
-      | "BUSINESS"
-      | "EMPLOYMENT_STATUS"
-      | "MAX_AGE"
-      | "MIN_AGE"
-      | "MIN_INCOME"
-      | "MIN_TURNOVER"
-      | "NATURAL_PERSON"
-      | "OTHER"
-      | "PENSION_RECIPIENT"
-      | "RESIDENCY_STATUS"
-      | "STAFF"
-      | "STUDENT";
-    [k: string]: unknown;
-  }[];
-  /**
-   * Fees applicable for the product
-   */
-  fees?: {
-    /**
-     * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    accrualFrequency?: string | null;
-    /**
-     * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    accruedRate?: string | null;
-    /**
-     * Display text providing more information on the fee
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this fee
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    amount?: string | null;
-    /**
-     * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
-     */
-    balanceRate?: string | null;
-    /**
-     * The currency the fee will be charged in. Assumes AUD if absent
-     */
-    currency?: string | null;
-    /**
-     * An optional list of discounts to this fee that may be available
-     */
-    discounts?:
-      | {
-          /**
-           * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          accruedRate?: string | null;
-          /**
-           * Display text providing more information on the discount
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this discount
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-           */
-          additionalValue?: string | null;
-          /**
-           * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-           */
-          amount?: string | null;
-          /**
-           * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          balanceRate?: string | null;
-          /**
-           * Description of the discount
-           */
-          description: string;
-          /**
-           * The type of discount. See the next section for an overview of valid values and their meaning
-           */
-          discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-          /**
-           * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-           */
-          eligibility?:
-            | {
-                /**
-                 * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                 */
-                additionalInfo?: string | null;
-                /**
-                 * Link to a web page with more information on this eligibility constraint
-                 */
-                additionalInfoUri?: string | null;
-                /**
-                 * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                 */
-                additionalValue?: string | null;
-                /**
-                 * The type of the specific eligibility constraint for a discount
-                 */
-                discountEligibilityType:
-                  | "BUSINESS"
-                  | "EMPLOYMENT_STATUS"
-                  | "INTRODUCTORY"
-                  | "MAX_AGE"
-                  | "MIN_AGE"
-                  | "MIN_INCOME"
-                  | "MIN_TURNOVER"
-                  | "NATURAL_PERSON"
-                  | "OTHER"
-                  | "PENSION_RECIPIENT"
-                  | "RESIDENCY_STATUS"
-                  | "STAFF"
-                  | "STUDENT";
-                [k: string]: unknown;
-              }[]
-            | null;
-          /**
-           * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-           */
-          feeRate?: string | null;
-          /**
-           * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-           */
-          transactionRate?: string | null;
-          [k: string]: unknown;
-        }[]
-      | null;
-    /**
-     * The type of fee
-     */
-    feeType:
-      | "DEPOSIT"
-      | "EVENT"
-      | "EXIT"
-      | "PAYMENT"
-      | "PERIODIC"
-      | "PURCHASE"
-      | "TRANSACTION"
-      | "UPFRONT"
-      | "VARIABLE"
-      | "WITHDRAWAL";
-    /**
-     * Name of the fee
-     */
-    name: string;
-    /**
-     * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-     */
-    transactionRate?: string | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Interest rates available for deposits
-   */
-  depositRates?: {
-    /**
-     * Display text providing more information on the rate
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this rate
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    applicationFrequency?: string | null;
-    /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    calculationFrequency?: string | null;
-    /**
-     * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
-     */
-    depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
-    /**
-     * The rate to be applied
-     */
-    rate: string;
-    /**
-     * Rate tiers applicable for this rate
-     */
-    tiers?:
-      | {
-          /**
-           * Display text providing more information on the rate tier.
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this rate tier
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Defines a condition for the applicability of a tiered rate
-           */
-          applicabilityConditions?: {
-            /**
-             * Display text providing more information on the condition
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this condition
-             */
-            additionalInfoUri?: string | null;
-            [k: string]: unknown;
-          };
-          /**
-           * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-           */
-          maximumValue?: number | null;
-          /**
-           * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-           */
-          minimumValue: number;
-          /**
-           * A display name for the tier
-           */
-          name: string;
-          /**
-           * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-           */
-          rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-          /**
-           * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-           */
-          unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-          [k: string]: unknown;
-        }[]
-      | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Interest rates charged against lending balances
-   */
-  lendingRates?: {
-    /**
-     * Display text providing more information on the rate.
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this rate
-     */
-    additionalInfoUri?: string | null;
-    /**
-     * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
-     */
-    additionalValue?: string | null;
-    /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    applicationFrequency?: string | null;
-    /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    calculationFrequency?: string | null;
-    /**
-     * A comparison rate equivalent for this rate
-     */
-    comparisonRate?: string | null;
-    /**
-     * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
-     */
-    interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
-    /**
-     * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
-     */
-    lendingRateType:
-      | "BUNDLE_DISCOUNT_FIXED"
-      | "BUNDLE_DISCOUNT_VARIABLE"
-      | "CASH_ADVANCE"
-      | "DISCOUNT"
-      | "FIXED"
-      | "FLOATING"
-      | "INTRODUCTORY"
-      | "MARKET_LINKED"
-      | "PENALTY"
-      | "PURCHASE"
-      | "VARIABLE";
-    /**
-     * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
-     */
-    loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
-    /**
-     * The rate to be applied
-     */
-    rate: string;
-    /**
-     * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
-     */
-    repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-    /**
-     * Rate tiers applicable for this rate
-     */
-    tiers?:
-      | {
-          /**
-           * Display text providing more information on the rate tier.
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this rate tier
-           */
-          additionalInfoUri?: string | null;
-          /**
-           * Defines a condition for the applicability of a tiered rate
-           */
-          applicabilityConditions?: {
-            /**
-             * Display text providing more information on the condition
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this condition
-             */
-            additionalInfoUri?: string | null;
-            [k: string]: unknown;
-          };
-          /**
-           * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-           */
-          maximumValue?: number | null;
-          /**
-           * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-           */
-          minimumValue: number;
-          /**
-           * A display name for the tier
-           */
-          name: string;
-          /**
-           * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-           */
-          rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-          /**
-           * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-           */
-          unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-          [k: string]: unknown;
-        }[]
-      | null;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductDiscount {
-  /**
-   * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-   */
-  accruedRate?: string | null;
-  /**
-   * Display text providing more information on the discount
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this discount
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-   */
-  amount?: string | null;
-  /**
-   * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-   */
-  balanceRate?: string | null;
-  /**
-   * Description of the discount
-   */
-  description: string;
-  /**
-   * The type of discount. See the next section for an overview of valid values and their meaning
-   */
-  discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-  /**
-   * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-   */
-  eligibility?:
-    | {
-        /**
-         * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-         */
-        additionalInfo?: string | null;
-        /**
-         * Link to a web page with more information on this eligibility constraint
-         */
-        additionalInfoUri?: string | null;
-        /**
-         * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-         */
-        additionalValue?: string | null;
-        /**
-         * The type of the specific eligibility constraint for a discount
-         */
-        discountEligibilityType:
-          | "BUSINESS"
-          | "EMPLOYMENT_STATUS"
-          | "INTRODUCTORY"
-          | "MAX_AGE"
-          | "MIN_AGE"
-          | "MIN_INCOME"
-          | "MIN_TURNOVER"
-          | "NATURAL_PERSON"
-          | "OTHER"
-          | "PENSION_RECIPIENT"
-          | "RESIDENCY_STATUS"
-          | "STAFF"
-          | "STUDENT";
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-   */
-  feeRate?: string | null;
-  /**
-   * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-   */
-  transactionRate?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductDiscountEligibility {
-  /**
-   * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this eligibility constraint
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The type of the specific eligibility constraint for a discount
-   */
-  discountEligibilityType:
-    | "BUSINESS"
-    | "EMPLOYMENT_STATUS"
-    | "INTRODUCTORY"
-    | "MAX_AGE"
-    | "MIN_AGE"
-    | "MIN_INCOME"
-    | "MIN_TURNOVER"
-    | "NATURAL_PERSON"
-    | "OTHER"
-    | "PENSION_RECIPIENT"
-    | "RESIDENCY_STATUS"
-    | "STAFF"
-    | "STUDENT";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductEligibility {
-  /**
-   * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this eligibility criteria
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
-   */
-  eligibilityType:
-    | "BUSINESS"
-    | "EMPLOYMENT_STATUS"
-    | "MAX_AGE"
-    | "MIN_AGE"
-    | "MIN_INCOME"
-    | "MIN_TURNOVER"
-    | "NATURAL_PERSON"
-    | "OTHER"
-    | "PENSION_RECIPIENT"
-    | "RESIDENCY_STATUS"
-    | "STAFF"
-    | "STUDENT";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductFeatureV2 {
-  /**
-   * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this feature
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The type of feature described
-   */
-  featureType:
-    | "ADDITIONAL_CARDS"
-    | "BALANCE_TRANSFERS"
-    | "BILL_PAYMENT"
-    | "BONUS_REWARDS"
-    | "CARD_ACCESS"
-    | "CASHBACK_OFFER"
-    | "COMPLEMENTARY_PRODUCT_DISCOUNTS"
-    | "DIGITAL_BANKING"
-    | "DIGITAL_WALLET"
-    | "DONATE_INTEREST"
-    | "EXTRA_REPAYMENTS"
-    | "FRAUD_PROTECTION"
-    | "FREE_TXNS"
-    | "FREE_TXNS_ALLOWANCE"
-    | "GUARANTOR"
-    | "INSURANCE"
-    | "INSTALMENT_PLAN"
-    | "INTEREST_FREE"
-    | "INTEREST_FREE_TRANSFERS"
-    | "LOYALTY_PROGRAM"
-    | "NOTIFICATIONS"
-    | "NPP_ENABLED"
-    | "NPP_PAYID"
-    | "OFFSET"
-    | "OTHER"
-    | "OVERDRAFT"
-    | "REDRAW"
-    | "RELATIONSHIP_MANAGEMENT"
-    | "UNLIMITED_TXNS";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductFee {
-  /**
-   * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  accrualFrequency?: string | null;
-  /**
-   * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-   */
-  accruedRate?: string | null;
-  /**
-   * Display text providing more information on the fee
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this fee
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-   */
-  amount?: string | null;
-  /**
-   * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
-   */
-  balanceRate?: string | null;
-  /**
-   * The currency the fee will be charged in. Assumes AUD if absent
-   */
-  currency?: string | null;
-  /**
-   * An optional list of discounts to this fee that may be available
-   */
-  discounts?:
-    | {
-        /**
-         * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-         */
-        accruedRate?: string | null;
-        /**
-         * Display text providing more information on the discount
-         */
-        additionalInfo?: string | null;
-        /**
-         * Link to a web page with more information on this discount
-         */
-        additionalInfoUri?: string | null;
-        /**
-         * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-         */
-        additionalValue?: string | null;
-        /**
-         * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-         */
-        amount?: string | null;
-        /**
-         * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-         */
-        balanceRate?: string | null;
-        /**
-         * Description of the discount
-         */
-        description: string;
-        /**
-         * The type of discount. See the next section for an overview of valid values and their meaning
-         */
-        discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-        /**
-         * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-         */
-        eligibility?:
-          | {
-              /**
-               * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-               */
-              additionalInfo?: string | null;
-              /**
-               * Link to a web page with more information on this eligibility constraint
-               */
-              additionalInfoUri?: string | null;
-              /**
-               * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-               */
-              additionalValue?: string | null;
-              /**
-               * The type of the specific eligibility constraint for a discount
-               */
-              discountEligibilityType:
-                | "BUSINESS"
-                | "EMPLOYMENT_STATUS"
-                | "INTRODUCTORY"
-                | "MAX_AGE"
-                | "MIN_AGE"
-                | "MIN_INCOME"
-                | "MIN_TURNOVER"
-                | "NATURAL_PERSON"
-                | "OTHER"
-                | "PENSION_RECIPIENT"
-                | "RESIDENCY_STATUS"
-                | "STAFF"
-                | "STUDENT";
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-         */
-        feeRate?: string | null;
-        /**
-         * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-         */
-        transactionRate?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The type of fee
-   */
-  feeType:
-    | "DEPOSIT"
-    | "EVENT"
-    | "EXIT"
-    | "PAYMENT"
-    | "PERIODIC"
-    | "PURCHASE"
-    | "TRANSACTION"
-    | "UPFRONT"
-    | "VARIABLE"
-    | "WITHDRAWAL";
-  /**
-   * Name of the fee
-   */
-  name: string;
-  /**
-   * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-   */
-  transactionRate?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductLendingRateV2 {
-  /**
-   * Display text providing more information on the rate.
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this rate
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
-   */
-  additionalValue?: string | null;
-  /**
-   * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  applicationFrequency?: string | null;
-  /**
-   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  calculationFrequency?: string | null;
-  /**
-   * A comparison rate equivalent for this rate
-   */
-  comparisonRate?: string | null;
-  /**
-   * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
-   */
-  interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
-  /**
-   * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
-   */
-  lendingRateType:
-    | "BUNDLE_DISCOUNT_FIXED"
-    | "BUNDLE_DISCOUNT_VARIABLE"
-    | "CASH_ADVANCE"
-    | "DISCOUNT"
-    | "FIXED"
-    | "FLOATING"
-    | "INTRODUCTORY"
-    | "MARKET_LINKED"
-    | "PENALTY"
-    | "PURCHASE"
-    | "VARIABLE";
-  /**
-   * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
-   */
-  loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
-  /**
-   * The rate to be applied
-   */
-  rate: string;
-  /**
-   * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
-   */
-  repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-  /**
-   * Rate tiers applicable for this rate
-   */
-  tiers?:
-    | {
-        /**
-         * Display text providing more information on the rate tier.
-         */
-        additionalInfo?: string | null;
-        /**
-         * Link to a web page with more information on this rate tier
-         */
-        additionalInfoUri?: string | null;
-        /**
-         * Defines a condition for the applicability of a tiered rate
-         */
-        applicabilityConditions?: {
-          /**
-           * Display text providing more information on the condition
-           */
-          additionalInfo?: string | null;
-          /**
-           * Link to a web page with more information on this condition
-           */
-          additionalInfoUri?: string | null;
-          [k: string]: unknown;
-        };
-        /**
-         * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-         */
-        maximumValue?: number | null;
-        /**
-         * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-         */
-        minimumValue: number;
-        /**
-         * A display name for the tier
-         */
-        name: string;
-        /**
-         * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-         */
-        rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-        /**
-         * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-         */
-        unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Defines a condition for the applicability of a tiered rate
- */
-export interface BankingProductRateCondition {
-  /**
-   * Display text providing more information on the condition
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this condition
-   */
-  additionalInfoUri?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Defines the criteria and conditions for which a rate applies
- */
-export interface BankingProductRateTierV3 {
-  /**
-   * Display text providing more information on the rate tier.
-   */
-  additionalInfo?: string | null;
-  /**
-   * Link to a web page with more information on this rate tier
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Defines a condition for the applicability of a tiered rate
-   */
-  applicabilityConditions?: {
-    /**
-     * Display text providing more information on the condition
-     */
-    additionalInfo?: string | null;
-    /**
-     * Link to a web page with more information on this condition
-     */
-    additionalInfoUri?: string | null;
-    [k: string]: unknown;
-  };
-  /**
-   * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-   */
-  maximumValue?: number | null;
-  /**
-   * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-   */
-  minimumValue: number;
-  /**
-   * A display name for the tier
-   */
-  name: string;
-  /**
-   * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-   */
-  rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-  /**
-   * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-   */
-  unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingProductV4 {
-  /**
-   * Object that contains links to additional information on specific topics
-   */
-  additionalInformation?: {
     /**
      * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
      */
     additionalBundleUris?:
-      | {
-          /**
-           * The URI describing the additional information
-           */
-          additionalInfoUri: string;
-          /**
-           * Display text providing more information about the document URI
-           */
-          description?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI describing the additional information
+             */
+            additionalInfoUri: string;
+            /**
+             * Display text providing more information about the document URI
+             */
+            description?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
      */
     additionalEligibilityUris?:
-      | {
-          /**
-           * The URI describing the additional information
-           */
-          additionalInfoUri: string;
-          /**
-           * Display text providing more information about the document URI
-           */
-          description?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI describing the additional information
+             */
+            additionalInfoUri: string;
+            /**
+             * Display text providing more information about the document URI
+             */
+            description?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
      */
     additionalFeesAndPricingUris?:
-      | {
-          /**
-           * The URI describing the additional information
-           */
-          additionalInfoUri: string;
-          /**
-           * Display text providing more information about the document URI
-           */
-          description?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI describing the additional information
+             */
+            additionalInfoUri: string;
+            /**
+             * Display text providing more information about the document URI
+             */
+            description?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
      */
     additionalOverviewUris?:
-      | {
-          /**
-           * The URI describing the additional information
-           */
-          additionalInfoUri: string;
-          /**
-           * Display text providing more information about the document URI
-           */
-          description?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI describing the additional information
+             */
+            additionalInfoUri: string;
+            /**
+             * Display text providing more information about the document URI
+             */
+            description?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
      */
     additionalTermsUris?:
-      | {
-          /**
-           * The URI describing the additional information
-           */
-          additionalInfoUri: string;
-          /**
-           * Display text providing more information about the document URI
-           */
-          description?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI describing the additional information
+             */
+            additionalInfoUri: string;
+            /**
+             * Display text providing more information about the document URI
+             */
+            description?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
      */
@@ -2787,107 +1528,1856 @@ export interface BankingProductV4 {
      */
     termsUri?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * A link to an application web page where this product can be applied for.
-   */
-  applicationUri?: string | null;
-  /**
-   * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
-   */
-  brand: string;
-  /**
-   * An optional display name of the brand
-   */
-  brandName?: string | null;
-  /**
-   * An array of card art images
-   */
-  cardArt?:
-    | {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductAdditionalInformationV2AdditionalInformationUris {
+    /**
+     * The URI describing the additional information
+     */
+    additionalInfoUri: string;
+    /**
+     * Display text providing more information about the document URI
+     */
+    description?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductBundle {
+    /**
+     * Display text providing more information on the bundle
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on the bundle criteria and benefits
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Description of the bundle
+     */
+    description: string;
+    /**
+     * Name of the bundle
+     */
+    name: string;
+    /**
+     * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
+     */
+    productIds?: string[] | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * The category to which a product or account belongs. See [here](#product-categories) for more details
+ */
+export type BankingProductCategory =
+    | 'BUSINESS_LOANS'
+    | 'CRED_AND_CHRG_CARDS'
+    | 'LEASES'
+    | 'MARGIN_LOANS'
+    | 'OVERDRAFTS'
+    | 'PERS_LOANS'
+    | 'REGULATED_TRUST_ACCOUNTS'
+    | 'RESIDENTIAL_MORTGAGES'
+    | 'TERM_DEPOSITS'
+    | 'TRADE_FINANCE'
+    | 'TRANS_AND_SAVINGS_ACCOUNTS'
+    | 'TRAVEL_CARDS';
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductConstraint {
+    /**
+     * Display text providing more information the constraint
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on the constraint
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The type of constraint described.  See the next section for an overview of valid values and their meaning
+     */
+    constraintType: 'MAX_BALANCE' | 'MAX_LIMIT' | 'MIN_BALANCE' | 'MIN_LIMIT' | 'OPENING_BALANCE';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductDepositRate {
+    /**
+     * Display text providing more information on the rate
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this rate
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    applicationFrequency?: string | null;
+    /**
+     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    calculationFrequency?: string | null;
+    /**
+     * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+     */
+    depositRateType: 'BONUS' | 'BUNDLE_BONUS' | 'FIXED' | 'FLOATING' | 'INTRODUCTORY' | 'MARKET_LINKED' | 'VARIABLE';
+    /**
+     * The rate to be applied
+     */
+    rate: string;
+    /**
+     * Rate tiers applicable for this rate
+     */
+    tiers?:
+        | {
+            /**
+             * Display text providing more information on the rate tier.
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate tier
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Defines a condition for the applicability of a tiered rate
+             */
+            applicabilityConditions?: {
+                /**
+                 * Display text providing more information on the condition
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this condition
+                 */
+                additionalInfoUri?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+             */
+            maximumValue?: number | null;
+            /**
+             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+             */
+            minimumValue: number;
+            /**
+             * A display name for the tier
+             */
+            name: string;
+            /**
+             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+             */
+            rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+            /**
+             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+             */
+            unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductDetailV4 extends BankingProductV4 {
+    /**
+     * An array of bundles that this product participates in.  Each bundle is described by free form information but also by a list of product IDs of the other products that are included in the bundle.  It is assumed that the current product is included in the bundle also
+     */
+    bundles?: {
         /**
-         * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+         * Display text providing more information on the bundle
          */
-        imageUri: string;
+        additionalInfo?: string | null;
         /**
-         * Display label for the specific image
+         * Link to a web page with more information on the bundle criteria and benefits
          */
-        title?: string;
+        additionalInfoUri?: string | null;
+        /**
+         * Description of the bundle
+         */
+        description: string;
+        /**
+         * Name of the bundle
+         */
+        name: string;
+        /**
+         * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
+         */
+        productIds?: string[] | null;
         [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * A description of the product
-   */
-  description: string;
-  /**
-   * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
-   */
-  effectiveFrom?: string | null;
-  /**
-   * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
-   */
-  effectiveTo?: string | null;
-  /**
-   * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
-   */
-  isTailored: boolean;
-  /**
-   * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
-   */
-  lastUpdated: string;
-  /**
-   * The display name of the product
-   */
-  name: string;
-  /**
-   * The category to which a product or account belongs. See [here](#product-categories) for more details
-   */
-  productCategory:
-    | "BUSINESS_LOANS"
-    | "CRED_AND_CHRG_CARDS"
-    | "LEASES"
-    | "MARGIN_LOANS"
-    | "OVERDRAFTS"
-    | "PERS_LOANS"
-    | "REGULATED_TRUST_ACCOUNTS"
-    | "RESIDENTIAL_MORTGAGES"
-    | "TERM_DEPOSITS"
-    | "TRADE_FINANCE"
-    | "TRANS_AND_SAVINGS_ACCOUNTS"
-    | "TRAVEL_CARDS";
-  /**
-   * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
-   */
-  productId: string;
-  [k: string]: unknown;
+    }[];
+    /**
+     * Array of features available for the product
+     */
+    features?: {
+        /**
+         * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this feature
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The type of feature described
+         */
+        featureType:
+            | 'ADDITIONAL_CARDS'
+            | 'BALANCE_TRANSFERS'
+            | 'BILL_PAYMENT'
+            | 'BONUS_REWARDS'
+            | 'CARD_ACCESS'
+            | 'CASHBACK_OFFER'
+            | 'COMPLEMENTARY_PRODUCT_DISCOUNTS'
+            | 'DIGITAL_BANKING'
+            | 'DIGITAL_WALLET'
+            | 'DONATE_INTEREST'
+            | 'EXTRA_REPAYMENTS'
+            | 'FRAUD_PROTECTION'
+            | 'FREE_TXNS'
+            | 'FREE_TXNS_ALLOWANCE'
+            | 'GUARANTOR'
+            | 'INSURANCE'
+            | 'INSTALMENT_PLAN'
+            | 'INTEREST_FREE'
+            | 'INTEREST_FREE_TRANSFERS'
+            | 'LOYALTY_PROGRAM'
+            | 'NOTIFICATIONS'
+            | 'NPP_ENABLED'
+            | 'NPP_PAYID'
+            | 'OFFSET'
+            | 'OTHER'
+            | 'OVERDRAFT'
+            | 'REDRAW'
+            | 'RELATIONSHIP_MANAGEMENT'
+            | 'UNLIMITED_TXNS';
+        [k: string]: unknown;
+    }[];
+    /**
+     * Constraints on the application for or operation of the product such as minimum balances or limit thresholds
+     */
+    constraints?: {
+        /**
+         * Display text providing more information the constraint
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on the constraint
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The type of constraint described.  See the next section for an overview of valid values and their meaning
+         */
+        constraintType: 'MAX_BALANCE' | 'MAX_LIMIT' | 'MIN_BALANCE' | 'MIN_LIMIT' | 'OPENING_BALANCE';
+        [k: string]: unknown;
+    }[];
+    /**
+     * Eligibility criteria for the product
+     */
+    eligibility?: {
+        /**
+         * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this eligibility criteria
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
+         */
+        eligibilityType:
+            | 'BUSINESS'
+            | 'EMPLOYMENT_STATUS'
+            | 'MAX_AGE'
+            | 'MIN_AGE'
+            | 'MIN_INCOME'
+            | 'MIN_TURNOVER'
+            | 'NATURAL_PERSON'
+            | 'OTHER'
+            | 'PENSION_RECIPIENT'
+            | 'RESIDENCY_STATUS'
+            | 'STAFF'
+            | 'STUDENT';
+        [k: string]: unknown;
+    }[];
+    /**
+     * Fees applicable for the product
+     */
+    fees?: {
+        /**
+         * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        accrualFrequency?: string | null;
+        /**
+         * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        accruedRate?: string | null;
+        /**
+         * Display text providing more information on the fee
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this fee
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        amount?: string | null;
+        /**
+         * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+         */
+        balanceRate?: string | null;
+        /**
+         * The currency the fee will be charged in. Assumes AUD if absent
+         */
+        currency?: string | null;
+        /**
+         * An optional list of discounts to this fee that may be available
+         */
+        discounts?:
+            | {
+                /**
+                 * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                accruedRate?: string | null;
+                /**
+                 * Display text providing more information on the discount
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this discount
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+                 */
+                additionalValue?: string | null;
+                /**
+                 * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+                 */
+                amount?: string | null;
+                /**
+                 * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                balanceRate?: string | null;
+                /**
+                 * Description of the discount
+                 */
+                description: string;
+                /**
+                 * The type of discount. See the next section for an overview of valid values and their meaning
+                 */
+                discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+                /**
+                 * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+                 */
+                eligibility?:
+                    | {
+                        /**
+                         * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this eligibility constraint
+                         */
+                        additionalInfoUri?: string | null;
+                        /**
+                         * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                         */
+                        additionalValue?: string | null;
+                        /**
+                         * The type of the specific eligibility constraint for a discount
+                         */
+                        discountEligibilityType:
+                            | 'BUSINESS'
+                            | 'EMPLOYMENT_STATUS'
+                            | 'INTRODUCTORY'
+                            | 'MAX_AGE'
+                            | 'MIN_AGE'
+                            | 'MIN_INCOME'
+                            | 'MIN_TURNOVER'
+                            | 'NATURAL_PERSON'
+                            | 'OTHER'
+                            | 'PENSION_RECIPIENT'
+                            | 'RESIDENCY_STATUS'
+                            | 'STAFF'
+                            | 'STUDENT';
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                 */
+                feeRate?: string | null;
+                /**
+                 * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+                 */
+                transactionRate?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The type of fee
+         */
+        feeType:
+            | 'DEPOSIT'
+            | 'EVENT'
+            | 'EXIT'
+            | 'PAYMENT'
+            | 'PERIODIC'
+            | 'PURCHASE'
+            | 'TRANSACTION'
+            | 'UPFRONT'
+            | 'VARIABLE'
+            | 'WITHDRAWAL';
+        /**
+         * Name of the fee
+         */
+        name: string;
+        /**
+         * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+         */
+        transactionRate?: string | null;
+        [k: string]: unknown;
+    }[];
+    /**
+     * Interest rates available for deposits
+     */
+    depositRates?: {
+        /**
+         * Display text providing more information on the rate
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this rate
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        applicationFrequency?: string | null;
+        /**
+         * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        calculationFrequency?: string | null;
+        /**
+         * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+         */
+        depositRateType:
+            | 'BONUS'
+            | 'BUNDLE_BONUS'
+            | 'FIXED'
+            | 'FLOATING'
+            | 'INTRODUCTORY'
+            | 'MARKET_LINKED'
+            | 'VARIABLE';
+        /**
+         * The rate to be applied
+         */
+        rate: string;
+        /**
+         * Rate tiers applicable for this rate
+         */
+        tiers?:
+            | {
+                /**
+                 * Display text providing more information on the rate tier.
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this rate tier
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Defines a condition for the applicability of a tiered rate
+                 */
+                applicabilityConditions?: {
+                    /**
+                     * Display text providing more information on the condition
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this condition
+                     */
+                    additionalInfoUri?: string | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                 */
+                maximumValue?: number | null;
+                /**
+                 * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                 */
+                minimumValue: number;
+                /**
+                 * A display name for the tier
+                 */
+                name: string;
+                /**
+                 * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                 */
+                rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                /**
+                 * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                 */
+                unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    }[];
+    /**
+     * Interest rates charged against lending balances
+     */
+    lendingRates?: {
+        /**
+         * Display text providing more information on the rate.
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this rate
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+         */
+        additionalValue?: string | null;
+        /**
+         * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        applicationFrequency?: string | null;
+        /**
+         * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        calculationFrequency?: string | null;
+        /**
+         * A comparison rate equivalent for this rate
+         */
+        comparisonRate?: string | null;
+        /**
+         * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+         */
+        interestPaymentDue?: ('IN_ADVANCE' | 'IN_ARREARS') | null;
+        /**
+         * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+         */
+        lendingRateType:
+            | 'BUNDLE_DISCOUNT_FIXED'
+            | 'BUNDLE_DISCOUNT_VARIABLE'
+            | 'CASH_ADVANCE'
+            | 'DISCOUNT'
+            | 'FIXED'
+            | 'FLOATING'
+            | 'INTRODUCTORY'
+            | 'MARKET_LINKED'
+            | 'PENALTY'
+            | 'PURCHASE'
+            | 'VARIABLE';
+        /**
+         * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+         */
+        loanPurpose?: ('INVESTMENT' | 'OWNER_OCCUPIED') | null;
+        /**
+         * The rate to be applied
+         */
+        rate: string;
+        /**
+         * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+         */
+        repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+        /**
+         * Rate tiers applicable for this rate
+         */
+        tiers?:
+            | {
+                /**
+                 * Display text providing more information on the rate tier.
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this rate tier
+                 */
+                additionalInfoUri?: string | null;
+                /**
+                 * Defines a condition for the applicability of a tiered rate
+                 */
+                applicabilityConditions?: {
+                    /**
+                     * Display text providing more information on the condition
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this condition
+                     */
+                    additionalInfoUri?: string | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                 */
+                maximumValue?: number | null;
+                /**
+                 * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                 */
+                minimumValue: number;
+                /**
+                 * A display name for the tier
+                 */
+                name: string;
+                /**
+                 * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                 */
+                rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                /**
+                 * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                 */
+                unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductDiscount {
+    /**
+     * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+     */
+    accruedRate?: string | null;
+    /**
+     * Display text providing more information on the discount
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this discount
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+     */
+    amount?: string | null;
+    /**
+     * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+     */
+    balanceRate?: string | null;
+    /**
+     * Description of the discount
+     */
+    description: string;
+    /**
+     * The type of discount. See the next section for an overview of valid values and their meaning
+     */
+    discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+    /**
+     * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+     */
+    eligibility?:
+        | {
+            /**
+             * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this eligibility constraint
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The type of the specific eligibility constraint for a discount
+             */
+            discountEligibilityType:
+                | 'BUSINESS'
+                | 'EMPLOYMENT_STATUS'
+                | 'INTRODUCTORY'
+                | 'MAX_AGE'
+                | 'MIN_AGE'
+                | 'MIN_INCOME'
+                | 'MIN_TURNOVER'
+                | 'NATURAL_PERSON'
+                | 'OTHER'
+                | 'PENSION_RECIPIENT'
+                | 'RESIDENCY_STATUS'
+                | 'STAFF'
+                | 'STUDENT';
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+     */
+    feeRate?: string | null;
+    /**
+     * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+     */
+    transactionRate?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductDiscountEligibility {
+    /**
+     * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this eligibility constraint
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The type of the specific eligibility constraint for a discount
+     */
+    discountEligibilityType:
+        | 'BUSINESS'
+        | 'EMPLOYMENT_STATUS'
+        | 'INTRODUCTORY'
+        | 'MAX_AGE'
+        | 'MIN_AGE'
+        | 'MIN_INCOME'
+        | 'MIN_TURNOVER'
+        | 'NATURAL_PERSON'
+        | 'OTHER'
+        | 'PENSION_RECIPIENT'
+        | 'RESIDENCY_STATUS'
+        | 'STAFF'
+        | 'STUDENT';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductEligibility {
+    /**
+     * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this eligibility criteria
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
+     */
+    eligibilityType:
+        | 'BUSINESS'
+        | 'EMPLOYMENT_STATUS'
+        | 'MAX_AGE'
+        | 'MIN_AGE'
+        | 'MIN_INCOME'
+        | 'MIN_TURNOVER'
+        | 'NATURAL_PERSON'
+        | 'OTHER'
+        | 'PENSION_RECIPIENT'
+        | 'RESIDENCY_STATUS'
+        | 'STAFF'
+        | 'STUDENT';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductFeatureV2 {
+    /**
+     * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this feature
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The type of feature described
+     */
+    featureType:
+        | 'ADDITIONAL_CARDS'
+        | 'BALANCE_TRANSFERS'
+        | 'BILL_PAYMENT'
+        | 'BONUS_REWARDS'
+        | 'CARD_ACCESS'
+        | 'CASHBACK_OFFER'
+        | 'COMPLEMENTARY_PRODUCT_DISCOUNTS'
+        | 'DIGITAL_BANKING'
+        | 'DIGITAL_WALLET'
+        | 'DONATE_INTEREST'
+        | 'EXTRA_REPAYMENTS'
+        | 'FRAUD_PROTECTION'
+        | 'FREE_TXNS'
+        | 'FREE_TXNS_ALLOWANCE'
+        | 'GUARANTOR'
+        | 'INSURANCE'
+        | 'INSTALMENT_PLAN'
+        | 'INTEREST_FREE'
+        | 'INTEREST_FREE_TRANSFERS'
+        | 'LOYALTY_PROGRAM'
+        | 'NOTIFICATIONS'
+        | 'NPP_ENABLED'
+        | 'NPP_PAYID'
+        | 'OFFSET'
+        | 'OTHER'
+        | 'OVERDRAFT'
+        | 'REDRAW'
+        | 'RELATIONSHIP_MANAGEMENT'
+        | 'UNLIMITED_TXNS';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductFee {
+    /**
+     * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    accrualFrequency?: string | null;
+    /**
+     * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+     */
+    accruedRate?: string | null;
+    /**
+     * Display text providing more information on the fee
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this fee
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+     */
+    amount?: string | null;
+    /**
+     * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+     */
+    balanceRate?: string | null;
+    /**
+     * The currency the fee will be charged in. Assumes AUD if absent
+     */
+    currency?: string | null;
+    /**
+     * An optional list of discounts to this fee that may be available
+     */
+    discounts?:
+        | {
+            /**
+             * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+             */
+            accruedRate?: string | null;
+            /**
+             * Display text providing more information on the discount
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this discount
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+             */
+            amount?: string | null;
+            /**
+             * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+             */
+            balanceRate?: string | null;
+            /**
+             * Description of the discount
+             */
+            description: string;
+            /**
+             * The type of discount. See the next section for an overview of valid values and their meaning
+             */
+            discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+            /**
+             * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+             */
+            eligibility?:
+                | {
+                    /**
+                     * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this eligibility constraint
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                     */
+                    additionalValue?: string | null;
+                    /**
+                     * The type of the specific eligibility constraint for a discount
+                     */
+                    discountEligibilityType:
+                        | 'BUSINESS'
+                        | 'EMPLOYMENT_STATUS'
+                        | 'INTRODUCTORY'
+                        | 'MAX_AGE'
+                        | 'MIN_AGE'
+                        | 'MIN_INCOME'
+                        | 'MIN_TURNOVER'
+                        | 'NATURAL_PERSON'
+                        | 'OTHER'
+                        | 'PENSION_RECIPIENT'
+                        | 'RESIDENCY_STATUS'
+                        | 'STAFF'
+                        | 'STUDENT';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+             */
+            feeRate?: string | null;
+            /**
+             * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+             */
+            transactionRate?: string | null;
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The type of fee
+     */
+    feeType:
+        | 'DEPOSIT'
+        | 'EVENT'
+        | 'EXIT'
+        | 'PAYMENT'
+        | 'PERIODIC'
+        | 'PURCHASE'
+        | 'TRANSACTION'
+        | 'UPFRONT'
+        | 'VARIABLE'
+        | 'WITHDRAWAL';
+    /**
+     * Name of the fee
+     */
+    name: string;
+    /**
+     * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+     */
+    transactionRate?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductLendingRateV2 {
+    /**
+     * Display text providing more information on the rate.
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this rate
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+     */
+    additionalValue?: string | null;
+    /**
+     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    applicationFrequency?: string | null;
+    /**
+     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    calculationFrequency?: string | null;
+    /**
+     * A comparison rate equivalent for this rate
+     */
+    comparisonRate?: string | null;
+    /**
+     * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+     */
+    interestPaymentDue?: ('IN_ADVANCE' | 'IN_ARREARS') | null;
+    /**
+     * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+     */
+    lendingRateType:
+        | 'BUNDLE_DISCOUNT_FIXED'
+        | 'BUNDLE_DISCOUNT_VARIABLE'
+        | 'CASH_ADVANCE'
+        | 'DISCOUNT'
+        | 'FIXED'
+        | 'FLOATING'
+        | 'INTRODUCTORY'
+        | 'MARKET_LINKED'
+        | 'PENALTY'
+        | 'PURCHASE'
+        | 'VARIABLE';
+    /**
+     * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+     */
+    loanPurpose?: ('INVESTMENT' | 'OWNER_OCCUPIED') | null;
+    /**
+     * The rate to be applied
+     */
+    rate: string;
+    /**
+     * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+     */
+    repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+    /**
+     * Rate tiers applicable for this rate
+     */
+    tiers?:
+        | {
+            /**
+             * Display text providing more information on the rate tier.
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate tier
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Defines a condition for the applicability of a tiered rate
+             */
+            applicabilityConditions?: {
+                /**
+                 * Display text providing more information on the condition
+                 */
+                additionalInfo?: string | null;
+                /**
+                 * Link to a web page with more information on this condition
+                 */
+                additionalInfoUri?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+             */
+            maximumValue?: number | null;
+            /**
+             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+             */
+            minimumValue: number;
+            /**
+             * A display name for the tier
+             */
+            name: string;
+            /**
+             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+             */
+            rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+            /**
+             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+             */
+            unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Defines a condition for the applicability of a tiered rate
+ */
+export interface BankingProductRateCondition {
+    /**
+     * Display text providing more information on the condition
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this condition
+     */
+    additionalInfoUri?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Defines the criteria and conditions for which a rate applies
+ */
+export interface BankingProductRateTierV3 {
+    /**
+     * Display text providing more information on the rate tier.
+     */
+    additionalInfo?: string | null;
+    /**
+     * Link to a web page with more information on this rate tier
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Defines a condition for the applicability of a tiered rate
+     */
+    applicabilityConditions?: {
+        /**
+         * Display text providing more information on the condition
+         */
+        additionalInfo?: string | null;
+        /**
+         * Link to a web page with more information on this condition
+         */
+        additionalInfoUri?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+     */
+    maximumValue?: number | null;
+    /**
+     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+     */
+    minimumValue: number;
+    /**
+     * A display name for the tier
+     */
+    name: string;
+    /**
+     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+     */
+    rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+    /**
+     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+     */
+    unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingProductV4 {
+    /**
+     * Object that contains links to additional information on specific topics
+     */
+    additionalInformation?: {
+        /**
+         * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+         */
+        additionalBundleUris?:
+            | {
+                /**
+                 * The URI describing the additional information
+                 */
+                additionalInfoUri: string;
+                /**
+                 * Display text providing more information about the document URI
+                 */
+                description?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
+         */
+        additionalEligibilityUris?:
+            | {
+                /**
+                 * The URI describing the additional information
+                 */
+                additionalInfoUri: string;
+                /**
+                 * Display text providing more information about the document URI
+                 */
+                description?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
+         */
+        additionalFeesAndPricingUris?:
+            | {
+                /**
+                 * The URI describing the additional information
+                 */
+                additionalInfoUri: string;
+                /**
+                 * Display text providing more information about the document URI
+                 */
+                description?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
+         */
+        additionalOverviewUris?:
+            | {
+                /**
+                 * The URI describing the additional information
+                 */
+                additionalInfoUri: string;
+                /**
+                 * Display text providing more information about the document URI
+                 */
+                description?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
+         */
+        additionalTermsUris?:
+            | {
+                /**
+                 * The URI describing the additional information
+                 */
+                additionalInfoUri: string;
+                /**
+                 * Display text providing more information about the document URI
+                 */
+                description?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
+         */
+        bundleUri?: string | null;
+        /**
+         * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
+         */
+        eligibilityUri?: string | null;
+        /**
+         * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
+         */
+        feesAndPricingUri?: string | null;
+        /**
+         * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
+         */
+        overviewUri?: string | null;
+        /**
+         * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
+         */
+        termsUri?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * A link to an application web page where this product can be applied for.
+     */
+    applicationUri?: string | null;
+    /**
+     * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+     */
+    brand: string;
+    /**
+     * An optional display name of the brand
+     */
+    brandName?: string | null;
+    /**
+     * An array of card art images
+     */
+    cardArt?:
+        | {
+            /**
+             * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+             */
+            imageUri: string;
+            /**
+             * Display label for the specific image
+             */
+            title?: string;
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * A description of the product
+     */
+    description: string;
+    /**
+     * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+     */
+    effectiveFrom?: string | null;
+    /**
+     * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+     */
+    effectiveTo?: string | null;
+    /**
+     * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+     */
+    isTailored: boolean;
+    /**
+     * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+     */
+    lastUpdated: string;
+    /**
+     * The display name of the product
+     */
+    name: string;
+    /**
+     * The category to which a product or account belongs. See [here](#product-categories) for more details
+     */
+    productCategory:
+        | 'BUSINESS_LOANS'
+        | 'CRED_AND_CHRG_CARDS'
+        | 'LEASES'
+        | 'MARGIN_LOANS'
+        | 'OVERDRAFTS'
+        | 'PERS_LOANS'
+        | 'REGULATED_TRUST_ACCOUNTS'
+        | 'RESIDENTIAL_MORTGAGES'
+        | 'TERM_DEPOSITS'
+        | 'TRADE_FINANCE'
+        | 'TRANS_AND_SAVINGS_ACCOUNTS'
+        | 'TRAVEL_CARDS';
+    /**
+     * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
+     */
+    productId: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingScheduledPayment {
-  /**
-   * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
-   */
-  from: {
+    /**
+     * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+     */
+    from: {
+        /**
+         * ID of the account that is the source of funds for the payment
+         */
+        accountId: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels
+     */
+    nickname?: string | null;
+    /**
+     * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided
+     */
+    payeeReference?: string | null;
+    /**
+     * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided
+     */
+    payerReference: string;
+    paymentSet: {
+        /**
+         * The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
+         */
+        amount?: string | null;
+        /**
+         * The currency for the payment. AUD assumed if not present
+         */
+        currency?: string | null;
+        /**
+         * Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
+         */
+        isAmountCalculated?: boolean | null;
+        /**
+         * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+         */
+        to: {
+            /**
+             * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+             */
+            accountId?: string | null;
+            biller?: {
+                /**
+                 * BPAY Biller Code of the Biller
+                 */
+                billerCode: string;
+                /**
+                 * Name of the Biller
+                 */
+                billerName: string;
+                /**
+                 * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+                 */
+                crn?: string | null;
+                [k: string]: unknown;
+            };
+            domestic?: {
+                account?: {
+                    /**
+                     * Name of the account to pay to
+                     */
+                    accountName?: string | null;
+                    /**
+                     * Number of the account to pay to
+                     */
+                    accountNumber: string;
+                    /**
+                     * BSB of the account to pay to
+                     */
+                    bsb: string;
+                    [k: string]: unknown;
+                };
+                card?: {
+                    /**
+                     * Name of the account to pay to
+                     */
+                    cardNumber: string;
+                    [k: string]: unknown;
+                };
+                payId?: {
+                    /**
+                     * The identifier of the PayID (dependent on type)
+                     */
+                    identifier: string;
+                    /**
+                     * The name assigned to the PayID by the owner of the PayID
+                     */
+                    name?: string | null;
+                    /**
+                     * The type of the PayID
+                     */
+                    type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+                    [k: string]: unknown;
+                };
+                /**
+                 * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
+                 */
+                payeeAccountUType: 'account' | 'card' | 'payId';
+                [k: string]: unknown;
+            };
+            international?: {
+                bankDetails: {
+                    /**
+                     * Account Targeted for payment
+                     */
+                    accountNumber: string;
+                    bankAddress?: {
+                        /**
+                         * Address of the recipient Bank
+                         */
+                        address: string;
+                        /**
+                         * Name of the recipient Bank
+                         */
+                        name: string;
+                        [k: string]: unknown;
+                    } | null;
+                    /**
+                     * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+                     */
+                    beneficiaryBankBIC?: string | null;
+                    /**
+                     * Number for the Clearing House Interbank Payments System
+                     */
+                    chipNumber?: string | null;
+                    /**
+                     * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                     */
+                    country: string;
+                    /**
+                     * Number for Fedwire payment (Federal Reserve Wire Network)
+                     */
+                    fedWireNumber?: string | null;
+                    /**
+                     * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+                     */
+                    legalEntityIdentifier?: string | null;
+                    /**
+                     * International bank routing number
+                     */
+                    routingNumber?: string | null;
+                    /**
+                     * Sort code used for account identification in some jurisdictions
+                     */
+                    sortCode?: string | null;
+                    [k: string]: unknown;
+                };
+                beneficiaryDetails: {
+                    /**
+                     * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                     */
+                    country: string;
+                    /**
+                     * Response message for the payment
+                     */
+                    message?: string | null;
+                    /**
+                     * Name of the beneficiary
+                     */
+                    name?: string | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
+             */
+            nickname?: string | null;
+            /**
+             * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+             */
+            payeeId?: string | null;
+            /**
+             * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
+             */
+            payeeReference?: string | null;
+            /**
+             * The type of object provided that specifies the destination of the funds for the payment.
+             */
+            toUType: 'accountId' | 'biller' | 'domestic' | 'international' | 'payeeId';
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    }[];
+    /**
+     * Object containing the detail of the schedule for the payment
+     */
+    recurrence: {
+        /**
+         * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+         */
+        eventBased?: {
+            /**
+             * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+             */
+            description: string;
+            [k: string]: unknown;
+        };
+        /**
+         * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+         */
+        intervalSchedule?: {
+            /**
+             * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+             */
+            finalPaymentDate?: string | null;
+            /**
+             * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+             */
+            intervals: {
+                /**
+                 * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+                 */
+                dayInInterval?: string | null;
+                /**
+                 * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+                 */
+                interval: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+             */
+            nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+            /**
+             * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+             */
+            paymentsRemaining?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+         */
+        lastWeekDay?: {
+            /**
+             * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+             */
+            finalPaymentDate?: string | null;
+            /**
+             * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+             */
+            interval: string;
+            /**
+             * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+             */
+            lastWeekDay: 'FRI' | 'MON' | 'SAT' | 'SUN' | 'THU' | 'TUE' | 'WED';
+            /**
+             * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+             */
+            nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+            /**
+             * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+             */
+            paymentsRemaining?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * The date of the next payment under the recurrence schedule
+         */
+        nextPaymentDate?: string | null;
+        /**
+         * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+         */
+        onceOff?: {
+            /**
+             * The scheduled date for the once off payment
+             */
+            paymentDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The type of recurrence used to define the schedule
+         */
+        recurrenceUType: 'eventBased' | 'intervalSchedule' | 'lastWeekDay' | 'onceOff';
+        [k: string]: unknown;
+    };
+    /**
+     * A unique ID of the scheduled payment adhering to the standards for ID permanence
+     */
+    scheduledPaymentId: string;
+    /**
+     * Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
+     */
+    status: 'ACTIVE' | 'INACTIVE' | 'SKIP';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+ */
+export interface BankingScheduledPaymentFrom {
     /**
      * ID of the account that is the source of funds for the payment
      */
     accountId: string;
     [k: string]: unknown;
-  };
-  /**
-   * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels
-   */
-  nickname?: string | null;
-  /**
-   * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided
-   */
-  payeeReference?: string | null;
-  /**
-   * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided
-   */
-  payerReference: string;
-  paymentSet: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface BankingScheduledPaymentInterval {
+    /**
+     * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+     */
+    dayInInterval?: string | null;
+    /**
+     * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+     */
+    interval: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Object containing the detail of the schedule for the payment
+ */
+export interface BankingScheduledPaymentRecurrence {
+    /**
+     * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+     */
+    eventBased?: {
+        /**
+         * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+         */
+        description: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+     */
+    intervalSchedule?: {
+        /**
+         * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+         */
+        finalPaymentDate?: string | null;
+        /**
+         * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+         */
+        intervals: {
+            /**
+             * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+             */
+            dayInInterval?: string | null;
+            /**
+             * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+             */
+            interval: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+         */
+        nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+        /**
+         * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+         */
+        paymentsRemaining?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+     */
+    lastWeekDay?: {
+        /**
+         * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+         */
+        finalPaymentDate?: string | null;
+        /**
+         * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+         */
+        interval: string;
+        /**
+         * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+         */
+        lastWeekDay: 'FRI' | 'MON' | 'SAT' | 'SUN' | 'THU' | 'TUE' | 'WED';
+        /**
+         * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+         */
+        nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+        /**
+         * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+         */
+        paymentsRemaining?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * The date of the next payment under the recurrence schedule
+     */
+    nextPaymentDate?: string | null;
+    /**
+     * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+     */
+    onceOff?: {
+        /**
+         * The scheduled date for the once off payment
+         */
+        paymentDate: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The type of recurrence used to define the schedule
+     */
+    recurrenceUType: 'eventBased' | 'intervalSchedule' | 'lastWeekDay' | 'onceOff';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+ */
+export interface BankingScheduledPaymentRecurrenceEventBased {
+    /**
+     * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+     */
+    description: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+ */
+export interface BankingScheduledPaymentRecurrenceIntervalSchedule {
+    /**
+     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+     */
+    finalPaymentDate?: string | null;
+    /**
+     * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+     */
+    intervals: {
+        /**
+         * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+         */
+        dayInInterval?: string | null;
+        /**
+         * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+         */
+        interval: string;
+        [k: string]: unknown;
+    }[];
+    /**
+     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+     */
+    nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+    /**
+     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+     */
+    paymentsRemaining?: number | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+ */
+export interface BankingScheduledPaymentRecurrenceLastWeekday {
+    /**
+     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+     */
+    finalPaymentDate?: string | null;
+    /**
+     * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+     */
+    interval: string;
+    /**
+     * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+     */
+    lastWeekDay: 'FRI' | 'MON' | 'SAT' | 'SUN' | 'THU' | 'TUE' | 'WED';
+    /**
+     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+     */
+    nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+    /**
+     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+     */
+    paymentsRemaining?: number | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+ */
+export interface BankingScheduledPaymentRecurrenceOnceOff {
+    /**
+     * The scheduled date for the once off payment
+     */
+    paymentDate: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * The set of payment amounts and destination accounts for this payment accommodating multi-part payments. A single entry indicates a simple payment with one destination account. Must have at least one entry
+ */
+export interface BankingScheduledPaymentSet {
     /**
      * The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
      */
@@ -2904,11 +3394,164 @@ export interface BankingScheduledPayment {
      * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
      */
     to: {
-      /**
-       * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
-       */
-      accountId?: string | null;
-      biller?: {
+        /**
+         * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+         */
+        accountId?: string | null;
+        biller?: {
+            /**
+             * BPAY Biller Code of the Biller
+             */
+            billerCode: string;
+            /**
+             * Name of the Biller
+             */
+            billerName: string;
+            /**
+             * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+             */
+            crn?: string | null;
+            [k: string]: unknown;
+        };
+        domestic?: {
+            account?: {
+                /**
+                 * Name of the account to pay to
+                 */
+                accountName?: string | null;
+                /**
+                 * Number of the account to pay to
+                 */
+                accountNumber: string;
+                /**
+                 * BSB of the account to pay to
+                 */
+                bsb: string;
+                [k: string]: unknown;
+            };
+            card?: {
+                /**
+                 * Name of the account to pay to
+                 */
+                cardNumber: string;
+                [k: string]: unknown;
+            };
+            payId?: {
+                /**
+                 * The identifier of the PayID (dependent on type)
+                 */
+                identifier: string;
+                /**
+                 * The name assigned to the PayID by the owner of the PayID
+                 */
+                name?: string | null;
+                /**
+                 * The type of the PayID
+                 */
+                type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+                [k: string]: unknown;
+            };
+            /**
+             * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
+             */
+            payeeAccountUType: 'account' | 'card' | 'payId';
+            [k: string]: unknown;
+        };
+        international?: {
+            bankDetails: {
+                /**
+                 * Account Targeted for payment
+                 */
+                accountNumber: string;
+                bankAddress?: {
+                    /**
+                     * Address of the recipient Bank
+                     */
+                    address: string;
+                    /**
+                     * Name of the recipient Bank
+                     */
+                    name: string;
+                    [k: string]: unknown;
+                } | null;
+                /**
+                 * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+                 */
+                beneficiaryBankBIC?: string | null;
+                /**
+                 * Number for the Clearing House Interbank Payments System
+                 */
+                chipNumber?: string | null;
+                /**
+                 * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                 */
+                country: string;
+                /**
+                 * Number for Fedwire payment (Federal Reserve Wire Network)
+                 */
+                fedWireNumber?: string | null;
+                /**
+                 * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+                 */
+                legalEntityIdentifier?: string | null;
+                /**
+                 * International bank routing number
+                 */
+                routingNumber?: string | null;
+                /**
+                 * Sort code used for account identification in some jurisdictions
+                 */
+                sortCode?: string | null;
+                [k: string]: unknown;
+            };
+            beneficiaryDetails: {
+                /**
+                 * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                 */
+                country: string;
+                /**
+                 * Response message for the payment
+                 */
+                message?: string | null;
+                /**
+                 * Name of the beneficiary
+                 */
+                name?: string | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
+         */
+        nickname?: string | null;
+        /**
+         * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+         */
+        payeeId?: string | null;
+        /**
+         * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
+         */
+        payeeReference?: string | null;
+        /**
+         * The type of object provided that specifies the destination of the funds for the payment.
+         */
+        toUType: 'accountId' | 'biller' | 'domestic' | 'international' | 'payeeId';
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+ */
+export interface BankingScheduledPaymentTo {
+    /**
+     * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+     */
+    accountId?: string | null;
+    biller?: {
         /**
          * BPAY Biller Code of the Biller
          */
@@ -2922,590 +3565,114 @@ export interface BankingScheduledPayment {
          */
         crn?: string | null;
         [k: string]: unknown;
-      };
-      domestic?: {
+    };
+    domestic?: {
         account?: {
-          /**
-           * Name of the account to pay to
-           */
-          accountName?: string | null;
-          /**
-           * Number of the account to pay to
-           */
-          accountNumber: string;
-          /**
-           * BSB of the account to pay to
-           */
-          bsb: string;
-          [k: string]: unknown;
+            /**
+             * Name of the account to pay to
+             */
+            accountName?: string | null;
+            /**
+             * Number of the account to pay to
+             */
+            accountNumber: string;
+            /**
+             * BSB of the account to pay to
+             */
+            bsb: string;
+            [k: string]: unknown;
         };
         card?: {
-          /**
-           * Name of the account to pay to
-           */
-          cardNumber: string;
-          [k: string]: unknown;
+            /**
+             * Name of the account to pay to
+             */
+            cardNumber: string;
+            [k: string]: unknown;
         };
         payId?: {
-          /**
-           * The identifier of the PayID (dependent on type)
-           */
-          identifier: string;
-          /**
-           * The name assigned to the PayID by the owner of the PayID
-           */
-          name?: string | null;
-          /**
-           * The type of the PayID
-           */
-          type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-          [k: string]: unknown;
+            /**
+             * The identifier of the PayID (dependent on type)
+             */
+            identifier: string;
+            /**
+             * The name assigned to the PayID by the owner of the PayID
+             */
+            name?: string | null;
+            /**
+             * The type of the PayID
+             */
+            type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+            [k: string]: unknown;
         };
         /**
          * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
          */
-        payeeAccountUType: "account" | "card" | "payId";
+        payeeAccountUType: 'account' | 'card' | 'payId';
         [k: string]: unknown;
-      };
-      international?: {
-        bankDetails: {
-          /**
-           * Account Targeted for payment
-           */
-          accountNumber: string;
-          bankAddress?: {
-            /**
-             * Address of the recipient Bank
-             */
-            address: string;
-            /**
-             * Name of the recipient Bank
-             */
-            name: string;
-            [k: string]: unknown;
-          } | null;
-          /**
-           * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-           */
-          beneficiaryBankBIC?: string | null;
-          /**
-           * Number for the Clearing House Interbank Payments System
-           */
-          chipNumber?: string | null;
-          /**
-           * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-           */
-          country: string;
-          /**
-           * Number for Fedwire payment (Federal Reserve Wire Network)
-           */
-          fedWireNumber?: string | null;
-          /**
-           * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-           */
-          legalEntityIdentifier?: string | null;
-          /**
-           * International bank routing number
-           */
-          routingNumber?: string | null;
-          /**
-           * Sort code used for account identification in some jurisdictions
-           */
-          sortCode?: string | null;
-          [k: string]: unknown;
-        };
-        beneficiaryDetails: {
-          /**
-           * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-           */
-          country: string;
-          /**
-           * Response message for the payment
-           */
-          message?: string | null;
-          /**
-           * Name of the beneficiary
-           */
-          name?: string | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
-       */
-      nickname?: string | null;
-      /**
-       * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
-       */
-      payeeId?: string | null;
-      /**
-       * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
-       */
-      payeeReference?: string | null;
-      /**
-       * The type of object provided that specifies the destination of the funds for the payment.
-       */
-      toUType: "accountId" | "biller" | "domestic" | "international" | "payeeId";
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  }[];
-  /**
-   * Object containing the detail of the schedule for the payment
-   */
-  recurrence: {
-    /**
-     * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
-     */
-    eventBased?: {
-      /**
-       * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
-       */
-      description: string;
-      [k: string]: unknown;
-    };
-    /**
-     * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
-     */
-    intervalSchedule?: {
-      /**
-       * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-       */
-      finalPaymentDate?: string | null;
-      /**
-       * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
-       */
-      intervals: {
-        /**
-         * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
-         */
-        dayInInterval?: string | null;
-        /**
-         * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-         */
-        interval: string;
-        [k: string]: unknown;
-      }[];
-      /**
-       * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-       */
-      nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-      /**
-       * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
-       */
-      paymentsRemaining?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
-     */
-    lastWeekDay?: {
-      /**
-       * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-       */
-      finalPaymentDate?: string | null;
-      /**
-       * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-       */
-      interval: string;
-      /**
-       * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
-       */
-      lastWeekDay: "FRI" | "MON" | "SAT" | "SUN" | "THU" | "TUE" | "WED";
-      /**
-       * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-       */
-      nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-      /**
-       * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-       */
-      paymentsRemaining?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * The date of the next payment under the recurrence schedule
-     */
-    nextPaymentDate?: string | null;
-    /**
-     * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
-     */
-    onceOff?: {
-      /**
-       * The scheduled date for the once off payment
-       */
-      paymentDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The type of recurrence used to define the schedule
-     */
-    recurrenceUType: "eventBased" | "intervalSchedule" | "lastWeekDay" | "onceOff";
-    [k: string]: unknown;
-  };
-  /**
-   * A unique ID of the scheduled payment adhering to the standards for ID permanence
-   */
-  scheduledPaymentId: string;
-  /**
-   * Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
-   */
-  status: "ACTIVE" | "INACTIVE" | "SKIP";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
- */
-export interface BankingScheduledPaymentFrom {
-  /**
-   * ID of the account that is the source of funds for the payment
-   */
-  accountId: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface BankingScheduledPaymentInterval {
-  /**
-   * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
-   */
-  dayInInterval?: string | null;
-  /**
-   * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-   */
-  interval: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Object containing the detail of the schedule for the payment
- */
-export interface BankingScheduledPaymentRecurrence {
-  /**
-   * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
-   */
-  eventBased?: {
-    /**
-     * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
-     */
-    description: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
-   */
-  intervalSchedule?: {
-    /**
-     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-     */
-    finalPaymentDate?: string | null;
-    /**
-     * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
-     */
-    intervals: {
-      /**
-       * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
-       */
-      dayInInterval?: string | null;
-      /**
-       * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-       */
-      interval: string;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-     */
-    nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-    /**
-     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
-     */
-    paymentsRemaining?: number | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
-   */
-  lastWeekDay?: {
-    /**
-     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-     */
-    finalPaymentDate?: string | null;
-    /**
-     * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-     */
-    interval: string;
-    /**
-     * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
-     */
-    lastWeekDay: "FRI" | "MON" | "SAT" | "SUN" | "THU" | "TUE" | "WED";
-    /**
-     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-     */
-    nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-    /**
-     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-     */
-    paymentsRemaining?: number | null;
-    [k: string]: unknown;
-  };
-  /**
-   * The date of the next payment under the recurrence schedule
-   */
-  nextPaymentDate?: string | null;
-  /**
-   * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
-   */
-  onceOff?: {
-    /**
-     * The scheduled date for the once off payment
-     */
-    paymentDate: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The type of recurrence used to define the schedule
-   */
-  recurrenceUType: "eventBased" | "intervalSchedule" | "lastWeekDay" | "onceOff";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
- */
-export interface BankingScheduledPaymentRecurrenceEventBased {
-  /**
-   * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
-   */
-  description: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
- */
-export interface BankingScheduledPaymentRecurrenceIntervalSchedule {
-  /**
-   * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-   */
-  finalPaymentDate?: string | null;
-  /**
-   * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
-   */
-  intervals: {
-    /**
-     * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
-     */
-    dayInInterval?: string | null;
-    /**
-     * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-     */
-    interval: string;
-    [k: string]: unknown;
-  }[];
-  /**
-   * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-   */
-  nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-  /**
-   * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
-   */
-  paymentsRemaining?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
- */
-export interface BankingScheduledPaymentRecurrenceLastWeekday {
-  /**
-   * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-   */
-  finalPaymentDate?: string | null;
-  /**
-   * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-   */
-  interval: string;
-  /**
-   * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
-   */
-  lastWeekDay: "FRI" | "MON" | "SAT" | "SUN" | "THU" | "TUE" | "WED";
-  /**
-   * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-   */
-  nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-  /**
-   * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-   */
-  paymentsRemaining?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
- */
-export interface BankingScheduledPaymentRecurrenceOnceOff {
-  /**
-   * The scheduled date for the once off payment
-   */
-  paymentDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * The set of payment amounts and destination accounts for this payment accommodating multi-part payments. A single entry indicates a simple payment with one destination account. Must have at least one entry
- */
-export interface BankingScheduledPaymentSet {
-  /**
-   * The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
-   */
-  amount?: string | null;
-  /**
-   * The currency for the payment. AUD assumed if not present
-   */
-  currency?: string | null;
-  /**
-   * Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
-   */
-  isAmountCalculated?: boolean | null;
-  /**
-   * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
-   */
-  to: {
-    /**
-     * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
-     */
-    accountId?: string | null;
-    biller?: {
-      /**
-       * BPAY Biller Code of the Biller
-       */
-      billerCode: string;
-      /**
-       * Name of the Biller
-       */
-      billerName: string;
-      /**
-       * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-       */
-      crn?: string | null;
-      [k: string]: unknown;
-    };
-    domestic?: {
-      account?: {
-        /**
-         * Name of the account to pay to
-         */
-        accountName?: string | null;
-        /**
-         * Number of the account to pay to
-         */
-        accountNumber: string;
-        /**
-         * BSB of the account to pay to
-         */
-        bsb: string;
-        [k: string]: unknown;
-      };
-      card?: {
-        /**
-         * Name of the account to pay to
-         */
-        cardNumber: string;
-        [k: string]: unknown;
-      };
-      payId?: {
-        /**
-         * The identifier of the PayID (dependent on type)
-         */
-        identifier: string;
-        /**
-         * The name assigned to the PayID by the owner of the PayID
-         */
-        name?: string | null;
-        /**
-         * The type of the PayID
-         */
-        type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-        [k: string]: unknown;
-      };
-      /**
-       * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
-       */
-      payeeAccountUType: "account" | "card" | "payId";
-      [k: string]: unknown;
     };
     international?: {
-      bankDetails: {
-        /**
-         * Account Targeted for payment
-         */
-        accountNumber: string;
-        bankAddress?: {
-          /**
-           * Address of the recipient Bank
-           */
-          address: string;
-          /**
-           * Name of the recipient Bank
-           */
-          name: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-         */
-        beneficiaryBankBIC?: string | null;
-        /**
-         * Number for the Clearing House Interbank Payments System
-         */
-        chipNumber?: string | null;
-        /**
-         * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-         */
-        country: string;
-        /**
-         * Number for Fedwire payment (Federal Reserve Wire Network)
-         */
-        fedWireNumber?: string | null;
-        /**
-         * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-         */
-        legalEntityIdentifier?: string | null;
-        /**
-         * International bank routing number
-         */
-        routingNumber?: string | null;
-        /**
-         * Sort code used for account identification in some jurisdictions
-         */
-        sortCode?: string | null;
+        bankDetails: {
+            /**
+             * Account Targeted for payment
+             */
+            accountNumber: string;
+            bankAddress?: {
+                /**
+                 * Address of the recipient Bank
+                 */
+                address: string;
+                /**
+                 * Name of the recipient Bank
+                 */
+                name: string;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+             */
+            beneficiaryBankBIC?: string | null;
+            /**
+             * Number for the Clearing House Interbank Payments System
+             */
+            chipNumber?: string | null;
+            /**
+             * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+             */
+            country: string;
+            /**
+             * Number for Fedwire payment (Federal Reserve Wire Network)
+             */
+            fedWireNumber?: string | null;
+            /**
+             * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+             */
+            legalEntityIdentifier?: string | null;
+            /**
+             * International bank routing number
+             */
+            routingNumber?: string | null;
+            /**
+             * Sort code used for account identification in some jurisdictions
+             */
+            sortCode?: string | null;
+            [k: string]: unknown;
+        };
+        beneficiaryDetails: {
+            /**
+             * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+             */
+            country: string;
+            /**
+             * Response message for the payment
+             */
+            message?: string | null;
+            /**
+             * Name of the beneficiary
+             */
+            name?: string | null;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
-      };
-      beneficiaryDetails: {
-        /**
-         * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-         */
-        country: string;
-        /**
-         * Response message for the payment
-         */
-        message?: string | null;
-        /**
-         * Name of the beneficiary
-         */
-        name?: string | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     /**
      * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
@@ -3522,310 +3689,157 @@ export interface BankingScheduledPaymentSet {
     /**
      * The type of object provided that specifies the destination of the funds for the payment.
      */
-    toUType: "accountId" | "biller" | "domestic" | "international" | "payeeId";
+    toUType: 'accountId' | 'biller' | 'domestic' | 'international' | 'payeeId';
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
- */
-export interface BankingScheduledPaymentTo {
-  /**
-   * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
-   */
-  accountId?: string | null;
-  biller?: {
-    /**
-     * BPAY Biller Code of the Biller
-     */
-    billerCode: string;
-    /**
-     * Name of the Biller
-     */
-    billerName: string;
-    /**
-     * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-     */
-    crn?: string | null;
-    [k: string]: unknown;
-  };
-  domestic?: {
-    account?: {
-      /**
-       * Name of the account to pay to
-       */
-      accountName?: string | null;
-      /**
-       * Number of the account to pay to
-       */
-      accountNumber: string;
-      /**
-       * BSB of the account to pay to
-       */
-      bsb: string;
-      [k: string]: unknown;
-    };
-    card?: {
-      /**
-       * Name of the account to pay to
-       */
-      cardNumber: string;
-      [k: string]: unknown;
-    };
-    payId?: {
-      /**
-       * The identifier of the PayID (dependent on type)
-       */
-      identifier: string;
-      /**
-       * The name assigned to the PayID by the owner of the PayID
-       */
-      name?: string | null;
-      /**
-       * The type of the PayID
-       */
-      type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-      [k: string]: unknown;
-    };
-    /**
-     * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
-     */
-    payeeAccountUType: "account" | "card" | "payId";
-    [k: string]: unknown;
-  };
-  international?: {
-    bankDetails: {
-      /**
-       * Account Targeted for payment
-       */
-      accountNumber: string;
-      bankAddress?: {
-        /**
-         * Address of the recipient Bank
-         */
-        address: string;
-        /**
-         * Name of the recipient Bank
-         */
-        name: string;
-        [k: string]: unknown;
-      } | null;
-      /**
-       * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-       */
-      beneficiaryBankBIC?: string | null;
-      /**
-       * Number for the Clearing House Interbank Payments System
-       */
-      chipNumber?: string | null;
-      /**
-       * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-       */
-      country: string;
-      /**
-       * Number for Fedwire payment (Federal Reserve Wire Network)
-       */
-      fedWireNumber?: string | null;
-      /**
-       * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-       */
-      legalEntityIdentifier?: string | null;
-      /**
-       * International bank routing number
-       */
-      routingNumber?: string | null;
-      /**
-       * Sort code used for account identification in some jurisdictions
-       */
-      sortCode?: string | null;
-      [k: string]: unknown;
-    };
-    beneficiaryDetails: {
-      /**
-       * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-       */
-      country: string;
-      /**
-       * Response message for the payment
-       */
-      message?: string | null;
-      /**
-       * Name of the beneficiary
-       */
-      name?: string | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
-   */
-  nickname?: string | null;
-  /**
-   * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
-   */
-  payeeId?: string | null;
-  /**
-   * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
-   */
-  payeeReference?: string | null;
-  /**
-   * The type of object provided that specifies the destination of the funds for the payment.
-   */
-  toUType: "accountId" | "biller" | "domestic" | "international" | "payeeId";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingTermDepositAccount {
-  /**
-   * The lodgement date of the original deposit
-   */
-  lodgementDate: string;
-  /**
-   * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
-   */
-  maturityAmount?: string | null;
-  /**
-   * If absent assumes AUD
-   */
-  maturityCurrency?: string | null;
-  /**
-   * Maturity date for the term deposit
-   */
-  maturityDate: string;
-  /**
-   * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
-   */
-  maturityInstructions: "HOLD_ON_MATURITY" | "PAID_OUT_AT_MATURITY" | "ROLLED_OVER";
-  [k: string]: unknown;
+    /**
+     * The lodgement date of the original deposit
+     */
+    lodgementDate: string;
+    /**
+     * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+     */
+    maturityAmount?: string | null;
+    /**
+     * If absent assumes AUD
+     */
+    maturityCurrency?: string | null;
+    /**
+     * Maturity date for the term deposit
+     */
+    maturityDate: string;
+    /**
+     * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+     */
+    maturityInstructions: 'HOLD_ON_MATURITY' | 'PAID_OUT_AT_MATURITY' | 'ROLLED_OVER';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingTransaction {
-  /**
-   * ID of the account for which transactions are provided
-   */
-  accountId: string;
-  /**
-   * The value of the transaction. Negative values mean money was outgoing from the account
-   */
-  amount: string;
-  /**
-   * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
-   */
-  apcaNumber?: string | null;
-  /**
-   * BPAY Biller Code for the transaction (if available)
-   */
-  billerCode?: string | null;
-  /**
-   * Name of the BPAY biller for the transaction (if available)
-   */
-  billerName?: string | null;
-  /**
-   * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-   */
-  crn?: string | null;
-  /**
-   * The currency for the transaction amount. AUD assumed if not present
-   */
-  currency?: string | null;
-  /**
-   * The transaction description as applied by the financial institution
-   */
-  description: string;
-  /**
-   * The time the transaction was executed by the originating customer, if available
-   */
-  executionDateTime?: string | null;
-  /**
-   * True if extended information is available using the transaction detail end point. False if extended data is not available
-   */
-  isDetailAvailable: boolean;
-  /**
-   * The merchant category code (or MCC) for an outgoing payment to a merchant
-   */
-  merchantCategoryCode?: string | null;
-  /**
-   * Name of the merchant for an outgoing payment to a merchant
-   */
-  merchantName?: string | null;
-  /**
-   * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
-   */
-  postingDateTime?: string | null;
-  /**
-   * The reference for the transaction provided by the originating institution. Empty string if no data provided
-   */
-  reference: string;
-  /**
-   * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
-   */
-  status: "PENDING" | "POSTED";
-  /**
-   * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
-   */
-  transactionId?: string | null;
-  /**
-   * The type of the transaction
-   */
-  type:
-    | "DIRECT_DEBIT"
-    | "FEE"
-    | "INTEREST_CHARGED"
-    | "INTEREST_PAID"
-    | "OTHER"
-    | "PAYMENT"
-    | "TRANSFER_INCOMING"
-    | "TRANSFER_OUTGOING";
-  /**
-   * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
-   */
-  valueDateTime?: string | null;
-  [k: string]: unknown;
+    /**
+     * ID of the account for which transactions are provided
+     */
+    accountId: string;
+    /**
+     * The value of the transaction. Negative values mean money was outgoing from the account
+     */
+    amount: string;
+    /**
+     * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
+     */
+    apcaNumber?: string | null;
+    /**
+     * BPAY Biller Code for the transaction (if available)
+     */
+    billerCode?: string | null;
+    /**
+     * Name of the BPAY biller for the transaction (if available)
+     */
+    billerName?: string | null;
+    /**
+     * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+     */
+    crn?: string | null;
+    /**
+     * The currency for the transaction amount. AUD assumed if not present
+     */
+    currency?: string | null;
+    /**
+     * The transaction description as applied by the financial institution
+     */
+    description: string;
+    /**
+     * The time the transaction was executed by the originating customer, if available
+     */
+    executionDateTime?: string | null;
+    /**
+     * True if extended information is available using the transaction detail end point. False if extended data is not available
+     */
+    isDetailAvailable: boolean;
+    /**
+     * The merchant category code (or MCC) for an outgoing payment to a merchant
+     */
+    merchantCategoryCode?: string | null;
+    /**
+     * Name of the merchant for an outgoing payment to a merchant
+     */
+    merchantName?: string | null;
+    /**
+     * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
+     */
+    postingDateTime?: string | null;
+    /**
+     * The reference for the transaction provided by the originating institution. Empty string if no data provided
+     */
+    reference: string;
+    /**
+     * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+     */
+    status: 'PENDING' | 'POSTED';
+    /**
+     * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
+     */
+    transactionId?: string | null;
+    /**
+     * The type of the transaction
+     */
+    type:
+        | 'DIRECT_DEBIT'
+        | 'FEE'
+        | 'INTEREST_CHARGED'
+        | 'INTEREST_PAID'
+        | 'OTHER'
+        | 'PAYMENT'
+        | 'TRANSFER_INCOMING'
+        | 'TRANSFER_OUTGOING';
+    /**
+     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+     */
+    valueDateTime?: string | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface BankingTransactionDetail extends BankingTransaction {
-  extendedData: {
-    /**
-     * Label of the originating payer. Mandatory for inbound payment
-     */
-    payer?: string;
-    /**
-     * Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
-     */
-    payee?: string;
-    /**
-     * Optional extended data provided specific to transaction originated via NPP
-     */
-    extensionUType?: "x2p101Payload";
-    x2p101Payload?: {
-      /**
-       * An extended string description. Only present if specified by the extensionUType field
-       */
-      extendedDescription: string;
-      /**
-       * An end to end ID for the payment created at initiation
-       */
-      endToEndId?: string;
-      /**
-       * Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
-       */
-      purposeCode?: string;
-      [k: string]: unknown;
+    extendedData: {
+        /**
+         * Label of the originating payer. Mandatory for inbound payment
+         */
+        payer?: string;
+        /**
+         * Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
+         */
+        payee?: string;
+        /**
+         * Optional extended data provided specific to transaction originated via NPP
+         */
+        extensionUType?: 'x2p101Payload';
+        x2p101Payload?: {
+            /**
+             * An extended string description. Only present if specified by the extensionUType field
+             */
+            extendedDescription: string;
+            /**
+             * An end to end ID for the payment created at initiation
+             */
+            endToEndId?: string;
+            /**
+             * Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+             */
+            purposeCode?: string;
+            [k: string]: unknown;
+        };
+        /**
+         * Identifier of the applicable overlay service. Valid values are: X2P1.01
+         */
+        service: 'X2P1.01';
+        [k: string]: unknown;
     };
-    /**
-     * Identifier of the applicable overlay service. Valid values are: X2P1.01
-     */
-    service: "X2P1.01";
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
@@ -3833,107 +3847,6 @@ export interface BankingTransactionDetail extends BankingTransaction {
  * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
  */
 export interface CommonPAFAddress {
-  /**
-   * Building/Property name 1
-   */
-  buildingName1?: string | null;
-  /**
-   * Building/Property name 2
-   */
-  buildingName2?: string | null;
-  /**
-   * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-   */
-  dpid?: string | null;
-  /**
-   * Unit number (including suffix, if applicable)
-   */
-  flatUnitNumber?: string | null;
-  /**
-   * Type of flat or unit for the address
-   */
-  flatUnitType?: string | null;
-  /**
-   * Floor or level number (including alpha characters)
-   */
-  floorLevelNumber?: string | null;
-  /**
-   * Type of floor or level for the address
-   */
-  floorLevelType?: string | null;
-  /**
-   * Full name of locality
-   */
-  localityName: string;
-  /**
-   * Allotment number for the address
-   */
-  lotNumber?: string | null;
-  /**
-   * Postal delivery number if the address is a postal delivery type
-   */
-  postalDeliveryNumber?: number | null;
-  /**
-   * Postal delivery number prefix related to the postal delivery number
-   */
-  postalDeliveryNumberPrefix?: string | null;
-  /**
-   * Postal delivery number suffix related to the postal delivery number
-   */
-  postalDeliveryNumberSuffix?: string | null;
-  /**
-   * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-   */
-  postalDeliveryType?: string | null;
-  /**
-   * Postcode for the locality
-   */
-  postcode: string;
-  /**
-   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  /**
-   * The name of the street
-   */
-  streetName?: string | null;
-  /**
-   * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetSuffix?: string | null;
-  /**
-   * The street type. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetType?: string | null;
-  /**
-   * Thoroughfare number for a property (first number in a property ranged address)
-   */
-  thoroughfareNumber1?: number | null;
-  /**
-   * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-   */
-  thoroughfareNumber1Suffix?: string | null;
-  /**
-   * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-   */
-  thoroughfareNumber2?: number | null;
-  /**
-   * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-   */
-  thoroughfareNumber2Suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface CommonPhysicalAddress {
-  /**
-   * The type of address object present
-   */
-  addressUType: "paf" | "simple";
-  /**
-   * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-   */
-  paf?: {
     /**
      * Building/Property name 1
      */
@@ -4023,749 +3936,18 @@ export interface CommonPhysicalAddress {
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
-  };
-  simple?: {
-    /**
-     * First line of the standard address object
-     */
-    addressLine1: string;
-    /**
-     * Second line of the standard address object
-     */
-    addressLine2?: string | null;
-    /**
-     * Third line of the standard address object
-     */
-    addressLine3?: string | null;
-    /**
-     * Name of the city or locality
-     */
-    city: string;
-    /**
-     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-     */
-    country?: string | null;
-    /**
-     * Name of the individual or business formatted for inclusion in an address used for physical mail
-     */
-    mailingName?: string | null;
-    /**
-     * Mandatory for Australian addresses
-     */
-    postcode?: string | null;
-    /**
-     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-     */
-    state: string;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
-export interface CommonSimpleAddress {
-  /**
-   * First line of the standard address object
-   */
-  addressLine1: string;
-  /**
-   * Second line of the standard address object
-   */
-  addressLine2?: string | null;
-  /**
-   * Third line of the standard address object
-   */
-  addressLine3?: string | null;
-  /**
-   * Name of the city or locality
-   */
-  city: string;
-  /**
-   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-   */
-  country?: string | null;
-  /**
-   * Name of the individual or business formatted for inclusion in an address used for physical mail
-   */
-  mailingName?: string | null;
-  /**
-   * Mandatory for Australian addresses
-   */
-  postcode?: string | null;
-  /**
-   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface Links {
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface LinksPaginated {
-  /**
-   * URI to the first page of this set. Mandatory if this response is not the first page
-   */
-  first?: string | null;
-  /**
-   * URI to the last page of this set. Mandatory if this response is not the last page
-   */
-  last?: string | null;
-  /**
-   * URI to the next page of this set. Mandatory if this response is not the last page
-   */
-  next?: string | null;
-  /**
-   * URI to the previous page of this set. Mandatory if this response is not the first page
-   */
-  prev?: string | null;
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface Meta {
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-/**
- * Additional data for customised error codes
- */
-export interface MetaError {
-  /**
-   * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-   */
-  urn?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface MetaPaginated {
-  /**
-   * The total number of pages in the full set. See [pagination](#pagination).
-   */
-  totalPages: number;
-  /**
-   * The total number of records in the full set. See [pagination](#pagination).
-   */
-  totalRecords: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface RequestAccountIds {
-  data: {
-    accountIds: string[];
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface ResponseBankingAccountByIdV2 {
-  data: {
+export interface CommonPhysicalAddress {
     /**
-     * A unique ID of the account adhering to the standards for ID permanence
+     * The type of address object present
      */
-    accountId: string;
+    addressUType: 'paf' | 'simple';
     /**
-     * Date that the account was created (if known)
+     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
      */
-    creationDate?: string | null;
-    /**
-     * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-     */
-    displayName: string;
-    /**
-     * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-     */
-    isOwned?: boolean | null;
-    /**
-     * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-     */
-    maskedNumber: string;
-    /**
-     * A customer supplied nick name for the account
-     */
-    nickname?: string | null;
-    /**
-     * Open or closed status for the account. If not present then OPEN is assumed
-     */
-    openStatus?: ("CLOSED" | "OPEN") | null;
-    /**
-     * The category to which a product or account belongs. See [here](#product-categories) for more details
-     */
-    productCategory:
-      | "BUSINESS_LOANS"
-      | "CRED_AND_CHRG_CARDS"
-      | "LEASES"
-      | "MARGIN_LOANS"
-      | "OVERDRAFTS"
-      | "PERS_LOANS"
-      | "REGULATED_TRUST_ACCOUNTS"
-      | "RESIDENTIAL_MORTGAGES"
-      | "TERM_DEPOSITS"
-      | "TRADE_FINANCE"
-      | "TRANS_AND_SAVINGS_ACCOUNTS"
-      | "TRAVEL_CARDS";
-    /**
-     * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-     */
-    productName: string;
-    [k: string]: unknown;
-  } & {
-    /**
-     * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-     */
-    bsb?: string;
-    /**
-     * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
-     */
-    accountNumber?: string;
-    /**
-     * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
-     */
-    bundleName?: string;
-    /**
-     * The type of structure to present account specific fields.
-     */
-    specificAccountUType?: "creditCard" | "loan" | "termDeposit";
-    termDeposit?: {
-      /**
-       * The lodgement date of the original deposit
-       */
-      lodgementDate: string;
-      /**
-       * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
-       */
-      maturityAmount?: string | null;
-      /**
-       * If absent assumes AUD
-       */
-      maturityCurrency?: string | null;
-      /**
-       * Maturity date for the term deposit
-       */
-      maturityDate: string;
-      /**
-       * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
-       */
-      maturityInstructions: "HOLD_ON_MATURITY" | "PAID_OUT_AT_MATURITY" | "ROLLED_OVER";
-      [k: string]: unknown;
-    }[];
-    creditCard?: {
-      /**
-       * The minimum payment amount due for the next card payment
-       */
-      minPaymentAmount: string;
-      /**
-       * If absent assumes AUD
-       */
-      paymentCurrency?: string | null;
-      /**
-       * The amount due for the next card payment
-       */
-      paymentDueAmount: string;
-      /**
-       * Date that the next payment for the card is due
-       */
-      paymentDueDate: string;
-      [k: string]: unknown;
-    };
-    loan?: {
-      /**
-       * Date that the loan is due to be repaid in full
-       */
-      loanEndDate?: string | null;
-      /**
-       * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
-       */
-      maxRedraw?: string | null;
-      /**
-       * If absent assumes AUD
-       */
-      maxRedrawCurrency?: string | null;
-      /**
-       * Minimum amount of next instalment
-       */
-      minInstalmentAmount?: string | null;
-      /**
-       * If absent assumes AUD
-       */
-      minInstalmentCurrency?: string | null;
-      /**
-       * Minimum redraw amount
-       */
-      minRedraw?: string | null;
-      /**
-       * If absent assumes AUD
-       */
-      minRedrawCurrency?: string | null;
-      /**
-       * Next date that an instalment is required
-       */
-      nextInstalmentDate?: string | null;
-      /**
-       * Set to true if one or more offset accounts are configured for this loan account
-       */
-      offsetAccountEnabled?: boolean | null;
-      /**
-       * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
-       */
-      offsetAccountIds?: string[] | null;
-      /**
-       * Optional original loan value
-       */
-      originalLoanAmount?: string | null;
-      /**
-       * If absent assumes AUD
-       */
-      originalLoanCurrency?: string | null;
-      /**
-       * Optional original start date for the loan
-       */
-      originalStartDate?: string | null;
-      /**
-       * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      repaymentFrequency?: string | null;
-      /**
-       * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
-       */
-      repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-      [k: string]: unknown;
-    };
-    /**
-     * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
-     */
-    depositRate?: string;
-    /**
-     * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
-     */
-    lendingRate?: string;
-    /**
-     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-     */
-    depositRates?: {
-      /**
-       * Display text providing more information on the rate
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this rate
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      applicationFrequency?: string | null;
-      /**
-       * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      calculationFrequency?: string | null;
-      /**
-       * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
-       */
-      depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
-      /**
-       * The rate to be applied
-       */
-      rate: string;
-      /**
-       * Rate tiers applicable for this rate
-       */
-      tiers?:
-        | {
-            /**
-             * Display text providing more information on the rate tier.
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this rate tier
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Defines a condition for the applicability of a tiered rate
-             */
-            applicabilityConditions?: {
-              /**
-               * Display text providing more information on the condition
-               */
-              additionalInfo?: string | null;
-              /**
-               * Link to a web page with more information on this condition
-               */
-              additionalInfoUri?: string | null;
-              [k: string]: unknown;
-            };
-            /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-             */
-            maximumValue?: number | null;
-            /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-             */
-            minimumValue: number;
-            /**
-             * A display name for the tier
-             */
-            name: string;
-            /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-             */
-            rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-            /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-             */
-            unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-            [k: string]: unknown;
-          }[]
-        | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
-     */
-    lendingRates?: {
-      /**
-       * Display text providing more information on the rate.
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this rate
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      applicationFrequency?: string | null;
-      /**
-       * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      calculationFrequency?: string | null;
-      /**
-       * A comparison rate equivalent for this rate
-       */
-      comparisonRate?: string | null;
-      /**
-       * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
-       */
-      interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
-      /**
-       * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
-       */
-      lendingRateType:
-        | "BUNDLE_DISCOUNT_FIXED"
-        | "BUNDLE_DISCOUNT_VARIABLE"
-        | "CASH_ADVANCE"
-        | "DISCOUNT"
-        | "FIXED"
-        | "FLOATING"
-        | "INTRODUCTORY"
-        | "MARKET_LINKED"
-        | "PENALTY"
-        | "PURCHASE"
-        | "VARIABLE";
-      /**
-       * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
-       */
-      loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
-      /**
-       * The rate to be applied
-       */
-      rate: string;
-      /**
-       * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
-       */
-      repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-      /**
-       * Rate tiers applicable for this rate
-       */
-      tiers?:
-        | {
-            /**
-             * Display text providing more information on the rate tier.
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this rate tier
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Defines a condition for the applicability of a tiered rate
-             */
-            applicabilityConditions?: {
-              /**
-               * Display text providing more information on the condition
-               */
-              additionalInfo?: string | null;
-              /**
-               * Link to a web page with more information on this condition
-               */
-              additionalInfoUri?: string | null;
-              [k: string]: unknown;
-            };
-            /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-             */
-            maximumValue?: number | null;
-            /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-             */
-            minimumValue: number;
-            /**
-             * A display name for the tier
-             */
-            name: string;
-            /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-             */
-            rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-            /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-             */
-            unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-            [k: string]: unknown;
-          }[]
-        | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
-     */
-    features?: ({
-      /**
-       * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this feature
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The type of feature described
-       */
-      featureType:
-        | "ADDITIONAL_CARDS"
-        | "BALANCE_TRANSFERS"
-        | "BILL_PAYMENT"
-        | "BONUS_REWARDS"
-        | "CARD_ACCESS"
-        | "CASHBACK_OFFER"
-        | "COMPLEMENTARY_PRODUCT_DISCOUNTS"
-        | "DIGITAL_BANKING"
-        | "DIGITAL_WALLET"
-        | "DONATE_INTEREST"
-        | "EXTRA_REPAYMENTS"
-        | "FRAUD_PROTECTION"
-        | "FREE_TXNS"
-        | "FREE_TXNS_ALLOWANCE"
-        | "GUARANTOR"
-        | "INSURANCE"
-        | "INSTALMENT_PLAN"
-        | "INTEREST_FREE"
-        | "INTEREST_FREE_TRANSFERS"
-        | "LOYALTY_PROGRAM"
-        | "NOTIFICATIONS"
-        | "NPP_ENABLED"
-        | "NPP_PAYID"
-        | "OFFSET"
-        | "OTHER"
-        | "OVERDRAFT"
-        | "REDRAW"
-        | "RELATIONSHIP_MANAGEMENT"
-        | "UNLIMITED_TXNS";
-      [k: string]: unknown;
-    } & {
-      /**
-       * True if the feature is already activated and false if the feature is available for activation. Defaults to true if absent. (note this is an additional field appended to the feature object defined in the Product Reference payload)
-       */
-      isActivated?: boolean;
-      [k: string]: unknown;
-    })[];
-    /**
-     * Fees and charges applicable to the account based on the equivalent structure in Product Reference
-     */
-    fees?: {
-      /**
-       * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      accrualFrequency?: string | null;
-      /**
-       * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      accruedRate?: string | null;
-      /**
-       * Display text providing more information on the fee
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this fee
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      amount?: string | null;
-      /**
-       * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
-       */
-      balanceRate?: string | null;
-      /**
-       * The currency the fee will be charged in. Assumes AUD if absent
-       */
-      currency?: string | null;
-      /**
-       * An optional list of discounts to this fee that may be available
-       */
-      discounts?:
-        | {
-            /**
-             * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            accruedRate?: string | null;
-            /**
-             * Display text providing more information on the discount
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this discount
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-             */
-            additionalValue?: string | null;
-            /**
-             * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-             */
-            amount?: string | null;
-            /**
-             * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            balanceRate?: string | null;
-            /**
-             * Description of the discount
-             */
-            description: string;
-            /**
-             * The type of discount. See the next section for an overview of valid values and their meaning
-             */
-            discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-            /**
-             * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-             */
-            eligibility?:
-              | {
-                  /**
-                   * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                   */
-                  additionalInfo?: string | null;
-                  /**
-                   * Link to a web page with more information on this eligibility constraint
-                   */
-                  additionalInfoUri?: string | null;
-                  /**
-                   * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                   */
-                  additionalValue?: string | null;
-                  /**
-                   * The type of the specific eligibility constraint for a discount
-                   */
-                  discountEligibilityType:
-                    | "BUSINESS"
-                    | "EMPLOYMENT_STATUS"
-                    | "INTRODUCTORY"
-                    | "MAX_AGE"
-                    | "MIN_AGE"
-                    | "MIN_INCOME"
-                    | "MIN_TURNOVER"
-                    | "NATURAL_PERSON"
-                    | "OTHER"
-                    | "PENSION_RECIPIENT"
-                    | "RESIDENCY_STATUS"
-                    | "STAFF"
-                    | "STUDENT";
-                  [k: string]: unknown;
-                }[]
-              | null;
-            /**
-             * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            feeRate?: string | null;
-            /**
-             * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-             */
-            transactionRate?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * The type of fee
-       */
-      feeType:
-        | "DEPOSIT"
-        | "EVENT"
-        | "EXIT"
-        | "PAYMENT"
-        | "PERIODIC"
-        | "PURCHASE"
-        | "TRANSACTION"
-        | "UPFRONT"
-        | "VARIABLE"
-        | "WITHDRAWAL";
-      /**
-       * Name of the fee
-       */
-      name: string;
-      /**
-       * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      transactionRate?: string | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * The addresses for the account to be used for correspondence
-     */
-    addresses?: {
-      /**
-       * The type of address object present
-       */
-      addressUType: "paf" | "simple";
-      /**
-       * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-       */
-      paf?: {
+    paf?: {
         /**
          * Building/Property name 1
          */
@@ -4855,8 +4037,8 @@ export interface ResponseBankingAccountByIdV2 {
          */
         thoroughfareNumber2Suffix?: string | null;
         [k: string]: unknown;
-      };
-      simple?: {
+    };
+    simple?: {
         /**
          * First line of the standard address object
          */
@@ -4890,84 +4072,58 @@ export interface ResponseBankingAccountByIdV2 {
          */
         state: string;
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    }[];
+    };
     [k: string]: unknown;
-  };
-  links: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface CommonSimpleAddress {
+    /**
+     * First line of the standard address object
+     */
+    addressLine1: string;
+    /**
+     * Second line of the standard address object
+     */
+    addressLine2?: string | null;
+    /**
+     * Third line of the standard address object
+     */
+    addressLine3?: string | null;
+    /**
+     * Name of the city or locality
+     */
+    city: string;
+    /**
+     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+     */
+    country?: string | null;
+    /**
+     * Name of the individual or business formatted for inclusion in an address used for physical mail
+     */
+    mailingName?: string | null;
+    /**
+     * Mandatory for Australian addresses
+     */
+    postcode?: string | null;
+    /**
+     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+     */
+    state: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface Links {
     /**
      * Fully qualified link that generated the current response document
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
-export interface ResponseBankingAccountList {
-  data: {
-    /**
-     * The list of accounts returned. If the filter results in an empty set then this array may have no records
-     */
-    accounts: {
-      /**
-       * A unique ID of the account adhering to the standards for ID permanence
-       */
-      accountId: string;
-      /**
-       * Date that the account was created (if known)
-       */
-      creationDate?: string | null;
-      /**
-       * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-       */
-      displayName: string;
-      /**
-       * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-       */
-      isOwned?: boolean | null;
-      /**
-       * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-       */
-      maskedNumber: string;
-      /**
-       * A customer supplied nick name for the account
-       */
-      nickname?: string | null;
-      /**
-       * Open or closed status for the account. If not present then OPEN is assumed
-       */
-      openStatus?: ("CLOSED" | "OPEN") | null;
-      /**
-       * The category to which a product or account belongs. See [here](#product-categories) for more details
-       */
-      productCategory:
-        | "BUSINESS_LOANS"
-        | "CRED_AND_CHRG_CARDS"
-        | "LEASES"
-        | "MARGIN_LOANS"
-        | "OVERDRAFTS"
-        | "PERS_LOANS"
-        | "REGULATED_TRUST_ACCOUNTS"
-        | "RESIDENTIAL_MORTGAGES"
-        | "TERM_DEPOSITS"
-        | "TRADE_FINANCE"
-        | "TRANS_AND_SAVINGS_ACCOUNTS"
-        | "TRAVEL_CARDS";
-      /**
-       * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-       */
-      productName: string;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
+export interface LinksPaginated {
     /**
      * URI to the first page of this set. Mandatory if this response is not the first page
      */
@@ -4989,8 +4145,27 @@ export interface ResponseBankingAccountList {
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface Meta {
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+/**
+ * Additional data for customised error codes
+ */
+export interface MetaError {
+    /**
+     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+     */
+    urn?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface MetaPaginated {
     /**
      * The total number of pages in the full set. See [pagination](#pagination).
      */
@@ -5000,1615 +4175,1289 @@ export interface ResponseBankingAccountList {
      */
     totalRecords: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface RequestAccountIds {
+    data: {
+        accountIds: string[];
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingAccountByIdV2 {
+    data: {
+        /**
+         * A unique ID of the account adhering to the standards for ID permanence
+         */
+        accountId: string;
+        /**
+         * Date that the account was created (if known)
+         */
+        creationDate?: string | null;
+        /**
+         * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+         */
+        displayName: string;
+        /**
+         * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+         */
+        isOwned?: boolean | null;
+        /**
+         * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+         */
+        maskedNumber: string;
+        /**
+         * A customer supplied nick name for the account
+         */
+        nickname?: string | null;
+        /**
+         * Open or closed status for the account. If not present then OPEN is assumed
+         */
+        openStatus?: ('CLOSED' | 'OPEN') | null;
+        /**
+         * The category to which a product or account belongs. See [here](#product-categories) for more details
+         */
+        productCategory:
+            | 'BUSINESS_LOANS'
+            | 'CRED_AND_CHRG_CARDS'
+            | 'LEASES'
+            | 'MARGIN_LOANS'
+            | 'OVERDRAFTS'
+            | 'PERS_LOANS'
+            | 'REGULATED_TRUST_ACCOUNTS'
+            | 'RESIDENTIAL_MORTGAGES'
+            | 'TERM_DEPOSITS'
+            | 'TRADE_FINANCE'
+            | 'TRANS_AND_SAVINGS_ACCOUNTS'
+            | 'TRAVEL_CARDS';
+        /**
+         * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+         */
+        productName: string;
+        [k: string]: unknown;
+    } & {
+        /**
+         * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+         */
+        bsb?: string;
+        /**
+         * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+         */
+        accountNumber?: string;
+        /**
+         * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
+         */
+        bundleName?: string;
+        /**
+         * The type of structure to present account specific fields.
+         */
+        specificAccountUType?: 'creditCard' | 'loan' | 'termDeposit';
+        termDeposit?: {
+            /**
+             * The lodgement date of the original deposit
+             */
+            lodgementDate: string;
+            /**
+             * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+             */
+            maturityAmount?: string | null;
+            /**
+             * If absent assumes AUD
+             */
+            maturityCurrency?: string | null;
+            /**
+             * Maturity date for the term deposit
+             */
+            maturityDate: string;
+            /**
+             * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+             */
+            maturityInstructions: 'HOLD_ON_MATURITY' | 'PAID_OUT_AT_MATURITY' | 'ROLLED_OVER';
+            [k: string]: unknown;
+        }[];
+        creditCard?: {
+            /**
+             * The minimum payment amount due for the next card payment
+             */
+            minPaymentAmount: string;
+            /**
+             * If absent assumes AUD
+             */
+            paymentCurrency?: string | null;
+            /**
+             * The amount due for the next card payment
+             */
+            paymentDueAmount: string;
+            /**
+             * Date that the next payment for the card is due
+             */
+            paymentDueDate: string;
+            [k: string]: unknown;
+        };
+        loan?: {
+            /**
+             * Date that the loan is due to be repaid in full
+             */
+            loanEndDate?: string | null;
+            /**
+             * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+             */
+            maxRedraw?: string | null;
+            /**
+             * If absent assumes AUD
+             */
+            maxRedrawCurrency?: string | null;
+            /**
+             * Minimum amount of next instalment
+             */
+            minInstalmentAmount?: string | null;
+            /**
+             * If absent assumes AUD
+             */
+            minInstalmentCurrency?: string | null;
+            /**
+             * Minimum redraw amount
+             */
+            minRedraw?: string | null;
+            /**
+             * If absent assumes AUD
+             */
+            minRedrawCurrency?: string | null;
+            /**
+             * Next date that an instalment is required
+             */
+            nextInstalmentDate?: string | null;
+            /**
+             * Set to true if one or more offset accounts are configured for this loan account
+             */
+            offsetAccountEnabled?: boolean | null;
+            /**
+             * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
+             */
+            offsetAccountIds?: string[] | null;
+            /**
+             * Optional original loan value
+             */
+            originalLoanAmount?: string | null;
+            /**
+             * If absent assumes AUD
+             */
+            originalLoanCurrency?: string | null;
+            /**
+             * Optional original start date for the loan
+             */
+            originalStartDate?: string | null;
+            /**
+             * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            repaymentFrequency?: string | null;
+            /**
+             * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+             */
+            repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+            [k: string]: unknown;
+        };
+        /**
+         * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
+         */
+        depositRate?: string;
+        /**
+         * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+         */
+        lendingRate?: string;
+        /**
+         * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+         */
+        depositRates?: {
+            /**
+             * Display text providing more information on the rate
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            applicationFrequency?: string | null;
+            /**
+             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            calculationFrequency?: string | null;
+            /**
+             * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+             */
+            depositRateType:
+                | 'BONUS'
+                | 'BUNDLE_BONUS'
+                | 'FIXED'
+                | 'FLOATING'
+                | 'INTRODUCTORY'
+                | 'MARKET_LINKED'
+                | 'VARIABLE';
+            /**
+             * The rate to be applied
+             */
+            rate: string;
+            /**
+             * Rate tiers applicable for this rate
+             */
+            tiers?:
+                | {
+                    /**
+                     * Display text providing more information on the rate tier.
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this rate tier
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Defines a condition for the applicability of a tiered rate
+                     */
+                    applicabilityConditions?: {
+                        /**
+                         * Display text providing more information on the condition
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this condition
+                         */
+                        additionalInfoUri?: string | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                     */
+                    maximumValue?: number | null;
+                    /**
+                     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                     */
+                    minimumValue: number;
+                    /**
+                     * A display name for the tier
+                     */
+                    name: string;
+                    /**
+                     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                     */
+                    rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                    /**
+                     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                     */
+                    unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+         */
+        lendingRates?: {
+            /**
+             * Display text providing more information on the rate.
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            applicationFrequency?: string | null;
+            /**
+             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            calculationFrequency?: string | null;
+            /**
+             * A comparison rate equivalent for this rate
+             */
+            comparisonRate?: string | null;
+            /**
+             * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+             */
+            interestPaymentDue?: ('IN_ADVANCE' | 'IN_ARREARS') | null;
+            /**
+             * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+             */
+            lendingRateType:
+                | 'BUNDLE_DISCOUNT_FIXED'
+                | 'BUNDLE_DISCOUNT_VARIABLE'
+                | 'CASH_ADVANCE'
+                | 'DISCOUNT'
+                | 'FIXED'
+                | 'FLOATING'
+                | 'INTRODUCTORY'
+                | 'MARKET_LINKED'
+                | 'PENALTY'
+                | 'PURCHASE'
+                | 'VARIABLE';
+            /**
+             * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+             */
+            loanPurpose?: ('INVESTMENT' | 'OWNER_OCCUPIED') | null;
+            /**
+             * The rate to be applied
+             */
+            rate: string;
+            /**
+             * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+             */
+            repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+            /**
+             * Rate tiers applicable for this rate
+             */
+            tiers?:
+                | {
+                    /**
+                     * Display text providing more information on the rate tier.
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this rate tier
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Defines a condition for the applicability of a tiered rate
+                     */
+                    applicabilityConditions?: {
+                        /**
+                         * Display text providing more information on the condition
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this condition
+                         */
+                        additionalInfoUri?: string | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                     */
+                    maximumValue?: number | null;
+                    /**
+                     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                     */
+                    minimumValue: number;
+                    /**
+                     * A display name for the tier
+                     */
+                    name: string;
+                    /**
+                     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                     */
+                    rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                    /**
+                     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                     */
+                    unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+         */
+        features?: ({
+            /**
+             * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this feature
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The type of feature described
+             */
+            featureType:
+                | 'ADDITIONAL_CARDS'
+                | 'BALANCE_TRANSFERS'
+                | 'BILL_PAYMENT'
+                | 'BONUS_REWARDS'
+                | 'CARD_ACCESS'
+                | 'CASHBACK_OFFER'
+                | 'COMPLEMENTARY_PRODUCT_DISCOUNTS'
+                | 'DIGITAL_BANKING'
+                | 'DIGITAL_WALLET'
+                | 'DONATE_INTEREST'
+                | 'EXTRA_REPAYMENTS'
+                | 'FRAUD_PROTECTION'
+                | 'FREE_TXNS'
+                | 'FREE_TXNS_ALLOWANCE'
+                | 'GUARANTOR'
+                | 'INSURANCE'
+                | 'INSTALMENT_PLAN'
+                | 'INTEREST_FREE'
+                | 'INTEREST_FREE_TRANSFERS'
+                | 'LOYALTY_PROGRAM'
+                | 'NOTIFICATIONS'
+                | 'NPP_ENABLED'
+                | 'NPP_PAYID'
+                | 'OFFSET'
+                | 'OTHER'
+                | 'OVERDRAFT'
+                | 'REDRAW'
+                | 'RELATIONSHIP_MANAGEMENT'
+                | 'UNLIMITED_TXNS';
+            [k: string]: unknown;
+        } & {
+            /**
+             * True if the feature is already activated and false if the feature is available for activation. Defaults to true if absent. (note this is an additional field appended to the feature object defined in the Product Reference payload)
+             */
+            isActivated?: boolean;
+            [k: string]: unknown;
+        })[];
+        /**
+         * Fees and charges applicable to the account based on the equivalent structure in Product Reference
+         */
+        fees?: {
+            /**
+             * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            accrualFrequency?: string | null;
+            /**
+             * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            accruedRate?: string | null;
+            /**
+             * Display text providing more information on the fee
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this fee
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            amount?: string | null;
+            /**
+             * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+             */
+            balanceRate?: string | null;
+            /**
+             * The currency the fee will be charged in. Assumes AUD if absent
+             */
+            currency?: string | null;
+            /**
+             * An optional list of discounts to this fee that may be available
+             */
+            discounts?:
+                | {
+                    /**
+                     * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    accruedRate?: string | null;
+                    /**
+                     * Display text providing more information on the discount
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this discount
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+                     */
+                    additionalValue?: string | null;
+                    /**
+                     * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+                     */
+                    amount?: string | null;
+                    /**
+                     * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    balanceRate?: string | null;
+                    /**
+                     * Description of the discount
+                     */
+                    description: string;
+                    /**
+                     * The type of discount. See the next section for an overview of valid values and their meaning
+                     */
+                    discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+                    /**
+                     * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+                     */
+                    eligibility?:
+                        | {
+                            /**
+                             * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                             */
+                            additionalInfo?: string | null;
+                            /**
+                             * Link to a web page with more information on this eligibility constraint
+                             */
+                            additionalInfoUri?: string | null;
+                            /**
+                             * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                             */
+                            additionalValue?: string | null;
+                            /**
+                             * The type of the specific eligibility constraint for a discount
+                             */
+                            discountEligibilityType:
+                                | 'BUSINESS'
+                                | 'EMPLOYMENT_STATUS'
+                                | 'INTRODUCTORY'
+                                | 'MAX_AGE'
+                                | 'MIN_AGE'
+                                | 'MIN_INCOME'
+                                | 'MIN_TURNOVER'
+                                | 'NATURAL_PERSON'
+                                | 'OTHER'
+                                | 'PENSION_RECIPIENT'
+                                | 'RESIDENCY_STATUS'
+                                | 'STAFF'
+                                | 'STUDENT';
+                            [k: string]: unknown;
+                        }[]
+                        | null;
+                    /**
+                     * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    feeRate?: string | null;
+                    /**
+                     * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+                     */
+                    transactionRate?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The type of fee
+             */
+            feeType:
+                | 'DEPOSIT'
+                | 'EVENT'
+                | 'EXIT'
+                | 'PAYMENT'
+                | 'PERIODIC'
+                | 'PURCHASE'
+                | 'TRANSACTION'
+                | 'UPFRONT'
+                | 'VARIABLE'
+                | 'WITHDRAWAL';
+            /**
+             * Name of the fee
+             */
+            name: string;
+            /**
+             * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            transactionRate?: string | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The addresses for the account to be used for correspondence
+         */
+        addresses?: {
+            /**
+             * The type of address object present
+             */
+            addressUType: 'paf' | 'simple';
+            /**
+             * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+             */
+            paf?: {
+                /**
+                 * Building/Property name 1
+                 */
+                buildingName1?: string | null;
+                /**
+                 * Building/Property name 2
+                 */
+                buildingName2?: string | null;
+                /**
+                 * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+                 */
+                dpid?: string | null;
+                /**
+                 * Unit number (including suffix, if applicable)
+                 */
+                flatUnitNumber?: string | null;
+                /**
+                 * Type of flat or unit for the address
+                 */
+                flatUnitType?: string | null;
+                /**
+                 * Floor or level number (including alpha characters)
+                 */
+                floorLevelNumber?: string | null;
+                /**
+                 * Type of floor or level for the address
+                 */
+                floorLevelType?: string | null;
+                /**
+                 * Full name of locality
+                 */
+                localityName: string;
+                /**
+                 * Allotment number for the address
+                 */
+                lotNumber?: string | null;
+                /**
+                 * Postal delivery number if the address is a postal delivery type
+                 */
+                postalDeliveryNumber?: number | null;
+                /**
+                 * Postal delivery number prefix related to the postal delivery number
+                 */
+                postalDeliveryNumberPrefix?: string | null;
+                /**
+                 * Postal delivery number suffix related to the postal delivery number
+                 */
+                postalDeliveryNumberSuffix?: string | null;
+                /**
+                 * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+                 */
+                postalDeliveryType?: string | null;
+                /**
+                 * Postcode for the locality
+                 */
+                postcode: string;
+                /**
+                 * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                 */
+                state: string;
+                /**
+                 * The name of the street
+                 */
+                streetName?: string | null;
+                /**
+                 * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+                 */
+                streetSuffix?: string | null;
+                /**
+                 * The street type. Valid enumeration defined by Australia Post PAF code file
+                 */
+                streetType?: string | null;
+                /**
+                 * Thoroughfare number for a property (first number in a property ranged address)
+                 */
+                thoroughfareNumber1?: number | null;
+                /**
+                 * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+                 */
+                thoroughfareNumber1Suffix?: string | null;
+                /**
+                 * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+                 */
+                thoroughfareNumber2?: number | null;
+                /**
+                 * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+                 */
+                thoroughfareNumber2Suffix?: string | null;
+                [k: string]: unknown;
+            };
+            simple?: {
+                /**
+                 * First line of the standard address object
+                 */
+                addressLine1: string;
+                /**
+                 * Second line of the standard address object
+                 */
+                addressLine2?: string | null;
+                /**
+                 * Third line of the standard address object
+                 */
+                addressLine3?: string | null;
+                /**
+                 * Name of the city or locality
+                 */
+                city: string;
+                /**
+                 * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+                 */
+                country?: string | null;
+                /**
+                 * Name of the individual or business formatted for inclusion in an address used for physical mail
+                 */
+                mailingName?: string | null;
+                /**
+                 * Mandatory for Australian addresses
+                 */
+                postcode?: string | null;
+                /**
+                 * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                 */
+                state: string;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingAccountList {
+    data: {
+        /**
+         * The list of accounts returned. If the filter results in an empty set then this array may have no records
+         */
+        accounts: {
+            /**
+             * A unique ID of the account adhering to the standards for ID permanence
+             */
+            accountId: string;
+            /**
+             * Date that the account was created (if known)
+             */
+            creationDate?: string | null;
+            /**
+             * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+             */
+            displayName: string;
+            /**
+             * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+             */
+            isOwned?: boolean | null;
+            /**
+             * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+             */
+            maskedNumber: string;
+            /**
+             * A customer supplied nick name for the account
+             */
+            nickname?: string | null;
+            /**
+             * Open or closed status for the account. If not present then OPEN is assumed
+             */
+            openStatus?: ('CLOSED' | 'OPEN') | null;
+            /**
+             * The category to which a product or account belongs. See [here](#product-categories) for more details
+             */
+            productCategory:
+                | 'BUSINESS_LOANS'
+                | 'CRED_AND_CHRG_CARDS'
+                | 'LEASES'
+                | 'MARGIN_LOANS'
+                | 'OVERDRAFTS'
+                | 'PERS_LOANS'
+                | 'REGULATED_TRUST_ACCOUNTS'
+                | 'RESIDENTIAL_MORTGAGES'
+                | 'TERM_DEPOSITS'
+                | 'TRADE_FINANCE'
+                | 'TRANS_AND_SAVINGS_ACCOUNTS'
+                | 'TRAVEL_CARDS';
+            /**
+             * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+             */
+            productName: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingAccountByIdV3 {
-  data: {
-    /**
-     * A unique ID of the account adhering to the standards for ID permanence
-     */
-    accountId: string;
-    /**
-     * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
-     */
-    accountOwnership: "UNKNOWN" | "ONE_PARTY" | "TWO_PARTY" | "MANY_PARTY" | "OTHER";
-    /**
-     * Date that the account was created (if known)
-     */
-    creationDate?: string | null;
-    /**
-     * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-     */
-    displayName: string;
-    /**
-     * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-     */
-    isOwned?: boolean | null;
-    /**
-     * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-     */
-    maskedNumber: string;
-    /**
-     * A customer supplied nick name for the account
-     */
-    nickname?: string | null;
-    /**
-     * Open or closed status for the account. If not present then OPEN is assumed
-     */
-    openStatus?: ("CLOSED" | "OPEN") | null;
-    /**
-     * The category to which a product or account belongs. See [here](#product-categories) for more details
-     */
-    productCategory:
-      | "BUSINESS_LOANS"
-      | "CRED_AND_CHRG_CARDS"
-      | "LEASES"
-      | "MARGIN_LOANS"
-      | "OVERDRAFTS"
-      | "PERS_LOANS"
-      | "REGULATED_TRUST_ACCOUNTS"
-      | "RESIDENTIAL_MORTGAGES"
-      | "TERM_DEPOSITS"
-      | "TRADE_FINANCE"
-      | "TRANS_AND_SAVINGS_ACCOUNTS"
-      | "TRAVEL_CARDS";
-    /**
-     * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-     */
-    productName: string;
+    data: {
+        /**
+         * A unique ID of the account adhering to the standards for ID permanence
+         */
+        accountId: string;
+        /**
+         * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+         */
+        accountOwnership: 'UNKNOWN' | 'ONE_PARTY' | 'TWO_PARTY' | 'MANY_PARTY' | 'OTHER';
+        /**
+         * Date that the account was created (if known)
+         */
+        creationDate?: string | null;
+        /**
+         * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+         */
+        displayName: string;
+        /**
+         * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+         */
+        isOwned?: boolean | null;
+        /**
+         * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+         */
+        maskedNumber: string;
+        /**
+         * A customer supplied nick name for the account
+         */
+        nickname?: string | null;
+        /**
+         * Open or closed status for the account. If not present then OPEN is assumed
+         */
+        openStatus?: ('CLOSED' | 'OPEN') | null;
+        /**
+         * The category to which a product or account belongs. See [here](#product-categories) for more details
+         */
+        productCategory:
+            | 'BUSINESS_LOANS'
+            | 'CRED_AND_CHRG_CARDS'
+            | 'LEASES'
+            | 'MARGIN_LOANS'
+            | 'OVERDRAFTS'
+            | 'PERS_LOANS'
+            | 'REGULATED_TRUST_ACCOUNTS'
+            | 'RESIDENTIAL_MORTGAGES'
+            | 'TERM_DEPOSITS'
+            | 'TRADE_FINANCE'
+            | 'TRANS_AND_SAVINGS_ACCOUNTS'
+            | 'TRAVEL_CARDS';
+        /**
+         * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+         */
+        productName: string;
+        [k: string]: unknown;
+    } & {
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  } & {
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingAccountListV2 {
-  data: {
-    /**
-     * The list of accounts returned. If the filter results in an empty set then this array may have no records
-     */
-    accounts: {
-      /**
-       * A unique ID of the account adhering to the standards for ID permanence
-       */
-      accountId: string;
-      /**
-       * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
-       */
-      accountOwnership: "UNKNOWN" | "ONE_PARTY" | "TWO_PARTY" | "MANY_PARTY" | "OTHER";
-      /**
-       * Date that the account was created (if known)
-       */
-      creationDate?: string | null;
-      /**
-       * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
-       */
-      displayName: string;
-      /**
-       * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
-       */
-      isOwned?: boolean | null;
-      /**
-       * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
-       */
-      maskedNumber: string;
-      /**
-       * A customer supplied nick name for the account
-       */
-      nickname?: string | null;
-      /**
-       * Open or closed status for the account. If not present then OPEN is assumed
-       */
-      openStatus?: ("CLOSED" | "OPEN") | null;
-      /**
-       * The category to which a product or account belongs. See [here](#product-categories) for more details
-       */
-      productCategory:
-        | "BUSINESS_LOANS"
-        | "CRED_AND_CHRG_CARDS"
-        | "LEASES"
-        | "MARGIN_LOANS"
-        | "OVERDRAFTS"
-        | "PERS_LOANS"
-        | "REGULATED_TRUST_ACCOUNTS"
-        | "RESIDENTIAL_MORTGAGES"
-        | "TERM_DEPOSITS"
-        | "TRADE_FINANCE"
-        | "TRANS_AND_SAVINGS_ACCOUNTS"
-        | "TRAVEL_CARDS";
-      /**
-       * The unique identifier of the account as defined by the data holder (akin to model number for the account)
-       */
-      productName: string;
-      [k: string]: unknown;
-    }[];
+    data: {
+        /**
+         * The list of accounts returned. If the filter results in an empty set then this array may have no records
+         */
+        accounts: {
+            /**
+             * A unique ID of the account adhering to the standards for ID permanence
+             */
+            accountId: string;
+            /**
+             * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+             */
+            accountOwnership: 'UNKNOWN' | 'ONE_PARTY' | 'TWO_PARTY' | 'MANY_PARTY' | 'OTHER';
+            /**
+             * Date that the account was created (if known)
+             */
+            creationDate?: string | null;
+            /**
+             * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+             */
+            displayName: string;
+            /**
+             * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+             */
+            isOwned?: boolean | null;
+            /**
+             * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+             */
+            maskedNumber: string;
+            /**
+             * A customer supplied nick name for the account
+             */
+            nickname?: string | null;
+            /**
+             * Open or closed status for the account. If not present then OPEN is assumed
+             */
+            openStatus?: ('CLOSED' | 'OPEN') | null;
+            /**
+             * The category to which a product or account belongs. See [here](#product-categories) for more details
+             */
+            productCategory:
+                | 'BUSINESS_LOANS'
+                | 'CRED_AND_CHRG_CARDS'
+                | 'LEASES'
+                | 'MARGIN_LOANS'
+                | 'OVERDRAFTS'
+                | 'PERS_LOANS'
+                | 'REGULATED_TRUST_ACCOUNTS'
+                | 'RESIDENTIAL_MORTGAGES'
+                | 'TERM_DEPOSITS'
+                | 'TRADE_FINANCE'
+                | 'TRANS_AND_SAVINGS_ACCOUNTS'
+                | 'TRAVEL_CARDS';
+            /**
+             * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+             */
+            productName: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingAccountsBalanceById {
-  data: {
-    /**
-     * A unique ID of the account adhering to the standards for ID permanence
-     */
-    accountId: string;
-    /**
-     * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
-     */
-    amortisedLimit?: string | null;
-    /**
-     * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
-     */
-    availableBalance: string;
-    /**
-     * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
-     */
-    creditLimit?: string | null;
-    /**
-     * The currency for the balance amounts. If absent assumed to be AUD
-     */
-    currency?: string | null;
-    /**
-     * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
-     */
-    currentBalance: string;
-    /**
-     * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
-     */
-    purses?:
-      | {
-          /**
-           * The balance available for this additional currency purse
-           */
-          amount: string;
-          /**
-           * The currency for the purse
-           */
-          currency?: string | null;
-          [k: string]: unknown;
-        }[]
-      | null;
+    data: {
+        /**
+         * A unique ID of the account adhering to the standards for ID permanence
+         */
+        accountId: string;
+        /**
+         * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+         */
+        amortisedLimit?: string | null;
+        /**
+         * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+         */
+        availableBalance: string;
+        /**
+         * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+         */
+        creditLimit?: string | null;
+        /**
+         * The currency for the balance amounts. If absent assumed to be AUD
+         */
+        currency?: string | null;
+        /**
+         * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+         */
+        currentBalance: string;
+        /**
+         * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+         */
+        purses?:
+            | {
+                /**
+                 * The balance available for this additional currency purse
+                 */
+                amount: string;
+                /**
+                 * The currency for the purse
+                 */
+                currency?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingAccountsBalanceList {
-  data: {
-    /**
-     * The list of balances returned
-     */
-    balances: {
-      /**
-       * A unique ID of the account adhering to the standards for ID permanence
-       */
-      accountId: string;
-      /**
-       * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
-       */
-      amortisedLimit?: string | null;
-      /**
-       * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
-       */
-      availableBalance: string;
-      /**
-       * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
-       */
-      creditLimit?: string | null;
-      /**
-       * The currency for the balance amounts. If absent assumed to be AUD
-       */
-      currency?: string | null;
-      /**
-       * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
-       */
-      currentBalance: string;
-      /**
-       * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
-       */
-      purses?:
-        | {
+    data: {
+        /**
+         * The list of balances returned
+         */
+        balances: {
             /**
-             * The balance available for this additional currency purse
+             * A unique ID of the account adhering to the standards for ID permanence
              */
-            amount: string;
+            accountId: string;
             /**
-             * The currency for the purse
+             * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+             */
+            amortisedLimit?: string | null;
+            /**
+             * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+             */
+            availableBalance: string;
+            /**
+             * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+             */
+            creditLimit?: string | null;
+            /**
+             * The currency for the balance amounts. If absent assumed to be AUD
              */
             currency?: string | null;
+            /**
+             * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+             */
+            currentBalance: string;
+            /**
+             * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+             */
+            purses?:
+                | {
+                    /**
+                     * The balance available for this additional currency purse
+                     */
+                    amount: string;
+                    /**
+                     * The currency for the purse
+                     */
+                    currency?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
             [k: string]: unknown;
-          }[]
-        | null;
-      [k: string]: unknown;
-    }[];
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingDirectDebitAuthorisationList {
-  data: {
-    /**
-     * The list of authorisations returned
-     */
-    directDebitAuthorisations: {
-      /**
-       * A unique ID of the account adhering to the standards for ID permanence.
-       */
-      accountId: string;
-      authorisedEntity: {
+    data: {
         /**
-         * Australian Business Number for the authorised entity
+         * The list of authorisations returned
          */
-        abn?: string | null;
-        /**
-         * Australian Company Number for the authorised entity
-         */
-        acn?: string | null;
-        /**
-         * Australian Registered Body Number for the authorised entity
-         */
-        arbn?: string | null;
-        /**
-         * Description of the authorised entity derived from previously executed direct debits
-         */
-        description?: string | null;
-        /**
-         * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
-         */
-        financialInstitution?: string | null;
+        directDebitAuthorisations: {
+            /**
+             * A unique ID of the account adhering to the standards for ID permanence.
+             */
+            accountId: string;
+            authorisedEntity: {
+                /**
+                 * Australian Business Number for the authorised entity
+                 */
+                abn?: string | null;
+                /**
+                 * Australian Company Number for the authorised entity
+                 */
+                acn?: string | null;
+                /**
+                 * Australian Registered Body Number for the authorised entity
+                 */
+                arbn?: string | null;
+                /**
+                 * Description of the authorised entity derived from previously executed direct debits
+                 */
+                description?: string | null;
+                /**
+                 * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+                 */
+                financialInstitution?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The amount of the last debit executed under this authorisation
+             */
+            lastDebitAmount?: string | null;
+            /**
+             * The date and time of the last debit executed under this authorisation
+             */
+            lastDebitDateTime?: string | null;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
-      };
-      /**
-       * The amount of the last debit executed under this authorisation
-       */
-      lastDebitAmount?: string | null;
-      /**
-       * The date and time of the last debit executed under this authorisation
-       */
-      lastDebitDateTime?: string | null;
-      [k: string]: unknown;
-    }[];
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingPayeeByIdV2 {
-  data: {
-    /**
-     * The date the payee was created by the customer
-     */
-    creationDate?: string | null;
-    /**
-     * A description of the payee provided by the customer
-     */
-    description?: string | null;
-    /**
-     * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
-     */
-    nickname: string;
-    /**
-     * ID of the payee adhering to the rules of ID permanence
-     */
-    payeeId: string;
-    /**
-     * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
-     */
-    type: "BILLER" | "DIGITAL_WALLET" | "DOMESTIC" | "INTERNATIONAL";
-    [k: string]: unknown;
-  } & {
-    /**
-     * Type of object included that describes the payee in detail
-     */
-    payeeUType: "biller" | "digitalWallet" | "domestic" | "international";
-    biller?: {
-      /**
-       * BPAY Biller Code of the Biller
-       */
-      billerCode: string;
-      /**
-       * Name of the Biller
-       */
-      billerName: string;
-      /**
-       * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-       */
-      crn?: string | null;
-      [k: string]: unknown;
-    };
-    domestic?: {
-      account?: {
+    data: {
         /**
-         * Name of the account to pay to
+         * The date the payee was created by the customer
          */
-        accountName?: string | null;
+        creationDate?: string | null;
         /**
-         * Number of the account to pay to
+         * A description of the payee provided by the customer
          */
-        accountNumber: string;
+        description?: string | null;
         /**
-         * BSB of the account to pay to
+         * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
          */
-        bsb: string;
+        nickname: string;
+        /**
+         * ID of the payee adhering to the rules of ID permanence
+         */
+        payeeId: string;
+        /**
+         * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
+         */
+        type: 'BILLER' | 'DIGITAL_WALLET' | 'DOMESTIC' | 'INTERNATIONAL';
         [k: string]: unknown;
-      };
-      card?: {
+    } & {
         /**
-         * Name of the account to pay to
+         * Type of object included that describes the payee in detail
          */
-        cardNumber: string;
-        [k: string]: unknown;
-      };
-      payId?: {
-        /**
-         * The identifier of the PayID (dependent on type)
-         */
-        identifier: string;
-        /**
-         * The name assigned to the PayID by the owner of the PayID
-         */
-        name?: string | null;
-        /**
-         * The type of the PayID
-         */
-        type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-        [k: string]: unknown;
-      };
-      /**
-       * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
-       */
-      payeeAccountUType: "account" | "card" | "payId";
-      [k: string]: unknown;
-    };
-    digitalWallet?: {
-      /**
-       * The identifier of the digital wallet (dependent on type)
-       */
-      identifier: string;
-      /**
-       * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-       */
-      name: string;
-      /**
-       * The provider of the digital wallet
-       */
-      provider: "PAYPAL_AU" | "OTHER";
-      /**
-       * The type of the digital wallet identifier
-       */
-      type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-      [k: string]: unknown;
-    };
-    international?: {
-      bankDetails: {
-        /**
-         * Account Targeted for payment
-         */
-        accountNumber: string;
-        bankAddress?: {
-          /**
-           * Address of the recipient Bank
-           */
-          address: string;
-          /**
-           * Name of the recipient Bank
-           */
-          name: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-         */
-        beneficiaryBankBIC?: string | null;
-        /**
-         * Number for the Clearing House Interbank Payments System
-         */
-        chipNumber?: string | null;
-        /**
-         * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-         */
-        country: string;
-        /**
-         * Number for Fedwire payment (Federal Reserve Wire Network)
-         */
-        fedWireNumber?: string | null;
-        /**
-         * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-         */
-        legalEntityIdentifier?: string | null;
-        /**
-         * International bank routing number
-         */
-        routingNumber?: string | null;
-        /**
-         * Sort code used for account identification in some jurisdictions
-         */
-        sortCode?: string | null;
-        [k: string]: unknown;
-      };
-      beneficiaryDetails: {
-        /**
-         * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-         */
-        country: string;
-        /**
-         * Response message for the payment
-         */
-        message?: string | null;
-        /**
-         * Name of the beneficiary
-         */
-        name?: string | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface ResponseBankingPayeeListV2 {
-  data: {
-    /**
-     * The list of payees returned
-     */
-    payees: {
-      /**
-       * The date the payee was created by the customer
-       */
-      creationDate?: string | null;
-      /**
-       * A description of the payee provided by the customer
-       */
-      description?: string | null;
-      /**
-       * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
-       */
-      nickname: string;
-      /**
-       * ID of the payee adhering to the rules of ID permanence
-       */
-      payeeId: string;
-      /**
-       * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
-       */
-      type: "BILLER" | "DIGITAL_WALLET" | "DOMESTIC" | "INTERNATIONAL";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface ResponseBankingProductByIdV4 {
-  data: {
-    /**
-     * Object that contains links to additional information on specific topics
-     */
-    additionalInformation?: {
-      /**
-       * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
-       */
-      additionalBundleUris?:
-        | {
-            /**
-             * The URI describing the additional information
-             */
-            additionalInfoUri: string;
-            /**
-             * Display text providing more information about the document URI
-             */
-            description?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
-       */
-      additionalEligibilityUris?:
-        | {
-            /**
-             * The URI describing the additional information
-             */
-            additionalInfoUri: string;
-            /**
-             * Display text providing more information about the document URI
-             */
-            description?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
-       */
-      additionalFeesAndPricingUris?:
-        | {
-            /**
-             * The URI describing the additional information
-             */
-            additionalInfoUri: string;
-            /**
-             * Display text providing more information about the document URI
-             */
-            description?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
-       */
-      additionalOverviewUris?:
-        | {
-            /**
-             * The URI describing the additional information
-             */
-            additionalInfoUri: string;
-            /**
-             * Display text providing more information about the document URI
-             */
-            description?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
-       */
-      additionalTermsUris?:
-        | {
-            /**
-             * The URI describing the additional information
-             */
-            additionalInfoUri: string;
-            /**
-             * Display text providing more information about the document URI
-             */
-            description?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
-       */
-      bundleUri?: string | null;
-      /**
-       * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
-       */
-      eligibilityUri?: string | null;
-      /**
-       * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
-       */
-      feesAndPricingUri?: string | null;
-      /**
-       * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
-       */
-      overviewUri?: string | null;
-      /**
-       * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
-       */
-      termsUri?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A link to an application web page where this product can be applied for.
-     */
-    applicationUri?: string | null;
-    /**
-     * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
-     */
-    brand: string;
-    /**
-     * An optional display name of the brand
-     */
-    brandName?: string | null;
-    /**
-     * An array of card art images
-     */
-    cardArt?:
-      | {
-          /**
-           * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
-           */
-          imageUri: string;
-          /**
-           * Display label for the specific image
-           */
-          title?: string;
-          [k: string]: unknown;
-        }[]
-      | null;
-    /**
-     * A description of the product
-     */
-    description: string;
-    /**
-     * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
-     */
-    effectiveFrom?: string | null;
-    /**
-     * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
-     */
-    effectiveTo?: string | null;
-    /**
-     * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
-     */
-    isTailored: boolean;
-    /**
-     * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
-     */
-    lastUpdated: string;
-    /**
-     * The display name of the product
-     */
-    name: string;
-    /**
-     * The category to which a product or account belongs. See [here](#product-categories) for more details
-     */
-    productCategory:
-      | "BUSINESS_LOANS"
-      | "CRED_AND_CHRG_CARDS"
-      | "LEASES"
-      | "MARGIN_LOANS"
-      | "OVERDRAFTS"
-      | "PERS_LOANS"
-      | "REGULATED_TRUST_ACCOUNTS"
-      | "RESIDENTIAL_MORTGAGES"
-      | "TERM_DEPOSITS"
-      | "TRADE_FINANCE"
-      | "TRANS_AND_SAVINGS_ACCOUNTS"
-      | "TRAVEL_CARDS";
-    /**
-     * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
-     */
-    productId: string;
-    [k: string]: unknown;
-  } & {
-    /**
-     * An array of bundles that this product participates in.  Each bundle is described by free form information but also by a list of product IDs of the other products that are included in the bundle.  It is assumed that the current product is included in the bundle also
-     */
-    bundles?: {
-      /**
-       * Display text providing more information on the bundle
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on the bundle criteria and benefits
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Description of the bundle
-       */
-      description: string;
-      /**
-       * Name of the bundle
-       */
-      name: string;
-      /**
-       * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
-       */
-      productIds?: string[] | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Array of features available for the product
-     */
-    features?: {
-      /**
-       * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this feature
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The type of feature described
-       */
-      featureType:
-        | "ADDITIONAL_CARDS"
-        | "BALANCE_TRANSFERS"
-        | "BILL_PAYMENT"
-        | "BONUS_REWARDS"
-        | "CARD_ACCESS"
-        | "CASHBACK_OFFER"
-        | "COMPLEMENTARY_PRODUCT_DISCOUNTS"
-        | "DIGITAL_BANKING"
-        | "DIGITAL_WALLET"
-        | "DONATE_INTEREST"
-        | "EXTRA_REPAYMENTS"
-        | "FRAUD_PROTECTION"
-        | "FREE_TXNS"
-        | "FREE_TXNS_ALLOWANCE"
-        | "GUARANTOR"
-        | "INSURANCE"
-        | "INSTALMENT_PLAN"
-        | "INTEREST_FREE"
-        | "INTEREST_FREE_TRANSFERS"
-        | "LOYALTY_PROGRAM"
-        | "NOTIFICATIONS"
-        | "NPP_ENABLED"
-        | "NPP_PAYID"
-        | "OFFSET"
-        | "OTHER"
-        | "OVERDRAFT"
-        | "REDRAW"
-        | "RELATIONSHIP_MANAGEMENT"
-        | "UNLIMITED_TXNS";
-      [k: string]: unknown;
-    }[];
-    /**
-     * Constraints on the application for or operation of the product such as minimum balances or limit thresholds
-     */
-    constraints?: {
-      /**
-       * Display text providing more information the constraint
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on the constraint
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The type of constraint described.  See the next section for an overview of valid values and their meaning
-       */
-      constraintType: "MAX_BALANCE" | "MAX_LIMIT" | "MIN_BALANCE" | "MIN_LIMIT" | "OPENING_BALANCE";
-      [k: string]: unknown;
-    }[];
-    /**
-     * Eligibility criteria for the product
-     */
-    eligibility?: {
-      /**
-       * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this eligibility criteria
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
-       */
-      eligibilityType:
-        | "BUSINESS"
-        | "EMPLOYMENT_STATUS"
-        | "MAX_AGE"
-        | "MIN_AGE"
-        | "MIN_INCOME"
-        | "MIN_TURNOVER"
-        | "NATURAL_PERSON"
-        | "OTHER"
-        | "PENSION_RECIPIENT"
-        | "RESIDENCY_STATUS"
-        | "STAFF"
-        | "STUDENT";
-      [k: string]: unknown;
-    }[];
-    /**
-     * Fees applicable for the product
-     */
-    fees?: {
-      /**
-       * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      accrualFrequency?: string | null;
-      /**
-       * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      accruedRate?: string | null;
-      /**
-       * Display text providing more information on the fee
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this fee
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      amount?: string | null;
-      /**
-       * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
-       */
-      balanceRate?: string | null;
-      /**
-       * The currency the fee will be charged in. Assumes AUD if absent
-       */
-      currency?: string | null;
-      /**
-       * An optional list of discounts to this fee that may be available
-       */
-      discounts?:
-        | {
-            /**
-             * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            accruedRate?: string | null;
-            /**
-             * Display text providing more information on the discount
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this discount
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
-             */
-            additionalValue?: string | null;
-            /**
-             * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
-             */
-            amount?: string | null;
-            /**
-             * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            balanceRate?: string | null;
-            /**
-             * Description of the discount
-             */
-            description: string;
-            /**
-             * The type of discount. See the next section for an overview of valid values and their meaning
-             */
-            discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
-            /**
-             * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
-             */
-            eligibility?:
-              | {
-                  /**
-                   * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                   */
-                  additionalInfo?: string | null;
-                  /**
-                   * Link to a web page with more information on this eligibility constraint
-                   */
-                  additionalInfoUri?: string | null;
-                  /**
-                   * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
-                   */
-                  additionalValue?: string | null;
-                  /**
-                   * The type of the specific eligibility constraint for a discount
-                   */
-                  discountEligibilityType:
-                    | "BUSINESS"
-                    | "EMPLOYMENT_STATUS"
-                    | "INTRODUCTORY"
-                    | "MAX_AGE"
-                    | "MIN_AGE"
-                    | "MIN_INCOME"
-                    | "MIN_TURNOVER"
-                    | "NATURAL_PERSON"
-                    | "OTHER"
-                    | "PENSION_RECIPIENT"
-                    | "RESIDENCY_STATUS"
-                    | "STAFF"
-                    | "STUDENT";
-                  [k: string]: unknown;
-                }[]
-              | null;
-            /**
-             * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
-             */
-            feeRate?: string | null;
-            /**
-             * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
-             */
-            transactionRate?: string | null;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * The type of fee
-       */
-      feeType:
-        | "DEPOSIT"
-        | "EVENT"
-        | "EXIT"
-        | "PAYMENT"
-        | "PERIODIC"
-        | "PURCHASE"
-        | "TRANSACTION"
-        | "UPFRONT"
-        | "VARIABLE"
-        | "WITHDRAWAL";
-      /**
-       * Name of the fee
-       */
-      name: string;
-      /**
-       * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
-       */
-      transactionRate?: string | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Interest rates available for deposits
-     */
-    depositRates?: {
-      /**
-       * Display text providing more information on the rate
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this rate
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      applicationFrequency?: string | null;
-      /**
-       * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      calculationFrequency?: string | null;
-      /**
-       * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
-       */
-      depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
-      /**
-       * The rate to be applied
-       */
-      rate: string;
-      /**
-       * Rate tiers applicable for this rate
-       */
-      tiers?:
-        | {
-            /**
-             * Display text providing more information on the rate tier.
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this rate tier
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Defines a condition for the applicability of a tiered rate
-             */
-            applicabilityConditions?: {
-              /**
-               * Display text providing more information on the condition
-               */
-              additionalInfo?: string | null;
-              /**
-               * Link to a web page with more information on this condition
-               */
-              additionalInfoUri?: string | null;
-              [k: string]: unknown;
-            };
-            /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-             */
-            maximumValue?: number | null;
-            /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-             */
-            minimumValue: number;
-            /**
-             * A display name for the tier
-             */
-            name: string;
-            /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-             */
-            rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-            /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-             */
-            unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-            [k: string]: unknown;
-          }[]
-        | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Interest rates charged against lending balances
-     */
-    lendingRates?: {
-      /**
-       * Display text providing more information on the rate.
-       */
-      additionalInfo?: string | null;
-      /**
-       * Link to a web page with more information on this rate
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
-       */
-      additionalValue?: string | null;
-      /**
-       * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      applicationFrequency?: string | null;
-      /**
-       * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      calculationFrequency?: string | null;
-      /**
-       * A comparison rate equivalent for this rate
-       */
-      comparisonRate?: string | null;
-      /**
-       * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
-       */
-      interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
-      /**
-       * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
-       */
-      lendingRateType:
-        | "BUNDLE_DISCOUNT_FIXED"
-        | "BUNDLE_DISCOUNT_VARIABLE"
-        | "CASH_ADVANCE"
-        | "DISCOUNT"
-        | "FIXED"
-        | "FLOATING"
-        | "INTRODUCTORY"
-        | "MARKET_LINKED"
-        | "PENALTY"
-        | "PURCHASE"
-        | "VARIABLE";
-      /**
-       * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
-       */
-      loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
-      /**
-       * The rate to be applied
-       */
-      rate: string;
-      /**
-       * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
-       */
-      repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
-      /**
-       * Rate tiers applicable for this rate
-       */
-      tiers?:
-        | {
-            /**
-             * Display text providing more information on the rate tier.
-             */
-            additionalInfo?: string | null;
-            /**
-             * Link to a web page with more information on this rate tier
-             */
-            additionalInfoUri?: string | null;
-            /**
-             * Defines a condition for the applicability of a tiered rate
-             */
-            applicabilityConditions?: {
-              /**
-               * Display text providing more information on the condition
-               */
-              additionalInfo?: string | null;
-              /**
-               * Link to a web page with more information on this condition
-               */
-              additionalInfoUri?: string | null;
-              [k: string]: unknown;
-            };
-            /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
-             */
-            maximumValue?: number | null;
-            /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
-             */
-            minimumValue: number;
-            /**
-             * A display name for the tier
-             */
-            name: string;
-            /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
-             */
-            rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
-            /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
-             */
-            unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
-            [k: string]: unknown;
-          }[]
-        | null;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface ResponseBankingProductListV2 {
-  data: {
-    /**
-     * The list of products returned.  If the filter results in an empty set then this array may have no records
-     */
-    products: {
-      /**
-       * Object that contains links to additional information on specific topics
-       */
-      additionalInformation?: {
-        /**
-         * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
-         */
-        additionalBundleUris?:
-          | {
-              /**
-               * The URI describing the additional information
-               */
-              additionalInfoUri: string;
-              /**
-               * Display text providing more information about the document URI
-               */
-              description?: string | null;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
-         */
-        additionalEligibilityUris?:
-          | {
-              /**
-               * The URI describing the additional information
-               */
-              additionalInfoUri: string;
-              /**
-               * Display text providing more information about the document URI
-               */
-              description?: string | null;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
-         */
-        additionalFeesAndPricingUris?:
-          | {
-              /**
-               * The URI describing the additional information
-               */
-              additionalInfoUri: string;
-              /**
-               * Display text providing more information about the document URI
-               */
-              description?: string | null;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
-         */
-        additionalOverviewUris?:
-          | {
-              /**
-               * The URI describing the additional information
-               */
-              additionalInfoUri: string;
-              /**
-               * Display text providing more information about the document URI
-               */
-              description?: string | null;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
-         */
-        additionalTermsUris?:
-          | {
-              /**
-               * The URI describing the additional information
-               */
-              additionalInfoUri: string;
-              /**
-               * Display text providing more information about the document URI
-               */
-              description?: string | null;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
-         */
-        bundleUri?: string | null;
-        /**
-         * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
-         */
-        eligibilityUri?: string | null;
-        /**
-         * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
-         */
-        feesAndPricingUri?: string | null;
-        /**
-         * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
-         */
-        overviewUri?: string | null;
-        /**
-         * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
-         */
-        termsUri?: string | null;
-        [k: string]: unknown;
-      };
-      /**
-       * A link to an application web page where this product can be applied for.
-       */
-      applicationUri?: string | null;
-      /**
-       * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
-       */
-      brand: string;
-      /**
-       * An optional display name of the brand
-       */
-      brandName?: string | null;
-      /**
-       * An array of card art images
-       */
-      cardArt?:
-        | {
-            /**
-             * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
-             */
-            imageUri: string;
-            /**
-             * Display label for the specific image
-             */
-            title?: string;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * A description of the product
-       */
-      description: string;
-      /**
-       * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
-       */
-      effectiveFrom?: string | null;
-      /**
-       * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
-       */
-      effectiveTo?: string | null;
-      /**
-       * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
-       */
-      isTailored: boolean;
-      /**
-       * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
-       */
-      lastUpdated: string;
-      /**
-       * The display name of the product
-       */
-      name: string;
-      /**
-       * The category to which a product or account belongs. See [here](#product-categories) for more details
-       */
-      productCategory:
-        | "BUSINESS_LOANS"
-        | "CRED_AND_CHRG_CARDS"
-        | "LEASES"
-        | "MARGIN_LOANS"
-        | "OVERDRAFTS"
-        | "PERS_LOANS"
-        | "REGULATED_TRUST_ACCOUNTS"
-        | "RESIDENTIAL_MORTGAGES"
-        | "TERM_DEPOSITS"
-        | "TRADE_FINANCE"
-        | "TRANS_AND_SAVINGS_ACCOUNTS"
-        | "TRAVEL_CARDS";
-      /**
-       * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
-       */
-      productId: string;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
-
-export interface ResponseBankingScheduledPaymentsList {
-  data: {
-    /**
-     * The list of scheduled payments to return
-     */
-    scheduledPayments: {
-      /**
-       * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
-       */
-      from: {
-        /**
-         * ID of the account that is the source of funds for the payment
-         */
-        accountId: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels
-       */
-      nickname?: string | null;
-      /**
-       * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided
-       */
-      payeeReference?: string | null;
-      /**
-       * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided
-       */
-      payerReference: string;
-      paymentSet: {
-        /**
-         * The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
-         */
-        amount?: string | null;
-        /**
-         * The currency for the payment. AUD assumed if not present
-         */
-        currency?: string | null;
-        /**
-         * Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
-         */
-        isAmountCalculated?: boolean | null;
-        /**
-         * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
-         */
-        to: {
-          /**
-           * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
-           */
-          accountId?: string | null;
-          biller?: {
+        payeeUType: 'biller' | 'digitalWallet' | 'domestic' | 'international';
+        biller?: {
             /**
              * BPAY Biller Code of the Biller
              */
@@ -6622,561 +5471,1740 @@ export interface ResponseBankingScheduledPaymentsList {
              */
             crn?: string | null;
             [k: string]: unknown;
-          };
-          domestic?: {
+        };
+        domestic?: {
             account?: {
-              /**
-               * Name of the account to pay to
-               */
-              accountName?: string | null;
-              /**
-               * Number of the account to pay to
-               */
-              accountNumber: string;
-              /**
-               * BSB of the account to pay to
-               */
-              bsb: string;
-              [k: string]: unknown;
+                /**
+                 * Name of the account to pay to
+                 */
+                accountName?: string | null;
+                /**
+                 * Number of the account to pay to
+                 */
+                accountNumber: string;
+                /**
+                 * BSB of the account to pay to
+                 */
+                bsb: string;
+                [k: string]: unknown;
             };
             card?: {
-              /**
-               * Name of the account to pay to
-               */
-              cardNumber: string;
-              [k: string]: unknown;
+                /**
+                 * Name of the account to pay to
+                 */
+                cardNumber: string;
+                [k: string]: unknown;
             };
             payId?: {
-              /**
-               * The identifier of the PayID (dependent on type)
-               */
-              identifier: string;
-              /**
-               * The name assigned to the PayID by the owner of the PayID
-               */
-              name?: string | null;
-              /**
-               * The type of the PayID
-               */
-              type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
-              [k: string]: unknown;
+                /**
+                 * The identifier of the PayID (dependent on type)
+                 */
+                identifier: string;
+                /**
+                 * The name assigned to the PayID by the owner of the PayID
+                 */
+                name?: string | null;
+                /**
+                 * The type of the PayID
+                 */
+                type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+                [k: string]: unknown;
             };
             /**
              * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
              */
-            payeeAccountUType: "account" | "card" | "payId";
+            payeeAccountUType: 'account' | 'card' | 'payId';
             [k: string]: unknown;
-          };
-          international?: {
+        };
+        digitalWallet?: {
+            /**
+             * The identifier of the digital wallet (dependent on type)
+             */
+            identifier: string;
+            /**
+             * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+             */
+            name: string;
+            /**
+             * The provider of the digital wallet
+             */
+            provider: 'PAYPAL_AU' | 'OTHER';
+            /**
+             * The type of the digital wallet identifier
+             */
+            type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+            [k: string]: unknown;
+        };
+        international?: {
             bankDetails: {
-              /**
-               * Account Targeted for payment
-               */
-              accountNumber: string;
-              bankAddress?: {
                 /**
-                 * Address of the recipient Bank
+                 * Account Targeted for payment
                  */
-                address: string;
+                accountNumber: string;
+                bankAddress?: {
+                    /**
+                     * Address of the recipient Bank
+                     */
+                    address: string;
+                    /**
+                     * Name of the recipient Bank
+                     */
+                    name: string;
+                    [k: string]: unknown;
+                } | null;
                 /**
-                 * Name of the recipient Bank
+                 * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
                  */
-                name: string;
+                beneficiaryBankBIC?: string | null;
+                /**
+                 * Number for the Clearing House Interbank Payments System
+                 */
+                chipNumber?: string | null;
+                /**
+                 * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                 */
+                country: string;
+                /**
+                 * Number for Fedwire payment (Federal Reserve Wire Network)
+                 */
+                fedWireNumber?: string | null;
+                /**
+                 * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+                 */
+                legalEntityIdentifier?: string | null;
+                /**
+                 * International bank routing number
+                 */
+                routingNumber?: string | null;
+                /**
+                 * Sort code used for account identification in some jurisdictions
+                 */
+                sortCode?: string | null;
                 [k: string]: unknown;
-              } | null;
-              /**
-               * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
-               */
-              beneficiaryBankBIC?: string | null;
-              /**
-               * Number for the Clearing House Interbank Payments System
-               */
-              chipNumber?: string | null;
-              /**
-               * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-               */
-              country: string;
-              /**
-               * Number for Fedwire payment (Federal Reserve Wire Network)
-               */
-              fedWireNumber?: string | null;
-              /**
-               * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
-               */
-              legalEntityIdentifier?: string | null;
-              /**
-               * International bank routing number
-               */
-              routingNumber?: string | null;
-              /**
-               * Sort code used for account identification in some jurisdictions
-               */
-              sortCode?: string | null;
-              [k: string]: unknown;
             };
             beneficiaryDetails: {
-              /**
-               * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
-               */
-              country: string;
-              /**
-               * Response message for the payment
-               */
-              message?: string | null;
-              /**
-               * Name of the beneficiary
-               */
-              name?: string | null;
-              [k: string]: unknown;
+                /**
+                 * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                 */
+                country: string;
+                /**
+                 * Response message for the payment
+                 */
+                message?: string | null;
+                /**
+                 * Name of the beneficiary
+                 */
+                name?: string | null;
+                [k: string]: unknown;
             };
             [k: string]: unknown;
-          };
-          /**
-           * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
-           */
-          nickname?: string | null;
-          /**
-           * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
-           */
-          payeeId?: string | null;
-          /**
-           * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
-           */
-          payeeReference?: string | null;
-          /**
-           * The type of object provided that specifies the destination of the funds for the payment.
-           */
-          toUType: "accountId" | "biller" | "domestic" | "international" | "payeeId";
-          [k: string]: unknown;
         };
         [k: string]: unknown;
-      }[];
-      /**
-       * Object containing the detail of the schedule for the payment
-       */
-      recurrence: {
+    };
+    links: {
         /**
-         * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+         * Fully qualified link that generated the current response document
          */
-        eventBased?: {
-          /**
-           * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
-           */
-          description: string;
-          [k: string]: unknown;
-        };
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingPayeeListV2 {
+    data: {
         /**
-         * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+         * The list of payees returned
          */
-        intervalSchedule?: {
-          /**
-           * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-           */
-          finalPaymentDate?: string | null;
-          /**
-           * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
-           */
-          intervals: {
+        payees: {
             /**
-             * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+             * The date the payee was created by the customer
              */
-            dayInInterval?: string | null;
+            creationDate?: string | null;
             /**
-             * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+             * A description of the payee provided by the customer
              */
-            interval: string;
+            description?: string | null;
+            /**
+             * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
+             */
+            nickname: string;
+            /**
+             * ID of the payee adhering to the rules of ID permanence
+             */
+            payeeId: string;
+            /**
+             * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
+             */
+            type: 'BILLER' | 'DIGITAL_WALLET' | 'DOMESTIC' | 'INTERNATIONAL';
             [k: string]: unknown;
-          }[];
-          /**
-           * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-           */
-          nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-          /**
-           * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
-           */
-          paymentsRemaining?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
-         */
-        lastWeekDay?: {
-          /**
-           * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-           */
-          finalPaymentDate?: string | null;
-          /**
-           * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
-           */
-          interval: string;
-          /**
-           * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
-           */
-          lastWeekDay: "FRI" | "MON" | "SAT" | "SUN" | "THU" | "TUE" | "WED";
-          /**
-           * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
-           */
-          nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
-          /**
-           * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
-           */
-          paymentsRemaining?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * The date of the next payment under the recurrence schedule
-         */
-        nextPaymentDate?: string | null;
-        /**
-         * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
-         */
-        onceOff?: {
-          /**
-           * The scheduled date for the once off payment
-           */
-          paymentDate: string;
-          [k: string]: unknown;
-        };
-        /**
-         * The type of recurrence used to define the schedule
-         */
-        recurrenceUType: "eventBased" | "intervalSchedule" | "lastWeekDay" | "onceOff";
+        }[];
         [k: string]: unknown;
-      };
-      /**
-       * A unique ID of the scheduled payment adhering to the standards for ID permanence
-       */
-      scheduledPaymentId: string;
-      /**
-       * Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
-       */
-      status: "ACTIVE" | "INACTIVE" | "SKIP";
-      [k: string]: unknown;
-    }[];
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingProductByIdV4 {
+    data: {
+        /**
+         * Object that contains links to additional information on specific topics
+         */
+        additionalInformation?: {
+            /**
+             * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+             */
+            additionalBundleUris?:
+                | {
+                    /**
+                     * The URI describing the additional information
+                     */
+                    additionalInfoUri: string;
+                    /**
+                     * Display text providing more information about the document URI
+                     */
+                    description?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
+             */
+            additionalEligibilityUris?:
+                | {
+                    /**
+                     * The URI describing the additional information
+                     */
+                    additionalInfoUri: string;
+                    /**
+                     * Display text providing more information about the document URI
+                     */
+                    description?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
+             */
+            additionalFeesAndPricingUris?:
+                | {
+                    /**
+                     * The URI describing the additional information
+                     */
+                    additionalInfoUri: string;
+                    /**
+                     * Display text providing more information about the document URI
+                     */
+                    description?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
+             */
+            additionalOverviewUris?:
+                | {
+                    /**
+                     * The URI describing the additional information
+                     */
+                    additionalInfoUri: string;
+                    /**
+                     * Display text providing more information about the document URI
+                     */
+                    description?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
+             */
+            additionalTermsUris?:
+                | {
+                    /**
+                     * The URI describing the additional information
+                     */
+                    additionalInfoUri: string;
+                    /**
+                     * Display text providing more information about the document URI
+                     */
+                    description?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
+             */
+            bundleUri?: string | null;
+            /**
+             * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
+             */
+            eligibilityUri?: string | null;
+            /**
+             * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
+             */
+            feesAndPricingUri?: string | null;
+            /**
+             * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
+             */
+            overviewUri?: string | null;
+            /**
+             * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
+             */
+            termsUri?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A link to an application web page where this product can be applied for.
+         */
+        applicationUri?: string | null;
+        /**
+         * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+         */
+        brand: string;
+        /**
+         * An optional display name of the brand
+         */
+        brandName?: string | null;
+        /**
+         * An array of card art images
+         */
+        cardArt?:
+            | {
+                /**
+                 * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+                 */
+                imageUri: string;
+                /**
+                 * Display label for the specific image
+                 */
+                title?: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * A description of the product
+         */
+        description: string;
+        /**
+         * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+         */
+        effectiveFrom?: string | null;
+        /**
+         * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+         */
+        effectiveTo?: string | null;
+        /**
+         * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+         */
+        isTailored: boolean;
+        /**
+         * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+         */
+        lastUpdated: string;
+        /**
+         * The display name of the product
+         */
+        name: string;
+        /**
+         * The category to which a product or account belongs. See [here](#product-categories) for more details
+         */
+        productCategory:
+            | 'BUSINESS_LOANS'
+            | 'CRED_AND_CHRG_CARDS'
+            | 'LEASES'
+            | 'MARGIN_LOANS'
+            | 'OVERDRAFTS'
+            | 'PERS_LOANS'
+            | 'REGULATED_TRUST_ACCOUNTS'
+            | 'RESIDENTIAL_MORTGAGES'
+            | 'TERM_DEPOSITS'
+            | 'TRADE_FINANCE'
+            | 'TRANS_AND_SAVINGS_ACCOUNTS'
+            | 'TRAVEL_CARDS';
+        /**
+         * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
+         */
+        productId: string;
+        [k: string]: unknown;
+    } & {
+        /**
+         * An array of bundles that this product participates in.  Each bundle is described by free form information but also by a list of product IDs of the other products that are included in the bundle.  It is assumed that the current product is included in the bundle also
+         */
+        bundles?: {
+            /**
+             * Display text providing more information on the bundle
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on the bundle criteria and benefits
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Description of the bundle
+             */
+            description: string;
+            /**
+             * Name of the bundle
+             */
+            name: string;
+            /**
+             * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
+             */
+            productIds?: string[] | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Array of features available for the product
+         */
+        features?: {
+            /**
+             * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this feature
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The type of feature described
+             */
+            featureType:
+                | 'ADDITIONAL_CARDS'
+                | 'BALANCE_TRANSFERS'
+                | 'BILL_PAYMENT'
+                | 'BONUS_REWARDS'
+                | 'CARD_ACCESS'
+                | 'CASHBACK_OFFER'
+                | 'COMPLEMENTARY_PRODUCT_DISCOUNTS'
+                | 'DIGITAL_BANKING'
+                | 'DIGITAL_WALLET'
+                | 'DONATE_INTEREST'
+                | 'EXTRA_REPAYMENTS'
+                | 'FRAUD_PROTECTION'
+                | 'FREE_TXNS'
+                | 'FREE_TXNS_ALLOWANCE'
+                | 'GUARANTOR'
+                | 'INSURANCE'
+                | 'INSTALMENT_PLAN'
+                | 'INTEREST_FREE'
+                | 'INTEREST_FREE_TRANSFERS'
+                | 'LOYALTY_PROGRAM'
+                | 'NOTIFICATIONS'
+                | 'NPP_ENABLED'
+                | 'NPP_PAYID'
+                | 'OFFSET'
+                | 'OTHER'
+                | 'OVERDRAFT'
+                | 'REDRAW'
+                | 'RELATIONSHIP_MANAGEMENT'
+                | 'UNLIMITED_TXNS';
+            [k: string]: unknown;
+        }[];
+        /**
+         * Constraints on the application for or operation of the product such as minimum balances or limit thresholds
+         */
+        constraints?: {
+            /**
+             * Display text providing more information the constraint
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on the constraint
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The type of constraint described.  See the next section for an overview of valid values and their meaning
+             */
+            constraintType: 'MAX_BALANCE' | 'MAX_LIMIT' | 'MIN_BALANCE' | 'MIN_LIMIT' | 'OPENING_BALANCE';
+            [k: string]: unknown;
+        }[];
+        /**
+         * Eligibility criteria for the product
+         */
+        eligibility?: {
+            /**
+             * Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this eligibility criteria
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
+             */
+            eligibilityType:
+                | 'BUSINESS'
+                | 'EMPLOYMENT_STATUS'
+                | 'MAX_AGE'
+                | 'MIN_AGE'
+                | 'MIN_INCOME'
+                | 'MIN_TURNOVER'
+                | 'NATURAL_PERSON'
+                | 'OTHER'
+                | 'PENSION_RECIPIENT'
+                | 'RESIDENCY_STATUS'
+                | 'STAFF'
+                | 'STUDENT';
+            [k: string]: unknown;
+        }[];
+        /**
+         * Fees applicable for the product
+         */
+        fees?: {
+            /**
+             * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            accrualFrequency?: string | null;
+            /**
+             * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            accruedRate?: string | null;
+            /**
+             * Display text providing more information on the fee
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this fee
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            amount?: string | null;
+            /**
+             * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+             */
+            balanceRate?: string | null;
+            /**
+             * The currency the fee will be charged in. Assumes AUD if absent
+             */
+            currency?: string | null;
+            /**
+             * An optional list of discounts to this fee that may be available
+             */
+            discounts?:
+                | {
+                    /**
+                     * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    accruedRate?: string | null;
+                    /**
+                     * Display text providing more information on the discount
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this discount
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+                     */
+                    additionalValue?: string | null;
+                    /**
+                     * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+                     */
+                    amount?: string | null;
+                    /**
+                     * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    balanceRate?: string | null;
+                    /**
+                     * Description of the discount
+                     */
+                    description: string;
+                    /**
+                     * The type of discount. See the next section for an overview of valid values and their meaning
+                     */
+                    discountType: 'BALANCE' | 'DEPOSITS' | 'ELIGIBILITY_ONLY' | 'FEE_CAP' | 'PAYMENTS';
+                    /**
+                     * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+                     */
+                    eligibility?:
+                        | {
+                            /**
+                             * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                             */
+                            additionalInfo?: string | null;
+                            /**
+                             * Link to a web page with more information on this eligibility constraint
+                             */
+                            additionalInfoUri?: string | null;
+                            /**
+                             * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+                             */
+                            additionalValue?: string | null;
+                            /**
+                             * The type of the specific eligibility constraint for a discount
+                             */
+                            discountEligibilityType:
+                                | 'BUSINESS'
+                                | 'EMPLOYMENT_STATUS'
+                                | 'INTRODUCTORY'
+                                | 'MAX_AGE'
+                                | 'MIN_AGE'
+                                | 'MIN_INCOME'
+                                | 'MIN_TURNOVER'
+                                | 'NATURAL_PERSON'
+                                | 'OTHER'
+                                | 'PENSION_RECIPIENT'
+                                | 'RESIDENCY_STATUS'
+                                | 'STAFF'
+                                | 'STUDENT';
+                            [k: string]: unknown;
+                        }[]
+                        | null;
+                    /**
+                     * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+                     */
+                    feeRate?: string | null;
+                    /**
+                     * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+                     */
+                    transactionRate?: string | null;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The type of fee
+             */
+            feeType:
+                | 'DEPOSIT'
+                | 'EVENT'
+                | 'EXIT'
+                | 'PAYMENT'
+                | 'PERIODIC'
+                | 'PURCHASE'
+                | 'TRANSACTION'
+                | 'UPFRONT'
+                | 'VARIABLE'
+                | 'WITHDRAWAL';
+            /**
+             * Name of the fee
+             */
+            name: string;
+            /**
+             * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+             */
+            transactionRate?: string | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Interest rates available for deposits
+         */
+        depositRates?: {
+            /**
+             * Display text providing more information on the rate
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            applicationFrequency?: string | null;
+            /**
+             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            calculationFrequency?: string | null;
+            /**
+             * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+             */
+            depositRateType:
+                | 'BONUS'
+                | 'BUNDLE_BONUS'
+                | 'FIXED'
+                | 'FLOATING'
+                | 'INTRODUCTORY'
+                | 'MARKET_LINKED'
+                | 'VARIABLE';
+            /**
+             * The rate to be applied
+             */
+            rate: string;
+            /**
+             * Rate tiers applicable for this rate
+             */
+            tiers?:
+                | {
+                    /**
+                     * Display text providing more information on the rate tier.
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this rate tier
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Defines a condition for the applicability of a tiered rate
+                     */
+                    applicabilityConditions?: {
+                        /**
+                         * Display text providing more information on the condition
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this condition
+                         */
+                        additionalInfoUri?: string | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                     */
+                    maximumValue?: number | null;
+                    /**
+                     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                     */
+                    minimumValue: number;
+                    /**
+                     * A display name for the tier
+                     */
+                    name: string;
+                    /**
+                     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                     */
+                    rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                    /**
+                     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                     */
+                    unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Interest rates charged against lending balances
+         */
+        lendingRates?: {
+            /**
+             * Display text providing more information on the rate.
+             */
+            additionalInfo?: string | null;
+            /**
+             * Link to a web page with more information on this rate
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+             */
+            additionalValue?: string | null;
+            /**
+             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            applicationFrequency?: string | null;
+            /**
+             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            calculationFrequency?: string | null;
+            /**
+             * A comparison rate equivalent for this rate
+             */
+            comparisonRate?: string | null;
+            /**
+             * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+             */
+            interestPaymentDue?: ('IN_ADVANCE' | 'IN_ARREARS') | null;
+            /**
+             * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+             */
+            lendingRateType:
+                | 'BUNDLE_DISCOUNT_FIXED'
+                | 'BUNDLE_DISCOUNT_VARIABLE'
+                | 'CASH_ADVANCE'
+                | 'DISCOUNT'
+                | 'FIXED'
+                | 'FLOATING'
+                | 'INTRODUCTORY'
+                | 'MARKET_LINKED'
+                | 'PENALTY'
+                | 'PURCHASE'
+                | 'VARIABLE';
+            /**
+             * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+             */
+            loanPurpose?: ('INVESTMENT' | 'OWNER_OCCUPIED') | null;
+            /**
+             * The rate to be applied
+             */
+            rate: string;
+            /**
+             * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+             */
+            repaymentType?: ('INTEREST_ONLY' | 'PRINCIPAL_AND_INTEREST') | null;
+            /**
+             * Rate tiers applicable for this rate
+             */
+            tiers?:
+                | {
+                    /**
+                     * Display text providing more information on the rate tier.
+                     */
+                    additionalInfo?: string | null;
+                    /**
+                     * Link to a web page with more information on this rate tier
+                     */
+                    additionalInfoUri?: string | null;
+                    /**
+                     * Defines a condition for the applicability of a tiered rate
+                     */
+                    applicabilityConditions?: {
+                        /**
+                         * Display text providing more information on the condition
+                         */
+                        additionalInfo?: string | null;
+                        /**
+                         * Link to a web page with more information on this condition
+                         */
+                        additionalInfoUri?: string | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+                     */
+                    maximumValue?: number | null;
+                    /**
+                     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+                     */
+                    minimumValue: number;
+                    /**
+                     * A display name for the tier
+                     */
+                    name: string;
+                    /**
+                     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+                     */
+                    rateApplicationMethod?: ('PER_TIER' | 'WHOLE_BALANCE') | null;
+                    /**
+                     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+                     */
+                    unitOfMeasure: 'DAY' | 'DOLLAR' | 'MONTH' | 'PERCENT';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingProductListV2 {
+    data: {
+        /**
+         * The list of products returned.  If the filter results in an empty set then this array may have no records
+         */
+        products: {
+            /**
+             * Object that contains links to additional information on specific topics
+             */
+            additionalInformation?: {
+                /**
+                 * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+                 */
+                additionalBundleUris?:
+                    | {
+                        /**
+                         * The URI describing the additional information
+                         */
+                        additionalInfoUri: string;
+                        /**
+                         * Display text providing more information about the document URI
+                         */
+                        description?: string | null;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
+                 */
+                additionalEligibilityUris?:
+                    | {
+                        /**
+                         * The URI describing the additional information
+                         */
+                        additionalInfoUri: string;
+                        /**
+                         * Display text providing more information about the document URI
+                         */
+                        description?: string | null;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
+                 */
+                additionalFeesAndPricingUris?:
+                    | {
+                        /**
+                         * The URI describing the additional information
+                         */
+                        additionalInfoUri: string;
+                        /**
+                         * Display text providing more information about the document URI
+                         */
+                        description?: string | null;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
+                 */
+                additionalOverviewUris?:
+                    | {
+                        /**
+                         * The URI describing the additional information
+                         */
+                        additionalInfoUri: string;
+                        /**
+                         * Display text providing more information about the document URI
+                         */
+                        description?: string | null;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
+                 */
+                additionalTermsUris?:
+                    | {
+                        /**
+                         * The URI describing the additional information
+                         */
+                        additionalInfoUri: string;
+                        /**
+                         * Display text providing more information about the document URI
+                         */
+                        description?: string | null;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
+                 */
+                bundleUri?: string | null;
+                /**
+                 * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
+                 */
+                eligibilityUri?: string | null;
+                /**
+                 * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
+                 */
+                feesAndPricingUri?: string | null;
+                /**
+                 * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
+                 */
+                overviewUri?: string | null;
+                /**
+                 * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
+                 */
+                termsUri?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * A link to an application web page where this product can be applied for.
+             */
+            applicationUri?: string | null;
+            /**
+             * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+             */
+            brand: string;
+            /**
+             * An optional display name of the brand
+             */
+            brandName?: string | null;
+            /**
+             * An array of card art images
+             */
+            cardArt?:
+                | {
+                    /**
+                     * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+                     */
+                    imageUri: string;
+                    /**
+                     * Display label for the specific image
+                     */
+                    title?: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * A description of the product
+             */
+            description: string;
+            /**
+             * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+             */
+            effectiveFrom?: string | null;
+            /**
+             * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+             */
+            effectiveTo?: string | null;
+            /**
+             * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+             */
+            isTailored: boolean;
+            /**
+             * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+             */
+            lastUpdated: string;
+            /**
+             * The display name of the product
+             */
+            name: string;
+            /**
+             * The category to which a product or account belongs. See [here](#product-categories) for more details
+             */
+            productCategory:
+                | 'BUSINESS_LOANS'
+                | 'CRED_AND_CHRG_CARDS'
+                | 'LEASES'
+                | 'MARGIN_LOANS'
+                | 'OVERDRAFTS'
+                | 'PERS_LOANS'
+                | 'REGULATED_TRUST_ACCOUNTS'
+                | 'RESIDENTIAL_MORTGAGES'
+                | 'TERM_DEPOSITS'
+                | 'TRADE_FINANCE'
+                | 'TRANS_AND_SAVINGS_ACCOUNTS'
+                | 'TRAVEL_CARDS';
+            /**
+             * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
+             */
+            productId: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
+
+export interface ResponseBankingScheduledPaymentsList {
+    data: {
+        /**
+         * The list of scheduled payments to return
+         */
+        scheduledPayments: {
+            /**
+             * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+             */
+            from: {
+                /**
+                 * ID of the account that is the source of funds for the payment
+                 */
+                accountId: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels
+             */
+            nickname?: string | null;
+            /**
+             * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided
+             */
+            payeeReference?: string | null;
+            /**
+             * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided
+             */
+            payerReference: string;
+            paymentSet: {
+                /**
+                 * The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
+                 */
+                amount?: string | null;
+                /**
+                 * The currency for the payment. AUD assumed if not present
+                 */
+                currency?: string | null;
+                /**
+                 * Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
+                 */
+                isAmountCalculated?: boolean | null;
+                /**
+                 * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+                 */
+                to: {
+                    /**
+                     * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+                     */
+                    accountId?: string | null;
+                    biller?: {
+                        /**
+                         * BPAY Biller Code of the Biller
+                         */
+                        billerCode: string;
+                        /**
+                         * Name of the Biller
+                         */
+                        billerName: string;
+                        /**
+                         * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+                         */
+                        crn?: string | null;
+                        [k: string]: unknown;
+                    };
+                    domestic?: {
+                        account?: {
+                            /**
+                             * Name of the account to pay to
+                             */
+                            accountName?: string | null;
+                            /**
+                             * Number of the account to pay to
+                             */
+                            accountNumber: string;
+                            /**
+                             * BSB of the account to pay to
+                             */
+                            bsb: string;
+                            [k: string]: unknown;
+                        };
+                        card?: {
+                            /**
+                             * Name of the account to pay to
+                             */
+                            cardNumber: string;
+                            [k: string]: unknown;
+                        };
+                        payId?: {
+                            /**
+                             * The identifier of the PayID (dependent on type)
+                             */
+                            identifier: string;
+                            /**
+                             * The name assigned to the PayID by the owner of the PayID
+                             */
+                            name?: string | null;
+                            /**
+                             * The type of the PayID
+                             */
+                            type: 'ABN' | 'EMAIL' | 'ORG_IDENTIFIER' | 'TELEPHONE';
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP
+                         */
+                        payeeAccountUType: 'account' | 'card' | 'payId';
+                        [k: string]: unknown;
+                    };
+                    international?: {
+                        bankDetails: {
+                            /**
+                             * Account Targeted for payment
+                             */
+                            accountNumber: string;
+                            bankAddress?: {
+                                /**
+                                 * Address of the recipient Bank
+                                 */
+                                address: string;
+                                /**
+                                 * Name of the recipient Bank
+                                 */
+                                name: string;
+                                [k: string]: unknown;
+                            } | null;
+                            /**
+                             * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+                             */
+                            beneficiaryBankBIC?: string | null;
+                            /**
+                             * Number for the Clearing House Interbank Payments System
+                             */
+                            chipNumber?: string | null;
+                            /**
+                             * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                             */
+                            country: string;
+                            /**
+                             * Number for Fedwire payment (Federal Reserve Wire Network)
+                             */
+                            fedWireNumber?: string | null;
+                            /**
+                             * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+                             */
+                            legalEntityIdentifier?: string | null;
+                            /**
+                             * International bank routing number
+                             */
+                            routingNumber?: string | null;
+                            /**
+                             * Sort code used for account identification in some jurisdictions
+                             */
+                            sortCode?: string | null;
+                            [k: string]: unknown;
+                        };
+                        beneficiaryDetails: {
+                            /**
+                             * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+                             */
+                            country: string;
+                            /**
+                             * Response message for the payment
+                             */
+                            message?: string | null;
+                            /**
+                             * Name of the beneficiary
+                             */
+                            name?: string | null;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
+                     */
+                    nickname?: string | null;
+                    /**
+                     * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+                     */
+                    payeeId?: string | null;
+                    /**
+                     * The reference for the transaction, if applicable, that will be provided by the originating institution for the specific payment. If not empty, it overrides the value provided at the BankingScheduledPayment level.
+                     */
+                    payeeReference?: string | null;
+                    /**
+                     * The type of object provided that specifies the destination of the funds for the payment.
+                     */
+                    toUType: 'accountId' | 'biller' | 'domestic' | 'international' | 'payeeId';
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            }[];
+            /**
+             * Object containing the detail of the schedule for the payment
+             */
+            recurrence: {
+                /**
+                 * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+                 */
+                eventBased?: {
+                    /**
+                     * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+                     */
+                    description: string;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+                 */
+                intervalSchedule?: {
+                    /**
+                     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+                     */
+                    finalPaymentDate?: string | null;
+                    /**
+                     * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+                     */
+                    intervals: {
+                        /**
+                         * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+                         */
+                        dayInInterval?: string | null;
+                        /**
+                         * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+                         */
+                        interval: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+                     */
+                    nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+                    /**
+                     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+                     */
+                    paymentsRemaining?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+                 */
+                lastWeekDay?: {
+                    /**
+                     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+                     */
+                    finalPaymentDate?: string | null;
+                    /**
+                     * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+                     */
+                    interval: string;
+                    /**
+                     * The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+                     */
+                    lastWeekDay: 'FRI' | 'MON' | 'SAT' | 'SUN' | 'THU' | 'TUE' | 'WED';
+                    /**
+                     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+                     */
+                    nonBusinessDayTreatment?: ('AFTER' | 'BEFORE' | 'ON' | 'ONLY') | null;
+                    /**
+                     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+                     */
+                    paymentsRemaining?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The date of the next payment under the recurrence schedule
+                 */
+                nextPaymentDate?: string | null;
+                /**
+                 * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+                 */
+                onceOff?: {
+                    /**
+                     * The scheduled date for the once off payment
+                     */
+                    paymentDate: string;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The type of recurrence used to define the schedule
+                 */
+                recurrenceUType: 'eventBased' | 'intervalSchedule' | 'lastWeekDay' | 'onceOff';
+                [k: string]: unknown;
+            };
+            /**
+             * A unique ID of the scheduled payment adhering to the standards for ID permanence
+             */
+            scheduledPaymentId: string;
+            /**
+             * Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
+             */
+            status: 'ACTIVE' | 'INACTIVE' | 'SKIP';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingTransactionById {
-  data: {
-    /**
-     * ID of the account for which transactions are provided
-     */
-    accountId: string;
-    /**
-     * The value of the transaction. Negative values mean money was outgoing from the account
-     */
-    amount: string;
-    /**
-     * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
-     */
-    apcaNumber?: string | null;
-    /**
-     * BPAY Biller Code for the transaction (if available)
-     */
-    billerCode?: string | null;
-    /**
-     * Name of the BPAY biller for the transaction (if available)
-     */
-    billerName?: string | null;
-    /**
-     * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-     */
-    crn?: string | null;
-    /**
-     * The currency for the transaction amount. AUD assumed if not present
-     */
-    currency?: string | null;
-    /**
-     * The transaction description as applied by the financial institution
-     */
-    description: string;
-    /**
-     * The time the transaction was executed by the originating customer, if available
-     */
-    executionDateTime?: string | null;
-    /**
-     * True if extended information is available using the transaction detail end point. False if extended data is not available
-     */
-    isDetailAvailable: boolean;
-    /**
-     * The merchant category code (or MCC) for an outgoing payment to a merchant
-     */
-    merchantCategoryCode?: string | null;
-    /**
-     * Name of the merchant for an outgoing payment to a merchant
-     */
-    merchantName?: string | null;
-    /**
-     * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
-     */
-    postingDateTime?: string | null;
-    /**
-     * The reference for the transaction provided by the originating institution. Empty string if no data provided
-     */
-    reference: string;
-    /**
-     * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
-     */
-    status: "PENDING" | "POSTED";
-    /**
-     * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
-     */
-    transactionId?: string | null;
-    /**
-     * The type of the transaction
-     */
-    type:
-      | "DIRECT_DEBIT"
-      | "FEE"
-      | "INTEREST_CHARGED"
-      | "INTEREST_PAID"
-      | "OTHER"
-      | "PAYMENT"
-      | "TRANSFER_INCOMING"
-      | "TRANSFER_OUTGOING";
-    /**
-     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
-     */
-    valueDateTime?: string | null;
-    [k: string]: unknown;
-  } & {
-    extendedData: {
-      /**
-       * Label of the originating payer. Mandatory for inbound payment
-       */
-      payer?: string;
-      /**
-       * Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
-       */
-      payee?: string;
-      /**
-       * Optional extended data provided specific to transaction originated via NPP
-       */
-      extensionUType?: "x2p101Payload";
-      x2p101Payload?: {
+    data: {
         /**
-         * An extended string description. Only present if specified by the extensionUType field
+         * ID of the account for which transactions are provided
          */
-        extendedDescription: string;
+        accountId: string;
         /**
-         * An end to end ID for the payment created at initiation
+         * The value of the transaction. Negative values mean money was outgoing from the account
          */
-        endToEndId?: string;
+        amount: string;
         /**
-         * Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+         * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
          */
-        purposeCode?: string;
+        apcaNumber?: string | null;
+        /**
+         * BPAY Biller Code for the transaction (if available)
+         */
+        billerCode?: string | null;
+        /**
+         * Name of the BPAY biller for the transaction (if available)
+         */
+        billerName?: string | null;
+        /**
+         * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+         */
+        crn?: string | null;
+        /**
+         * The currency for the transaction amount. AUD assumed if not present
+         */
+        currency?: string | null;
+        /**
+         * The transaction description as applied by the financial institution
+         */
+        description: string;
+        /**
+         * The time the transaction was executed by the originating customer, if available
+         */
+        executionDateTime?: string | null;
+        /**
+         * True if extended information is available using the transaction detail end point. False if extended data is not available
+         */
+        isDetailAvailable: boolean;
+        /**
+         * The merchant category code (or MCC) for an outgoing payment to a merchant
+         */
+        merchantCategoryCode?: string | null;
+        /**
+         * Name of the merchant for an outgoing payment to a merchant
+         */
+        merchantName?: string | null;
+        /**
+         * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
+         */
+        postingDateTime?: string | null;
+        /**
+         * The reference for the transaction provided by the originating institution. Empty string if no data provided
+         */
+        reference: string;
+        /**
+         * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+         */
+        status: 'PENDING' | 'POSTED';
+        /**
+         * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
+         */
+        transactionId?: string | null;
+        /**
+         * The type of the transaction
+         */
+        type:
+            | 'DIRECT_DEBIT'
+            | 'FEE'
+            | 'INTEREST_CHARGED'
+            | 'INTEREST_PAID'
+            | 'OTHER'
+            | 'PAYMENT'
+            | 'TRANSFER_INCOMING'
+            | 'TRANSFER_OUTGOING';
+        /**
+         * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+         */
+        valueDateTime?: string | null;
         [k: string]: unknown;
-      };
-      /**
-       * Identifier of the applicable overlay service. Valid values are: X2P1.01
-       */
-      service: "X2P1.01";
-      [k: string]: unknown;
+    } & {
+        extendedData: {
+            /**
+             * Label of the originating payer. Mandatory for inbound payment
+             */
+            payer?: string;
+            /**
+             * Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
+             */
+            payee?: string;
+            /**
+             * Optional extended data provided specific to transaction originated via NPP
+             */
+            extensionUType?: 'x2p101Payload';
+            x2p101Payload?: {
+                /**
+                 * An extended string description. Only present if specified by the extensionUType field
+                 */
+                extendedDescription: string;
+                /**
+                 * An end to end ID for the payment created at initiation
+                 */
+                endToEndId?: string;
+                /**
+                 * Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+                 */
+                purposeCode?: string;
+                [k: string]: unknown;
+            };
+            /**
+             * Identifier of the applicable overlay service. Valid values are: X2P1.01
+             */
+            service: 'X2P1.01';
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseBankingTransactionList {
-  data: {
-    transactions: {
-      /**
-       * ID of the account for which transactions are provided
-       */
-      accountId: string;
-      /**
-       * The value of the transaction. Negative values mean money was outgoing from the account
-       */
-      amount: string;
-      /**
-       * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
-       */
-      apcaNumber?: string | null;
-      /**
-       * BPAY Biller Code for the transaction (if available)
-       */
-      billerCode?: string | null;
-      /**
-       * Name of the BPAY biller for the transaction (if available)
-       */
-      billerName?: string | null;
-      /**
-       * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
-       */
-      crn?: string | null;
-      /**
-       * The currency for the transaction amount. AUD assumed if not present
-       */
-      currency?: string | null;
-      /**
-       * The transaction description as applied by the financial institution
-       */
-      description: string;
-      /**
-       * The time the transaction was executed by the originating customer, if available
-       */
-      executionDateTime?: string | null;
-      /**
-       * True if extended information is available using the transaction detail end point. False if extended data is not available
-       */
-      isDetailAvailable: boolean;
-      /**
-       * The merchant category code (or MCC) for an outgoing payment to a merchant
-       */
-      merchantCategoryCode?: string | null;
-      /**
-       * Name of the merchant for an outgoing payment to a merchant
-       */
-      merchantName?: string | null;
-      /**
-       * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
-       */
-      postingDateTime?: string | null;
-      /**
-       * The reference for the transaction provided by the originating institution. Empty string if no data provided
-       */
-      reference: string;
-      /**
-       * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
-       */
-      status: "PENDING" | "POSTED";
-      /**
-       * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
-       */
-      transactionId?: string | null;
-      /**
-       * The type of the transaction
-       */
-      type:
-        | "DIRECT_DEBIT"
-        | "FEE"
-        | "INTEREST_CHARGED"
-        | "INTEREST_PAID"
-        | "OTHER"
-        | "PAYMENT"
-        | "TRANSFER_INCOMING"
-        | "TRANSFER_OUTGOING";
-      /**
-       * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
-       */
-      valueDateTime?: string | null;
-      [k: string]: unknown;
-    }[];
+    data: {
+        transactions: {
+            /**
+             * ID of the account for which transactions are provided
+             */
+            accountId: string;
+            /**
+             * The value of the transaction. Negative values mean money was outgoing from the account
+             */
+            amount: string;
+            /**
+             * 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
+             */
+            apcaNumber?: string | null;
+            /**
+             * BPAY Biller Code for the transaction (if available)
+             */
+            billerCode?: string | null;
+            /**
+             * Name of the BPAY biller for the transaction (if available)
+             */
+            billerName?: string | null;
+            /**
+             * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+             */
+            crn?: string | null;
+            /**
+             * The currency for the transaction amount. AUD assumed if not present
+             */
+            currency?: string | null;
+            /**
+             * The transaction description as applied by the financial institution
+             */
+            description: string;
+            /**
+             * The time the transaction was executed by the originating customer, if available
+             */
+            executionDateTime?: string | null;
+            /**
+             * True if extended information is available using the transaction detail end point. False if extended data is not available
+             */
+            isDetailAvailable: boolean;
+            /**
+             * The merchant category code (or MCC) for an outgoing payment to a merchant
+             */
+            merchantCategoryCode?: string | null;
+            /**
+             * Name of the merchant for an outgoing payment to a merchant
+             */
+            merchantName?: string | null;
+            /**
+             * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
+             */
+            postingDateTime?: string | null;
+            /**
+             * The reference for the transaction provided by the originating institution. Empty string if no data provided
+             */
+            reference: string;
+            /**
+             * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+             */
+            status: 'PENDING' | 'POSTED';
+            /**
+             * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
+             */
+            transactionId?: string | null;
+            /**
+             * The type of the transaction
+             */
+            type:
+                | 'DIRECT_DEBIT'
+                | 'FEE'
+                | 'INTEREST_CHARGED'
+                | 'INTEREST_PAID'
+                | 'OTHER'
+                | 'PAYMENT'
+                | 'TRANSFER_INCOMING'
+                | 'TRANSFER_OUTGOING';
+            /**
+             * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+             */
+            valueDateTime?: string | null;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }

--- a/types/consumer-data-standards/common/index.d.ts
+++ b/types/consumer-data-standards/common/index.d.ts
@@ -1,411 +1,6 @@
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface CommonEmailAddress {
-  /**
-   * A correctly formatted email address, as defined by the addr-spec format in **[[RFC5322]](#nref-RFC5322)**
-   */
-  address: string;
-  /**
-   * May be true for one and only one email record in the collection. Denotes the default email address
-   */
-  isPreferred?: boolean | null;
-  /**
-   * The purpose for the email, as specified by the customer (Enumeration)
-   */
-  purpose: "HOME" | "OTHER" | "UNSPECIFIED" | "WORK";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonOrganisation {
-  /**
-   * Australian Business Number for the organisation
-   */
-  abn?: string | null;
-  /**
-   * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
-   */
-  acn?: string | null;
-  /**
-   * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
-   */
-  agentFirstName?: string | null;
-  /**
-   * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
-   */
-  agentLastName: string;
-  /**
-   * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
-   */
-  agentRole: string;
-  /**
-   * Name of the organisation
-   */
-  businessName: string;
-  /**
-   * The date the organisation described was established
-   */
-  establishmentDate?: string | null;
-  /**
-   * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
-   */
-  industryCode?: string | null;
-  /**
-   * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
-   */
-  industryCodeVersion?: ("ANZSIC_1292.0_2006_V1.0" | "ANZSIC_1292.0_2006_V2.0") | null;
-  /**
-   * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
-   */
-  isACNCRegistered?: boolean | null;
-  /**
-   * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
-   */
-  lastUpdateTime?: string | null;
-  /**
-   * Legal name, if different to the business name
-   */
-  legalName?: string | null;
-  /**
-   * Legal organisation type
-   */
-  organisationType: "COMPANY" | "GOVERNMENT_ENTITY" | "OTHER" | "PARTNERSHIP" | "SOLE_TRADER" | "TRUST";
-  /**
-   * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
-   */
-  registeredCountry?: string | null;
-  /**
-   * Short name used for communication, if different to the business name
-   */
-  shortName?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonOrganisationDetailV2 extends CommonOrganisation {
-  /**
-   * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
-   */
-  physicalAddresses: ({
-    /**
-     * The type of address object present
-     */
-    addressUType: "paf" | "simple";
-    /**
-     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-     */
-    paf?: {
-      /**
-       * Building/Property name 1
-       */
-      buildingName1?: string | null;
-      /**
-       * Building/Property name 2
-       */
-      buildingName2?: string | null;
-      /**
-       * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-       */
-      dpid?: string | null;
-      /**
-       * Unit number (including suffix, if applicable)
-       */
-      flatUnitNumber?: string | null;
-      /**
-       * Type of flat or unit for the address
-       */
-      flatUnitType?: string | null;
-      /**
-       * Floor or level number (including alpha characters)
-       */
-      floorLevelNumber?: string | null;
-      /**
-       * Type of floor or level for the address
-       */
-      floorLevelType?: string | null;
-      /**
-       * Full name of locality
-       */
-      localityName: string;
-      /**
-       * Allotment number for the address
-       */
-      lotNumber?: string | null;
-      /**
-       * Postal delivery number if the address is a postal delivery type
-       */
-      postalDeliveryNumber?: number | null;
-      /**
-       * Postal delivery number prefix related to the postal delivery number
-       */
-      postalDeliveryNumberPrefix?: string | null;
-      /**
-       * Postal delivery number suffix related to the postal delivery number
-       */
-      postalDeliveryNumberSuffix?: string | null;
-      /**
-       * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-       */
-      postalDeliveryType?: string | null;
-      /**
-       * Postcode for the locality
-       */
-      postcode: string;
-      /**
-       * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      /**
-       * The name of the street
-       */
-      streetName?: string | null;
-      /**
-       * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetSuffix?: string | null;
-      /**
-       * The street type. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetType?: string | null;
-      /**
-       * Thoroughfare number for a property (first number in a property ranged address)
-       */
-      thoroughfareNumber1?: number | null;
-      /**
-       * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-       */
-      thoroughfareNumber1Suffix?: string | null;
-      /**
-       * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-       */
-      thoroughfareNumber2?: number | null;
-      /**
-       * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-       */
-      thoroughfareNumber2Suffix?: string | null;
-      [k: string]: unknown;
-    };
-    simple?: {
-      /**
-       * First line of the standard address object
-       */
-      addressLine1: string;
-      /**
-       * Second line of the standard address object
-       */
-      addressLine2?: string | null;
-      /**
-       * Third line of the standard address object
-       */
-      addressLine3?: string | null;
-      /**
-       * Name of the city or locality
-       */
-      city: string;
-      /**
-       * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-       */
-      country?: string | null;
-      /**
-       * Name of the individual or business formatted for inclusion in an address used for physical mail
-       */
-      mailingName?: string | null;
-      /**
-       * Mandatory for Australian addresses
-       */
-      postcode?: string | null;
-      /**
-       * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  } & {
-    /**
-     * Enumeration of values indicating the purpose of the physical address
-     */
-    purpose: "MAIL" | "OTHER" | "PHYSICAL" | "REGISTERED" | "WORK";
-    [k: string]: unknown;
-  })[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-/**
- * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
- */
-export interface CommonPAFAddress {
-  /**
-   * Building/Property name 1
-   */
-  buildingName1?: string | null;
-  /**
-   * Building/Property name 2
-   */
-  buildingName2?: string | null;
-  /**
-   * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-   */
-  dpid?: string | null;
-  /**
-   * Unit number (including suffix, if applicable)
-   */
-  flatUnitNumber?: string | null;
-  /**
-   * Type of flat or unit for the address
-   */
-  flatUnitType?: string | null;
-  /**
-   * Floor or level number (including alpha characters)
-   */
-  floorLevelNumber?: string | null;
-  /**
-   * Type of floor or level for the address
-   */
-  floorLevelType?: string | null;
-  /**
-   * Full name of locality
-   */
-  localityName: string;
-  /**
-   * Allotment number for the address
-   */
-  lotNumber?: string | null;
-  /**
-   * Postal delivery number if the address is a postal delivery type
-   */
-  postalDeliveryNumber?: number | null;
-  /**
-   * Postal delivery number prefix related to the postal delivery number
-   */
-  postalDeliveryNumberPrefix?: string | null;
-  /**
-   * Postal delivery number suffix related to the postal delivery number
-   */
-  postalDeliveryNumberSuffix?: string | null;
-  /**
-   * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-   */
-  postalDeliveryType?: string | null;
-  /**
-   * Postcode for the locality
-   */
-  postcode: string;
-  /**
-   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  /**
-   * The name of the street
-   */
-  streetName?: string | null;
-  /**
-   * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetSuffix?: string | null;
-  /**
-   * The street type. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetType?: string | null;
-  /**
-   * Thoroughfare number for a property (first number in a property ranged address)
-   */
-  thoroughfareNumber1?: number | null;
-  /**
-   * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-   */
-  thoroughfareNumber1Suffix?: string | null;
-  /**
-   * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-   */
-  thoroughfareNumber2?: number | null;
-  /**
-   * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-   */
-  thoroughfareNumber2Suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonPerson {
-  /**
-   * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
-   */
-  firstName?: string | null;
-  /**
-   * For people with single names the single name should be in this field
-   */
-  lastName: string;
-  /**
-   * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
-   */
-  lastUpdateTime?: string | null;
-  /**
-   * Field is mandatory but array may be empty
-   */
-  middleNames: string[];
-  /**
-   * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
-   */
-  occupationCode?: string | null;
-  /**
-   * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
-   */
-  occupationCodeVersion?:
-    | ("ANZSCO_1220.0_2006_V1.0" | "ANZSCO_1220.0_2006_V1.1" | "ANZSCO_1220.0_2013_V1.2" | "ANZSCO_1220.0_2013_V1.3")
-    | null;
-  /**
-   * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-   */
-  prefix?: string | null;
-  /**
-   * Used for a trailing suffix to the name (e.g. Jr)
-   */
-  suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonPersonDetailV2 extends CommonPerson {
-  /**
-   * Array is mandatory but may be empty if no phone numbers are held
-   */
-  phoneNumbers: {
-    /**
-     * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
-     */
-    areaCode?: string | null;
-    /**
-     * If absent, assumed to be Australia (+61). The + should be included
-     */
-    countryCode?: string | null;
-    /**
-     * An extension number (if applicable)
-     */
-    extension?: string | null;
-    /**
-     * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
-     */
-    fullNumber: string;
-    /**
-     * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
-     */
-    isPreferred?: boolean | null;
-    /**
-     * The actual phone number, with leading zeros as appropriate
-     */
-    number: string;
-    /**
-     * The purpose of the number as specified by the customer
-     */
-    purpose: "HOME" | "INTERNATIONAL" | "MOBILE" | "OTHER" | "UNSPECIFIED" | "WORK";
-    [k: string]: unknown;
-  }[];
-  /**
-   * May be empty
-   */
-  emailAddresses: {
     /**
      * A correctly formatted email address, as defined by the addr-spec format in **[[RFC5322]](#nref-RFC5322)**
      */
@@ -417,200 +12,230 @@ export interface CommonPersonDetailV2 extends CommonPerson {
     /**
      * The purpose for the email, as specified by the customer (Enumeration)
      */
-    purpose: "HOME" | "OTHER" | "UNSPECIFIED" | "WORK";
+    purpose: 'HOME' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
     [k: string]: unknown;
-  }[];
-  /**
-   * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
-   */
-  physicalAddresses: ({
-    /**
-     * The type of address object present
-     */
-    addressUType: "paf" | "simple";
-    /**
-     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-     */
-    paf?: {
-      /**
-       * Building/Property name 1
-       */
-      buildingName1?: string | null;
-      /**
-       * Building/Property name 2
-       */
-      buildingName2?: string | null;
-      /**
-       * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-       */
-      dpid?: string | null;
-      /**
-       * Unit number (including suffix, if applicable)
-       */
-      flatUnitNumber?: string | null;
-      /**
-       * Type of flat or unit for the address
-       */
-      flatUnitType?: string | null;
-      /**
-       * Floor or level number (including alpha characters)
-       */
-      floorLevelNumber?: string | null;
-      /**
-       * Type of floor or level for the address
-       */
-      floorLevelType?: string | null;
-      /**
-       * Full name of locality
-       */
-      localityName: string;
-      /**
-       * Allotment number for the address
-       */
-      lotNumber?: string | null;
-      /**
-       * Postal delivery number if the address is a postal delivery type
-       */
-      postalDeliveryNumber?: number | null;
-      /**
-       * Postal delivery number prefix related to the postal delivery number
-       */
-      postalDeliveryNumberPrefix?: string | null;
-      /**
-       * Postal delivery number suffix related to the postal delivery number
-       */
-      postalDeliveryNumberSuffix?: string | null;
-      /**
-       * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-       */
-      postalDeliveryType?: string | null;
-      /**
-       * Postcode for the locality
-       */
-      postcode: string;
-      /**
-       * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      /**
-       * The name of the street
-       */
-      streetName?: string | null;
-      /**
-       * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetSuffix?: string | null;
-      /**
-       * The street type. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetType?: string | null;
-      /**
-       * Thoroughfare number for a property (first number in a property ranged address)
-       */
-      thoroughfareNumber1?: number | null;
-      /**
-       * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-       */
-      thoroughfareNumber1Suffix?: string | null;
-      /**
-       * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-       */
-      thoroughfareNumber2?: number | null;
-      /**
-       * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-       */
-      thoroughfareNumber2Suffix?: string | null;
-      [k: string]: unknown;
-    };
-    simple?: {
-      /**
-       * First line of the standard address object
-       */
-      addressLine1: string;
-      /**
-       * Second line of the standard address object
-       */
-      addressLine2?: string | null;
-      /**
-       * Third line of the standard address object
-       */
-      addressLine3?: string | null;
-      /**
-       * Name of the city or locality
-       */
-      city: string;
-      /**
-       * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-       */
-      country?: string | null;
-      /**
-       * Name of the individual or business formatted for inclusion in an address used for physical mail
-       */
-      mailingName?: string | null;
-      /**
-       * Mandatory for Australian addresses
-       */
-      postcode?: string | null;
-      /**
-       * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  } & {
-    /**
-     * Enumeration of values indicating the purpose of the physical address
-     */
-    purpose: "MAIL" | "OTHER" | "PHYSICAL" | "REGISTERED" | "WORK";
-    [k: string]: unknown;
-  })[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
-export interface CommonPhoneNumber {
-  /**
-   * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
-   */
-  areaCode?: string | null;
-  /**
-   * If absent, assumed to be Australia (+61). The + should be included
-   */
-  countryCode?: string | null;
-  /**
-   * An extension number (if applicable)
-   */
-  extension?: string | null;
-  /**
-   * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
-   */
-  fullNumber: string;
-  /**
-   * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
-   */
-  isPreferred?: boolean | null;
-  /**
-   * The actual phone number, with leading zeros as appropriate
-   */
-  number: string;
-  /**
-   * The purpose of the number as specified by the customer
-   */
-  purpose: "HOME" | "INTERNATIONAL" | "MOBILE" | "OTHER" | "UNSPECIFIED" | "WORK";
-  [k: string]: unknown;
+export interface CommonOrganisation {
+    /**
+     * Australian Business Number for the organisation
+     */
+    abn?: string | null;
+    /**
+     * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
+     */
+    acn?: string | null;
+    /**
+     * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
+     */
+    agentFirstName?: string | null;
+    /**
+     * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
+     */
+    agentLastName: string;
+    /**
+     * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
+     */
+    agentRole: string;
+    /**
+     * Name of the organisation
+     */
+    businessName: string;
+    /**
+     * The date the organisation described was established
+     */
+    establishmentDate?: string | null;
+    /**
+     * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
+     */
+    industryCode?: string | null;
+    /**
+     * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
+     */
+    industryCodeVersion?: ('ANZSIC_1292.0_2006_V1.0' | 'ANZSIC_1292.0_2006_V2.0') | null;
+    /**
+     * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
+     */
+    isACNCRegistered?: boolean | null;
+    /**
+     * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
+     */
+    lastUpdateTime?: string | null;
+    /**
+     * Legal name, if different to the business name
+     */
+    legalName?: string | null;
+    /**
+     * Legal organisation type
+     */
+    organisationType: 'COMPANY' | 'GOVERNMENT_ENTITY' | 'OTHER' | 'PARTNERSHIP' | 'SOLE_TRADER' | 'TRUST';
+    /**
+     * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
+     */
+    registeredCountry?: string | null;
+    /**
+     * Short name used for communication, if different to the business name
+     */
+    shortName?: string | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
-export interface CommonPhysicalAddress {
-  /**
-   * The type of address object present
-   */
-  addressUType: "paf" | "simple";
-  /**
-   * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-   */
-  paf?: {
+export interface CommonOrganisationDetailV2 extends CommonOrganisation {
+    /**
+     * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+     */
+    physicalAddresses: ({
+        /**
+         * The type of address object present
+         */
+        addressUType: 'paf' | 'simple';
+        /**
+         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+         */
+        paf?: {
+            /**
+             * Building/Property name 1
+             */
+            buildingName1?: string | null;
+            /**
+             * Building/Property name 2
+             */
+            buildingName2?: string | null;
+            /**
+             * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+             */
+            dpid?: string | null;
+            /**
+             * Unit number (including suffix, if applicable)
+             */
+            flatUnitNumber?: string | null;
+            /**
+             * Type of flat or unit for the address
+             */
+            flatUnitType?: string | null;
+            /**
+             * Floor or level number (including alpha characters)
+             */
+            floorLevelNumber?: string | null;
+            /**
+             * Type of floor or level for the address
+             */
+            floorLevelType?: string | null;
+            /**
+             * Full name of locality
+             */
+            localityName: string;
+            /**
+             * Allotment number for the address
+             */
+            lotNumber?: string | null;
+            /**
+             * Postal delivery number if the address is a postal delivery type
+             */
+            postalDeliveryNumber?: number | null;
+            /**
+             * Postal delivery number prefix related to the postal delivery number
+             */
+            postalDeliveryNumberPrefix?: string | null;
+            /**
+             * Postal delivery number suffix related to the postal delivery number
+             */
+            postalDeliveryNumberSuffix?: string | null;
+            /**
+             * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+             */
+            postalDeliveryType?: string | null;
+            /**
+             * Postcode for the locality
+             */
+            postcode: string;
+            /**
+             * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            /**
+             * The name of the street
+             */
+            streetName?: string | null;
+            /**
+             * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetSuffix?: string | null;
+            /**
+             * The street type. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetType?: string | null;
+            /**
+             * Thoroughfare number for a property (first number in a property ranged address)
+             */
+            thoroughfareNumber1?: number | null;
+            /**
+             * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+             */
+            thoroughfareNumber1Suffix?: string | null;
+            /**
+             * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+             */
+            thoroughfareNumber2?: number | null;
+            /**
+             * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+             */
+            thoroughfareNumber2Suffix?: string | null;
+            [k: string]: unknown;
+        };
+        simple?: {
+            /**
+             * First line of the standard address object
+             */
+            addressLine1: string;
+            /**
+             * Second line of the standard address object
+             */
+            addressLine2?: string | null;
+            /**
+             * Third line of the standard address object
+             */
+            addressLine3?: string | null;
+            /**
+             * Name of the city or locality
+             */
+            city: string;
+            /**
+             * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+             */
+            country?: string | null;
+            /**
+             * Name of the individual or business formatted for inclusion in an address used for physical mail
+             */
+            mailingName?: string | null;
+            /**
+             * Mandatory for Australian addresses
+             */
+            postcode?: string | null;
+            /**
+             * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    } & {
+        /**
+         * Enumeration of values indicating the purpose of the physical address
+         */
+        purpose: 'MAIL' | 'OTHER' | 'PHYSICAL' | 'REGISTERED' | 'WORK';
+        [k: string]: unknown;
+    })[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+/**
+ * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+ */
+export interface CommonPAFAddress {
     /**
      * Building/Property name 1
      */
@@ -700,8 +325,436 @@ export interface CommonPhysicalAddress {
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
-  };
-  simple?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonPerson {
+    /**
+     * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
+     */
+    firstName?: string | null;
+    /**
+     * For people with single names the single name should be in this field
+     */
+    lastName: string;
+    /**
+     * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
+     */
+    lastUpdateTime?: string | null;
+    /**
+     * Field is mandatory but array may be empty
+     */
+    middleNames: string[];
+    /**
+     * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
+     */
+    occupationCode?: string | null;
+    /**
+     * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
+     */
+    occupationCodeVersion?:
+        | (
+            | 'ANZSCO_1220.0_2006_V1.0'
+            | 'ANZSCO_1220.0_2006_V1.1'
+            | 'ANZSCO_1220.0_2013_V1.2'
+            | 'ANZSCO_1220.0_2013_V1.3'
+        )
+        | null;
+    /**
+     * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+     */
+    prefix?: string | null;
+    /**
+     * Used for a trailing suffix to the name (e.g. Jr)
+     */
+    suffix?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonPersonDetailV2 extends CommonPerson {
+    /**
+     * Array is mandatory but may be empty if no phone numbers are held
+     */
+    phoneNumbers: {
+        /**
+         * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+         */
+        areaCode?: string | null;
+        /**
+         * If absent, assumed to be Australia (+61). The + should be included
+         */
+        countryCode?: string | null;
+        /**
+         * An extension number (if applicable)
+         */
+        extension?: string | null;
+        /**
+         * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
+         */
+        fullNumber: string;
+        /**
+         * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
+         */
+        isPreferred?: boolean | null;
+        /**
+         * The actual phone number, with leading zeros as appropriate
+         */
+        number: string;
+        /**
+         * The purpose of the number as specified by the customer
+         */
+        purpose: 'HOME' | 'INTERNATIONAL' | 'MOBILE' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
+        [k: string]: unknown;
+    }[];
+    /**
+     * May be empty
+     */
+    emailAddresses: {
+        /**
+         * A correctly formatted email address, as defined by the addr-spec format in **[[RFC5322]](#nref-RFC5322)**
+         */
+        address: string;
+        /**
+         * May be true for one and only one email record in the collection. Denotes the default email address
+         */
+        isPreferred?: boolean | null;
+        /**
+         * The purpose for the email, as specified by the customer (Enumeration)
+         */
+        purpose: 'HOME' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
+        [k: string]: unknown;
+    }[];
+    /**
+     * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+     */
+    physicalAddresses: ({
+        /**
+         * The type of address object present
+         */
+        addressUType: 'paf' | 'simple';
+        /**
+         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+         */
+        paf?: {
+            /**
+             * Building/Property name 1
+             */
+            buildingName1?: string | null;
+            /**
+             * Building/Property name 2
+             */
+            buildingName2?: string | null;
+            /**
+             * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+             */
+            dpid?: string | null;
+            /**
+             * Unit number (including suffix, if applicable)
+             */
+            flatUnitNumber?: string | null;
+            /**
+             * Type of flat or unit for the address
+             */
+            flatUnitType?: string | null;
+            /**
+             * Floor or level number (including alpha characters)
+             */
+            floorLevelNumber?: string | null;
+            /**
+             * Type of floor or level for the address
+             */
+            floorLevelType?: string | null;
+            /**
+             * Full name of locality
+             */
+            localityName: string;
+            /**
+             * Allotment number for the address
+             */
+            lotNumber?: string | null;
+            /**
+             * Postal delivery number if the address is a postal delivery type
+             */
+            postalDeliveryNumber?: number | null;
+            /**
+             * Postal delivery number prefix related to the postal delivery number
+             */
+            postalDeliveryNumberPrefix?: string | null;
+            /**
+             * Postal delivery number suffix related to the postal delivery number
+             */
+            postalDeliveryNumberSuffix?: string | null;
+            /**
+             * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+             */
+            postalDeliveryType?: string | null;
+            /**
+             * Postcode for the locality
+             */
+            postcode: string;
+            /**
+             * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            /**
+             * The name of the street
+             */
+            streetName?: string | null;
+            /**
+             * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetSuffix?: string | null;
+            /**
+             * The street type. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetType?: string | null;
+            /**
+             * Thoroughfare number for a property (first number in a property ranged address)
+             */
+            thoroughfareNumber1?: number | null;
+            /**
+             * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+             */
+            thoroughfareNumber1Suffix?: string | null;
+            /**
+             * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+             */
+            thoroughfareNumber2?: number | null;
+            /**
+             * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+             */
+            thoroughfareNumber2Suffix?: string | null;
+            [k: string]: unknown;
+        };
+        simple?: {
+            /**
+             * First line of the standard address object
+             */
+            addressLine1: string;
+            /**
+             * Second line of the standard address object
+             */
+            addressLine2?: string | null;
+            /**
+             * Third line of the standard address object
+             */
+            addressLine3?: string | null;
+            /**
+             * Name of the city or locality
+             */
+            city: string;
+            /**
+             * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+             */
+            country?: string | null;
+            /**
+             * Name of the individual or business formatted for inclusion in an address used for physical mail
+             */
+            mailingName?: string | null;
+            /**
+             * Mandatory for Australian addresses
+             */
+            postcode?: string | null;
+            /**
+             * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    } & {
+        /**
+         * Enumeration of values indicating the purpose of the physical address
+         */
+        purpose: 'MAIL' | 'OTHER' | 'PHYSICAL' | 'REGISTERED' | 'WORK';
+        [k: string]: unknown;
+    })[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonPhoneNumber {
+    /**
+     * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+     */
+    areaCode?: string | null;
+    /**
+     * If absent, assumed to be Australia (+61). The + should be included
+     */
+    countryCode?: string | null;
+    /**
+     * An extension number (if applicable)
+     */
+    extension?: string | null;
+    /**
+     * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
+     */
+    fullNumber: string;
+    /**
+     * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
+     */
+    isPreferred?: boolean | null;
+    /**
+     * The actual phone number, with leading zeros as appropriate
+     */
+    number: string;
+    /**
+     * The purpose of the number as specified by the customer
+     */
+    purpose: 'HOME' | 'INTERNATIONAL' | 'MOBILE' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonPhysicalAddress {
+    /**
+     * The type of address object present
+     */
+    addressUType: 'paf' | 'simple';
+    /**
+     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+     */
+    paf?: {
+        /**
+         * Building/Property name 1
+         */
+        buildingName1?: string | null;
+        /**
+         * Building/Property name 2
+         */
+        buildingName2?: string | null;
+        /**
+         * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+         */
+        dpid?: string | null;
+        /**
+         * Unit number (including suffix, if applicable)
+         */
+        flatUnitNumber?: string | null;
+        /**
+         * Type of flat or unit for the address
+         */
+        flatUnitType?: string | null;
+        /**
+         * Floor or level number (including alpha characters)
+         */
+        floorLevelNumber?: string | null;
+        /**
+         * Type of floor or level for the address
+         */
+        floorLevelType?: string | null;
+        /**
+         * Full name of locality
+         */
+        localityName: string;
+        /**
+         * Allotment number for the address
+         */
+        lotNumber?: string | null;
+        /**
+         * Postal delivery number if the address is a postal delivery type
+         */
+        postalDeliveryNumber?: number | null;
+        /**
+         * Postal delivery number prefix related to the postal delivery number
+         */
+        postalDeliveryNumberPrefix?: string | null;
+        /**
+         * Postal delivery number suffix related to the postal delivery number
+         */
+        postalDeliveryNumberSuffix?: string | null;
+        /**
+         * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+         */
+        postalDeliveryType?: string | null;
+        /**
+         * Postcode for the locality
+         */
+        postcode: string;
+        /**
+         * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        /**
+         * The name of the street
+         */
+        streetName?: string | null;
+        /**
+         * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetSuffix?: string | null;
+        /**
+         * The street type. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetType?: string | null;
+        /**
+         * Thoroughfare number for a property (first number in a property ranged address)
+         */
+        thoroughfareNumber1?: number | null;
+        /**
+         * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+         */
+        thoroughfareNumber1Suffix?: string | null;
+        /**
+         * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+         */
+        thoroughfareNumber2?: number | null;
+        /**
+         * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+         */
+        thoroughfareNumber2Suffix?: string | null;
+        [k: string]: unknown;
+    };
+    simple?: {
+        /**
+         * First line of the standard address object
+         */
+        addressLine1: string;
+        /**
+         * Second line of the standard address object
+         */
+        addressLine2?: string | null;
+        /**
+         * Third line of the standard address object
+         */
+        addressLine3?: string | null;
+        /**
+         * Name of the city or locality
+         */
+        city: string;
+        /**
+         * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+         */
+        country?: string | null;
+        /**
+         * Name of the individual or business formatted for inclusion in an address used for physical mail
+         */
+        mailingName?: string | null;
+        /**
+         * Mandatory for Australian addresses
+         */
+        postcode?: string | null;
+        /**
+         * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonPhysicalAddressWithPurpose extends CommonPhysicalAddress {
+    /**
+     * Enumeration of values indicating the purpose of the physical address
+     */
+    purpose: 'MAIL' | 'OTHER' | 'PHYSICAL' | 'REGISTERED' | 'WORK';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
+
+export interface CommonSimpleAddress {
     /**
      * First line of the standard address object
      */
@@ -735,89 +788,41 @@ export interface CommonPhysicalAddress {
      */
     state: string;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonPhysicalAddressWithPurpose extends CommonPhysicalAddress {
-  /**
-   * Enumeration of values indicating the purpose of the physical address
-   */
-  purpose: "MAIL" | "OTHER" | "PHYSICAL" | "REGISTERED" | "WORK";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the common api. */
-
-export interface CommonSimpleAddress {
-  /**
-   * First line of the standard address object
-   */
-  addressLine1: string;
-  /**
-   * Second line of the standard address object
-   */
-  addressLine2?: string | null;
-  /**
-   * Third line of the standard address object
-   */
-  addressLine3?: string | null;
-  /**
-   * Name of the city or locality
-   */
-  city: string;
-  /**
-   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-   */
-  country?: string | null;
-  /**
-   * Name of the individual or business formatted for inclusion in an address used for physical mail
-   */
-  mailingName?: string | null;
-  /**
-   * Mandatory for Australian addresses
-   */
-  postcode?: string | null;
-  /**
-   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface DiscoveryOutage {
-  /**
-   * Planned duration of the outage. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  duration: string;
-  /**
-   * Provides an explanation of the current outage that can be displayed to an end customer
-   */
-  explanation: string;
-  /**
-   * Flag that indicates, if present and set to true, that the outage is only partial meaning that only a subset of normally available end points will be affected by the outage
-   */
-  isPartial?: boolean | null;
-  /**
-   * Date and time that the outage is scheduled to begin
-   */
-  outageTime: string;
-  [k: string]: unknown;
+    /**
+     * Planned duration of the outage. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    duration: string;
+    /**
+     * Provides an explanation of the current outage that can be displayed to an end customer
+     */
+    explanation: string;
+    /**
+     * Flag that indicates, if present and set to true, that the outage is only partial meaning that only a subset of normally available end points will be affected by the outage
+     */
+    isPartial?: boolean | null;
+    /**
+     * Date and time that the outage is scheduled to begin
+     */
+    outageTime: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface Links {
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
+    /**
+     * Fully qualified link that generated the current response document
+     */
+    self: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface Meta {
-  [k: string]: unknown;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
@@ -825,717 +830,717 @@ export interface Meta {
  * Additional data for customised error codes
  */
 export interface MetaError {
-  /**
-   * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-   */
-  urn?: string | null;
-  [k: string]: unknown;
+    /**
+     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+     */
+    urn?: string | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface ResponseCommonCustomer {
-  data: {
-    /**
-     * The type of customer object that is present
-     */
-    customerUType: "organisation" | "person";
-    organisation?: {
-      /**
-       * Australian Business Number for the organisation
-       */
-      abn?: string | null;
-      /**
-       * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
-       */
-      acn?: string | null;
-      /**
-       * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
-       */
-      agentFirstName?: string | null;
-      /**
-       * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
-       */
-      agentLastName: string;
-      /**
-       * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
-       */
-      agentRole: string;
-      /**
-       * Name of the organisation
-       */
-      businessName: string;
-      /**
-       * The date the organisation described was established
-       */
-      establishmentDate?: string | null;
-      /**
-       * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
-       */
-      industryCode?: string | null;
-      /**
-       * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
-       */
-      industryCodeVersion?: ("ANZSIC_1292.0_2006_V1.0" | "ANZSIC_1292.0_2006_V2.0") | null;
-      /**
-       * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
-       */
-      isACNCRegistered?: boolean | null;
-      /**
-       * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
-       */
-      lastUpdateTime?: string | null;
-      /**
-       * Legal name, if different to the business name
-       */
-      legalName?: string | null;
-      /**
-       * Legal organisation type
-       */
-      organisationType: "COMPANY" | "GOVERNMENT_ENTITY" | "OTHER" | "PARTNERSHIP" | "SOLE_TRADER" | "TRUST";
-      /**
-       * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
-       */
-      registeredCountry?: string | null;
-      /**
-       * Short name used for communication, if different to the business name
-       */
-      shortName?: string | null;
-      [k: string]: unknown;
+    data: {
+        /**
+         * The type of customer object that is present
+         */
+        customerUType: 'organisation' | 'person';
+        organisation?: {
+            /**
+             * Australian Business Number for the organisation
+             */
+            abn?: string | null;
+            /**
+             * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
+             */
+            acn?: string | null;
+            /**
+             * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
+             */
+            agentFirstName?: string | null;
+            /**
+             * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
+             */
+            agentLastName: string;
+            /**
+             * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
+             */
+            agentRole: string;
+            /**
+             * Name of the organisation
+             */
+            businessName: string;
+            /**
+             * The date the organisation described was established
+             */
+            establishmentDate?: string | null;
+            /**
+             * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
+             */
+            industryCode?: string | null;
+            /**
+             * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
+             */
+            industryCodeVersion?: ('ANZSIC_1292.0_2006_V1.0' | 'ANZSIC_1292.0_2006_V2.0') | null;
+            /**
+             * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
+             */
+            isACNCRegistered?: boolean | null;
+            /**
+             * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
+             */
+            lastUpdateTime?: string | null;
+            /**
+             * Legal name, if different to the business name
+             */
+            legalName?: string | null;
+            /**
+             * Legal organisation type
+             */
+            organisationType: 'COMPANY' | 'GOVERNMENT_ENTITY' | 'OTHER' | 'PARTNERSHIP' | 'SOLE_TRADER' | 'TRUST';
+            /**
+             * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
+             */
+            registeredCountry?: string | null;
+            /**
+             * Short name used for communication, if different to the business name
+             */
+            shortName?: string | null;
+            [k: string]: unknown;
+        };
+        person?: {
+            /**
+             * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
+             */
+            firstName?: string | null;
+            /**
+             * For people with single names the single name should be in this field
+             */
+            lastName: string;
+            /**
+             * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
+             */
+            lastUpdateTime?: string | null;
+            /**
+             * Field is mandatory but array may be empty
+             */
+            middleNames: string[];
+            /**
+             * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
+             */
+            occupationCode?: string | null;
+            /**
+             * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
+             */
+            occupationCodeVersion?:
+                | (
+                    | 'ANZSCO_1220.0_2006_V1.0'
+                    | 'ANZSCO_1220.0_2006_V1.1'
+                    | 'ANZSCO_1220.0_2013_V1.2'
+                    | 'ANZSCO_1220.0_2013_V1.3'
+                )
+                | null;
+            /**
+             * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+             */
+            prefix?: string | null;
+            /**
+             * Used for a trailing suffix to the name (e.g. Jr)
+             */
+            suffix?: string | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
     };
-    person?: {
-      /**
-       * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
-       */
-      firstName?: string | null;
-      /**
-       * For people with single names the single name should be in this field
-       */
-      lastName: string;
-      /**
-       * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
-       */
-      lastUpdateTime?: string | null;
-      /**
-       * Field is mandatory but array may be empty
-       */
-      middleNames: string[];
-      /**
-       * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
-       */
-      occupationCode?: string | null;
-      /**
-       * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
-       */
-      occupationCodeVersion?:
-        | (
-            | "ANZSCO_1220.0_2006_V1.0"
-            | "ANZSCO_1220.0_2006_V1.1"
-            | "ANZSCO_1220.0_2013_V1.2"
-            | "ANZSCO_1220.0_2013_V1.3"
-          )
-        | null;
-      /**
-       * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-       */
-      prefix?: string | null;
-      /**
-       * Used for a trailing suffix to the name (e.g. Jr)
-       */
-      suffix?: string | null;
-      [k: string]: unknown;
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface ResponseCommonCustomerDetailV2 {
-  data: {
-    /**
-     * The type of customer object that is present
-     */
-    customerUType: "organisation" | "person";
-    organisation?: {
-      /**
-       * Australian Business Number for the organisation
-       */
-      abn?: string | null;
-      /**
-       * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
-       */
-      acn?: string | null;
-      /**
-       * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
-       */
-      agentFirstName?: string | null;
-      /**
-       * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
-       */
-      agentLastName: string;
-      /**
-       * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
-       */
-      agentRole: string;
-      /**
-       * Name of the organisation
-       */
-      businessName: string;
-      /**
-       * The date the organisation described was established
-       */
-      establishmentDate?: string | null;
-      /**
-       * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
-       */
-      industryCode?: string | null;
-      /**
-       * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
-       */
-      industryCodeVersion?: ("ANZSIC_1292.0_2006_V1.0" | "ANZSIC_1292.0_2006_V2.0") | null;
-      /**
-       * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
-       */
-      isACNCRegistered?: boolean | null;
-      /**
-       * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
-       */
-      lastUpdateTime?: string | null;
-      /**
-       * Legal name, if different to the business name
-       */
-      legalName?: string | null;
-      /**
-       * Legal organisation type
-       */
-      organisationType: "COMPANY" | "GOVERNMENT_ENTITY" | "OTHER" | "PARTNERSHIP" | "SOLE_TRADER" | "TRUST";
-      /**
-       * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
-       */
-      registeredCountry?: string | null;
-      /**
-       * Short name used for communication, if different to the business name
-       */
-      shortName?: string | null;
-      [k: string]: unknown;
-    } & {
-      /**
-       * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
-       */
-      physicalAddresses: ({
+    data: {
         /**
-         * The type of address object present
+         * The type of customer object that is present
          */
-        addressUType: "paf" | "simple";
-        /**
-         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-         */
-        paf?: {
-          /**
-           * Building/Property name 1
-           */
-          buildingName1?: string | null;
-          /**
-           * Building/Property name 2
-           */
-          buildingName2?: string | null;
-          /**
-           * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-           */
-          dpid?: string | null;
-          /**
-           * Unit number (including suffix, if applicable)
-           */
-          flatUnitNumber?: string | null;
-          /**
-           * Type of flat or unit for the address
-           */
-          flatUnitType?: string | null;
-          /**
-           * Floor or level number (including alpha characters)
-           */
-          floorLevelNumber?: string | null;
-          /**
-           * Type of floor or level for the address
-           */
-          floorLevelType?: string | null;
-          /**
-           * Full name of locality
-           */
-          localityName: string;
-          /**
-           * Allotment number for the address
-           */
-          lotNumber?: string | null;
-          /**
-           * Postal delivery number if the address is a postal delivery type
-           */
-          postalDeliveryNumber?: number | null;
-          /**
-           * Postal delivery number prefix related to the postal delivery number
-           */
-          postalDeliveryNumberPrefix?: string | null;
-          /**
-           * Postal delivery number suffix related to the postal delivery number
-           */
-          postalDeliveryNumberSuffix?: string | null;
-          /**
-           * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-           */
-          postalDeliveryType?: string | null;
-          /**
-           * Postcode for the locality
-           */
-          postcode: string;
-          /**
-           * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-           */
-          state: string;
-          /**
-           * The name of the street
-           */
-          streetName?: string | null;
-          /**
-           * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-           */
-          streetSuffix?: string | null;
-          /**
-           * The street type. Valid enumeration defined by Australia Post PAF code file
-           */
-          streetType?: string | null;
-          /**
-           * Thoroughfare number for a property (first number in a property ranged address)
-           */
-          thoroughfareNumber1?: number | null;
-          /**
-           * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-           */
-          thoroughfareNumber1Suffix?: string | null;
-          /**
-           * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-           */
-          thoroughfareNumber2?: number | null;
-          /**
-           * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-           */
-          thoroughfareNumber2Suffix?: string | null;
-          [k: string]: unknown;
+        customerUType: 'organisation' | 'person';
+        organisation?: {
+            /**
+             * Australian Business Number for the organisation
+             */
+            abn?: string | null;
+            /**
+             * Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
+             */
+            acn?: string | null;
+            /**
+             * The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
+             */
+            agentFirstName?: string | null;
+            /**
+             * The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
+             */
+            agentLastName: string;
+            /**
+             * The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
+             */
+            agentRole: string;
+            /**
+             * Name of the organisation
+             */
+            businessName: string;
+            /**
+             * The date the organisation described was established
+             */
+            establishmentDate?: string | null;
+            /**
+             * A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
+             */
+            industryCode?: string | null;
+            /**
+             * The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
+             */
+            industryCodeVersion?: ('ANZSIC_1292.0_2006_V1.0' | 'ANZSIC_1292.0_2006_V2.0') | null;
+            /**
+             * True if registered with the ACNC.  False if not. Absent or null if not confirmed.
+             */
+            isACNCRegistered?: boolean | null;
+            /**
+             * The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
+             */
+            lastUpdateTime?: string | null;
+            /**
+             * Legal name, if different to the business name
+             */
+            legalName?: string | null;
+            /**
+             * Legal organisation type
+             */
+            organisationType: 'COMPANY' | 'GOVERNMENT_ENTITY' | 'OTHER' | 'PARTNERSHIP' | 'SOLE_TRADER' | 'TRUST';
+            /**
+             * Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
+             */
+            registeredCountry?: string | null;
+            /**
+             * Short name used for communication, if different to the business name
+             */
+            shortName?: string | null;
+            [k: string]: unknown;
+        } & {
+            /**
+             * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+             */
+            physicalAddresses: ({
+                /**
+                 * The type of address object present
+                 */
+                addressUType: 'paf' | 'simple';
+                /**
+                 * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+                 */
+                paf?: {
+                    /**
+                     * Building/Property name 1
+                     */
+                    buildingName1?: string | null;
+                    /**
+                     * Building/Property name 2
+                     */
+                    buildingName2?: string | null;
+                    /**
+                     * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+                     */
+                    dpid?: string | null;
+                    /**
+                     * Unit number (including suffix, if applicable)
+                     */
+                    flatUnitNumber?: string | null;
+                    /**
+                     * Type of flat or unit for the address
+                     */
+                    flatUnitType?: string | null;
+                    /**
+                     * Floor or level number (including alpha characters)
+                     */
+                    floorLevelNumber?: string | null;
+                    /**
+                     * Type of floor or level for the address
+                     */
+                    floorLevelType?: string | null;
+                    /**
+                     * Full name of locality
+                     */
+                    localityName: string;
+                    /**
+                     * Allotment number for the address
+                     */
+                    lotNumber?: string | null;
+                    /**
+                     * Postal delivery number if the address is a postal delivery type
+                     */
+                    postalDeliveryNumber?: number | null;
+                    /**
+                     * Postal delivery number prefix related to the postal delivery number
+                     */
+                    postalDeliveryNumberPrefix?: string | null;
+                    /**
+                     * Postal delivery number suffix related to the postal delivery number
+                     */
+                    postalDeliveryNumberSuffix?: string | null;
+                    /**
+                     * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+                     */
+                    postalDeliveryType?: string | null;
+                    /**
+                     * Postcode for the locality
+                     */
+                    postcode: string;
+                    /**
+                     * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                     */
+                    state: string;
+                    /**
+                     * The name of the street
+                     */
+                    streetName?: string | null;
+                    /**
+                     * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+                     */
+                    streetSuffix?: string | null;
+                    /**
+                     * The street type. Valid enumeration defined by Australia Post PAF code file
+                     */
+                    streetType?: string | null;
+                    /**
+                     * Thoroughfare number for a property (first number in a property ranged address)
+                     */
+                    thoroughfareNumber1?: number | null;
+                    /**
+                     * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+                     */
+                    thoroughfareNumber1Suffix?: string | null;
+                    /**
+                     * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+                     */
+                    thoroughfareNumber2?: number | null;
+                    /**
+                     * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+                     */
+                    thoroughfareNumber2Suffix?: string | null;
+                    [k: string]: unknown;
+                };
+                simple?: {
+                    /**
+                     * First line of the standard address object
+                     */
+                    addressLine1: string;
+                    /**
+                     * Second line of the standard address object
+                     */
+                    addressLine2?: string | null;
+                    /**
+                     * Third line of the standard address object
+                     */
+                    addressLine3?: string | null;
+                    /**
+                     * Name of the city or locality
+                     */
+                    city: string;
+                    /**
+                     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+                     */
+                    country?: string | null;
+                    /**
+                     * Name of the individual or business formatted for inclusion in an address used for physical mail
+                     */
+                    mailingName?: string | null;
+                    /**
+                     * Mandatory for Australian addresses
+                     */
+                    postcode?: string | null;
+                    /**
+                     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                     */
+                    state: string;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            } & {
+                /**
+                 * Enumeration of values indicating the purpose of the physical address
+                 */
+                purpose: 'MAIL' | 'OTHER' | 'PHYSICAL' | 'REGISTERED' | 'WORK';
+                [k: string]: unknown;
+            })[];
+            [k: string]: unknown;
         };
-        simple?: {
-          /**
-           * First line of the standard address object
-           */
-          addressLine1: string;
-          /**
-           * Second line of the standard address object
-           */
-          addressLine2?: string | null;
-          /**
-           * Third line of the standard address object
-           */
-          addressLine3?: string | null;
-          /**
-           * Name of the city or locality
-           */
-          city: string;
-          /**
-           * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-           */
-          country?: string | null;
-          /**
-           * Name of the individual or business formatted for inclusion in an address used for physical mail
-           */
-          mailingName?: string | null;
-          /**
-           * Mandatory for Australian addresses
-           */
-          postcode?: string | null;
-          /**
-           * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-           */
-          state: string;
-          [k: string]: unknown;
+        person?: {
+            /**
+             * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
+             */
+            firstName?: string | null;
+            /**
+             * For people with single names the single name should be in this field
+             */
+            lastName: string;
+            /**
+             * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
+             */
+            lastUpdateTime?: string | null;
+            /**
+             * Field is mandatory but array may be empty
+             */
+            middleNames: string[];
+            /**
+             * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
+             */
+            occupationCode?: string | null;
+            /**
+             * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
+             */
+            occupationCodeVersion?:
+                | (
+                    | 'ANZSCO_1220.0_2006_V1.0'
+                    | 'ANZSCO_1220.0_2006_V1.1'
+                    | 'ANZSCO_1220.0_2013_V1.2'
+                    | 'ANZSCO_1220.0_2013_V1.3'
+                )
+                | null;
+            /**
+             * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+             */
+            prefix?: string | null;
+            /**
+             * Used for a trailing suffix to the name (e.g. Jr)
+             */
+            suffix?: string | null;
+            [k: string]: unknown;
+        } & {
+            /**
+             * Array is mandatory but may be empty if no phone numbers are held
+             */
+            phoneNumbers: {
+                /**
+                 * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+                 */
+                areaCode?: string | null;
+                /**
+                 * If absent, assumed to be Australia (+61). The + should be included
+                 */
+                countryCode?: string | null;
+                /**
+                 * An extension number (if applicable)
+                 */
+                extension?: string | null;
+                /**
+                 * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
+                 */
+                fullNumber: string;
+                /**
+                 * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
+                 */
+                isPreferred?: boolean | null;
+                /**
+                 * The actual phone number, with leading zeros as appropriate
+                 */
+                number: string;
+                /**
+                 * The purpose of the number as specified by the customer
+                 */
+                purpose: 'HOME' | 'INTERNATIONAL' | 'MOBILE' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
+                [k: string]: unknown;
+            }[];
+            /**
+             * May be empty
+             */
+            emailAddresses: {
+                /**
+                 * A correctly formatted email address, as defined by the addr-spec format in **[[RFC5322]](#nref-RFC5322)**
+                 */
+                address: string;
+                /**
+                 * May be true for one and only one email record in the collection. Denotes the default email address
+                 */
+                isPreferred?: boolean | null;
+                /**
+                 * The purpose for the email, as specified by the customer (Enumeration)
+                 */
+                purpose: 'HOME' | 'OTHER' | 'UNSPECIFIED' | 'WORK';
+                [k: string]: unknown;
+            }[];
+            /**
+             * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+             */
+            physicalAddresses: ({
+                /**
+                 * The type of address object present
+                 */
+                addressUType: 'paf' | 'simple';
+                /**
+                 * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+                 */
+                paf?: {
+                    /**
+                     * Building/Property name 1
+                     */
+                    buildingName1?: string | null;
+                    /**
+                     * Building/Property name 2
+                     */
+                    buildingName2?: string | null;
+                    /**
+                     * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+                     */
+                    dpid?: string | null;
+                    /**
+                     * Unit number (including suffix, if applicable)
+                     */
+                    flatUnitNumber?: string | null;
+                    /**
+                     * Type of flat or unit for the address
+                     */
+                    flatUnitType?: string | null;
+                    /**
+                     * Floor or level number (including alpha characters)
+                     */
+                    floorLevelNumber?: string | null;
+                    /**
+                     * Type of floor or level for the address
+                     */
+                    floorLevelType?: string | null;
+                    /**
+                     * Full name of locality
+                     */
+                    localityName: string;
+                    /**
+                     * Allotment number for the address
+                     */
+                    lotNumber?: string | null;
+                    /**
+                     * Postal delivery number if the address is a postal delivery type
+                     */
+                    postalDeliveryNumber?: number | null;
+                    /**
+                     * Postal delivery number prefix related to the postal delivery number
+                     */
+                    postalDeliveryNumberPrefix?: string | null;
+                    /**
+                     * Postal delivery number suffix related to the postal delivery number
+                     */
+                    postalDeliveryNumberSuffix?: string | null;
+                    /**
+                     * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+                     */
+                    postalDeliveryType?: string | null;
+                    /**
+                     * Postcode for the locality
+                     */
+                    postcode: string;
+                    /**
+                     * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                     */
+                    state: string;
+                    /**
+                     * The name of the street
+                     */
+                    streetName?: string | null;
+                    /**
+                     * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+                     */
+                    streetSuffix?: string | null;
+                    /**
+                     * The street type. Valid enumeration defined by Australia Post PAF code file
+                     */
+                    streetType?: string | null;
+                    /**
+                     * Thoroughfare number for a property (first number in a property ranged address)
+                     */
+                    thoroughfareNumber1?: number | null;
+                    /**
+                     * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+                     */
+                    thoroughfareNumber1Suffix?: string | null;
+                    /**
+                     * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+                     */
+                    thoroughfareNumber2?: number | null;
+                    /**
+                     * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+                     */
+                    thoroughfareNumber2Suffix?: string | null;
+                    [k: string]: unknown;
+                };
+                simple?: {
+                    /**
+                     * First line of the standard address object
+                     */
+                    addressLine1: string;
+                    /**
+                     * Second line of the standard address object
+                     */
+                    addressLine2?: string | null;
+                    /**
+                     * Third line of the standard address object
+                     */
+                    addressLine3?: string | null;
+                    /**
+                     * Name of the city or locality
+                     */
+                    city: string;
+                    /**
+                     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+                     */
+                    country?: string | null;
+                    /**
+                     * Name of the individual or business formatted for inclusion in an address used for physical mail
+                     */
+                    mailingName?: string | null;
+                    /**
+                     * Mandatory for Australian addresses
+                     */
+                    postcode?: string | null;
+                    /**
+                     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                     */
+                    state: string;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            } & {
+                /**
+                 * Enumeration of values indicating the purpose of the physical address
+                 */
+                purpose: 'MAIL' | 'OTHER' | 'PHYSICAL' | 'REGISTERED' | 'WORK';
+                [k: string]: unknown;
+            })[];
+            [k: string]: unknown;
         };
         [k: string]: unknown;
-      } & {
-        /**
-         * Enumeration of values indicating the purpose of the physical address
-         */
-        purpose: "MAIL" | "OTHER" | "PHYSICAL" | "REGISTERED" | "WORK";
-        [k: string]: unknown;
-      })[];
-      [k: string]: unknown;
     };
-    person?: {
-      /**
-       * For people with single names this field need not be present. The single name should be in the lastName field. Where a data holder cannot determine first and middle names from a collection of given names, a single string representing all given names MAY be provided.
-       */
-      firstName?: string | null;
-      /**
-       * For people with single names the single name should be in this field
-       */
-      lastName: string;
-      /**
-       * The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
-       */
-      lastUpdateTime?: string | null;
-      /**
-       * Field is mandatory but array may be empty
-       */
-      middleNames: string[];
-      /**
-       * Value is a valid **[[ANZSCO]](#iref-ANZSCO)** Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported **[[ANZSCO]](#iref-ANZSCO)** versions, then it must not be supplied.
-       */
-      occupationCode?: string | null;
-      /**
-       * The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
-       */
-      occupationCodeVersion?:
-        | (
-            | "ANZSCO_1220.0_2006_V1.0"
-            | "ANZSCO_1220.0_2006_V1.1"
-            | "ANZSCO_1220.0_2013_V1.2"
-            | "ANZSCO_1220.0_2013_V1.3"
-          )
-        | null;
-      /**
-       * Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-       */
-      prefix?: string | null;
-      /**
-       * Used for a trailing suffix to the name (e.g. Jr)
-       */
-      suffix?: string | null;
-      [k: string]: unknown;
-    } & {
-      /**
-       * Array is mandatory but may be empty if no phone numbers are held
-       */
-      phoneNumbers: {
+    links: {
         /**
-         * Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+         * Fully qualified link that generated the current response document
          */
-        areaCode?: string | null;
-        /**
-         * If absent, assumed to be Australia (+61). The + should be included
-         */
-        countryCode?: string | null;
-        /**
-         * An extension number (if applicable)
-         */
-        extension?: string | null;
-        /**
-         * Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of **[[RFC3966]](#iref-RFC3966)**
-         */
-        fullNumber: string;
-        /**
-         * May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
-         */
-        isPreferred?: boolean | null;
-        /**
-         * The actual phone number, with leading zeros as appropriate
-         */
-        number: string;
-        /**
-         * The purpose of the number as specified by the customer
-         */
-        purpose: "HOME" | "INTERNATIONAL" | "MOBILE" | "OTHER" | "UNSPECIFIED" | "WORK";
+        self: string;
         [k: string]: unknown;
-      }[];
-      /**
-       * May be empty
-       */
-      emailAddresses: {
-        /**
-         * A correctly formatted email address, as defined by the addr-spec format in **[[RFC5322]](#nref-RFC5322)**
-         */
-        address: string;
-        /**
-         * May be true for one and only one email record in the collection. Denotes the default email address
-         */
-        isPreferred?: boolean | null;
-        /**
-         * The purpose for the email, as specified by the customer (Enumeration)
-         */
-        purpose: "HOME" | "OTHER" | "UNSPECIFIED" | "WORK";
+    };
+    meta?: {
         [k: string]: unknown;
-      }[];
-      /**
-       * Array is mandatory but may be empty if no valid addresses are held. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
-       */
-      physicalAddresses: ({
-        /**
-         * The type of address object present
-         */
-        addressUType: "paf" | "simple";
-        /**
-         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
-         */
-        paf?: {
-          /**
-           * Building/Property name 1
-           */
-          buildingName1?: string | null;
-          /**
-           * Building/Property name 2
-           */
-          buildingName2?: string | null;
-          /**
-           * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-           */
-          dpid?: string | null;
-          /**
-           * Unit number (including suffix, if applicable)
-           */
-          flatUnitNumber?: string | null;
-          /**
-           * Type of flat or unit for the address
-           */
-          flatUnitType?: string | null;
-          /**
-           * Floor or level number (including alpha characters)
-           */
-          floorLevelNumber?: string | null;
-          /**
-           * Type of floor or level for the address
-           */
-          floorLevelType?: string | null;
-          /**
-           * Full name of locality
-           */
-          localityName: string;
-          /**
-           * Allotment number for the address
-           */
-          lotNumber?: string | null;
-          /**
-           * Postal delivery number if the address is a postal delivery type
-           */
-          postalDeliveryNumber?: number | null;
-          /**
-           * Postal delivery number prefix related to the postal delivery number
-           */
-          postalDeliveryNumberPrefix?: string | null;
-          /**
-           * Postal delivery number suffix related to the postal delivery number
-           */
-          postalDeliveryNumberSuffix?: string | null;
-          /**
-           * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-           */
-          postalDeliveryType?: string | null;
-          /**
-           * Postcode for the locality
-           */
-          postcode: string;
-          /**
-           * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-           */
-          state: string;
-          /**
-           * The name of the street
-           */
-          streetName?: string | null;
-          /**
-           * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-           */
-          streetSuffix?: string | null;
-          /**
-           * The street type. Valid enumeration defined by Australia Post PAF code file
-           */
-          streetType?: string | null;
-          /**
-           * Thoroughfare number for a property (first number in a property ranged address)
-           */
-          thoroughfareNumber1?: number | null;
-          /**
-           * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-           */
-          thoroughfareNumber1Suffix?: string | null;
-          /**
-           * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-           */
-          thoroughfareNumber2?: number | null;
-          /**
-           * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-           */
-          thoroughfareNumber2Suffix?: string | null;
-          [k: string]: unknown;
-        };
-        simple?: {
-          /**
-           * First line of the standard address object
-           */
-          addressLine1: string;
-          /**
-           * Second line of the standard address object
-           */
-          addressLine2?: string | null;
-          /**
-           * Third line of the standard address object
-           */
-          addressLine3?: string | null;
-          /**
-           * Name of the city or locality
-           */
-          city: string;
-          /**
-           * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-           */
-          country?: string | null;
-          /**
-           * Name of the individual or business formatted for inclusion in an address used for physical mail
-           */
-          mailingName?: string | null;
-          /**
-           * Mandatory for Australian addresses
-           */
-          postcode?: string | null;
-          /**
-           * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-           */
-          state: string;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      } & {
-        /**
-         * Enumeration of values indicating the purpose of the physical address
-         */
-        purpose: "MAIL" | "OTHER" | "PHYSICAL" | "REGISTERED" | "WORK";
-        [k: string]: unknown;
-      })[];
-      [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface ResponseCommonDiscoveryStatus {
-  data: {
-    /**
-     * The date and time that the current outage was detected. Should only be present if the status property is PARTIAL_FAILURE or UNAVAILABLE
-     */
-    detectionTime?: string | null;
-    /**
-     * The date and time that full service is expected to resume (if known). Should not be present if the status property has a value of OK.
-     */
-    expectedResolutionTime?: string | null;
-    /**
-     * Provides an explanation of the current outage that can be displayed to an end customer. Mandatory if the status property is any value other than OK
-     */
-    explanation?: string | null;
-    /**
-     * Enumeration with values. OK (implementation is fully functional). PARTIAL_FAILURE (one or more end points are unexpectedly unavailable). UNAVAILABLE (the full implementation is unexpectedly unavailable). SCHEDULED_OUTAGE (an advertised outage is in effect)
-     */
-    status: "OK" | "PARTIAL_FAILURE" | "SCHEDULED_OUTAGE" | "UNAVAILABLE";
-    /**
-     * The date and time that this status was last updated by the Data Holder.
-     */
-    updateTime: string;
+    data: {
+        /**
+         * The date and time that the current outage was detected. Should only be present if the status property is PARTIAL_FAILURE or UNAVAILABLE
+         */
+        detectionTime?: string | null;
+        /**
+         * The date and time that full service is expected to resume (if known). Should not be present if the status property has a value of OK.
+         */
+        expectedResolutionTime?: string | null;
+        /**
+         * Provides an explanation of the current outage that can be displayed to an end customer. Mandatory if the status property is any value other than OK
+         */
+        explanation?: string | null;
+        /**
+         * Enumeration with values. OK (implementation is fully functional). PARTIAL_FAILURE (one or more end points are unexpectedly unavailable). UNAVAILABLE (the full implementation is unexpectedly unavailable). SCHEDULED_OUTAGE (an advertised outage is in effect)
+         */
+        status: 'OK' | 'PARTIAL_FAILURE' | 'SCHEDULED_OUTAGE' | 'UNAVAILABLE';
+        /**
+         * The date and time that this status was last updated by the Data Holder.
+         */
+        updateTime: string;
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface ResponseDiscoveryOutagesList {
-  data: {
-    /**
-     * List of scheduled outages. Property is mandatory but may contain and empty list if no outages are scheduled
-     */
-    outages: {
-      /**
-       * Planned duration of the outage. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      duration: string;
-      /**
-       * Provides an explanation of the current outage that can be displayed to an end customer
-       */
-      explanation: string;
-      /**
-       * Flag that indicates, if present and set to true, that the outage is only partial meaning that only a subset of normally available end points will be affected by the outage
-       */
-      isPartial?: boolean | null;
-      /**
-       * Date and time that the outage is scheduled to begin
-       */
-      outageTime: string;
-      [k: string]: unknown;
-    }[];
+    data: {
+        /**
+         * List of scheduled outages. Property is mandatory but may contain and empty list if no outages are scheduled
+         */
+        outages: {
+            /**
+             * Planned duration of the outage. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            duration: string;
+            /**
+             * Provides an explanation of the current outage that can be displayed to an end customer
+             */
+            explanation: string;
+            /**
+             * Flag that indicates, if present and set to true, that the outage is only partial meaning that only a subset of normally available end points will be affected by the outage
+             */
+            isPartial?: boolean | null;
+            /**
+             * Date and time that the outage is scheduled to begin
+             */
+            outageTime: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the common api. */
 
 export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }

--- a/types/consumer-data-standards/dcr/index.d.ts
+++ b/types/consumer-data-standards/dcr/index.d.ts
@@ -1,149 +1,149 @@
 /* These are the schema definitions stipulated by the Data Standards Body for the dcr api. */
 
 export type ClientRegistration = {
-  /**
-   * Contains the identifier for the ADR Software Product (SoftwareProductId) as defined in the CDR Register
-   */
-  iss: string;
-  /**
-   * The time at which the request was issued by the Data Recipient  expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
-   */
-  iat: number;
-  /**
-   * The time at which the request expires expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
-   */
-  exp: number;
-  /**
-   * Unique identifier for the JWT, used to prevent replay of the token
-   */
-  jti: string;
-  /**
-   * 'Contains the Data Holder issuer value as described in the OIDC Discovery Document
-   */
-  aud: string;
-  [k: string]: unknown;
+    /**
+     * Contains the identifier for the ADR Software Product (SoftwareProductId) as defined in the CDR Register
+     */
+    iss: string;
+    /**
+     * The time at which the request was issued by the Data Recipient  expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
+     */
+    iat: number;
+    /**
+     * The time at which the request expires expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
+     */
+    exp: number;
+    /**
+     * Unique identifier for the JWT, used to prevent replay of the token
+     */
+    jti: string;
+    /**
+     * 'Contains the Data Holder issuer value as described in the OIDC Discovery Document
+     */
+    aud: string;
+    [k: string]: unknown;
 } & {
-  /**
-   * Kind of the application. The only supported application type will be `web`
-   */
-  application_type?: "web" | null;
-  /**
-   * Human-readable string name of the software product description to be presented to the end user during authorization
-   */
-  client_description: string;
-  /**
-   * Data Holder issued client identifier string
-   */
-  client_id: string;
-  /**
-   * Time at which the client identifier was issued expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
-   */
-  client_id_issued_at?: number | null;
-  /**
-   * Human-readable string name of the software product to be presented to the end-user during authorization
-   */
-  client_name: string;
-  /**
-   * URL string of a web page providing information about the client
-   */
-  client_uri: string;
-  /**
-   * Array of OAuth 2.0 grant type strings that the client can use at the token endpoint
-   */
-  grant_types: ("client_credentials" | "authorization_code" | "refresh_token")[];
-  /**
-   * JWE `alg` algorithm with which an id_token is to be encrypted. Required if OIDC Hybrid Flow (response type `code id_token`) is registered.
-   */
-  id_token_encrypted_response_alg: string;
-  /**
-   * JWE `enc` algorithm with which an id_token is to be encrypted
-   */
-  id_token_encrypted_response_enc: string;
-  /**
-   * Algorithm with which an id_token is to be signed
-   */
-  id_token_signed_response_alg?: ("PS256" | "ES256") | null;
-  /**
-   * URL string referencing the client JSON Web Key (JWK) Set **[[RFC7517]](#nref-RFC7517)** document, which contains the client public keys
-   */
-  jwks_uri: string;
-  /**
-   * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Legal Entity
-   */
-  legal_entity_id?: string | null;
-  /**
-   * Human-readable string name of the Accredited Data Recipient Legal Entity
-   */
-  legal_entity_name?: string | null;
-  /**
-   * URL string that references a logo for the client. If present, the server SHOULD display this image to the end-user during approval
-   */
-  logo_uri: string;
-  /**
-   * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Brand
-   */
-  org_id: string;
-  /**
-   * Human-readable string name of the Accredited Data Recipient to be presented to the end user during authorization
-   */
-  org_name: string;
-  /**
-   * URL string that points to a human-readable policy document for the Software Product
-   */
-  policy_uri?: string | null;
-  /**
-   * Base URI for the Consumer Data Standard Data Recipient endpoints. This should be the base to provide reference to all other Data Recipient Endpoints
-   */
-  recipient_base_uri?: string | null;
-  /**
-   * Array of redirection URI strings for use in redirect-based flows. If used, redirect_uris MUST match or be a subset of the redirect_uris as defined in the SSA
-   */
-  redirect_uris: string[];
-  /**
-   * Algorithm which the ADR expects to sign the request object if a request object will be part of the authorization request sent to the Data Holder
-   */
-  request_object_signing_alg: "PS256" | "ES256";
-  /**
-   * Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.
-   */
-  response_types: "code id_token"[];
-  /**
-   * URI string that references the location of the Software Product consent revocation endpoint
-   */
-  revocation_uri?: string | null;
-  /**
-   * String containing a space-separated list of scope values that the client can use when requesting access tokens.
-   */
-  scope: string;
-  /**
-   * URL string referencing the client sector identifier URI, used as an optional input to the Pairwise Identifier
-   */
-  sector_identifier_uri?: string | null;
-  /**
-   * String representing a unique identifier assigned by the Register and used by registration endpoints to identify the software product to be dynamically registered. </br></br>The "software_id" will remain the same for the lifetime of the product, across multiple updates and versions
-   */
-  software_id: string;
-  /**
-   * String containing a role of the software in the CDR Regime. Initially the only value used with be `data-recipient-software-product`
-   */
-  software_roles?: string | null;
-  /**
-   * The Software Statement Assertion, as defined in CDR standards
-   */
-  software_statement: string;
-  /**
-   * The requested authentication method for the token endpoint
-   */
-  token_endpoint_auth_method: "private_key_jwt";
-  /**
-   * The algorithm used for signing the JWT
-   */
-  token_endpoint_auth_signing_alg: "PS256" | "ES256";
-  /**
-   * URL string that points to a human-readable terms of service document for the Software Product
-   */
-  tos_uri?: string | null;
-  [k: string]: unknown;
+    /**
+     * Kind of the application. The only supported application type will be `web`
+     */
+    application_type?: 'web' | null;
+    /**
+     * Human-readable string name of the software product description to be presented to the end user during authorization
+     */
+    client_description: string;
+    /**
+     * Data Holder issued client identifier string
+     */
+    client_id: string;
+    /**
+     * Time at which the client identifier was issued expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
+     */
+    client_id_issued_at?: number | null;
+    /**
+     * Human-readable string name of the software product to be presented to the end-user during authorization
+     */
+    client_name: string;
+    /**
+     * URL string of a web page providing information about the client
+     */
+    client_uri: string;
+    /**
+     * Array of OAuth 2.0 grant type strings that the client can use at the token endpoint
+     */
+    grant_types: ('client_credentials' | 'authorization_code' | 'refresh_token')[];
+    /**
+     * JWE `alg` algorithm with which an id_token is to be encrypted. Required if OIDC Hybrid Flow (response type `code id_token`) is registered.
+     */
+    id_token_encrypted_response_alg: string;
+    /**
+     * JWE `enc` algorithm with which an id_token is to be encrypted
+     */
+    id_token_encrypted_response_enc: string;
+    /**
+     * Algorithm with which an id_token is to be signed
+     */
+    id_token_signed_response_alg?: ('PS256' | 'ES256') | null;
+    /**
+     * URL string referencing the client JSON Web Key (JWK) Set **[[RFC7517]](#nref-RFC7517)** document, which contains the client public keys
+     */
+    jwks_uri: string;
+    /**
+     * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Legal Entity
+     */
+    legal_entity_id?: string | null;
+    /**
+     * Human-readable string name of the Accredited Data Recipient Legal Entity
+     */
+    legal_entity_name?: string | null;
+    /**
+     * URL string that references a logo for the client. If present, the server SHOULD display this image to the end-user during approval
+     */
+    logo_uri: string;
+    /**
+     * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Brand
+     */
+    org_id: string;
+    /**
+     * Human-readable string name of the Accredited Data Recipient to be presented to the end user during authorization
+     */
+    org_name: string;
+    /**
+     * URL string that points to a human-readable policy document for the Software Product
+     */
+    policy_uri?: string | null;
+    /**
+     * Base URI for the Consumer Data Standard Data Recipient endpoints. This should be the base to provide reference to all other Data Recipient Endpoints
+     */
+    recipient_base_uri?: string | null;
+    /**
+     * Array of redirection URI strings for use in redirect-based flows. If used, redirect_uris MUST match or be a subset of the redirect_uris as defined in the SSA
+     */
+    redirect_uris: string[];
+    /**
+     * Algorithm which the ADR expects to sign the request object if a request object will be part of the authorization request sent to the Data Holder
+     */
+    request_object_signing_alg: 'PS256' | 'ES256';
+    /**
+     * Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.
+     */
+    response_types: 'code id_token'[];
+    /**
+     * URI string that references the location of the Software Product consent revocation endpoint
+     */
+    revocation_uri?: string | null;
+    /**
+     * String containing a space-separated list of scope values that the client can use when requesting access tokens.
+     */
+    scope: string;
+    /**
+     * URL string referencing the client sector identifier URI, used as an optional input to the Pairwise Identifier
+     */
+    sector_identifier_uri?: string | null;
+    /**
+     * String representing a unique identifier assigned by the Register and used by registration endpoints to identify the software product to be dynamically registered. </br></br>The "software_id" will remain the same for the lifetime of the product, across multiple updates and versions
+     */
+    software_id: string;
+    /**
+     * String containing a role of the software in the CDR Regime. Initially the only value used with be `data-recipient-software-product`
+     */
+    software_roles?: string | null;
+    /**
+     * The Software Statement Assertion, as defined in CDR standards
+     */
+    software_statement: string;
+    /**
+     * The requested authentication method for the token endpoint
+     */
+    token_endpoint_auth_method: 'private_key_jwt';
+    /**
+     * The algorithm used for signing the JWT
+     */
+    token_endpoint_auth_signing_alg: 'PS256' | 'ES256';
+    /**
+     * URL string that points to a human-readable terms of service document for the Software Product
+     */
+    tos_uri?: string | null;
+    [k: string]: unknown;
 };
 /* These are the schema definitions stipulated by the Data Standards Body for the dcr api. */
 
@@ -154,154 +154,154 @@ export type ClientRegistrationRequest = string;
 /* These are the schema definitions stipulated by the Data Standards Body for the dcr api. */
 
 export interface RegistrationError {
-  /**
-   * Predefined error code as described in [section 3.3 OIDC Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html)
-   */
-  error:
-    | "invalid_redirect_uri"
-    | "invalid_client_metadata"
-    | "invalid_software_statement"
-    | "unapproved_software_statement";
-  /**
-   * Additional text description of the error for debugging.
-   */
-  error_description?: string | null;
-  [k: string]: unknown;
+    /**
+     * Predefined error code as described in [section 3.3 OIDC Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html)
+     */
+    error:
+        | 'invalid_redirect_uri'
+        | 'invalid_client_metadata'
+        | 'invalid_software_statement'
+        | 'unapproved_software_statement';
+    /**
+     * Additional text description of the error for debugging.
+     */
+    error_description?: string | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the dcr api. */
 
 export interface RegistrationProperties {
-  /**
-   * Kind of the application. The only supported application type will be `web`
-   */
-  application_type?: "web" | null;
-  /**
-   * The JWE `alg` algorithm required for encrypting authorization responses. If unspecified, the default is that no encryption is performed.<br><br>Required if “authorization_encrypted_response_enc” is included.
-   */
-  authorization_encrypted_response_alg?: ("RSA-OAEP" | "RSA-OAEP-256") | null;
-  /**
-   * The JWE `enc` algorithm required for encrypting authorization responses. If “authorization_encrypted_response_alg” is specified, the default for this value is “A128CBC-HS256”.
-   */
-  authorization_encrypted_response_enc?: ("A256GCM" | "A128CBC-HS256") | null;
-  /**
-   * The JWS `alg` algorithm required for signing authorization responses. If this is specified, the response will be signed using JWS and the configured algorithm. The algorithm “none” is not allowed.<br><br>Required if response_type of “code” is registered by the client.
-   */
-  authorization_signed_response_alg?: ("PS256" | "ES256") | null;
-  /**
-   * Human-readable string name of the software product description to be presented to the end user during authorization
-   */
-  client_description: string;
-  /**
-   * Data Holder issued client identifier string
-   */
-  client_id: string;
-  /**
-   * Time at which the client identifier was issued expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
-   */
-  client_id_issued_at?: number | null;
-  /**
-   * Human-readable string name of the software product to be presented to the end-user during authorization
-   */
-  client_name: string;
-  /**
-   * URL string of a web page providing information about the client
-   */
-  client_uri: string;
-  /**
-   * Array of OAuth 2.0 grant type strings that the client can use at the token endpoint
-   */
-  grant_types: ("client_credentials" | "authorization_code" | "refresh_token")[];
-  /**
-   * JWE `alg` algorithm with which an id_token is to be encrypted. Required if OIDC Hybrid Flow (response type `code id_token`) is registered.
-   */
-  id_token_encrypted_response_alg: string;
-  /**
-   * JWE `enc` algorithm with which an id_token is to be encrypted
-   */
-  id_token_encrypted_response_enc: string;
-  /**
-   * Algorithm with which an id_token is to be signed
-   */
-  id_token_signed_response_alg: "PS256" | "ES256";
-  /**
-   * URL string referencing the client JSON Web Key (JWK) Set **[[RFC7517]](#nref-RFC7517)** document, which contains the client public keys
-   */
-  jwks_uri: string;
-  /**
-   * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Legal Entity
-   */
-  legal_entity_id?: string | null;
-  /**
-   * Human-readable string name of the Accredited Data Recipient Legal Entity
-   */
-  legal_entity_name?: string | null;
-  /**
-   * URL string that references a logo for the client. If present, the server SHOULD display this image to the end-user during approval
-   */
-  logo_uri: string;
-  /**
-   * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Brand
-   */
-  org_id: string;
-  /**
-   * Human-readable string name of the Accredited Data Recipient to be presented to the end user during authorization
-   */
-  org_name: string;
-  /**
-   * URL string that points to a human-readable policy document for the Software Product
-   */
-  policy_uri?: string | null;
-  /**
-   * Base URI for the Consumer Data Standard Data Recipient endpoints. This should be the base to provide reference to all other Data Recipient Endpoints
-   */
-  recipient_base_uri?: string | null;
-  /**
-   * Array of redirection URI strings for use in redirect-based flows. If used, redirect_uris MUST match or be a subset of the redirect_uris as defined in the SSA
-   */
-  redirect_uris: string[];
-  /**
-   * Algorithm which the ADR expects to sign the request object if a request object will be part of the authorization request sent to the Data Holder
-   */
-  request_object_signing_alg: "PS256" | "ES256";
-  /**
-   * Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.<br><br>Response type value `code` is required for Authorization Code Flow. Response type value `code id_token` is required for OIDC Hybrid Flow.
-   */
-  response_types: ("code" | "code id_token")[];
-  /**
-   * URI string that references the location of the Software Product consent revocation endpoint
-   */
-  revocation_uri?: string | null;
-  /**
-   * String containing a space-separated list of scope values that the client can use when requesting access tokens.
-   */
-  scope: string;
-  /**
-   * URL string referencing the client sector identifier URI, used as an optional input to the Pairwise Identifier
-   */
-  sector_identifier_uri?: string | null;
-  /**
-   * String representing a unique identifier assigned by the Register and used by registration endpoints to identify the software product to be dynamically registered. </br></br>The "software_id" will remain the same for the lifetime of the product, across multiple updates and versions
-   */
-  software_id: string;
-  /**
-   * String containing a role of the software in the CDR Regime. Initially the only value used with be `data-recipient-software-product`
-   */
-  software_roles?: "data-recipient-software-product" | null;
-  /**
-   * The Software Statement Assertion, as defined in CDR standards
-   */
-  software_statement: string;
-  /**
-   * The requested authentication method for the token endpoint
-   */
-  token_endpoint_auth_method: "private_key_jwt";
-  /**
-   * The algorithm used for signing the JWT
-   */
-  token_endpoint_auth_signing_alg: "PS256" | "ES256";
-  /**
-   * URL string that points to a human-readable terms of service document for the Software Product
-   */
-  tos_uri?: string | null;
-  [k: string]: unknown;
+    /**
+     * Kind of the application. The only supported application type will be `web`
+     */
+    application_type?: 'web' | null;
+    /**
+     * The JWE `alg` algorithm required for encrypting authorization responses. If unspecified, the default is that no encryption is performed.<br><br>Required if “authorization_encrypted_response_enc” is included.
+     */
+    authorization_encrypted_response_alg?: ('RSA-OAEP' | 'RSA-OAEP-256') | null;
+    /**
+     * The JWE `enc` algorithm required for encrypting authorization responses. If “authorization_encrypted_response_alg” is specified, the default for this value is “A128CBC-HS256”.
+     */
+    authorization_encrypted_response_enc?: ('A256GCM' | 'A128CBC-HS256') | null;
+    /**
+     * The JWS `alg` algorithm required for signing authorization responses. If this is specified, the response will be signed using JWS and the configured algorithm. The algorithm “none” is not allowed.<br><br>Required if response_type of “code” is registered by the client.
+     */
+    authorization_signed_response_alg?: ('PS256' | 'ES256') | null;
+    /**
+     * Human-readable string name of the software product description to be presented to the end user during authorization
+     */
+    client_description: string;
+    /**
+     * Data Holder issued client identifier string
+     */
+    client_id: string;
+    /**
+     * Time at which the client identifier was issued expressed as seconds since 1970-01-01T00:00:00Z as measured in UTC
+     */
+    client_id_issued_at?: number | null;
+    /**
+     * Human-readable string name of the software product to be presented to the end-user during authorization
+     */
+    client_name: string;
+    /**
+     * URL string of a web page providing information about the client
+     */
+    client_uri: string;
+    /**
+     * Array of OAuth 2.0 grant type strings that the client can use at the token endpoint
+     */
+    grant_types: ('client_credentials' | 'authorization_code' | 'refresh_token')[];
+    /**
+     * JWE `alg` algorithm with which an id_token is to be encrypted. Required if OIDC Hybrid Flow (response type `code id_token`) is registered.
+     */
+    id_token_encrypted_response_alg: string;
+    /**
+     * JWE `enc` algorithm with which an id_token is to be encrypted
+     */
+    id_token_encrypted_response_enc: string;
+    /**
+     * Algorithm with which an id_token is to be signed
+     */
+    id_token_signed_response_alg: 'PS256' | 'ES256';
+    /**
+     * URL string referencing the client JSON Web Key (JWK) Set **[[RFC7517]](#nref-RFC7517)** document, which contains the client public keys
+     */
+    jwks_uri: string;
+    /**
+     * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Legal Entity
+     */
+    legal_entity_id?: string | null;
+    /**
+     * Human-readable string name of the Accredited Data Recipient Legal Entity
+     */
+    legal_entity_name?: string | null;
+    /**
+     * URL string that references a logo for the client. If present, the server SHOULD display this image to the end-user during approval
+     */
+    logo_uri: string;
+    /**
+     * A unique identifier string assigned by the CDR Register that identifies the Accredited Data Recipient Brand
+     */
+    org_id: string;
+    /**
+     * Human-readable string name of the Accredited Data Recipient to be presented to the end user during authorization
+     */
+    org_name: string;
+    /**
+     * URL string that points to a human-readable policy document for the Software Product
+     */
+    policy_uri?: string | null;
+    /**
+     * Base URI for the Consumer Data Standard Data Recipient endpoints. This should be the base to provide reference to all other Data Recipient Endpoints
+     */
+    recipient_base_uri?: string | null;
+    /**
+     * Array of redirection URI strings for use in redirect-based flows. If used, redirect_uris MUST match or be a subset of the redirect_uris as defined in the SSA
+     */
+    redirect_uris: string[];
+    /**
+     * Algorithm which the ADR expects to sign the request object if a request object will be part of the authorization request sent to the Data Holder
+     */
+    request_object_signing_alg: 'PS256' | 'ES256';
+    /**
+     * Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.<br><br>Response type value `code` is required for Authorization Code Flow. Response type value `code id_token` is required for OIDC Hybrid Flow.
+     */
+    response_types: ('code' | 'code id_token')[];
+    /**
+     * URI string that references the location of the Software Product consent revocation endpoint
+     */
+    revocation_uri?: string | null;
+    /**
+     * String containing a space-separated list of scope values that the client can use when requesting access tokens.
+     */
+    scope: string;
+    /**
+     * URL string referencing the client sector identifier URI, used as an optional input to the Pairwise Identifier
+     */
+    sector_identifier_uri?: string | null;
+    /**
+     * String representing a unique identifier assigned by the Register and used by registration endpoints to identify the software product to be dynamically registered. </br></br>The "software_id" will remain the same for the lifetime of the product, across multiple updates and versions
+     */
+    software_id: string;
+    /**
+     * String containing a role of the software in the CDR Regime. Initially the only value used with be `data-recipient-software-product`
+     */
+    software_roles?: 'data-recipient-software-product' | null;
+    /**
+     * The Software Statement Assertion, as defined in CDR standards
+     */
+    software_statement: string;
+    /**
+     * The requested authentication method for the token endpoint
+     */
+    token_endpoint_auth_method: 'private_key_jwt';
+    /**
+     * The algorithm used for signing the JWT
+     */
+    token_endpoint_auth_signing_alg: 'PS256' | 'ES256';
+    /**
+     * URL string that points to a human-readable terms of service document for the Software Product
+     */
+    tos_uri?: string | null;
+    [k: string]: unknown;
 }

--- a/types/consumer-data-standards/energy/index.d.ts
+++ b/types/consumer-data-standards/energy/index.d.ts
@@ -3,107 +3,6 @@
  * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
  */
 export interface CommonPAFAddress {
-  /**
-   * Building/Property name 1
-   */
-  buildingName1?: string | null;
-  /**
-   * Building/Property name 2
-   */
-  buildingName2?: string | null;
-  /**
-   * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-   */
-  dpid?: string | null;
-  /**
-   * Unit number (including suffix, if applicable)
-   */
-  flatUnitNumber?: string | null;
-  /**
-   * Type of flat or unit for the address
-   */
-  flatUnitType?: string | null;
-  /**
-   * Floor or level number (including alpha characters)
-   */
-  floorLevelNumber?: string | null;
-  /**
-   * Type of floor or level for the address
-   */
-  floorLevelType?: string | null;
-  /**
-   * Full name of locality
-   */
-  localityName: string;
-  /**
-   * Allotment number for the address
-   */
-  lotNumber?: string | null;
-  /**
-   * Postal delivery number if the address is a postal delivery type
-   */
-  postalDeliveryNumber?: number | null;
-  /**
-   * Postal delivery number prefix related to the postal delivery number
-   */
-  postalDeliveryNumberPrefix?: string | null;
-  /**
-   * Postal delivery number suffix related to the postal delivery number
-   */
-  postalDeliveryNumberSuffix?: string | null;
-  /**
-   * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-   */
-  postalDeliveryType?: string | null;
-  /**
-   * Postcode for the locality
-   */
-  postcode: string;
-  /**
-   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  /**
-   * The name of the street
-   */
-  streetName?: string | null;
-  /**
-   * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetSuffix?: string | null;
-  /**
-   * The street type. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetType?: string | null;
-  /**
-   * Thoroughfare number for a property (first number in a property ranged address)
-   */
-  thoroughfareNumber1?: number | null;
-  /**
-   * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-   */
-  thoroughfareNumber1Suffix?: string | null;
-  /**
-   * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-   */
-  thoroughfareNumber2?: number | null;
-  /**
-   * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-   */
-  thoroughfareNumber2Suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface CommonPhysicalAddress {
-  /**
-   * The type of address object present
-   */
-  addressUType: "paf" | "simple";
-  /**
-   * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
-   */
-  paf?: {
     /**
      * Building/Property name 1
      */
@@ -193,11 +92,154 @@ export interface CommonPhysicalAddress {
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * Required if addressUType is set to simple
-   */
-  simple?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface CommonPhysicalAddress {
+    /**
+     * The type of address object present
+     */
+    addressUType: 'paf' | 'simple';
+    /**
+     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
+     */
+    paf?: {
+        /**
+         * Building/Property name 1
+         */
+        buildingName1?: string | null;
+        /**
+         * Building/Property name 2
+         */
+        buildingName2?: string | null;
+        /**
+         * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+         */
+        dpid?: string | null;
+        /**
+         * Unit number (including suffix, if applicable)
+         */
+        flatUnitNumber?: string | null;
+        /**
+         * Type of flat or unit for the address
+         */
+        flatUnitType?: string | null;
+        /**
+         * Floor or level number (including alpha characters)
+         */
+        floorLevelNumber?: string | null;
+        /**
+         * Type of floor or level for the address
+         */
+        floorLevelType?: string | null;
+        /**
+         * Full name of locality
+         */
+        localityName: string;
+        /**
+         * Allotment number for the address
+         */
+        lotNumber?: string | null;
+        /**
+         * Postal delivery number if the address is a postal delivery type
+         */
+        postalDeliveryNumber?: number | null;
+        /**
+         * Postal delivery number prefix related to the postal delivery number
+         */
+        postalDeliveryNumberPrefix?: string | null;
+        /**
+         * Postal delivery number suffix related to the postal delivery number
+         */
+        postalDeliveryNumberSuffix?: string | null;
+        /**
+         * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+         */
+        postalDeliveryType?: string | null;
+        /**
+         * Postcode for the locality
+         */
+        postcode: string;
+        /**
+         * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        /**
+         * The name of the street
+         */
+        streetName?: string | null;
+        /**
+         * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetSuffix?: string | null;
+        /**
+         * The street type. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetType?: string | null;
+        /**
+         * Thoroughfare number for a property (first number in a property ranged address)
+         */
+        thoroughfareNumber1?: number | null;
+        /**
+         * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+         */
+        thoroughfareNumber1Suffix?: string | null;
+        /**
+         * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+         */
+        thoroughfareNumber2?: number | null;
+        /**
+         * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+         */
+        thoroughfareNumber2Suffix?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Required if addressUType is set to simple
+     */
+    simple?: {
+        /**
+         * First line of the standard address object
+         */
+        addressLine1: string;
+        /**
+         * Second line of the standard address object
+         */
+        addressLine2?: string | null;
+        /**
+         * Third line of the standard address object
+         */
+        addressLine3?: string | null;
+        /**
+         * Name of the city or locality
+         */
+        city: string;
+        /**
+         * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+         */
+        country?: string | null;
+        /**
+         * Name of the individual or business formatted for inclusion in an address used for physical mail
+         */
+        mailingName?: string | null;
+        /**
+         * Mandatory for Australian addresses
+         */
+        postcode?: string | null;
+        /**
+         * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+/**
+ * Required if addressUType is set to simple
+ */
+export interface CommonSimpleAddress {
     /**
      * First line of the standard address object
      */
@@ -231,1547 +273,44 @@ export interface CommonPhysicalAddress {
      */
     state: string;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-/**
- * Required if addressUType is set to simple
- */
-export interface CommonSimpleAddress {
-  /**
-   * First line of the standard address object
-   */
-  addressLine1: string;
-  /**
-   * Second line of the standard address object
-   */
-  addressLine2?: string | null;
-  /**
-   * Third line of the standard address object
-   */
-  addressLine3?: string | null;
-  /**
-   * Name of the city or locality
-   */
-  city: string;
-  /**
-   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-   */
-  country?: string | null;
-  /**
-   * Name of the individual or business formatted for inclusion in an address used for physical mail
-   */
-  mailingName?: string | null;
-  /**
-   * Mandatory for Australian addresses
-   */
-  postcode?: string | null;
-  /**
-   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccount extends EnergyAccountBase {
-  /**
-   * The array of plans containing service points and associated plan details
-   */
-  plans: {
     /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
+     * The array of plans containing service points and associated plan details
      */
-    nickname?: string;
-    /**
-     * An array of servicePointIds, representing NMIs, that this plan is linked to.  If there are no service points allocated to this plan then an empty array would be expected
-     */
-    servicePointIds: string[];
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string;
-      [k: string]: unknown;
-    };
+    plans: {
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string;
+        /**
+         * An array of servicePointIds, representing NMIs, that this plan is linked to.  If there are no service points allocated to this plan then an empty array would be expected
+         */
+        servicePointIds: string[];
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccountBase {
-  /**
-   * The ID of the account.  To be created in accordance with CDR ID permanence requirements
-   */
-  accountId: string;
-  /**
-   * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
-   */
-  accountNumber?: string | null;
-  /**
-   * The date that the account was created or opened
-   */
-  creationDate: string;
-  /**
-   * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
-   */
-  displayName?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyAccountBaseV2 {
-  /**
-   * The ID of the account.  To be created in accordance with CDR ID permanence requirements
-   */
-  accountId: string;
-  /**
-   * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
-   */
-  accountNumber?: string | null;
-  /**
-   * The date that the account was created or opened. Mandatory if openStatus is OPEN
-   */
-  creationDate?: string | null;
-  /**
-   * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
-   */
-  displayName?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyAccountDetail extends EnergyAccountBase {
-  /**
-   * The array of plans containing service points and associated plan details
-   */
-  plans: {
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string;
-    /**
-     * An array of servicePointIds, representing NMIs, that this account is linked to
-     */
-    servicePointIds: string[];
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string;
-      [k: string]: unknown;
-    };
-    /**
-     * Detail on the plan applicable to this account
-     */
-    planDetail: {
-      /**
-       * The fuel types covered by the plan
-       */
-      fuelType: "ELECTRICITY" | "GAS" | "DUAL";
-      /**
-       * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
-       */
-      isContingentPlan?: boolean;
-      /**
-       * Charges for metering included in the plan
-       */
-      meteringCharges?: {
-        /**
-         * Display name of the charge
-         */
-        displayName: string;
-        /**
-         * Description of the charge
-         */
-        description?: string;
-        /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-         */
-        minimumValue: string;
-        /**
-         * The upper limit of the charge if the charge could occur in a range
-         */
-        maximumValue?: string;
-        /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-         */
-        period?: string;
-        [k: string]: unknown;
-      }[];
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-       */
-      gasContract?: {
-        /**
-         * Free text field containing additional information of the fees for this contract
-         */
-        additionalFeeInformation?: string | null;
-        /**
-         * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-         */
-        controlledLoad?: {
-          /**
-           * A display name for the controlled load
-           */
-          displayName: string;
-          /**
-           * Optional end date of the application of the controlled load rate
-           */
-          endDate?: string;
-          /**
-           * Specifies the type of controlloed load rate
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates";
-          /**
-           * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * Optional start date of the application of the controlled load rate
-           */
-          startDate?: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use.
-             */
-            timeOfUse: {
-              /**
-               * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-               */
-              additionalInfo?: string;
-              /**
-               * Optional link to additional information regarding the controlled load
-               */
-              additionalInfoUri?: string;
-              /**
-               * The days that the rate applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-            [k: string]: unknown;
-          }[];
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of discounts available for the contract
-         */
-        discounts?: {
-          /**
-           * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-           */
-          category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-          /**
-           * The description of the discount
-           */
-          description?: string;
-          /**
-           * The display name of the discount
-           */
-          displayName: string;
-          /**
-           * Optional end date for the discount after which the discount is no longer available
-           */
-          endDate?: string;
-          /**
-           * Required if methodUType is fixedAmount
-           */
-          fixedAmount?: {
-            /**
-             * The amount of the discount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The method of calculation of the discount
-           */
-          methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-          /**
-           * Required if methodUType is percentOfBill
-           */
-          percentOfBill?: {
-            /**
-             * The rate of the discount applied to the bill amount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOfUse
-           */
-          percentOfUse?: {
-            /**
-             * The rate of the discount applied to the usageamount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOverThreshold
-           */
-          percentOverThreshold?: {
-            /**
-             * The rate of the discount over the usage amount
-             */
-            rate: string;
-            /**
-             * The usage amount threshold above which the discount applies
-             */
-            usageAmount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the discount
-           */
-          type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Eligibility restrictions or requirements
-         */
-        eligibility?: {
-          /**
-           * A description of the eligibility restriction
-           */
-          description?: string;
-          /**
-           * Information of the eligibility restriction specific to the type of the restriction
-           */
-          information: string;
-          /**
-           * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-           */
-          type:
-            | "EXISTING_CUST"
-            | "EXISTING_POOL"
-            | "EXISTING_SOLAR"
-            | "EXISTING_BATTERY"
-            | "EXISTING_SMART_METER"
-            | "EXISTING_BASIC_METER"
-            | "SENIOR_CARD"
-            | "SMALL_BUSINESS"
-            | "NO_SOLAR_FIT"
-            | "NEW_CUSTOMER"
-            | "ONLINE_ONLY"
-            | "REQ_EQUIP_SUPPLIER"
-            | "THIRD_PARTY_ONLY"
-            | "SPORT_CLUB_MEMBER"
-            | "ORG_MEMBER"
-            | "SPECIFIC_LOCATION"
-            | "MINIMUM_USAGE"
-            | "LOYALTY_MEMBER"
-            | "GROUP_BUY_MEMBER"
-            | "CONTINGENT_PLAN"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * An array of fees applicable to the plan
-         */
-        fees?: {
-          /**
-           * The fee amount. Required if term is not PERCENT_OF_BILL
-           */
-          amount?: string;
-          /**
-           * A description of the fee
-           */
-          description?: string;
-          /**
-           * The fee rate. Required if term is PERCENT_OF_BILL
-           */
-          rate?: string;
-          /**
-           * The term of the fee
-           */
-          term:
-            | "FIXED"
-            | "1_YEAR"
-            | "2_YEAR"
-            | "3_YEAR"
-            | "4_YEAR"
-            | "5_YEAR"
-            | "PERCENT_OF_BILL"
-            | "ANNUAL"
-            | "DAILY"
-            | "WEEKLY"
-            | "MONTHLY"
-            | "BIANNUAL"
-            | "VARIABLE";
-          /**
-           * The type of the fee
-           */
-          type:
-            | "EXIT"
-            | "ESTABLISHMENT"
-            | "LATE_PAYMENT"
-            | "DISCONNECTION"
-            | "DISCONNECT_MOVE_OUT"
-            | "DISCONNECT_NON_PAY"
-            | "RECONNECTION"
-            | "CONNECTION"
-            | "PAYMENT_PROCESSING"
-            | "CC_PROCESSING"
-            | "CHEQUE_DISHONOUR"
-            | "DD_DISHONOUR"
-            | "MEMBERSHIP"
-            | "CONTRIBUTION"
-            | "PAPER_BILL"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of charges applicable to green power
-         */
-        greenPowerCharges?: {
-          /**
-           * The description of the charge
-           */
-          description?: string;
-          /**
-           * The display name of the charge
-           */
-          displayName: string;
-          /**
-           * The applicable green power scheme
-           */
-          scheme: "GREENPOWER" | "OTHER";
-          /**
-           * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-           */
-          tiers: {
-            /**
-             * The amount of the charge if the type implies the application of a fixed amount
-             */
-            amount?: string;
-            /**
-             * The upper percentage of green power used applicable for this tier
-             */
-            percentGreen: string;
-            /**
-             * The rate of the charge if the type implies the application of a rate
-             */
-            rate?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The type of charge
-           */
-          type:
-            | "FIXED_PER_DAY"
-            | "FIXED_PER_WEEK"
-            | "FIXED_PER_MONTH"
-            | "FIXED_PER_UNIT"
-            | "PERCENT_OF_USE"
-            | "PERCENT_OF_BILL";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of incentives available for the contract
-         */
-        incentives?: {
-          /**
-           * The type of the incentive
-           */
-          category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-          /**
-           * The description of the incentive
-           */
-          description: string;
-          /**
-           * The display name of the incentive
-           */
-          displayName: string;
-          /**
-           * A display message outlining an eligibility criteria that may apply
-           */
-          eligibility?: string;
-          [k: string]: unknown;
-        }[];
-        /**
-         * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-         */
-        intrinsicGreenPower?: {
-          /**
-           * Percentage of green power intrinsically included in the plan
-           */
-          greenPercentage: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Flag indicating whether prices are fixed or variable
-         */
-        isFixed: boolean;
-        /**
-         * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-         */
-        onExpiryDescription?: string | null;
-        /**
-         * Payment options for this contract
-         */
-        paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-        /**
-         * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-         */
-        pricingModel:
-          | "SINGLE_RATE"
-          | "SINGLE_RATE_CONT_LOAD"
-          | "TIME_OF_USE"
-          | "TIME_OF_USE_CONT_LOAD"
-          | "FLEXIBLE"
-          | "FLEXIBLE_CONT_LOAD"
-          | "QUOTA";
-        /**
-         * Array of feed in tariffs for solar power
-         */
-        solarFeedInTariff?: {
-          /**
-           * A description of the tariff
-           */
-          description?: string;
-          /**
-           * The name of the tariff
-           */
-          displayName: string;
-          /**
-           * The type of the payer
-           */
-          payerType: "GOVERNMENT" | "RETAILER";
-          /**
-           * The applicable scheme
-           */
-          scheme: "PREMIUM" | "OTHER";
-          /**
-           * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-           */
-          singleTariff?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the payer
-           */
-          tariffUType: "singleTariff" | "timeVaryingTariffs";
-          /**
-           * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-           */
-          timeVaryingTariffs?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            /**
-             * Array of time periods for which this tariff is applicable
-             */
-            timeVariations: {
-              /**
-               * The days that the tariff applies to. At least one entry required
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of the charging time period. If absent applies to all periods
-             */
-            type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        }[];
-        /**
-         * Array of tariff periods
-         */
-        tariffPeriod: {
-          /**
-           * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-           */
-          dailySupplyCharges?: string;
-          /**
-           * Array of demand charges.  Required if rateBlockUType is demandCharges
-           */
-          demandCharges?: {
-            /**
-             * The charge amount per  measure unit exclusive of GST
-             */
-            amount: string;
-            /**
-             * Charge period for the demand tariff
-             */
-            chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * The days that the demand tariff applies to
-             */
-            days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-            /**
-             * Description of the charge
-             */
-            description?: string;
-            /**
-             * Display name of the charge
-             */
-            displayName: string;
-            /**
-             * End of the period
-             */
-            endTime: string;
-            /**
-             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-             */
-            maxDemand?: string;
-            /**
-             * The measurement unit of charge amount. Assumed to be KWH if absent
-             */
-            measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-            /**
-             * Application period for the demand tariff
-             */
-            measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-             */
-            minDemand?: string;
-            /**
-             * Start of the period
-             */
-            startTime: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The name of the tariff period
-           */
-          displayName: string;
-          /**
-           * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          endDate: string;
-          /**
-           * Specifies the type of rate applicable to this tariff period
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-          /**
-           * Object representing a single rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-             */
-            generalUnitPrice?: string;
-            /**
-             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-             */
-            period?: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          startDate: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use
-             */
-            timeOfUse: {
-              /**
-               * The days that the rate applies to
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-           */
-          timeZone?: "LOCAL" | "AEST";
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-         */
-        timeZone?: ("LOCAL" | "AEST") | null;
-        /**
-         * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-         */
-        variation?: string | null;
-        [k: string]: unknown;
-      };
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-       */
-      electricityContract?: {
-        /**
-         * Free text field containing additional information of the fees for this contract
-         */
-        additionalFeeInformation?: string | null;
-        /**
-         * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-         */
-        controlledLoad?: {
-          /**
-           * A display name for the controlled load
-           */
-          displayName: string;
-          /**
-           * Optional end date of the application of the controlled load rate
-           */
-          endDate?: string;
-          /**
-           * Specifies the type of controlloed load rate
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates";
-          /**
-           * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * Optional start date of the application of the controlled load rate
-           */
-          startDate?: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use.
-             */
-            timeOfUse: {
-              /**
-               * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-               */
-              additionalInfo?: string;
-              /**
-               * Optional link to additional information regarding the controlled load
-               */
-              additionalInfoUri?: string;
-              /**
-               * The days that the rate applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-            [k: string]: unknown;
-          }[];
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of discounts available for the contract
-         */
-        discounts?: {
-          /**
-           * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-           */
-          category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-          /**
-           * The description of the discount
-           */
-          description?: string;
-          /**
-           * The display name of the discount
-           */
-          displayName: string;
-          /**
-           * Optional end date for the discount after which the discount is no longer available
-           */
-          endDate?: string;
-          /**
-           * Required if methodUType is fixedAmount
-           */
-          fixedAmount?: {
-            /**
-             * The amount of the discount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The method of calculation of the discount
-           */
-          methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-          /**
-           * Required if methodUType is percentOfBill
-           */
-          percentOfBill?: {
-            /**
-             * The rate of the discount applied to the bill amount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOfUse
-           */
-          percentOfUse?: {
-            /**
-             * The rate of the discount applied to the usageamount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOverThreshold
-           */
-          percentOverThreshold?: {
-            /**
-             * The rate of the discount over the usage amount
-             */
-            rate: string;
-            /**
-             * The usage amount threshold above which the discount applies
-             */
-            usageAmount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the discount
-           */
-          type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Eligibility restrictions or requirements
-         */
-        eligibility?: {
-          /**
-           * A description of the eligibility restriction
-           */
-          description?: string;
-          /**
-           * Information of the eligibility restriction specific to the type of the restriction
-           */
-          information: string;
-          /**
-           * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-           */
-          type:
-            | "EXISTING_CUST"
-            | "EXISTING_POOL"
-            | "EXISTING_SOLAR"
-            | "EXISTING_BATTERY"
-            | "EXISTING_SMART_METER"
-            | "EXISTING_BASIC_METER"
-            | "SENIOR_CARD"
-            | "SMALL_BUSINESS"
-            | "NO_SOLAR_FIT"
-            | "NEW_CUSTOMER"
-            | "ONLINE_ONLY"
-            | "REQ_EQUIP_SUPPLIER"
-            | "THIRD_PARTY_ONLY"
-            | "SPORT_CLUB_MEMBER"
-            | "ORG_MEMBER"
-            | "SPECIFIC_LOCATION"
-            | "MINIMUM_USAGE"
-            | "LOYALTY_MEMBER"
-            | "GROUP_BUY_MEMBER"
-            | "CONTINGENT_PLAN"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * An array of fees applicable to the plan
-         */
-        fees?: {
-          /**
-           * The fee amount. Required if term is not PERCENT_OF_BILL
-           */
-          amount?: string;
-          /**
-           * A description of the fee
-           */
-          description?: string;
-          /**
-           * The fee rate. Required if term is PERCENT_OF_BILL
-           */
-          rate?: string;
-          /**
-           * The term of the fee
-           */
-          term:
-            | "FIXED"
-            | "1_YEAR"
-            | "2_YEAR"
-            | "3_YEAR"
-            | "4_YEAR"
-            | "5_YEAR"
-            | "PERCENT_OF_BILL"
-            | "ANNUAL"
-            | "DAILY"
-            | "WEEKLY"
-            | "MONTHLY"
-            | "BIANNUAL"
-            | "VARIABLE";
-          /**
-           * The type of the fee
-           */
-          type:
-            | "EXIT"
-            | "ESTABLISHMENT"
-            | "LATE_PAYMENT"
-            | "DISCONNECTION"
-            | "DISCONNECT_MOVE_OUT"
-            | "DISCONNECT_NON_PAY"
-            | "RECONNECTION"
-            | "CONNECTION"
-            | "PAYMENT_PROCESSING"
-            | "CC_PROCESSING"
-            | "CHEQUE_DISHONOUR"
-            | "DD_DISHONOUR"
-            | "MEMBERSHIP"
-            | "CONTRIBUTION"
-            | "PAPER_BILL"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of charges applicable to green power
-         */
-        greenPowerCharges?: {
-          /**
-           * The description of the charge
-           */
-          description?: string;
-          /**
-           * The display name of the charge
-           */
-          displayName: string;
-          /**
-           * The applicable green power scheme
-           */
-          scheme: "GREENPOWER" | "OTHER";
-          /**
-           * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-           */
-          tiers: {
-            /**
-             * The amount of the charge if the type implies the application of a fixed amount
-             */
-            amount?: string;
-            /**
-             * The upper percentage of green power used applicable for this tier
-             */
-            percentGreen: string;
-            /**
-             * The rate of the charge if the type implies the application of a rate
-             */
-            rate?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The type of charge
-           */
-          type:
-            | "FIXED_PER_DAY"
-            | "FIXED_PER_WEEK"
-            | "FIXED_PER_MONTH"
-            | "FIXED_PER_UNIT"
-            | "PERCENT_OF_USE"
-            | "PERCENT_OF_BILL";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of incentives available for the contract
-         */
-        incentives?: {
-          /**
-           * The type of the incentive
-           */
-          category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-          /**
-           * The description of the incentive
-           */
-          description: string;
-          /**
-           * The display name of the incentive
-           */
-          displayName: string;
-          /**
-           * A display message outlining an eligibility criteria that may apply
-           */
-          eligibility?: string;
-          [k: string]: unknown;
-        }[];
-        /**
-         * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-         */
-        intrinsicGreenPower?: {
-          /**
-           * Percentage of green power intrinsically included in the plan
-           */
-          greenPercentage: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Flag indicating whether prices are fixed or variable
-         */
-        isFixed: boolean;
-        /**
-         * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-         */
-        onExpiryDescription?: string | null;
-        /**
-         * Payment options for this contract
-         */
-        paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-        /**
-         * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-         */
-        pricingModel:
-          | "SINGLE_RATE"
-          | "SINGLE_RATE_CONT_LOAD"
-          | "TIME_OF_USE"
-          | "TIME_OF_USE_CONT_LOAD"
-          | "FLEXIBLE"
-          | "FLEXIBLE_CONT_LOAD"
-          | "QUOTA";
-        /**
-         * Array of feed in tariffs for solar power
-         */
-        solarFeedInTariff?: {
-          /**
-           * A description of the tariff
-           */
-          description?: string;
-          /**
-           * The name of the tariff
-           */
-          displayName: string;
-          /**
-           * The type of the payer
-           */
-          payerType: "GOVERNMENT" | "RETAILER";
-          /**
-           * The applicable scheme
-           */
-          scheme: "PREMIUM" | "OTHER";
-          /**
-           * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-           */
-          singleTariff?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the payer
-           */
-          tariffUType: "singleTariff" | "timeVaryingTariffs";
-          /**
-           * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-           */
-          timeVaryingTariffs?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            /**
-             * Array of time periods for which this tariff is applicable
-             */
-            timeVariations: {
-              /**
-               * The days that the tariff applies to. At least one entry required
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of the charging time period. If absent applies to all periods
-             */
-            type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        }[];
-        /**
-         * Array of tariff periods
-         */
-        tariffPeriod: {
-          /**
-           * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-           */
-          dailySupplyCharges?: string;
-          /**
-           * Array of demand charges.  Required if rateBlockUType is demandCharges
-           */
-          demandCharges?: {
-            /**
-             * The charge amount per  measure unit exclusive of GST
-             */
-            amount: string;
-            /**
-             * Charge period for the demand tariff
-             */
-            chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * The days that the demand tariff applies to
-             */
-            days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-            /**
-             * Description of the charge
-             */
-            description?: string;
-            /**
-             * Display name of the charge
-             */
-            displayName: string;
-            /**
-             * End of the period
-             */
-            endTime: string;
-            /**
-             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-             */
-            maxDemand?: string;
-            /**
-             * The measurement unit of charge amount. Assumed to be KWH if absent
-             */
-            measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-            /**
-             * Application period for the demand tariff
-             */
-            measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-             */
-            minDemand?: string;
-            /**
-             * Start of the period
-             */
-            startTime: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The name of the tariff period
-           */
-          displayName: string;
-          /**
-           * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          endDate: string;
-          /**
-           * Specifies the type of rate applicable to this tariff period
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-          /**
-           * Object representing a single rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-             */
-            generalUnitPrice?: string;
-            /**
-             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-             */
-            period?: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          startDate: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use
-             */
-            timeOfUse: {
-              /**
-               * The days that the rate applies to
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-           */
-          timeZone?: "LOCAL" | "AEST";
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-         */
-        timeZone?: ("LOCAL" | "AEST") | null;
-        /**
-         * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-         */
-        variation?: string | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * An array of additional contacts that are authorised to act on this account
-     */
-    authorisedContacts?: {
-      /**
-       * For people with single names this field need not be present. The single name should be in the lastName field
-       */
-      firstName?: string;
-      /**
-       * For people with single names the single name should be in this field
-       */
-      lastName: string;
-      /**
-       * Field is mandatory but array may be empty
-       */
-      middleNames?: string[];
-      /**
-       * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-       */
-      prefix?: string;
-      /**
-       * Used for a trailing suffix to the name (e.g. Jr)
-       */
-      suffix?: string;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyAccountDetailResponse {
-  data: {
     /**
      * The ID of the account.  To be created in accordance with CDR ID permanence requirements
      */
@@ -1789,3002 +328,4557 @@ export interface EnergyAccountDetailResponse {
      */
     displayName?: string | null;
     [k: string]: unknown;
-  } & {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyAccountBaseV2 {
+    /**
+     * The ID of the account.  To be created in accordance with CDR ID permanence requirements
+     */
+    accountId: string;
+    /**
+     * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
+     */
+    accountNumber?: string | null;
+    /**
+     * The date that the account was created or opened. Mandatory if openStatus is OPEN
+     */
+    creationDate?: string | null;
+    /**
+     * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
+     */
+    displayName?: string | null;
+    /**
+     * Open or closed status for the account. If not present then OPEN is assumed
+     */
+    openStatus?: ('CLOSED' | 'OPEN') | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyAccountDetail extends EnergyAccountBase {
     /**
      * The array of plans containing service points and associated plan details
      */
     plans: {
-      /**
-       * Optional display name for the plan provided by the customer to help differentiate multiple plans
-       */
-      nickname?: string;
-      /**
-       * An array of servicePointIds, representing NMIs, that this account is linked to
-       */
-      servicePointIds: string[];
-      planOverview: {
         /**
-         * The name of the plan if one exists
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
          */
-        displayName?: string;
+        nickname?: string;
         /**
-         * The start date of the applicability of this plan
+         * An array of servicePointIds, representing NMIs, that this account is linked to
          */
-        startDate: string;
+        servicePointIds: string[];
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string;
+            [k: string]: unknown;
+        };
         /**
-         * The end date of the applicability of this plan
+         * Detail on the plan applicable to this account
          */
-        endDate?: string;
-        [k: string]: unknown;
-      };
-      /**
-       * Detail on the plan applicable to this account
-       */
-      planDetail: {
+        planDetail: {
+            /**
+             * The fuel types covered by the plan
+             */
+            fuelType: 'ELECTRICITY' | 'GAS' | 'DUAL';
+            /**
+             * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
+             */
+            isContingentPlan?: boolean;
+            /**
+             * Charges for metering included in the plan
+             */
+            meteringCharges?: {
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * Description of the charge
+                 */
+                description?: string;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
+             */
+            gasContract?: {
+                /**
+                 * Free text field containing additional information of the fees for this contract
+                 */
+                additionalFeeInformation?: string | null;
+                /**
+                 * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                 */
+                controlledLoad?: {
+                    /**
+                     * A display name for the controlled load
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date of the application of the controlled load rate
+                     */
+                    endDate?: string;
+                    /**
+                     * Specifies the type of controlloed load rate
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                    /**
+                     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Optional start date of the application of the controlled load rate
+                     */
+                    startDate?: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use.
+                         */
+                        timeOfUse: {
+                            /**
+                             * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                             */
+                            additionalInfo?: string;
+                            /**
+                             * Optional link to additional information regarding the controlled load
+                             */
+                            additionalInfoUri?: string;
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                        [k: string]: unknown;
+                    }[];
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of discounts available for the contract
+                 */
+                discounts?: {
+                    /**
+                     * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                     */
+                    category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                    /**
+                     * The description of the discount
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the discount
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date for the discount after which the discount is no longer available
+                     */
+                    endDate?: string;
+                    /**
+                     * Required if methodUType is fixedAmount
+                     */
+                    fixedAmount?: {
+                        /**
+                         * The amount of the discount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The method of calculation of the discount
+                     */
+                    methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                    /**
+                     * Required if methodUType is percentOfBill
+                     */
+                    percentOfBill?: {
+                        /**
+                         * The rate of the discount applied to the bill amount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOfUse
+                     */
+                    percentOfUse?: {
+                        /**
+                         * The rate of the discount applied to the usageamount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOverThreshold
+                     */
+                    percentOverThreshold?: {
+                        /**
+                         * The rate of the discount over the usage amount
+                         */
+                        rate: string;
+                        /**
+                         * The usage amount threshold above which the discount applies
+                         */
+                        usageAmount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the discount
+                     */
+                    type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Eligibility restrictions or requirements
+                 */
+                eligibility?: {
+                    /**
+                     * A description of the eligibility restriction
+                     */
+                    description?: string;
+                    /**
+                     * Information of the eligibility restriction specific to the type of the restriction
+                     */
+                    information: string;
+                    /**
+                     * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                     */
+                    type:
+                        | 'EXISTING_CUST'
+                        | 'EXISTING_POOL'
+                        | 'EXISTING_SOLAR'
+                        | 'EXISTING_BATTERY'
+                        | 'EXISTING_SMART_METER'
+                        | 'EXISTING_BASIC_METER'
+                        | 'SENIOR_CARD'
+                        | 'SMALL_BUSINESS'
+                        | 'NO_SOLAR_FIT'
+                        | 'NEW_CUSTOMER'
+                        | 'ONLINE_ONLY'
+                        | 'REQ_EQUIP_SUPPLIER'
+                        | 'THIRD_PARTY_ONLY'
+                        | 'SPORT_CLUB_MEMBER'
+                        | 'ORG_MEMBER'
+                        | 'SPECIFIC_LOCATION'
+                        | 'MINIMUM_USAGE'
+                        | 'LOYALTY_MEMBER'
+                        | 'GROUP_BUY_MEMBER'
+                        | 'CONTINGENT_PLAN'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * An array of fees applicable to the plan
+                 */
+                fees?: {
+                    /**
+                     * The fee amount. Required if term is not PERCENT_OF_BILL
+                     */
+                    amount?: string;
+                    /**
+                     * A description of the fee
+                     */
+                    description?: string;
+                    /**
+                     * The fee rate. Required if term is PERCENT_OF_BILL
+                     */
+                    rate?: string;
+                    /**
+                     * The term of the fee
+                     */
+                    term:
+                        | 'FIXED'
+                        | '1_YEAR'
+                        | '2_YEAR'
+                        | '3_YEAR'
+                        | '4_YEAR'
+                        | '5_YEAR'
+                        | 'PERCENT_OF_BILL'
+                        | 'ANNUAL'
+                        | 'DAILY'
+                        | 'WEEKLY'
+                        | 'MONTHLY'
+                        | 'BIANNUAL'
+                        | 'VARIABLE';
+                    /**
+                     * The type of the fee
+                     */
+                    type:
+                        | 'EXIT'
+                        | 'ESTABLISHMENT'
+                        | 'LATE_PAYMENT'
+                        | 'DISCONNECTION'
+                        | 'DISCONNECT_MOVE_OUT'
+                        | 'DISCONNECT_NON_PAY'
+                        | 'RECONNECTION'
+                        | 'CONNECTION'
+                        | 'PAYMENT_PROCESSING'
+                        | 'CC_PROCESSING'
+                        | 'CHEQUE_DISHONOUR'
+                        | 'DD_DISHONOUR'
+                        | 'MEMBERSHIP'
+                        | 'CONTRIBUTION'
+                        | 'PAPER_BILL'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of charges applicable to green power
+                 */
+                greenPowerCharges?: {
+                    /**
+                     * The description of the charge
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * The applicable green power scheme
+                     */
+                    scheme: 'GREENPOWER' | 'OTHER';
+                    /**
+                     * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                     */
+                    tiers: {
+                        /**
+                         * The amount of the charge if the type implies the application of a fixed amount
+                         */
+                        amount?: string;
+                        /**
+                         * The upper percentage of green power used applicable for this tier
+                         */
+                        percentGreen: string;
+                        /**
+                         * The rate of the charge if the type implies the application of a rate
+                         */
+                        rate?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The type of charge
+                     */
+                    type:
+                        | 'FIXED_PER_DAY'
+                        | 'FIXED_PER_WEEK'
+                        | 'FIXED_PER_MONTH'
+                        | 'FIXED_PER_UNIT'
+                        | 'PERCENT_OF_USE'
+                        | 'PERCENT_OF_BILL';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of incentives available for the contract
+                 */
+                incentives?: {
+                    /**
+                     * The type of the incentive
+                     */
+                    category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                    /**
+                     * The description of the incentive
+                     */
+                    description: string;
+                    /**
+                     * The display name of the incentive
+                     */
+                    displayName: string;
+                    /**
+                     * A display message outlining an eligibility criteria that may apply
+                     */
+                    eligibility?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                 */
+                intrinsicGreenPower?: {
+                    /**
+                     * Percentage of green power intrinsically included in the plan
+                     */
+                    greenPercentage: string;
+                    [k: string]: unknown;
+                } | null;
+                /**
+                 * Flag indicating whether prices are fixed or variable
+                 */
+                isFixed: boolean;
+                /**
+                 * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                 */
+                onExpiryDescription?: string | null;
+                /**
+                 * Payment options for this contract
+                 */
+                paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                /**
+                 * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                 */
+                pricingModel:
+                    | 'SINGLE_RATE'
+                    | 'SINGLE_RATE_CONT_LOAD'
+                    | 'TIME_OF_USE'
+                    | 'TIME_OF_USE_CONT_LOAD'
+                    | 'FLEXIBLE'
+                    | 'FLEXIBLE_CONT_LOAD'
+                    | 'QUOTA';
+                /**
+                 * Array of feed in tariffs for solar power
+                 */
+                solarFeedInTariff?: {
+                    /**
+                     * A description of the tariff
+                     */
+                    description?: string;
+                    /**
+                     * The name of the tariff
+                     */
+                    displayName: string;
+                    /**
+                     * The type of the payer
+                     */
+                    payerType: 'GOVERNMENT' | 'RETAILER';
+                    /**
+                     * The applicable scheme
+                     */
+                    scheme: 'PREMIUM' | 'OTHER';
+                    /**
+                     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                     */
+                    singleTariff?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the payer
+                     */
+                    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                    /**
+                     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                     */
+                    timeVaryingTariffs?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        /**
+                         * Array of time periods for which this tariff is applicable
+                         */
+                        timeVariations: {
+                            /**
+                             * The days that the tariff applies to. At least one entry required
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of the charging time period. If absent applies to all periods
+                         */
+                        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Array of tariff periods
+                 */
+                tariffPeriod: {
+                    /**
+                     * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                     */
+                    dailySupplyCharges?: string;
+                    /**
+                     * Array of demand charges.  Required if rateBlockUType is demandCharges
+                     */
+                    demandCharges?: {
+                        /**
+                         * The charge amount per  measure unit exclusive of GST
+                         */
+                        amount: string;
+                        /**
+                         * Charge period for the demand tariff
+                         */
+                        chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * The days that the demand tariff applies to
+                         */
+                        days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                        /**
+                         * Description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * End of the period
+                         */
+                        endTime: string;
+                        /**
+                         * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                         */
+                        maxDemand?: string;
+                        /**
+                         * The measurement unit of charge amount. Assumed to be KWH if absent
+                         */
+                        measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                        /**
+                         * Application period for the demand tariff
+                         */
+                        measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                         */
+                        minDemand?: string;
+                        /**
+                         * Start of the period
+                         */
+                        startTime: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The name of the tariff period
+                     */
+                    displayName: string;
+                    /**
+                     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    endDate: string;
+                    /**
+                     * Specifies the type of rate applicable to this tariff period
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                    /**
+                     * Object representing a single rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                         */
+                        generalUnitPrice?: string;
+                        /**
+                         * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                         */
+                        period?: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    startDate: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use
+                         */
+                        timeOfUse: {
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                     */
+                    timeZone?: 'LOCAL' | 'AEST';
+                    /**
+                     * Type of charge. Assumed to be other if absent
+                     */
+                    type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                 */
+                timeZone?: ('LOCAL' | 'AEST') | null;
+                /**
+                 * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                 */
+                variation?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
+             */
+            electricityContract?: {
+                /**
+                 * Free text field containing additional information of the fees for this contract
+                 */
+                additionalFeeInformation?: string | null;
+                /**
+                 * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                 */
+                controlledLoad?: {
+                    /**
+                     * A display name for the controlled load
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date of the application of the controlled load rate
+                     */
+                    endDate?: string;
+                    /**
+                     * Specifies the type of controlloed load rate
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                    /**
+                     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Optional start date of the application of the controlled load rate
+                     */
+                    startDate?: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use.
+                         */
+                        timeOfUse: {
+                            /**
+                             * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                             */
+                            additionalInfo?: string;
+                            /**
+                             * Optional link to additional information regarding the controlled load
+                             */
+                            additionalInfoUri?: string;
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                        [k: string]: unknown;
+                    }[];
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of discounts available for the contract
+                 */
+                discounts?: {
+                    /**
+                     * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                     */
+                    category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                    /**
+                     * The description of the discount
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the discount
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date for the discount after which the discount is no longer available
+                     */
+                    endDate?: string;
+                    /**
+                     * Required if methodUType is fixedAmount
+                     */
+                    fixedAmount?: {
+                        /**
+                         * The amount of the discount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The method of calculation of the discount
+                     */
+                    methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                    /**
+                     * Required if methodUType is percentOfBill
+                     */
+                    percentOfBill?: {
+                        /**
+                         * The rate of the discount applied to the bill amount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOfUse
+                     */
+                    percentOfUse?: {
+                        /**
+                         * The rate of the discount applied to the usageamount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOverThreshold
+                     */
+                    percentOverThreshold?: {
+                        /**
+                         * The rate of the discount over the usage amount
+                         */
+                        rate: string;
+                        /**
+                         * The usage amount threshold above which the discount applies
+                         */
+                        usageAmount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the discount
+                     */
+                    type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Eligibility restrictions or requirements
+                 */
+                eligibility?: {
+                    /**
+                     * A description of the eligibility restriction
+                     */
+                    description?: string;
+                    /**
+                     * Information of the eligibility restriction specific to the type of the restriction
+                     */
+                    information: string;
+                    /**
+                     * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                     */
+                    type:
+                        | 'EXISTING_CUST'
+                        | 'EXISTING_POOL'
+                        | 'EXISTING_SOLAR'
+                        | 'EXISTING_BATTERY'
+                        | 'EXISTING_SMART_METER'
+                        | 'EXISTING_BASIC_METER'
+                        | 'SENIOR_CARD'
+                        | 'SMALL_BUSINESS'
+                        | 'NO_SOLAR_FIT'
+                        | 'NEW_CUSTOMER'
+                        | 'ONLINE_ONLY'
+                        | 'REQ_EQUIP_SUPPLIER'
+                        | 'THIRD_PARTY_ONLY'
+                        | 'SPORT_CLUB_MEMBER'
+                        | 'ORG_MEMBER'
+                        | 'SPECIFIC_LOCATION'
+                        | 'MINIMUM_USAGE'
+                        | 'LOYALTY_MEMBER'
+                        | 'GROUP_BUY_MEMBER'
+                        | 'CONTINGENT_PLAN'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * An array of fees applicable to the plan
+                 */
+                fees?: {
+                    /**
+                     * The fee amount. Required if term is not PERCENT_OF_BILL
+                     */
+                    amount?: string;
+                    /**
+                     * A description of the fee
+                     */
+                    description?: string;
+                    /**
+                     * The fee rate. Required if term is PERCENT_OF_BILL
+                     */
+                    rate?: string;
+                    /**
+                     * The term of the fee
+                     */
+                    term:
+                        | 'FIXED'
+                        | '1_YEAR'
+                        | '2_YEAR'
+                        | '3_YEAR'
+                        | '4_YEAR'
+                        | '5_YEAR'
+                        | 'PERCENT_OF_BILL'
+                        | 'ANNUAL'
+                        | 'DAILY'
+                        | 'WEEKLY'
+                        | 'MONTHLY'
+                        | 'BIANNUAL'
+                        | 'VARIABLE';
+                    /**
+                     * The type of the fee
+                     */
+                    type:
+                        | 'EXIT'
+                        | 'ESTABLISHMENT'
+                        | 'LATE_PAYMENT'
+                        | 'DISCONNECTION'
+                        | 'DISCONNECT_MOVE_OUT'
+                        | 'DISCONNECT_NON_PAY'
+                        | 'RECONNECTION'
+                        | 'CONNECTION'
+                        | 'PAYMENT_PROCESSING'
+                        | 'CC_PROCESSING'
+                        | 'CHEQUE_DISHONOUR'
+                        | 'DD_DISHONOUR'
+                        | 'MEMBERSHIP'
+                        | 'CONTRIBUTION'
+                        | 'PAPER_BILL'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of charges applicable to green power
+                 */
+                greenPowerCharges?: {
+                    /**
+                     * The description of the charge
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * The applicable green power scheme
+                     */
+                    scheme: 'GREENPOWER' | 'OTHER';
+                    /**
+                     * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                     */
+                    tiers: {
+                        /**
+                         * The amount of the charge if the type implies the application of a fixed amount
+                         */
+                        amount?: string;
+                        /**
+                         * The upper percentage of green power used applicable for this tier
+                         */
+                        percentGreen: string;
+                        /**
+                         * The rate of the charge if the type implies the application of a rate
+                         */
+                        rate?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The type of charge
+                     */
+                    type:
+                        | 'FIXED_PER_DAY'
+                        | 'FIXED_PER_WEEK'
+                        | 'FIXED_PER_MONTH'
+                        | 'FIXED_PER_UNIT'
+                        | 'PERCENT_OF_USE'
+                        | 'PERCENT_OF_BILL';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of incentives available for the contract
+                 */
+                incentives?: {
+                    /**
+                     * The type of the incentive
+                     */
+                    category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                    /**
+                     * The description of the incentive
+                     */
+                    description: string;
+                    /**
+                     * The display name of the incentive
+                     */
+                    displayName: string;
+                    /**
+                     * A display message outlining an eligibility criteria that may apply
+                     */
+                    eligibility?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                 */
+                intrinsicGreenPower?: {
+                    /**
+                     * Percentage of green power intrinsically included in the plan
+                     */
+                    greenPercentage: string;
+                    [k: string]: unknown;
+                } | null;
+                /**
+                 * Flag indicating whether prices are fixed or variable
+                 */
+                isFixed: boolean;
+                /**
+                 * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                 */
+                onExpiryDescription?: string | null;
+                /**
+                 * Payment options for this contract
+                 */
+                paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                /**
+                 * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                 */
+                pricingModel:
+                    | 'SINGLE_RATE'
+                    | 'SINGLE_RATE_CONT_LOAD'
+                    | 'TIME_OF_USE'
+                    | 'TIME_OF_USE_CONT_LOAD'
+                    | 'FLEXIBLE'
+                    | 'FLEXIBLE_CONT_LOAD'
+                    | 'QUOTA';
+                /**
+                 * Array of feed in tariffs for solar power
+                 */
+                solarFeedInTariff?: {
+                    /**
+                     * A description of the tariff
+                     */
+                    description?: string;
+                    /**
+                     * The name of the tariff
+                     */
+                    displayName: string;
+                    /**
+                     * The type of the payer
+                     */
+                    payerType: 'GOVERNMENT' | 'RETAILER';
+                    /**
+                     * The applicable scheme
+                     */
+                    scheme: 'PREMIUM' | 'OTHER';
+                    /**
+                     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                     */
+                    singleTariff?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the payer
+                     */
+                    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                    /**
+                     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                     */
+                    timeVaryingTariffs?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        /**
+                         * Array of time periods for which this tariff is applicable
+                         */
+                        timeVariations: {
+                            /**
+                             * The days that the tariff applies to. At least one entry required
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of the charging time period. If absent applies to all periods
+                         */
+                        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Array of tariff periods
+                 */
+                tariffPeriod: {
+                    /**
+                     * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                     */
+                    dailySupplyCharges?: string;
+                    /**
+                     * Array of demand charges.  Required if rateBlockUType is demandCharges
+                     */
+                    demandCharges?: {
+                        /**
+                         * The charge amount per  measure unit exclusive of GST
+                         */
+                        amount: string;
+                        /**
+                         * Charge period for the demand tariff
+                         */
+                        chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * The days that the demand tariff applies to
+                         */
+                        days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                        /**
+                         * Description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * End of the period
+                         */
+                        endTime: string;
+                        /**
+                         * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                         */
+                        maxDemand?: string;
+                        /**
+                         * The measurement unit of charge amount. Assumed to be KWH if absent
+                         */
+                        measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                        /**
+                         * Application period for the demand tariff
+                         */
+                        measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                         */
+                        minDemand?: string;
+                        /**
+                         * Start of the period
+                         */
+                        startTime: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The name of the tariff period
+                     */
+                    displayName: string;
+                    /**
+                     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    endDate: string;
+                    /**
+                     * Specifies the type of rate applicable to this tariff period
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                    /**
+                     * Object representing a single rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                         */
+                        generalUnitPrice?: string;
+                        /**
+                         * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                         */
+                        period?: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    startDate: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use
+                         */
+                        timeOfUse: {
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                     */
+                    timeZone?: 'LOCAL' | 'AEST';
+                    /**
+                     * Type of charge. Assumed to be other if absent
+                     */
+                    type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                 */
+                timeZone?: ('LOCAL' | 'AEST') | null;
+                /**
+                 * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                 */
+                variation?: string | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
         /**
-         * The fuel types covered by the plan
+         * An array of additional contacts that are authorised to act on this account
          */
-        fuelType: "ELECTRICITY" | "GAS" | "DUAL";
-        /**
-         * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
-         */
-        isContingentPlan?: boolean;
-        /**
-         * Charges for metering included in the plan
-         */
-        meteringCharges?: {
-          /**
-           * Display name of the charge
-           */
-          displayName: string;
-          /**
-           * Description of the charge
-           */
-          description?: string;
-          /**
-           * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-           */
-          minimumValue: string;
-          /**
-           * The upper limit of the charge if the charge could occur in a range
-           */
-          maximumValue?: string;
-          /**
-           * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-           */
-          period?: string;
-          [k: string]: unknown;
+        authorisedContacts?: {
+            /**
+             * For people with single names this field need not be present. The single name should be in the lastName field
+             */
+            firstName?: string;
+            /**
+             * For people with single names the single name should be in this field
+             */
+            lastName: string;
+            /**
+             * Field is mandatory but array may be empty
+             */
+            middleNames?: string[];
+            /**
+             * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+             */
+            prefix?: string;
+            /**
+             * Used for a trailing suffix to the name (e.g. Jr)
+             */
+            suffix?: string;
+            [k: string]: unknown;
         }[];
-        /**
-         * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-         */
-        gasContract?: {
-          /**
-           * Free text field containing additional information of the fees for this contract
-           */
-          additionalFeeInformation?: string | null;
-          /**
-           * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-           */
-          controlledLoad?: {
-            /**
-             * A display name for the controlled load
-             */
-            displayName: string;
-            /**
-             * Optional end date of the application of the controlled load rate
-             */
-            endDate?: string;
-            /**
-             * Specifies the type of controlloed load rate
-             */
-            rateBlockUType: "singleRate" | "timeOfUseRates";
-            /**
-             * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-             */
-            singleRate?: {
-              /**
-               * The daily supply charge (exclusive of GST) for this controlled load tier
-               */
-              dailySupplyCharge?: string;
-              /**
-               * Description of the controlled load rate
-               */
-              description?: string;
-              /**
-               * Display name of the controlled load rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              [k: string]: unknown;
-            };
-            /**
-             * Optional start date of the application of the controlled load rate
-             */
-            startDate?: string;
-            /**
-             * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-             */
-            timeOfUseRates?: {
-              /**
-               * The daily supply charge (exclusive of GST) for this controlled load tier
-               */
-              dailySupplyCharge?: string;
-              /**
-               * Description of the controlled load rate
-               */
-              description?: string;
-              /**
-               * Display name of the controlled load rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              /**
-               * Array of times of use.
-               */
-              timeOfUse: {
-                /**
-                 * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-                 */
-                additionalInfo?: string;
-                /**
-                 * Optional link to additional information regarding the controlled load
-                 */
-                additionalInfoUri?: string;
-                /**
-                 * The days that the rate applies to
-                 */
-                days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-                 */
-                endTime?: string;
-                /**
-                 * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-                 */
-                startTime?: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of usage that the rate applies to
-               */
-              type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of discounts available for the contract
-           */
-          discounts?: {
-            /**
-             * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-             */
-            category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-            /**
-             * The description of the discount
-             */
-            description?: string;
-            /**
-             * The display name of the discount
-             */
-            displayName: string;
-            /**
-             * Optional end date for the discount after which the discount is no longer available
-             */
-            endDate?: string;
-            /**
-             * Required if methodUType is fixedAmount
-             */
-            fixedAmount?: {
-              /**
-               * The amount of the discount
-               */
-              amount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The method of calculation of the discount
-             */
-            methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-            /**
-             * Required if methodUType is percentOfBill
-             */
-            percentOfBill?: {
-              /**
-               * The rate of the discount applied to the bill amount
-               */
-              rate: string;
-              [k: string]: unknown;
-            };
-            /**
-             * Required if methodUType is percentOfUse
-             */
-            percentOfUse?: {
-              /**
-               * The rate of the discount applied to the usageamount
-               */
-              rate: string;
-              [k: string]: unknown;
-            };
-            /**
-             * Required if methodUType is percentOverThreshold
-             */
-            percentOverThreshold?: {
-              /**
-               * The rate of the discount over the usage amount
-               */
-              rate: string;
-              /**
-               * The usage amount threshold above which the discount applies
-               */
-              usageAmount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The type of the discount
-             */
-            type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Eligibility restrictions or requirements
-           */
-          eligibility?: {
-            /**
-             * A description of the eligibility restriction
-             */
-            description?: string;
-            /**
-             * Information of the eligibility restriction specific to the type of the restriction
-             */
-            information: string;
-            /**
-             * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-             */
-            type:
-              | "EXISTING_CUST"
-              | "EXISTING_POOL"
-              | "EXISTING_SOLAR"
-              | "EXISTING_BATTERY"
-              | "EXISTING_SMART_METER"
-              | "EXISTING_BASIC_METER"
-              | "SENIOR_CARD"
-              | "SMALL_BUSINESS"
-              | "NO_SOLAR_FIT"
-              | "NEW_CUSTOMER"
-              | "ONLINE_ONLY"
-              | "REQ_EQUIP_SUPPLIER"
-              | "THIRD_PARTY_ONLY"
-              | "SPORT_CLUB_MEMBER"
-              | "ORG_MEMBER"
-              | "SPECIFIC_LOCATION"
-              | "MINIMUM_USAGE"
-              | "LOYALTY_MEMBER"
-              | "GROUP_BUY_MEMBER"
-              | "CONTINGENT_PLAN"
-              | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * An array of fees applicable to the plan
-           */
-          fees?: {
-            /**
-             * The fee amount. Required if term is not PERCENT_OF_BILL
-             */
-            amount?: string;
-            /**
-             * A description of the fee
-             */
-            description?: string;
-            /**
-             * The fee rate. Required if term is PERCENT_OF_BILL
-             */
-            rate?: string;
-            /**
-             * The term of the fee
-             */
-            term:
-              | "FIXED"
-              | "1_YEAR"
-              | "2_YEAR"
-              | "3_YEAR"
-              | "4_YEAR"
-              | "5_YEAR"
-              | "PERCENT_OF_BILL"
-              | "ANNUAL"
-              | "DAILY"
-              | "WEEKLY"
-              | "MONTHLY"
-              | "BIANNUAL"
-              | "VARIABLE";
-            /**
-             * The type of the fee
-             */
-            type:
-              | "EXIT"
-              | "ESTABLISHMENT"
-              | "LATE_PAYMENT"
-              | "DISCONNECTION"
-              | "DISCONNECT_MOVE_OUT"
-              | "DISCONNECT_NON_PAY"
-              | "RECONNECTION"
-              | "CONNECTION"
-              | "PAYMENT_PROCESSING"
-              | "CC_PROCESSING"
-              | "CHEQUE_DISHONOUR"
-              | "DD_DISHONOUR"
-              | "MEMBERSHIP"
-              | "CONTRIBUTION"
-              | "PAPER_BILL"
-              | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of charges applicable to green power
-           */
-          greenPowerCharges?: {
-            /**
-             * The description of the charge
-             */
-            description?: string;
-            /**
-             * The display name of the charge
-             */
-            displayName: string;
-            /**
-             * The applicable green power scheme
-             */
-            scheme: "GREENPOWER" | "OTHER";
-            /**
-             * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-             */
-            tiers: {
-              /**
-               * The amount of the charge if the type implies the application of a fixed amount
-               */
-              amount?: string;
-              /**
-               * The upper percentage of green power used applicable for this tier
-               */
-              percentGreen: string;
-              /**
-               * The rate of the charge if the type implies the application of a rate
-               */
-              rate?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of charge
-             */
-            type:
-              | "FIXED_PER_DAY"
-              | "FIXED_PER_WEEK"
-              | "FIXED_PER_MONTH"
-              | "FIXED_PER_UNIT"
-              | "PERCENT_OF_USE"
-              | "PERCENT_OF_BILL";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of incentives available for the contract
-           */
-          incentives?: {
-            /**
-             * The type of the incentive
-             */
-            category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-            /**
-             * The description of the incentive
-             */
-            description: string;
-            /**
-             * The display name of the incentive
-             */
-            displayName: string;
-            /**
-             * A display message outlining an eligibility criteria that may apply
-             */
-            eligibility?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-           */
-          intrinsicGreenPower?: {
-            /**
-             * Percentage of green power intrinsically included in the plan
-             */
-            greenPercentage: string;
-            [k: string]: unknown;
-          } | null;
-          /**
-           * Flag indicating whether prices are fixed or variable
-           */
-          isFixed: boolean;
-          /**
-           * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-           */
-          onExpiryDescription?: string | null;
-          /**
-           * Payment options for this contract
-           */
-          paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-          /**
-           * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-           */
-          pricingModel:
-            | "SINGLE_RATE"
-            | "SINGLE_RATE_CONT_LOAD"
-            | "TIME_OF_USE"
-            | "TIME_OF_USE_CONT_LOAD"
-            | "FLEXIBLE"
-            | "FLEXIBLE_CONT_LOAD"
-            | "QUOTA";
-          /**
-           * Array of feed in tariffs for solar power
-           */
-          solarFeedInTariff?: {
-            /**
-             * A description of the tariff
-             */
-            description?: string;
-            /**
-             * The name of the tariff
-             */
-            displayName: string;
-            /**
-             * The type of the payer
-             */
-            payerType: "GOVERNMENT" | "RETAILER";
-            /**
-             * The applicable scheme
-             */
-            scheme: "PREMIUM" | "OTHER";
-            /**
-             * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-             */
-            singleTariff?: {
-              /**
-               * The tariff amount
-               */
-              amount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The type of the payer
-             */
-            tariffUType: "singleTariff" | "timeVaryingTariffs";
-            /**
-             * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-             */
-            timeVaryingTariffs?: {
-              /**
-               * The tariff amount
-               */
-              amount: string;
-              /**
-               * Array of time periods for which this tariff is applicable
-               */
-              timeVariations: {
-                /**
-                 * The days that the tariff applies to. At least one entry required
-                 */
-                days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-                 */
-                endTime?: string;
-                /**
-                 * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-                 */
-                startTime?: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of the charging time period. If absent applies to all periods
-               */
-              type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          }[];
-          /**
-           * Array of tariff periods
-           */
-          tariffPeriod: {
-            /**
-             * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-             */
-            dailySupplyCharges?: string;
-            /**
-             * Array of demand charges.  Required if rateBlockUType is demandCharges
-             */
-            demandCharges?: {
-              /**
-               * The charge amount per  measure unit exclusive of GST
-               */
-              amount: string;
-              /**
-               * Charge period for the demand tariff
-               */
-              chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-              /**
-               * The days that the demand tariff applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * Description of the charge
-               */
-              description?: string;
-              /**
-               * Display name of the charge
-               */
-              displayName: string;
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-               */
-              maxDemand?: string;
-              /**
-               * The measurement unit of charge amount. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Application period for the demand tariff
-               */
-              measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-              /**
-               * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-               */
-              minDemand?: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The name of the tariff period
-             */
-            displayName: string;
-            /**
-             * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-             */
-            endDate: string;
-            /**
-             * Specifies the type of rate applicable to this tariff period
-             */
-            rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-            /**
-             * Object representing a single rate.  Required if rateBlockUType is singleRate
-             */
-            singleRate?: {
-              /**
-               * Description of the rate
-               */
-              description?: string;
-              /**
-               * Display name of the rate
-               */
-              displayName: string;
-              /**
-               * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-               */
-              generalUnitPrice?: string;
-              /**
-               * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-               */
-              period?: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              [k: string]: unknown;
-            };
-            /**
-             * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-             */
-            startDate: string;
-            /**
-             * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-             */
-            timeOfUseRates?: {
-              /**
-               * Description of the rate
-               */
-              description?: string;
-              /**
-               * Display name of the rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              /**
-               * Array of times of use
-               */
-              timeOfUse: {
-                /**
-                 * The days that the rate applies to
-                 */
-                days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * End of the period
-                 */
-                endTime: string;
-                /**
-                 * Start of the period
-                 */
-                startTime: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of usage that the rate applies to
-               */
-              type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-              [k: string]: unknown;
-            }[];
-            /**
-             * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-             */
-            timeZone?: "LOCAL" | "AEST";
-            /**
-             * Type of charge. Assumed to be other if absent
-             */
-            type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-           */
-          timeZone?: ("LOCAL" | "AEST") | null;
-          /**
-           * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-           */
-          variation?: string | null;
-          [k: string]: unknown;
-        };
-        /**
-         * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-         */
-        electricityContract?: {
-          /**
-           * Free text field containing additional information of the fees for this contract
-           */
-          additionalFeeInformation?: string | null;
-          /**
-           * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-           */
-          controlledLoad?: {
-            /**
-             * A display name for the controlled load
-             */
-            displayName: string;
-            /**
-             * Optional end date of the application of the controlled load rate
-             */
-            endDate?: string;
-            /**
-             * Specifies the type of controlloed load rate
-             */
-            rateBlockUType: "singleRate" | "timeOfUseRates";
-            /**
-             * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-             */
-            singleRate?: {
-              /**
-               * The daily supply charge (exclusive of GST) for this controlled load tier
-               */
-              dailySupplyCharge?: string;
-              /**
-               * Description of the controlled load rate
-               */
-              description?: string;
-              /**
-               * Display name of the controlled load rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              [k: string]: unknown;
-            };
-            /**
-             * Optional start date of the application of the controlled load rate
-             */
-            startDate?: string;
-            /**
-             * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-             */
-            timeOfUseRates?: {
-              /**
-               * The daily supply charge (exclusive of GST) for this controlled load tier
-               */
-              dailySupplyCharge?: string;
-              /**
-               * Description of the controlled load rate
-               */
-              description?: string;
-              /**
-               * Display name of the controlled load rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              /**
-               * Array of times of use.
-               */
-              timeOfUse: {
-                /**
-                 * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-                 */
-                additionalInfo?: string;
-                /**
-                 * Optional link to additional information regarding the controlled load
-                 */
-                additionalInfoUri?: string;
-                /**
-                 * The days that the rate applies to
-                 */
-                days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-                 */
-                endTime?: string;
-                /**
-                 * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-                 */
-                startTime?: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of usage that the rate applies to
-               */
-              type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of discounts available for the contract
-           */
-          discounts?: {
-            /**
-             * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-             */
-            category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-            /**
-             * The description of the discount
-             */
-            description?: string;
-            /**
-             * The display name of the discount
-             */
-            displayName: string;
-            /**
-             * Optional end date for the discount after which the discount is no longer available
-             */
-            endDate?: string;
-            /**
-             * Required if methodUType is fixedAmount
-             */
-            fixedAmount?: {
-              /**
-               * The amount of the discount
-               */
-              amount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The method of calculation of the discount
-             */
-            methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-            /**
-             * Required if methodUType is percentOfBill
-             */
-            percentOfBill?: {
-              /**
-               * The rate of the discount applied to the bill amount
-               */
-              rate: string;
-              [k: string]: unknown;
-            };
-            /**
-             * Required if methodUType is percentOfUse
-             */
-            percentOfUse?: {
-              /**
-               * The rate of the discount applied to the usageamount
-               */
-              rate: string;
-              [k: string]: unknown;
-            };
-            /**
-             * Required if methodUType is percentOverThreshold
-             */
-            percentOverThreshold?: {
-              /**
-               * The rate of the discount over the usage amount
-               */
-              rate: string;
-              /**
-               * The usage amount threshold above which the discount applies
-               */
-              usageAmount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The type of the discount
-             */
-            type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Eligibility restrictions or requirements
-           */
-          eligibility?: {
-            /**
-             * A description of the eligibility restriction
-             */
-            description?: string;
-            /**
-             * Information of the eligibility restriction specific to the type of the restriction
-             */
-            information: string;
-            /**
-             * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-             */
-            type:
-              | "EXISTING_CUST"
-              | "EXISTING_POOL"
-              | "EXISTING_SOLAR"
-              | "EXISTING_BATTERY"
-              | "EXISTING_SMART_METER"
-              | "EXISTING_BASIC_METER"
-              | "SENIOR_CARD"
-              | "SMALL_BUSINESS"
-              | "NO_SOLAR_FIT"
-              | "NEW_CUSTOMER"
-              | "ONLINE_ONLY"
-              | "REQ_EQUIP_SUPPLIER"
-              | "THIRD_PARTY_ONLY"
-              | "SPORT_CLUB_MEMBER"
-              | "ORG_MEMBER"
-              | "SPECIFIC_LOCATION"
-              | "MINIMUM_USAGE"
-              | "LOYALTY_MEMBER"
-              | "GROUP_BUY_MEMBER"
-              | "CONTINGENT_PLAN"
-              | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * An array of fees applicable to the plan
-           */
-          fees?: {
-            /**
-             * The fee amount. Required if term is not PERCENT_OF_BILL
-             */
-            amount?: string;
-            /**
-             * A description of the fee
-             */
-            description?: string;
-            /**
-             * The fee rate. Required if term is PERCENT_OF_BILL
-             */
-            rate?: string;
-            /**
-             * The term of the fee
-             */
-            term:
-              | "FIXED"
-              | "1_YEAR"
-              | "2_YEAR"
-              | "3_YEAR"
-              | "4_YEAR"
-              | "5_YEAR"
-              | "PERCENT_OF_BILL"
-              | "ANNUAL"
-              | "DAILY"
-              | "WEEKLY"
-              | "MONTHLY"
-              | "BIANNUAL"
-              | "VARIABLE";
-            /**
-             * The type of the fee
-             */
-            type:
-              | "EXIT"
-              | "ESTABLISHMENT"
-              | "LATE_PAYMENT"
-              | "DISCONNECTION"
-              | "DISCONNECT_MOVE_OUT"
-              | "DISCONNECT_NON_PAY"
-              | "RECONNECTION"
-              | "CONNECTION"
-              | "PAYMENT_PROCESSING"
-              | "CC_PROCESSING"
-              | "CHEQUE_DISHONOUR"
-              | "DD_DISHONOUR"
-              | "MEMBERSHIP"
-              | "CONTRIBUTION"
-              | "PAPER_BILL"
-              | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of charges applicable to green power
-           */
-          greenPowerCharges?: {
-            /**
-             * The description of the charge
-             */
-            description?: string;
-            /**
-             * The display name of the charge
-             */
-            displayName: string;
-            /**
-             * The applicable green power scheme
-             */
-            scheme: "GREENPOWER" | "OTHER";
-            /**
-             * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-             */
-            tiers: {
-              /**
-               * The amount of the charge if the type implies the application of a fixed amount
-               */
-              amount?: string;
-              /**
-               * The upper percentage of green power used applicable for this tier
-               */
-              percentGreen: string;
-              /**
-               * The rate of the charge if the type implies the application of a rate
-               */
-              rate?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of charge
-             */
-            type:
-              | "FIXED_PER_DAY"
-              | "FIXED_PER_WEEK"
-              | "FIXED_PER_MONTH"
-              | "FIXED_PER_UNIT"
-              | "PERCENT_OF_USE"
-              | "PERCENT_OF_BILL";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Optional list of incentives available for the contract
-           */
-          incentives?: {
-            /**
-             * The type of the incentive
-             */
-            category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-            /**
-             * The description of the incentive
-             */
-            description: string;
-            /**
-             * The display name of the incentive
-             */
-            displayName: string;
-            /**
-             * A display message outlining an eligibility criteria that may apply
-             */
-            eligibility?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-           */
-          intrinsicGreenPower?: {
-            /**
-             * Percentage of green power intrinsically included in the plan
-             */
-            greenPercentage: string;
-            [k: string]: unknown;
-          } | null;
-          /**
-           * Flag indicating whether prices are fixed or variable
-           */
-          isFixed: boolean;
-          /**
-           * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-           */
-          onExpiryDescription?: string | null;
-          /**
-           * Payment options for this contract
-           */
-          paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-          /**
-           * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-           */
-          pricingModel:
-            | "SINGLE_RATE"
-            | "SINGLE_RATE_CONT_LOAD"
-            | "TIME_OF_USE"
-            | "TIME_OF_USE_CONT_LOAD"
-            | "FLEXIBLE"
-            | "FLEXIBLE_CONT_LOAD"
-            | "QUOTA";
-          /**
-           * Array of feed in tariffs for solar power
-           */
-          solarFeedInTariff?: {
-            /**
-             * A description of the tariff
-             */
-            description?: string;
-            /**
-             * The name of the tariff
-             */
-            displayName: string;
-            /**
-             * The type of the payer
-             */
-            payerType: "GOVERNMENT" | "RETAILER";
-            /**
-             * The applicable scheme
-             */
-            scheme: "PREMIUM" | "OTHER";
-            /**
-             * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-             */
-            singleTariff?: {
-              /**
-               * The tariff amount
-               */
-              amount: string;
-              [k: string]: unknown;
-            };
-            /**
-             * The type of the payer
-             */
-            tariffUType: "singleTariff" | "timeVaryingTariffs";
-            /**
-             * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-             */
-            timeVaryingTariffs?: {
-              /**
-               * The tariff amount
-               */
-              amount: string;
-              /**
-               * Array of time periods for which this tariff is applicable
-               */
-              timeVariations: {
-                /**
-                 * The days that the tariff applies to. At least one entry required
-                 */
-                days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-                 */
-                endTime?: string;
-                /**
-                 * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-                 */
-                startTime?: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of the charging time period. If absent applies to all periods
-               */
-              type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          }[];
-          /**
-           * Array of tariff periods
-           */
-          tariffPeriod: {
-            /**
-             * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-             */
-            dailySupplyCharges?: string;
-            /**
-             * Array of demand charges.  Required if rateBlockUType is demandCharges
-             */
-            demandCharges?: {
-              /**
-               * The charge amount per  measure unit exclusive of GST
-               */
-              amount: string;
-              /**
-               * Charge period for the demand tariff
-               */
-              chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-              /**
-               * The days that the demand tariff applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * Description of the charge
-               */
-              description?: string;
-              /**
-               * Display name of the charge
-               */
-              displayName: string;
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-               */
-              maxDemand?: string;
-              /**
-               * The measurement unit of charge amount. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Application period for the demand tariff
-               */
-              measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-              /**
-               * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-               */
-              minDemand?: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The name of the tariff period
-             */
-            displayName: string;
-            /**
-             * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-             */
-            endDate: string;
-            /**
-             * Specifies the type of rate applicable to this tariff period
-             */
-            rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-            /**
-             * Object representing a single rate.  Required if rateBlockUType is singleRate
-             */
-            singleRate?: {
-              /**
-               * Description of the rate
-               */
-              description?: string;
-              /**
-               * Display name of the rate
-               */
-              displayName: string;
-              /**
-               * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-               */
-              generalUnitPrice?: string;
-              /**
-               * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-               */
-              period?: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              [k: string]: unknown;
-            };
-            /**
-             * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-             */
-            startDate: string;
-            /**
-             * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-             */
-            timeOfUseRates?: {
-              /**
-               * Description of the rate
-               */
-              description?: string;
-              /**
-               * Display name of the rate
-               */
-              displayName: string;
-              /**
-               * Array of controlled load rates in order of usage volume
-               */
-              rates: {
-                /**
-                 * The measurement unit of rate. Assumed to be KWH if absent
-                 */
-                measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-                /**
-                 * Unit price of usage per  measure unit (exclusive of GST)
-                 */
-                unitPrice: string;
-                /**
-                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-                 */
-                volume?: number;
-                [k: string]: unknown;
-              }[];
-              /**
-               * Array of times of use
-               */
-              timeOfUse: {
-                /**
-                 * The days that the rate applies to
-                 */
-                days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-                /**
-                 * End of the period
-                 */
-                endTime: string;
-                /**
-                 * Start of the period
-                 */
-                startTime: string;
-                [k: string]: unknown;
-              }[];
-              /**
-               * The type of usage that the rate applies to
-               */
-              type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-              [k: string]: unknown;
-            }[];
-            /**
-             * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-             */
-            timeZone?: "LOCAL" | "AEST";
-            /**
-             * Type of charge. Assumed to be other if absent
-             */
-            type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-           */
-          timeZone?: ("LOCAL" | "AEST") | null;
-          /**
-           * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-           */
-          variation?: string | null;
-          [k: string]: unknown;
-        };
         [k: string]: unknown;
-      };
-      /**
-       * An array of additional contacts that are authorised to act on this account
-       */
-      authorisedContacts?: {
-        /**
-         * For people with single names this field need not be present. The single name should be in the lastName field
-         */
-        firstName?: string;
-        /**
-         * For people with single names the single name should be in this field
-         */
-        lastName: string;
-        /**
-         * Field is mandatory but array may be empty
-         */
-        middleNames?: string[];
-        /**
-         * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-         */
-        prefix?: string;
-        /**
-         * Used for a trailing suffix to the name (e.g. Jr)
-         */
-        suffix?: string;
-        [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyAccountDetailResponse {
+    data: {
+        /**
+         * The ID of the account.  To be created in accordance with CDR ID permanence requirements
+         */
+        accountId: string;
+        /**
+         * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
+         */
+        accountNumber?: string | null;
+        /**
+         * The date that the account was created or opened
+         */
+        creationDate: string;
+        /**
+         * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
+         */
+        displayName?: string | null;
+        [k: string]: unknown;
+    } & {
+        /**
+         * The array of plans containing service points and associated plan details
+         */
+        plans: {
+            /**
+             * Optional display name for the plan provided by the customer to help differentiate multiple plans
+             */
+            nickname?: string;
+            /**
+             * An array of servicePointIds, representing NMIs, that this account is linked to
+             */
+            servicePointIds: string[];
+            planOverview: {
+                /**
+                 * The name of the plan if one exists
+                 */
+                displayName?: string;
+                /**
+                 * The start date of the applicability of this plan
+                 */
+                startDate: string;
+                /**
+                 * The end date of the applicability of this plan
+                 */
+                endDate?: string;
+                [k: string]: unknown;
+            };
+            /**
+             * Detail on the plan applicable to this account
+             */
+            planDetail: {
+                /**
+                 * The fuel types covered by the plan
+                 */
+                fuelType: 'ELECTRICITY' | 'GAS' | 'DUAL';
+                /**
+                 * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
+                 */
+                isContingentPlan?: boolean;
+                /**
+                 * Charges for metering included in the plan
+                 */
+                meteringCharges?: {
+                    /**
+                     * Display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * Description of the charge
+                     */
+                    description?: string;
+                    /**
+                     * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                     */
+                    minimumValue: string;
+                    /**
+                     * The upper limit of the charge if the charge could occur in a range
+                     */
+                    maximumValue?: string;
+                    /**
+                     * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                     */
+                    period?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
+                 */
+                gasContract?: {
+                    /**
+                     * Free text field containing additional information of the fees for this contract
+                     */
+                    additionalFeeInformation?: string | null;
+                    /**
+                     * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                     */
+                    controlledLoad?: {
+                        /**
+                         * A display name for the controlled load
+                         */
+                        displayName: string;
+                        /**
+                         * Optional end date of the application of the controlled load rate
+                         */
+                        endDate?: string;
+                        /**
+                         * Specifies the type of controlloed load rate
+                         */
+                        rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                        /**
+                         * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                         */
+                        singleRate?: {
+                            /**
+                             * The daily supply charge (exclusive of GST) for this controlled load tier
+                             */
+                            dailySupplyCharge?: string;
+                            /**
+                             * Description of the controlled load rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the controlled load rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Optional start date of the application of the controlled load rate
+                         */
+                        startDate?: string;
+                        /**
+                         * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                         */
+                        timeOfUseRates?: {
+                            /**
+                             * The daily supply charge (exclusive of GST) for this controlled load tier
+                             */
+                            dailySupplyCharge?: string;
+                            /**
+                             * Description of the controlled load rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the controlled load rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * Array of times of use.
+                             */
+                            timeOfUse: {
+                                /**
+                                 * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                                 */
+                                additionalInfo?: string;
+                                /**
+                                 * Optional link to additional information regarding the controlled load
+                                 */
+                                additionalInfoUri?: string;
+                                /**
+                                 * The days that the rate applies to
+                                 */
+                                days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                                 */
+                                endTime?: string;
+                                /**
+                                 * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                                 */
+                                startTime?: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of usage that the rate applies to
+                             */
+                            type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of discounts available for the contract
+                     */
+                    discounts?: {
+                        /**
+                         * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                         */
+                        category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                        /**
+                         * The description of the discount
+                         */
+                        description?: string;
+                        /**
+                         * The display name of the discount
+                         */
+                        displayName: string;
+                        /**
+                         * Optional end date for the discount after which the discount is no longer available
+                         */
+                        endDate?: string;
+                        /**
+                         * Required if methodUType is fixedAmount
+                         */
+                        fixedAmount?: {
+                            /**
+                             * The amount of the discount
+                             */
+                            amount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The method of calculation of the discount
+                         */
+                        methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                        /**
+                         * Required if methodUType is percentOfBill
+                         */
+                        percentOfBill?: {
+                            /**
+                             * The rate of the discount applied to the bill amount
+                             */
+                            rate: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Required if methodUType is percentOfUse
+                         */
+                        percentOfUse?: {
+                            /**
+                             * The rate of the discount applied to the usageamount
+                             */
+                            rate: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Required if methodUType is percentOverThreshold
+                         */
+                        percentOverThreshold?: {
+                            /**
+                             * The rate of the discount over the usage amount
+                             */
+                            rate: string;
+                            /**
+                             * The usage amount threshold above which the discount applies
+                             */
+                            usageAmount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The type of the discount
+                         */
+                        type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Eligibility restrictions or requirements
+                     */
+                    eligibility?: {
+                        /**
+                         * A description of the eligibility restriction
+                         */
+                        description?: string;
+                        /**
+                         * Information of the eligibility restriction specific to the type of the restriction
+                         */
+                        information: string;
+                        /**
+                         * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                         */
+                        type:
+                            | 'EXISTING_CUST'
+                            | 'EXISTING_POOL'
+                            | 'EXISTING_SOLAR'
+                            | 'EXISTING_BATTERY'
+                            | 'EXISTING_SMART_METER'
+                            | 'EXISTING_BASIC_METER'
+                            | 'SENIOR_CARD'
+                            | 'SMALL_BUSINESS'
+                            | 'NO_SOLAR_FIT'
+                            | 'NEW_CUSTOMER'
+                            | 'ONLINE_ONLY'
+                            | 'REQ_EQUIP_SUPPLIER'
+                            | 'THIRD_PARTY_ONLY'
+                            | 'SPORT_CLUB_MEMBER'
+                            | 'ORG_MEMBER'
+                            | 'SPECIFIC_LOCATION'
+                            | 'MINIMUM_USAGE'
+                            | 'LOYALTY_MEMBER'
+                            | 'GROUP_BUY_MEMBER'
+                            | 'CONTINGENT_PLAN'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * An array of fees applicable to the plan
+                     */
+                    fees?: {
+                        /**
+                         * The fee amount. Required if term is not PERCENT_OF_BILL
+                         */
+                        amount?: string;
+                        /**
+                         * A description of the fee
+                         */
+                        description?: string;
+                        /**
+                         * The fee rate. Required if term is PERCENT_OF_BILL
+                         */
+                        rate?: string;
+                        /**
+                         * The term of the fee
+                         */
+                        term:
+                            | 'FIXED'
+                            | '1_YEAR'
+                            | '2_YEAR'
+                            | '3_YEAR'
+                            | '4_YEAR'
+                            | '5_YEAR'
+                            | 'PERCENT_OF_BILL'
+                            | 'ANNUAL'
+                            | 'DAILY'
+                            | 'WEEKLY'
+                            | 'MONTHLY'
+                            | 'BIANNUAL'
+                            | 'VARIABLE';
+                        /**
+                         * The type of the fee
+                         */
+                        type:
+                            | 'EXIT'
+                            | 'ESTABLISHMENT'
+                            | 'LATE_PAYMENT'
+                            | 'DISCONNECTION'
+                            | 'DISCONNECT_MOVE_OUT'
+                            | 'DISCONNECT_NON_PAY'
+                            | 'RECONNECTION'
+                            | 'CONNECTION'
+                            | 'PAYMENT_PROCESSING'
+                            | 'CC_PROCESSING'
+                            | 'CHEQUE_DISHONOUR'
+                            | 'DD_DISHONOUR'
+                            | 'MEMBERSHIP'
+                            | 'CONTRIBUTION'
+                            | 'PAPER_BILL'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of charges applicable to green power
+                     */
+                    greenPowerCharges?: {
+                        /**
+                         * The description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * The display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * The applicable green power scheme
+                         */
+                        scheme: 'GREENPOWER' | 'OTHER';
+                        /**
+                         * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                         */
+                        tiers: {
+                            /**
+                             * The amount of the charge if the type implies the application of a fixed amount
+                             */
+                            amount?: string;
+                            /**
+                             * The upper percentage of green power used applicable for this tier
+                             */
+                            percentGreen: string;
+                            /**
+                             * The rate of the charge if the type implies the application of a rate
+                             */
+                            rate?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of charge
+                         */
+                        type:
+                            | 'FIXED_PER_DAY'
+                            | 'FIXED_PER_WEEK'
+                            | 'FIXED_PER_MONTH'
+                            | 'FIXED_PER_UNIT'
+                            | 'PERCENT_OF_USE'
+                            | 'PERCENT_OF_BILL';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of incentives available for the contract
+                     */
+                    incentives?: {
+                        /**
+                         * The type of the incentive
+                         */
+                        category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                        /**
+                         * The description of the incentive
+                         */
+                        description: string;
+                        /**
+                         * The display name of the incentive
+                         */
+                        displayName: string;
+                        /**
+                         * A display message outlining an eligibility criteria that may apply
+                         */
+                        eligibility?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                     */
+                    intrinsicGreenPower?: {
+                        /**
+                         * Percentage of green power intrinsically included in the plan
+                         */
+                        greenPercentage: string;
+                        [k: string]: unknown;
+                    } | null;
+                    /**
+                     * Flag indicating whether prices are fixed or variable
+                     */
+                    isFixed: boolean;
+                    /**
+                     * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                     */
+                    onExpiryDescription?: string | null;
+                    /**
+                     * Payment options for this contract
+                     */
+                    paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                    /**
+                     * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                     */
+                    pricingModel:
+                        | 'SINGLE_RATE'
+                        | 'SINGLE_RATE_CONT_LOAD'
+                        | 'TIME_OF_USE'
+                        | 'TIME_OF_USE_CONT_LOAD'
+                        | 'FLEXIBLE'
+                        | 'FLEXIBLE_CONT_LOAD'
+                        | 'QUOTA';
+                    /**
+                     * Array of feed in tariffs for solar power
+                     */
+                    solarFeedInTariff?: {
+                        /**
+                         * A description of the tariff
+                         */
+                        description?: string;
+                        /**
+                         * The name of the tariff
+                         */
+                        displayName: string;
+                        /**
+                         * The type of the payer
+                         */
+                        payerType: 'GOVERNMENT' | 'RETAILER';
+                        /**
+                         * The applicable scheme
+                         */
+                        scheme: 'PREMIUM' | 'OTHER';
+                        /**
+                         * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                         */
+                        singleTariff?: {
+                            /**
+                             * The tariff amount
+                             */
+                            amount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The type of the payer
+                         */
+                        tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                        /**
+                         * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                         */
+                        timeVaryingTariffs?: {
+                            /**
+                             * The tariff amount
+                             */
+                            amount: string;
+                            /**
+                             * Array of time periods for which this tariff is applicable
+                             */
+                            timeVariations: {
+                                /**
+                                 * The days that the tariff applies to. At least one entry required
+                                 */
+                                days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                                 */
+                                endTime?: string;
+                                /**
+                                 * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                                 */
+                                startTime?: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of the charging time period. If absent applies to all periods
+                             */
+                            type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Array of tariff periods
+                     */
+                    tariffPeriod: {
+                        /**
+                         * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                         */
+                        dailySupplyCharges?: string;
+                        /**
+                         * Array of demand charges.  Required if rateBlockUType is demandCharges
+                         */
+                        demandCharges?: {
+                            /**
+                             * The charge amount per  measure unit exclusive of GST
+                             */
+                            amount: string;
+                            /**
+                             * Charge period for the demand tariff
+                             */
+                            chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                            /**
+                             * The days that the demand tariff applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * Description of the charge
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the charge
+                             */
+                            displayName: string;
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                             */
+                            maxDemand?: string;
+                            /**
+                             * The measurement unit of charge amount. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Application period for the demand tariff
+                             */
+                            measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                            /**
+                             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                             */
+                            minDemand?: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The name of the tariff period
+                         */
+                        displayName: string;
+                        /**
+                         * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                         */
+                        endDate: string;
+                        /**
+                         * Specifies the type of rate applicable to this tariff period
+                         */
+                        rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                        /**
+                         * Object representing a single rate.  Required if rateBlockUType is singleRate
+                         */
+                        singleRate?: {
+                            /**
+                             * Description of the rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the rate
+                             */
+                            displayName: string;
+                            /**
+                             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                             */
+                            generalUnitPrice?: string;
+                            /**
+                             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                             */
+                            period?: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                         */
+                        startDate: string;
+                        /**
+                         * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                         */
+                        timeOfUseRates?: {
+                            /**
+                             * Description of the rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * Array of times of use
+                             */
+                            timeOfUse: {
+                                /**
+                                 * The days that the rate applies to
+                                 */
+                                days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * End of the period
+                                 */
+                                endTime: string;
+                                /**
+                                 * Start of the period
+                                 */
+                                startTime: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of usage that the rate applies to
+                             */
+                            type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                         */
+                        timeZone?: 'LOCAL' | 'AEST';
+                        /**
+                         * Type of charge. Assumed to be other if absent
+                         */
+                        type?:
+                            | 'ENVIRONMENTAL'
+                            | 'REGULATED'
+                            | 'NETWORK'
+                            | 'METERING'
+                            | 'RETAIL_SERVICE'
+                            | 'RCTI'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                     */
+                    timeZone?: ('LOCAL' | 'AEST') | null;
+                    /**
+                     * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                     */
+                    variation?: string | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
+                 */
+                electricityContract?: {
+                    /**
+                     * Free text field containing additional information of the fees for this contract
+                     */
+                    additionalFeeInformation?: string | null;
+                    /**
+                     * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                     */
+                    controlledLoad?: {
+                        /**
+                         * A display name for the controlled load
+                         */
+                        displayName: string;
+                        /**
+                         * Optional end date of the application of the controlled load rate
+                         */
+                        endDate?: string;
+                        /**
+                         * Specifies the type of controlloed load rate
+                         */
+                        rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                        /**
+                         * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                         */
+                        singleRate?: {
+                            /**
+                             * The daily supply charge (exclusive of GST) for this controlled load tier
+                             */
+                            dailySupplyCharge?: string;
+                            /**
+                             * Description of the controlled load rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the controlled load rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Optional start date of the application of the controlled load rate
+                         */
+                        startDate?: string;
+                        /**
+                         * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                         */
+                        timeOfUseRates?: {
+                            /**
+                             * The daily supply charge (exclusive of GST) for this controlled load tier
+                             */
+                            dailySupplyCharge?: string;
+                            /**
+                             * Description of the controlled load rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the controlled load rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * Array of times of use.
+                             */
+                            timeOfUse: {
+                                /**
+                                 * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                                 */
+                                additionalInfo?: string;
+                                /**
+                                 * Optional link to additional information regarding the controlled load
+                                 */
+                                additionalInfoUri?: string;
+                                /**
+                                 * The days that the rate applies to
+                                 */
+                                days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                                 */
+                                endTime?: string;
+                                /**
+                                 * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                                 */
+                                startTime?: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of usage that the rate applies to
+                             */
+                            type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of discounts available for the contract
+                     */
+                    discounts?: {
+                        /**
+                         * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                         */
+                        category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                        /**
+                         * The description of the discount
+                         */
+                        description?: string;
+                        /**
+                         * The display name of the discount
+                         */
+                        displayName: string;
+                        /**
+                         * Optional end date for the discount after which the discount is no longer available
+                         */
+                        endDate?: string;
+                        /**
+                         * Required if methodUType is fixedAmount
+                         */
+                        fixedAmount?: {
+                            /**
+                             * The amount of the discount
+                             */
+                            amount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The method of calculation of the discount
+                         */
+                        methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                        /**
+                         * Required if methodUType is percentOfBill
+                         */
+                        percentOfBill?: {
+                            /**
+                             * The rate of the discount applied to the bill amount
+                             */
+                            rate: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Required if methodUType is percentOfUse
+                         */
+                        percentOfUse?: {
+                            /**
+                             * The rate of the discount applied to the usageamount
+                             */
+                            rate: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Required if methodUType is percentOverThreshold
+                         */
+                        percentOverThreshold?: {
+                            /**
+                             * The rate of the discount over the usage amount
+                             */
+                            rate: string;
+                            /**
+                             * The usage amount threshold above which the discount applies
+                             */
+                            usageAmount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The type of the discount
+                         */
+                        type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Eligibility restrictions or requirements
+                     */
+                    eligibility?: {
+                        /**
+                         * A description of the eligibility restriction
+                         */
+                        description?: string;
+                        /**
+                         * Information of the eligibility restriction specific to the type of the restriction
+                         */
+                        information: string;
+                        /**
+                         * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                         */
+                        type:
+                            | 'EXISTING_CUST'
+                            | 'EXISTING_POOL'
+                            | 'EXISTING_SOLAR'
+                            | 'EXISTING_BATTERY'
+                            | 'EXISTING_SMART_METER'
+                            | 'EXISTING_BASIC_METER'
+                            | 'SENIOR_CARD'
+                            | 'SMALL_BUSINESS'
+                            | 'NO_SOLAR_FIT'
+                            | 'NEW_CUSTOMER'
+                            | 'ONLINE_ONLY'
+                            | 'REQ_EQUIP_SUPPLIER'
+                            | 'THIRD_PARTY_ONLY'
+                            | 'SPORT_CLUB_MEMBER'
+                            | 'ORG_MEMBER'
+                            | 'SPECIFIC_LOCATION'
+                            | 'MINIMUM_USAGE'
+                            | 'LOYALTY_MEMBER'
+                            | 'GROUP_BUY_MEMBER'
+                            | 'CONTINGENT_PLAN'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * An array of fees applicable to the plan
+                     */
+                    fees?: {
+                        /**
+                         * The fee amount. Required if term is not PERCENT_OF_BILL
+                         */
+                        amount?: string;
+                        /**
+                         * A description of the fee
+                         */
+                        description?: string;
+                        /**
+                         * The fee rate. Required if term is PERCENT_OF_BILL
+                         */
+                        rate?: string;
+                        /**
+                         * The term of the fee
+                         */
+                        term:
+                            | 'FIXED'
+                            | '1_YEAR'
+                            | '2_YEAR'
+                            | '3_YEAR'
+                            | '4_YEAR'
+                            | '5_YEAR'
+                            | 'PERCENT_OF_BILL'
+                            | 'ANNUAL'
+                            | 'DAILY'
+                            | 'WEEKLY'
+                            | 'MONTHLY'
+                            | 'BIANNUAL'
+                            | 'VARIABLE';
+                        /**
+                         * The type of the fee
+                         */
+                        type:
+                            | 'EXIT'
+                            | 'ESTABLISHMENT'
+                            | 'LATE_PAYMENT'
+                            | 'DISCONNECTION'
+                            | 'DISCONNECT_MOVE_OUT'
+                            | 'DISCONNECT_NON_PAY'
+                            | 'RECONNECTION'
+                            | 'CONNECTION'
+                            | 'PAYMENT_PROCESSING'
+                            | 'CC_PROCESSING'
+                            | 'CHEQUE_DISHONOUR'
+                            | 'DD_DISHONOUR'
+                            | 'MEMBERSHIP'
+                            | 'CONTRIBUTION'
+                            | 'PAPER_BILL'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of charges applicable to green power
+                     */
+                    greenPowerCharges?: {
+                        /**
+                         * The description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * The display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * The applicable green power scheme
+                         */
+                        scheme: 'GREENPOWER' | 'OTHER';
+                        /**
+                         * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                         */
+                        tiers: {
+                            /**
+                             * The amount of the charge if the type implies the application of a fixed amount
+                             */
+                            amount?: string;
+                            /**
+                             * The upper percentage of green power used applicable for this tier
+                             */
+                            percentGreen: string;
+                            /**
+                             * The rate of the charge if the type implies the application of a rate
+                             */
+                            rate?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of charge
+                         */
+                        type:
+                            | 'FIXED_PER_DAY'
+                            | 'FIXED_PER_WEEK'
+                            | 'FIXED_PER_MONTH'
+                            | 'FIXED_PER_UNIT'
+                            | 'PERCENT_OF_USE'
+                            | 'PERCENT_OF_BILL';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Optional list of incentives available for the contract
+                     */
+                    incentives?: {
+                        /**
+                         * The type of the incentive
+                         */
+                        category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                        /**
+                         * The description of the incentive
+                         */
+                        description: string;
+                        /**
+                         * The display name of the incentive
+                         */
+                        displayName: string;
+                        /**
+                         * A display message outlining an eligibility criteria that may apply
+                         */
+                        eligibility?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                     */
+                    intrinsicGreenPower?: {
+                        /**
+                         * Percentage of green power intrinsically included in the plan
+                         */
+                        greenPercentage: string;
+                        [k: string]: unknown;
+                    } | null;
+                    /**
+                     * Flag indicating whether prices are fixed or variable
+                     */
+                    isFixed: boolean;
+                    /**
+                     * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                     */
+                    onExpiryDescription?: string | null;
+                    /**
+                     * Payment options for this contract
+                     */
+                    paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                    /**
+                     * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                     */
+                    pricingModel:
+                        | 'SINGLE_RATE'
+                        | 'SINGLE_RATE_CONT_LOAD'
+                        | 'TIME_OF_USE'
+                        | 'TIME_OF_USE_CONT_LOAD'
+                        | 'FLEXIBLE'
+                        | 'FLEXIBLE_CONT_LOAD'
+                        | 'QUOTA';
+                    /**
+                     * Array of feed in tariffs for solar power
+                     */
+                    solarFeedInTariff?: {
+                        /**
+                         * A description of the tariff
+                         */
+                        description?: string;
+                        /**
+                         * The name of the tariff
+                         */
+                        displayName: string;
+                        /**
+                         * The type of the payer
+                         */
+                        payerType: 'GOVERNMENT' | 'RETAILER';
+                        /**
+                         * The applicable scheme
+                         */
+                        scheme: 'PREMIUM' | 'OTHER';
+                        /**
+                         * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                         */
+                        singleTariff?: {
+                            /**
+                             * The tariff amount
+                             */
+                            amount: string;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The type of the payer
+                         */
+                        tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                        /**
+                         * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                         */
+                        timeVaryingTariffs?: {
+                            /**
+                             * The tariff amount
+                             */
+                            amount: string;
+                            /**
+                             * Array of time periods for which this tariff is applicable
+                             */
+                            timeVariations: {
+                                /**
+                                 * The days that the tariff applies to. At least one entry required
+                                 */
+                                days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                                 */
+                                endTime?: string;
+                                /**
+                                 * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                                 */
+                                startTime?: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of the charging time period. If absent applies to all periods
+                             */
+                            type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Array of tariff periods
+                     */
+                    tariffPeriod: {
+                        /**
+                         * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                         */
+                        dailySupplyCharges?: string;
+                        /**
+                         * Array of demand charges.  Required if rateBlockUType is demandCharges
+                         */
+                        demandCharges?: {
+                            /**
+                             * The charge amount per  measure unit exclusive of GST
+                             */
+                            amount: string;
+                            /**
+                             * Charge period for the demand tariff
+                             */
+                            chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                            /**
+                             * The days that the demand tariff applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * Description of the charge
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the charge
+                             */
+                            displayName: string;
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                             */
+                            maxDemand?: string;
+                            /**
+                             * The measurement unit of charge amount. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Application period for the demand tariff
+                             */
+                            measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                            /**
+                             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                             */
+                            minDemand?: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The name of the tariff period
+                         */
+                        displayName: string;
+                        /**
+                         * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                         */
+                        endDate: string;
+                        /**
+                         * Specifies the type of rate applicable to this tariff period
+                         */
+                        rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                        /**
+                         * Object representing a single rate.  Required if rateBlockUType is singleRate
+                         */
+                        singleRate?: {
+                            /**
+                             * Description of the rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the rate
+                             */
+                            displayName: string;
+                            /**
+                             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                             */
+                            generalUnitPrice?: string;
+                            /**
+                             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                             */
+                            period?: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                         */
+                        startDate: string;
+                        /**
+                         * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                         */
+                        timeOfUseRates?: {
+                            /**
+                             * Description of the rate
+                             */
+                            description?: string;
+                            /**
+                             * Display name of the rate
+                             */
+                            displayName: string;
+                            /**
+                             * Array of controlled load rates in order of usage volume
+                             */
+                            rates: {
+                                /**
+                                 * The measurement unit of rate. Assumed to be KWH if absent
+                                 */
+                                measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                                /**
+                                 * Unit price of usage per  measure unit (exclusive of GST)
+                                 */
+                                unitPrice: string;
+                                /**
+                                 * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                                 */
+                                volume?: number;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * Array of times of use
+                             */
+                            timeOfUse: {
+                                /**
+                                 * The days that the rate applies to
+                                 */
+                                days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                                /**
+                                 * End of the period
+                                 */
+                                endTime: string;
+                                /**
+                                 * Start of the period
+                                 */
+                                startTime: string;
+                                [k: string]: unknown;
+                            }[];
+                            /**
+                             * The type of usage that the rate applies to
+                             */
+                            type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                         */
+                        timeZone?: 'LOCAL' | 'AEST';
+                        /**
+                         * Type of charge. Assumed to be other if absent
+                         */
+                        type?:
+                            | 'ENVIRONMENTAL'
+                            | 'REGULATED'
+                            | 'NETWORK'
+                            | 'METERING'
+                            | 'RETAIL_SERVICE'
+                            | 'RCTI'
+                            | 'OTHER';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                     */
+                    timeZone?: ('LOCAL' | 'AEST') | null;
+                    /**
+                     * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                     */
+                    variation?: string | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * An array of additional contacts that are authorised to act on this account
+             */
+            authorisedContacts?: {
+                /**
+                 * For people with single names this field need not be present. The single name should be in the lastName field
+                 */
+                firstName?: string;
+                /**
+                 * For people with single names the single name should be in this field
+                 */
+                lastName: string;
+                /**
+                 * Field is mandatory but array may be empty
+                 */
+                middleNames?: string[];
+                /**
+                 * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+                 */
+                prefix?: string;
+                /**
+                 * Used for a trailing suffix to the name (e.g. Jr)
+                 */
+                suffix?: string;
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccountDetailResponseV2 {
-  data: EnergyAccountDetailV2;
-  links: Links;
-  meta: Meta;
-  [k: string]: unknown;
+    data: EnergyAccountDetailV2;
+    links: Links;
+    meta: Meta;
+    [k: string]: unknown;
 }
 
 export interface EnergyAccountDetailResponseV3 {
-  data: EnergyAccountDetailV3;
-  links: Links;
-  meta: Meta;
-  [k: string]: unknown;
+    data: EnergyAccountDetailV3;
+    links: Links;
+    meta: Meta;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccountDetailV2 extends EnergyAccountBaseV2 {
-  /**
-   * The array of plans containing service points and associated plan details
-   */
-  plans: {
     /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
+     * The array of plans containing service points and associated plan details
      */
-    nickname?: string;
-    /**
-     * An array of servicePointIds, representing NMIs, that this account is linked to
-     */
-    servicePointIds: string[];
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview?: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string;
-      [k: string]: unknown;
-    };
-    /**
-     * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
-     */
-    planDetail?: {
-      /**
-       * The fuel types covered by the plan
-       */
-      fuelType: "ELECTRICITY" | "GAS" | "DUAL";
-      /**
-       * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
-       */
-      isContingentPlan?: boolean;
-      /**
-       * Charges for metering included in the plan
-       */
-      meteringCharges?: {
+    plans: {
         /**
-         * Display name of the charge
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
          */
-        displayName: string;
+        nickname?: string;
         /**
-         * Description of the charge
+         * An array of servicePointIds, representing NMIs, that this account is linked to
          */
-        description?: string;
+        servicePointIds: string[];
         /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+         * Mandatory if openStatus is OPEN
          */
-        minimumValue: string;
+        planOverview?: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string;
+            [k: string]: unknown;
+        };
         /**
-         * The upper limit of the charge if the charge could occur in a range
+         * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
          */
-        maximumValue?: string;
+        planDetail?: {
+            /**
+             * The fuel types covered by the plan
+             */
+            fuelType: 'ELECTRICITY' | 'GAS' | 'DUAL';
+            /**
+             * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
+             */
+            isContingentPlan?: boolean;
+            /**
+             * Charges for metering included in the plan
+             */
+            meteringCharges?: {
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * Description of the charge
+                 */
+                description?: string;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
+             */
+            gasContract?: {
+                /**
+                 * Free text field containing additional information of the fees for this contract
+                 */
+                additionalFeeInformation?: string | null;
+                /**
+                 * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                 */
+                controlledLoad?: {
+                    /**
+                     * A display name for the controlled load
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date of the application of the controlled load rate
+                     */
+                    endDate?: string;
+                    /**
+                     * Specifies the type of controlloed load rate
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                    /**
+                     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Optional start date of the application of the controlled load rate
+                     */
+                    startDate?: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use.
+                         */
+                        timeOfUse: {
+                            /**
+                             * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                             */
+                            additionalInfo?: string;
+                            /**
+                             * Optional link to additional information regarding the controlled load
+                             */
+                            additionalInfoUri?: string;
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                        [k: string]: unknown;
+                    }[];
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of discounts available for the contract
+                 */
+                discounts?: {
+                    /**
+                     * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                     */
+                    category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                    /**
+                     * The description of the discount
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the discount
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date for the discount after which the discount is no longer available
+                     */
+                    endDate?: string;
+                    /**
+                     * Required if methodUType is fixedAmount
+                     */
+                    fixedAmount?: {
+                        /**
+                         * The amount of the discount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The method of calculation of the discount
+                     */
+                    methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                    /**
+                     * Required if methodUType is percentOfBill
+                     */
+                    percentOfBill?: {
+                        /**
+                         * The rate of the discount applied to the bill amount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOfUse
+                     */
+                    percentOfUse?: {
+                        /**
+                         * The rate of the discount applied to the usageamount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOverThreshold
+                     */
+                    percentOverThreshold?: {
+                        /**
+                         * The rate of the discount over the usage amount
+                         */
+                        rate: string;
+                        /**
+                         * The usage amount threshold above which the discount applies
+                         */
+                        usageAmount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the discount
+                     */
+                    type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Eligibility restrictions or requirements
+                 */
+                eligibility?: {
+                    /**
+                     * A description of the eligibility restriction
+                     */
+                    description?: string;
+                    /**
+                     * Information of the eligibility restriction specific to the type of the restriction
+                     */
+                    information: string;
+                    /**
+                     * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                     */
+                    type:
+                        | 'EXISTING_CUST'
+                        | 'EXISTING_POOL'
+                        | 'EXISTING_SOLAR'
+                        | 'EXISTING_BATTERY'
+                        | 'EXISTING_SMART_METER'
+                        | 'EXISTING_BASIC_METER'
+                        | 'SENIOR_CARD'
+                        | 'SMALL_BUSINESS'
+                        | 'NO_SOLAR_FIT'
+                        | 'NEW_CUSTOMER'
+                        | 'ONLINE_ONLY'
+                        | 'REQ_EQUIP_SUPPLIER'
+                        | 'THIRD_PARTY_ONLY'
+                        | 'SPORT_CLUB_MEMBER'
+                        | 'ORG_MEMBER'
+                        | 'SPECIFIC_LOCATION'
+                        | 'MINIMUM_USAGE'
+                        | 'LOYALTY_MEMBER'
+                        | 'GROUP_BUY_MEMBER'
+                        | 'CONTINGENT_PLAN'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * An array of fees applicable to the plan
+                 */
+                fees?: {
+                    /**
+                     * The fee amount. Required if term is not PERCENT_OF_BILL
+                     */
+                    amount?: string;
+                    /**
+                     * A description of the fee
+                     */
+                    description?: string;
+                    /**
+                     * The fee rate. Required if term is PERCENT_OF_BILL
+                     */
+                    rate?: string;
+                    /**
+                     * The term of the fee
+                     */
+                    term:
+                        | 'FIXED'
+                        | '1_YEAR'
+                        | '2_YEAR'
+                        | '3_YEAR'
+                        | '4_YEAR'
+                        | '5_YEAR'
+                        | 'PERCENT_OF_BILL'
+                        | 'ANNUAL'
+                        | 'DAILY'
+                        | 'WEEKLY'
+                        | 'MONTHLY'
+                        | 'BIANNUAL'
+                        | 'VARIABLE';
+                    /**
+                     * The type of the fee
+                     */
+                    type:
+                        | 'EXIT'
+                        | 'ESTABLISHMENT'
+                        | 'LATE_PAYMENT'
+                        | 'DISCONNECTION'
+                        | 'DISCONNECT_MOVE_OUT'
+                        | 'DISCONNECT_NON_PAY'
+                        | 'RECONNECTION'
+                        | 'CONNECTION'
+                        | 'PAYMENT_PROCESSING'
+                        | 'CC_PROCESSING'
+                        | 'CHEQUE_DISHONOUR'
+                        | 'DD_DISHONOUR'
+                        | 'MEMBERSHIP'
+                        | 'CONTRIBUTION'
+                        | 'PAPER_BILL'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of charges applicable to green power
+                 */
+                greenPowerCharges?: {
+                    /**
+                     * The description of the charge
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * The applicable green power scheme
+                     */
+                    scheme: 'GREENPOWER' | 'OTHER';
+                    /**
+                     * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                     */
+                    tiers: {
+                        /**
+                         * The amount of the charge if the type implies the application of a fixed amount
+                         */
+                        amount?: string;
+                        /**
+                         * The upper percentage of green power used applicable for this tier
+                         */
+                        percentGreen: string;
+                        /**
+                         * The rate of the charge if the type implies the application of a rate
+                         */
+                        rate?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The type of charge
+                     */
+                    type:
+                        | 'FIXED_PER_DAY'
+                        | 'FIXED_PER_WEEK'
+                        | 'FIXED_PER_MONTH'
+                        | 'FIXED_PER_UNIT'
+                        | 'PERCENT_OF_USE'
+                        | 'PERCENT_OF_BILL';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of incentives available for the contract
+                 */
+                incentives?: {
+                    /**
+                     * The type of the incentive
+                     */
+                    category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                    /**
+                     * The description of the incentive
+                     */
+                    description: string;
+                    /**
+                     * The display name of the incentive
+                     */
+                    displayName: string;
+                    /**
+                     * A display message outlining an eligibility criteria that may apply
+                     */
+                    eligibility?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                 */
+                intrinsicGreenPower?: {
+                    /**
+                     * Percentage of green power intrinsically included in the plan
+                     */
+                    greenPercentage: string;
+                    [k: string]: unknown;
+                } | null;
+                /**
+                 * Flag indicating whether prices are fixed or variable
+                 */
+                isFixed: boolean;
+                /**
+                 * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                 */
+                onExpiryDescription?: string | null;
+                /**
+                 * Payment options for this contract
+                 */
+                paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                /**
+                 * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                 */
+                pricingModel:
+                    | 'SINGLE_RATE'
+                    | 'SINGLE_RATE_CONT_LOAD'
+                    | 'TIME_OF_USE'
+                    | 'TIME_OF_USE_CONT_LOAD'
+                    | 'FLEXIBLE'
+                    | 'FLEXIBLE_CONT_LOAD'
+                    | 'QUOTA';
+                /**
+                 * Array of feed in tariffs for solar power
+                 */
+                solarFeedInTariff?: {
+                    /**
+                     * A description of the tariff
+                     */
+                    description?: string;
+                    /**
+                     * The name of the tariff
+                     */
+                    displayName: string;
+                    /**
+                     * The type of the payer
+                     */
+                    payerType: 'GOVERNMENT' | 'RETAILER';
+                    /**
+                     * The applicable scheme
+                     */
+                    scheme: 'PREMIUM' | 'OTHER';
+                    /**
+                     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                     */
+                    singleTariff?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the payer
+                     */
+                    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                    /**
+                     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                     */
+                    timeVaryingTariffs?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        /**
+                         * Array of time periods for which this tariff is applicable
+                         */
+                        timeVariations: {
+                            /**
+                             * The days that the tariff applies to. At least one entry required
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of the charging time period. If absent applies to all periods
+                         */
+                        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Array of tariff periods
+                 */
+                tariffPeriod: {
+                    /**
+                     * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                     */
+                    dailySupplyCharges?: string;
+                    /**
+                     * Array of demand charges.  Required if rateBlockUType is demandCharges
+                     */
+                    demandCharges?: {
+                        /**
+                         * The charge amount per  measure unit exclusive of GST
+                         */
+                        amount: string;
+                        /**
+                         * Charge period for the demand tariff
+                         */
+                        chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * The days that the demand tariff applies to
+                         */
+                        days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                        /**
+                         * Description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * End of the period
+                         */
+                        endTime: string;
+                        /**
+                         * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                         */
+                        maxDemand?: string;
+                        /**
+                         * The measurement unit of charge amount. Assumed to be KWH if absent
+                         */
+                        measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                        /**
+                         * Application period for the demand tariff
+                         */
+                        measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                         */
+                        minDemand?: string;
+                        /**
+                         * Start of the period
+                         */
+                        startTime: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The name of the tariff period
+                     */
+                    displayName: string;
+                    /**
+                     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    endDate: string;
+                    /**
+                     * Specifies the type of rate applicable to this tariff period
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                    /**
+                     * Object representing a single rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                         */
+                        generalUnitPrice?: string;
+                        /**
+                         * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                         */
+                        period?: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    startDate: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use
+                         */
+                        timeOfUse: {
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                     */
+                    timeZone?: 'LOCAL' | 'AEST';
+                    /**
+                     * Type of charge. Assumed to be other if absent
+                     */
+                    type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                 */
+                timeZone?: ('LOCAL' | 'AEST') | null;
+                /**
+                 * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                 */
+                variation?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
+             */
+            electricityContract?: {
+                /**
+                 * Free text field containing additional information of the fees for this contract
+                 */
+                additionalFeeInformation?: string | null;
+                /**
+                 * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+                 */
+                controlledLoad?: {
+                    /**
+                     * A display name for the controlled load
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date of the application of the controlled load rate
+                     */
+                    endDate?: string;
+                    /**
+                     * Specifies the type of controlloed load rate
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates';
+                    /**
+                     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Optional start date of the application of the controlled load rate
+                     */
+                    startDate?: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * The daily supply charge (exclusive of GST) for this controlled load tier
+                         */
+                        dailySupplyCharge?: string;
+                        /**
+                         * Description of the controlled load rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the controlled load rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use.
+                         */
+                        timeOfUse: {
+                            /**
+                             * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+                             */
+                            additionalInfo?: string;
+                            /**
+                             * Optional link to additional information regarding the controlled load
+                             */
+                            additionalInfoUri?: string;
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+                        [k: string]: unknown;
+                    }[];
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of discounts available for the contract
+                 */
+                discounts?: {
+                    /**
+                     * The type of the discount.  Mandatory if the discount type is CONDITIONAL
+                     */
+                    category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+                    /**
+                     * The description of the discount
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the discount
+                     */
+                    displayName: string;
+                    /**
+                     * Optional end date for the discount after which the discount is no longer available
+                     */
+                    endDate?: string;
+                    /**
+                     * Required if methodUType is fixedAmount
+                     */
+                    fixedAmount?: {
+                        /**
+                         * The amount of the discount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The method of calculation of the discount
+                     */
+                    methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+                    /**
+                     * Required if methodUType is percentOfBill
+                     */
+                    percentOfBill?: {
+                        /**
+                         * The rate of the discount applied to the bill amount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOfUse
+                     */
+                    percentOfUse?: {
+                        /**
+                         * The rate of the discount applied to the usageamount
+                         */
+                        rate: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Required if methodUType is percentOverThreshold
+                     */
+                    percentOverThreshold?: {
+                        /**
+                         * The rate of the discount over the usage amount
+                         */
+                        rate: string;
+                        /**
+                         * The usage amount threshold above which the discount applies
+                         */
+                        usageAmount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the discount
+                     */
+                    type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Eligibility restrictions or requirements
+                 */
+                eligibility?: {
+                    /**
+                     * A description of the eligibility restriction
+                     */
+                    description?: string;
+                    /**
+                     * Information of the eligibility restriction specific to the type of the restriction
+                     */
+                    information: string;
+                    /**
+                     * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+                     */
+                    type:
+                        | 'EXISTING_CUST'
+                        | 'EXISTING_POOL'
+                        | 'EXISTING_SOLAR'
+                        | 'EXISTING_BATTERY'
+                        | 'EXISTING_SMART_METER'
+                        | 'EXISTING_BASIC_METER'
+                        | 'SENIOR_CARD'
+                        | 'SMALL_BUSINESS'
+                        | 'NO_SOLAR_FIT'
+                        | 'NEW_CUSTOMER'
+                        | 'ONLINE_ONLY'
+                        | 'REQ_EQUIP_SUPPLIER'
+                        | 'THIRD_PARTY_ONLY'
+                        | 'SPORT_CLUB_MEMBER'
+                        | 'ORG_MEMBER'
+                        | 'SPECIFIC_LOCATION'
+                        | 'MINIMUM_USAGE'
+                        | 'LOYALTY_MEMBER'
+                        | 'GROUP_BUY_MEMBER'
+                        | 'CONTINGENT_PLAN'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * An array of fees applicable to the plan
+                 */
+                fees?: {
+                    /**
+                     * The fee amount. Required if term is not PERCENT_OF_BILL
+                     */
+                    amount?: string;
+                    /**
+                     * A description of the fee
+                     */
+                    description?: string;
+                    /**
+                     * The fee rate. Required if term is PERCENT_OF_BILL
+                     */
+                    rate?: string;
+                    /**
+                     * The term of the fee
+                     */
+                    term:
+                        | 'FIXED'
+                        | '1_YEAR'
+                        | '2_YEAR'
+                        | '3_YEAR'
+                        | '4_YEAR'
+                        | '5_YEAR'
+                        | 'PERCENT_OF_BILL'
+                        | 'ANNUAL'
+                        | 'DAILY'
+                        | 'WEEKLY'
+                        | 'MONTHLY'
+                        | 'BIANNUAL'
+                        | 'VARIABLE';
+                    /**
+                     * The type of the fee
+                     */
+                    type:
+                        | 'EXIT'
+                        | 'ESTABLISHMENT'
+                        | 'LATE_PAYMENT'
+                        | 'DISCONNECTION'
+                        | 'DISCONNECT_MOVE_OUT'
+                        | 'DISCONNECT_NON_PAY'
+                        | 'RECONNECTION'
+                        | 'CONNECTION'
+                        | 'PAYMENT_PROCESSING'
+                        | 'CC_PROCESSING'
+                        | 'CHEQUE_DISHONOUR'
+                        | 'DD_DISHONOUR'
+                        | 'MEMBERSHIP'
+                        | 'CONTRIBUTION'
+                        | 'PAPER_BILL'
+                        | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of charges applicable to green power
+                 */
+                greenPowerCharges?: {
+                    /**
+                     * The description of the charge
+                     */
+                    description?: string;
+                    /**
+                     * The display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * The applicable green power scheme
+                     */
+                    scheme: 'GREENPOWER' | 'OTHER';
+                    /**
+                     * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+                     */
+                    tiers: {
+                        /**
+                         * The amount of the charge if the type implies the application of a fixed amount
+                         */
+                        amount?: string;
+                        /**
+                         * The upper percentage of green power used applicable for this tier
+                         */
+                        percentGreen: string;
+                        /**
+                         * The rate of the charge if the type implies the application of a rate
+                         */
+                        rate?: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The type of charge
+                     */
+                    type:
+                        | 'FIXED_PER_DAY'
+                        | 'FIXED_PER_WEEK'
+                        | 'FIXED_PER_MONTH'
+                        | 'FIXED_PER_UNIT'
+                        | 'PERCENT_OF_USE'
+                        | 'PERCENT_OF_BILL';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Optional list of incentives available for the contract
+                 */
+                incentives?: {
+                    /**
+                     * The type of the incentive
+                     */
+                    category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+                    /**
+                     * The description of the incentive
+                     */
+                    description: string;
+                    /**
+                     * The display name of the incentive
+                     */
+                    displayName: string;
+                    /**
+                     * A display message outlining an eligibility criteria that may apply
+                     */
+                    eligibility?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+                 */
+                intrinsicGreenPower?: {
+                    /**
+                     * Percentage of green power intrinsically included in the plan
+                     */
+                    greenPercentage: string;
+                    [k: string]: unknown;
+                } | null;
+                /**
+                 * Flag indicating whether prices are fixed or variable
+                 */
+                isFixed: boolean;
+                /**
+                 * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+                 */
+                onExpiryDescription?: string | null;
+                /**
+                 * Payment options for this contract
+                 */
+                paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+                /**
+                 * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+                 */
+                pricingModel:
+                    | 'SINGLE_RATE'
+                    | 'SINGLE_RATE_CONT_LOAD'
+                    | 'TIME_OF_USE'
+                    | 'TIME_OF_USE_CONT_LOAD'
+                    | 'FLEXIBLE'
+                    | 'FLEXIBLE_CONT_LOAD'
+                    | 'QUOTA';
+                /**
+                 * Array of feed in tariffs for solar power
+                 */
+                solarFeedInTariff?: {
+                    /**
+                     * A description of the tariff
+                     */
+                    description?: string;
+                    /**
+                     * The name of the tariff
+                     */
+                    displayName: string;
+                    /**
+                     * The type of the payer
+                     */
+                    payerType: 'GOVERNMENT' | 'RETAILER';
+                    /**
+                     * The applicable scheme
+                     */
+                    scheme: 'PREMIUM' | 'OTHER';
+                    /**
+                     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+                     */
+                    singleTariff?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The type of the payer
+                     */
+                    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+                    /**
+                     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+                     */
+                    timeVaryingTariffs?: {
+                        /**
+                         * The tariff amount
+                         */
+                        amount: string;
+                        /**
+                         * Array of time periods for which this tariff is applicable
+                         */
+                        timeVariations: {
+                            /**
+                             * The days that the tariff applies to. At least one entry required
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+                             */
+                            endTime?: string;
+                            /**
+                             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+                             */
+                            startTime?: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of the charging time period. If absent applies to all periods
+                         */
+                        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Array of tariff periods
+                 */
+                tariffPeriod: {
+                    /**
+                     * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
+                     */
+                    dailySupplyCharges?: string;
+                    /**
+                     * Array of demand charges.  Required if rateBlockUType is demandCharges
+                     */
+                    demandCharges?: {
+                        /**
+                         * The charge amount per  measure unit exclusive of GST
+                         */
+                        amount: string;
+                        /**
+                         * Charge period for the demand tariff
+                         */
+                        chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * The days that the demand tariff applies to
+                         */
+                        days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                        /**
+                         * Description of the charge
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the charge
+                         */
+                        displayName: string;
+                        /**
+                         * End of the period
+                         */
+                        endTime: string;
+                        /**
+                         * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+                         */
+                        maxDemand?: string;
+                        /**
+                         * The measurement unit of charge amount. Assumed to be KWH if absent
+                         */
+                        measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                        /**
+                         * Application period for the demand tariff
+                         */
+                        measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+                        /**
+                         * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+                         */
+                        minDemand?: string;
+                        /**
+                         * Start of the period
+                         */
+                        startTime: string;
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * The name of the tariff period
+                     */
+                    displayName: string;
+                    /**
+                     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    endDate: string;
+                    /**
+                     * Specifies the type of rate applicable to this tariff period
+                     */
+                    rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
+                    /**
+                     * Object representing a single rate.  Required if rateBlockUType is singleRate
+                     */
+                    singleRate?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+                         */
+                        generalUnitPrice?: string;
+                        /**
+                         * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                         */
+                        period?: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+                     */
+                    startDate: string;
+                    /**
+                     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+                     */
+                    timeOfUseRates?: {
+                        /**
+                         * Description of the rate
+                         */
+                        description?: string;
+                        /**
+                         * Display name of the rate
+                         */
+                        displayName: string;
+                        /**
+                         * Array of controlled load rates in order of usage volume
+                         */
+                        rates: {
+                            /**
+                             * The measurement unit of rate. Assumed to be KWH if absent
+                             */
+                            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+                            /**
+                             * Unit price of usage per  measure unit (exclusive of GST)
+                             */
+                            unitPrice: string;
+                            /**
+                             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                             */
+                            volume?: number;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * Array of times of use
+                         */
+                        timeOfUse: {
+                            /**
+                             * The days that the rate applies to
+                             */
+                            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+                            /**
+                             * End of the period
+                             */
+                            endTime: string;
+                            /**
+                             * Start of the period
+                             */
+                            startTime: string;
+                            [k: string]: unknown;
+                        }[];
+                        /**
+                         * The type of usage that the rate applies to
+                         */
+                        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+                        [k: string]: unknown;
+                    }[];
+                    /**
+                     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+                     */
+                    timeZone?: 'LOCAL' | 'AEST';
+                    /**
+                     * Type of charge. Assumed to be other if absent
+                     */
+                    type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+                 */
+                timeZone?: ('LOCAL' | 'AEST') | null;
+                /**
+                 * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+                 */
+                variation?: string | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
         /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         * An array of additional contacts that are authorised to act on this account
          */
-        period?: string;
+        authorisedContacts?: {
+            /**
+             * For people with single names this field need not be present. The single name should be in the lastName field
+             */
+            firstName?: string;
+            /**
+             * For people with single names the single name should be in this field
+             */
+            lastName: string;
+            /**
+             * Field is mandatory but array may be empty
+             */
+            middleNames?: string[];
+            /**
+             * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+             */
+            prefix?: string;
+            /**
+             * Used for a trailing suffix to the name (e.g. Jr)
+             */
+            suffix?: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
-      }[];
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-       */
-      gasContract?: {
-        /**
-         * Free text field containing additional information of the fees for this contract
-         */
-        additionalFeeInformation?: string | null;
-        /**
-         * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-         */
-        controlledLoad?: {
-          /**
-           * A display name for the controlled load
-           */
-          displayName: string;
-          /**
-           * Optional end date of the application of the controlled load rate
-           */
-          endDate?: string;
-          /**
-           * Specifies the type of controlloed load rate
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates";
-          /**
-           * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * Optional start date of the application of the controlled load rate
-           */
-          startDate?: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use.
-             */
-            timeOfUse: {
-              /**
-               * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-               */
-              additionalInfo?: string;
-              /**
-               * Optional link to additional information regarding the controlled load
-               */
-              additionalInfoUri?: string;
-              /**
-               * The days that the rate applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-            [k: string]: unknown;
-          }[];
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of discounts available for the contract
-         */
-        discounts?: {
-          /**
-           * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-           */
-          category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-          /**
-           * The description of the discount
-           */
-          description?: string;
-          /**
-           * The display name of the discount
-           */
-          displayName: string;
-          /**
-           * Optional end date for the discount after which the discount is no longer available
-           */
-          endDate?: string;
-          /**
-           * Required if methodUType is fixedAmount
-           */
-          fixedAmount?: {
-            /**
-             * The amount of the discount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The method of calculation of the discount
-           */
-          methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-          /**
-           * Required if methodUType is percentOfBill
-           */
-          percentOfBill?: {
-            /**
-             * The rate of the discount applied to the bill amount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOfUse
-           */
-          percentOfUse?: {
-            /**
-             * The rate of the discount applied to the usageamount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOverThreshold
-           */
-          percentOverThreshold?: {
-            /**
-             * The rate of the discount over the usage amount
-             */
-            rate: string;
-            /**
-             * The usage amount threshold above which the discount applies
-             */
-            usageAmount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the discount
-           */
-          type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Eligibility restrictions or requirements
-         */
-        eligibility?: {
-          /**
-           * A description of the eligibility restriction
-           */
-          description?: string;
-          /**
-           * Information of the eligibility restriction specific to the type of the restriction
-           */
-          information: string;
-          /**
-           * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-           */
-          type:
-            | "EXISTING_CUST"
-            | "EXISTING_POOL"
-            | "EXISTING_SOLAR"
-            | "EXISTING_BATTERY"
-            | "EXISTING_SMART_METER"
-            | "EXISTING_BASIC_METER"
-            | "SENIOR_CARD"
-            | "SMALL_BUSINESS"
-            | "NO_SOLAR_FIT"
-            | "NEW_CUSTOMER"
-            | "ONLINE_ONLY"
-            | "REQ_EQUIP_SUPPLIER"
-            | "THIRD_PARTY_ONLY"
-            | "SPORT_CLUB_MEMBER"
-            | "ORG_MEMBER"
-            | "SPECIFIC_LOCATION"
-            | "MINIMUM_USAGE"
-            | "LOYALTY_MEMBER"
-            | "GROUP_BUY_MEMBER"
-            | "CONTINGENT_PLAN"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * An array of fees applicable to the plan
-         */
-        fees?: {
-          /**
-           * The fee amount. Required if term is not PERCENT_OF_BILL
-           */
-          amount?: string;
-          /**
-           * A description of the fee
-           */
-          description?: string;
-          /**
-           * The fee rate. Required if term is PERCENT_OF_BILL
-           */
-          rate?: string;
-          /**
-           * The term of the fee
-           */
-          term:
-            | "FIXED"
-            | "1_YEAR"
-            | "2_YEAR"
-            | "3_YEAR"
-            | "4_YEAR"
-            | "5_YEAR"
-            | "PERCENT_OF_BILL"
-            | "ANNUAL"
-            | "DAILY"
-            | "WEEKLY"
-            | "MONTHLY"
-            | "BIANNUAL"
-            | "VARIABLE";
-          /**
-           * The type of the fee
-           */
-          type:
-            | "EXIT"
-            | "ESTABLISHMENT"
-            | "LATE_PAYMENT"
-            | "DISCONNECTION"
-            | "DISCONNECT_MOVE_OUT"
-            | "DISCONNECT_NON_PAY"
-            | "RECONNECTION"
-            | "CONNECTION"
-            | "PAYMENT_PROCESSING"
-            | "CC_PROCESSING"
-            | "CHEQUE_DISHONOUR"
-            | "DD_DISHONOUR"
-            | "MEMBERSHIP"
-            | "CONTRIBUTION"
-            | "PAPER_BILL"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of charges applicable to green power
-         */
-        greenPowerCharges?: {
-          /**
-           * The description of the charge
-           */
-          description?: string;
-          /**
-           * The display name of the charge
-           */
-          displayName: string;
-          /**
-           * The applicable green power scheme
-           */
-          scheme: "GREENPOWER" | "OTHER";
-          /**
-           * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-           */
-          tiers: {
-            /**
-             * The amount of the charge if the type implies the application of a fixed amount
-             */
-            amount?: string;
-            /**
-             * The upper percentage of green power used applicable for this tier
-             */
-            percentGreen: string;
-            /**
-             * The rate of the charge if the type implies the application of a rate
-             */
-            rate?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The type of charge
-           */
-          type:
-            | "FIXED_PER_DAY"
-            | "FIXED_PER_WEEK"
-            | "FIXED_PER_MONTH"
-            | "FIXED_PER_UNIT"
-            | "PERCENT_OF_USE"
-            | "PERCENT_OF_BILL";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of incentives available for the contract
-         */
-        incentives?: {
-          /**
-           * The type of the incentive
-           */
-          category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-          /**
-           * The description of the incentive
-           */
-          description: string;
-          /**
-           * The display name of the incentive
-           */
-          displayName: string;
-          /**
-           * A display message outlining an eligibility criteria that may apply
-           */
-          eligibility?: string;
-          [k: string]: unknown;
-        }[];
-        /**
-         * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-         */
-        intrinsicGreenPower?: {
-          /**
-           * Percentage of green power intrinsically included in the plan
-           */
-          greenPercentage: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Flag indicating whether prices are fixed or variable
-         */
-        isFixed: boolean;
-        /**
-         * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-         */
-        onExpiryDescription?: string | null;
-        /**
-         * Payment options for this contract
-         */
-        paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-        /**
-         * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-         */
-        pricingModel:
-          | "SINGLE_RATE"
-          | "SINGLE_RATE_CONT_LOAD"
-          | "TIME_OF_USE"
-          | "TIME_OF_USE_CONT_LOAD"
-          | "FLEXIBLE"
-          | "FLEXIBLE_CONT_LOAD"
-          | "QUOTA";
-        /**
-         * Array of feed in tariffs for solar power
-         */
-        solarFeedInTariff?: {
-          /**
-           * A description of the tariff
-           */
-          description?: string;
-          /**
-           * The name of the tariff
-           */
-          displayName: string;
-          /**
-           * The type of the payer
-           */
-          payerType: "GOVERNMENT" | "RETAILER";
-          /**
-           * The applicable scheme
-           */
-          scheme: "PREMIUM" | "OTHER";
-          /**
-           * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-           */
-          singleTariff?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the payer
-           */
-          tariffUType: "singleTariff" | "timeVaryingTariffs";
-          /**
-           * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-           */
-          timeVaryingTariffs?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            /**
-             * Array of time periods for which this tariff is applicable
-             */
-            timeVariations: {
-              /**
-               * The days that the tariff applies to. At least one entry required
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of the charging time period. If absent applies to all periods
-             */
-            type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        }[];
-        /**
-         * Array of tariff periods
-         */
-        tariffPeriod: {
-          /**
-           * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-           */
-          dailySupplyCharges?: string;
-          /**
-           * Array of demand charges.  Required if rateBlockUType is demandCharges
-           */
-          demandCharges?: {
-            /**
-             * The charge amount per  measure unit exclusive of GST
-             */
-            amount: string;
-            /**
-             * Charge period for the demand tariff
-             */
-            chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * The days that the demand tariff applies to
-             */
-            days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-            /**
-             * Description of the charge
-             */
-            description?: string;
-            /**
-             * Display name of the charge
-             */
-            displayName: string;
-            /**
-             * End of the period
-             */
-            endTime: string;
-            /**
-             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-             */
-            maxDemand?: string;
-            /**
-             * The measurement unit of charge amount. Assumed to be KWH if absent
-             */
-            measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-            /**
-             * Application period for the demand tariff
-             */
-            measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-             */
-            minDemand?: string;
-            /**
-             * Start of the period
-             */
-            startTime: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The name of the tariff period
-           */
-          displayName: string;
-          /**
-           * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          endDate: string;
-          /**
-           * Specifies the type of rate applicable to this tariff period
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-          /**
-           * Object representing a single rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-             */
-            generalUnitPrice?: string;
-            /**
-             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-             */
-            period?: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          startDate: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use
-             */
-            timeOfUse: {
-              /**
-               * The days that the rate applies to
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-           */
-          timeZone?: "LOCAL" | "AEST";
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-         */
-        timeZone?: ("LOCAL" | "AEST") | null;
-        /**
-         * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-         */
-        variation?: string | null;
-        [k: string]: unknown;
-      };
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-       */
-      electricityContract?: {
-        /**
-         * Free text field containing additional information of the fees for this contract
-         */
-        additionalFeeInformation?: string | null;
-        /**
-         * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-         */
-        controlledLoad?: {
-          /**
-           * A display name for the controlled load
-           */
-          displayName: string;
-          /**
-           * Optional end date of the application of the controlled load rate
-           */
-          endDate?: string;
-          /**
-           * Specifies the type of controlloed load rate
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates";
-          /**
-           * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * Optional start date of the application of the controlled load rate
-           */
-          startDate?: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * The daily supply charge (exclusive of GST) for this controlled load tier
-             */
-            dailySupplyCharge?: string;
-            /**
-             * Description of the controlled load rate
-             */
-            description?: string;
-            /**
-             * Display name of the controlled load rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use.
-             */
-            timeOfUse: {
-              /**
-               * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-               */
-              additionalInfo?: string;
-              /**
-               * Optional link to additional information regarding the controlled load
-               */
-              additionalInfoUri?: string;
-              /**
-               * The days that the rate applies to
-               */
-              days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-            [k: string]: unknown;
-          }[];
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of discounts available for the contract
-         */
-        discounts?: {
-          /**
-           * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-           */
-          category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-          /**
-           * The description of the discount
-           */
-          description?: string;
-          /**
-           * The display name of the discount
-           */
-          displayName: string;
-          /**
-           * Optional end date for the discount after which the discount is no longer available
-           */
-          endDate?: string;
-          /**
-           * Required if methodUType is fixedAmount
-           */
-          fixedAmount?: {
-            /**
-             * The amount of the discount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The method of calculation of the discount
-           */
-          methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-          /**
-           * Required if methodUType is percentOfBill
-           */
-          percentOfBill?: {
-            /**
-             * The rate of the discount applied to the bill amount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOfUse
-           */
-          percentOfUse?: {
-            /**
-             * The rate of the discount applied to the usageamount
-             */
-            rate: string;
-            [k: string]: unknown;
-          };
-          /**
-           * Required if methodUType is percentOverThreshold
-           */
-          percentOverThreshold?: {
-            /**
-             * The rate of the discount over the usage amount
-             */
-            rate: string;
-            /**
-             * The usage amount threshold above which the discount applies
-             */
-            usageAmount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the discount
-           */
-          type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Eligibility restrictions or requirements
-         */
-        eligibility?: {
-          /**
-           * A description of the eligibility restriction
-           */
-          description?: string;
-          /**
-           * Information of the eligibility restriction specific to the type of the restriction
-           */
-          information: string;
-          /**
-           * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-           */
-          type:
-            | "EXISTING_CUST"
-            | "EXISTING_POOL"
-            | "EXISTING_SOLAR"
-            | "EXISTING_BATTERY"
-            | "EXISTING_SMART_METER"
-            | "EXISTING_BASIC_METER"
-            | "SENIOR_CARD"
-            | "SMALL_BUSINESS"
-            | "NO_SOLAR_FIT"
-            | "NEW_CUSTOMER"
-            | "ONLINE_ONLY"
-            | "REQ_EQUIP_SUPPLIER"
-            | "THIRD_PARTY_ONLY"
-            | "SPORT_CLUB_MEMBER"
-            | "ORG_MEMBER"
-            | "SPECIFIC_LOCATION"
-            | "MINIMUM_USAGE"
-            | "LOYALTY_MEMBER"
-            | "GROUP_BUY_MEMBER"
-            | "CONTINGENT_PLAN"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * An array of fees applicable to the plan
-         */
-        fees?: {
-          /**
-           * The fee amount. Required if term is not PERCENT_OF_BILL
-           */
-          amount?: string;
-          /**
-           * A description of the fee
-           */
-          description?: string;
-          /**
-           * The fee rate. Required if term is PERCENT_OF_BILL
-           */
-          rate?: string;
-          /**
-           * The term of the fee
-           */
-          term:
-            | "FIXED"
-            | "1_YEAR"
-            | "2_YEAR"
-            | "3_YEAR"
-            | "4_YEAR"
-            | "5_YEAR"
-            | "PERCENT_OF_BILL"
-            | "ANNUAL"
-            | "DAILY"
-            | "WEEKLY"
-            | "MONTHLY"
-            | "BIANNUAL"
-            | "VARIABLE";
-          /**
-           * The type of the fee
-           */
-          type:
-            | "EXIT"
-            | "ESTABLISHMENT"
-            | "LATE_PAYMENT"
-            | "DISCONNECTION"
-            | "DISCONNECT_MOVE_OUT"
-            | "DISCONNECT_NON_PAY"
-            | "RECONNECTION"
-            | "CONNECTION"
-            | "PAYMENT_PROCESSING"
-            | "CC_PROCESSING"
-            | "CHEQUE_DISHONOUR"
-            | "DD_DISHONOUR"
-            | "MEMBERSHIP"
-            | "CONTRIBUTION"
-            | "PAPER_BILL"
-            | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of charges applicable to green power
-         */
-        greenPowerCharges?: {
-          /**
-           * The description of the charge
-           */
-          description?: string;
-          /**
-           * The display name of the charge
-           */
-          displayName: string;
-          /**
-           * The applicable green power scheme
-           */
-          scheme: "GREENPOWER" | "OTHER";
-          /**
-           * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-           */
-          tiers: {
-            /**
-             * The amount of the charge if the type implies the application of a fixed amount
-             */
-            amount?: string;
-            /**
-             * The upper percentage of green power used applicable for this tier
-             */
-            percentGreen: string;
-            /**
-             * The rate of the charge if the type implies the application of a rate
-             */
-            rate?: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The type of charge
-           */
-          type:
-            | "FIXED_PER_DAY"
-            | "FIXED_PER_WEEK"
-            | "FIXED_PER_MONTH"
-            | "FIXED_PER_UNIT"
-            | "PERCENT_OF_USE"
-            | "PERCENT_OF_BILL";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Optional list of incentives available for the contract
-         */
-        incentives?: {
-          /**
-           * The type of the incentive
-           */
-          category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-          /**
-           * The description of the incentive
-           */
-          description: string;
-          /**
-           * The display name of the incentive
-           */
-          displayName: string;
-          /**
-           * A display message outlining an eligibility criteria that may apply
-           */
-          eligibility?: string;
-          [k: string]: unknown;
-        }[];
-        /**
-         * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-         */
-        intrinsicGreenPower?: {
-          /**
-           * Percentage of green power intrinsically included in the plan
-           */
-          greenPercentage: string;
-          [k: string]: unknown;
-        } | null;
-        /**
-         * Flag indicating whether prices are fixed or variable
-         */
-        isFixed: boolean;
-        /**
-         * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-         */
-        onExpiryDescription?: string | null;
-        /**
-         * Payment options for this contract
-         */
-        paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-        /**
-         * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-         */
-        pricingModel:
-          | "SINGLE_RATE"
-          | "SINGLE_RATE_CONT_LOAD"
-          | "TIME_OF_USE"
-          | "TIME_OF_USE_CONT_LOAD"
-          | "FLEXIBLE"
-          | "FLEXIBLE_CONT_LOAD"
-          | "QUOTA";
-        /**
-         * Array of feed in tariffs for solar power
-         */
-        solarFeedInTariff?: {
-          /**
-           * A description of the tariff
-           */
-          description?: string;
-          /**
-           * The name of the tariff
-           */
-          displayName: string;
-          /**
-           * The type of the payer
-           */
-          payerType: "GOVERNMENT" | "RETAILER";
-          /**
-           * The applicable scheme
-           */
-          scheme: "PREMIUM" | "OTHER";
-          /**
-           * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-           */
-          singleTariff?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            [k: string]: unknown;
-          };
-          /**
-           * The type of the payer
-           */
-          tariffUType: "singleTariff" | "timeVaryingTariffs";
-          /**
-           * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-           */
-          timeVaryingTariffs?: {
-            /**
-             * The tariff amount
-             */
-            amount: string;
-            /**
-             * Array of time periods for which this tariff is applicable
-             */
-            timeVariations: {
-              /**
-               * The days that the tariff applies to. At least one entry required
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-               */
-              endTime?: string;
-              /**
-               * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-               */
-              startTime?: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of the charging time period. If absent applies to all periods
-             */
-            type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        }[];
-        /**
-         * Array of tariff periods
-         */
-        tariffPeriod: {
-          /**
-           * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-           */
-          dailySupplyCharges?: string;
-          /**
-           * Array of demand charges.  Required if rateBlockUType is demandCharges
-           */
-          demandCharges?: {
-            /**
-             * The charge amount per  measure unit exclusive of GST
-             */
-            amount: string;
-            /**
-             * Charge period for the demand tariff
-             */
-            chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * The days that the demand tariff applies to
-             */
-            days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-            /**
-             * Description of the charge
-             */
-            description?: string;
-            /**
-             * Display name of the charge
-             */
-            displayName: string;
-            /**
-             * End of the period
-             */
-            endTime: string;
-            /**
-             * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
-             */
-            maxDemand?: string;
-            /**
-             * The measurement unit of charge amount. Assumed to be KWH if absent
-             */
-            measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-            /**
-             * Application period for the demand tariff
-             */
-            measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
-            /**
-             * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
-             */
-            minDemand?: string;
-            /**
-             * Start of the period
-             */
-            startTime: string;
-            [k: string]: unknown;
-          }[];
-          /**
-           * The name of the tariff period
-           */
-          displayName: string;
-          /**
-           * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          endDate: string;
-          /**
-           * Specifies the type of rate applicable to this tariff period
-           */
-          rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-          /**
-           * Object representing a single rate.  Required if rateBlockUType is singleRate
-           */
-          singleRate?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-             */
-            generalUnitPrice?: string;
-            /**
-             * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-             */
-            period?: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            [k: string]: unknown;
-          };
-          /**
-           * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-           */
-          startDate: string;
-          /**
-           * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-           */
-          timeOfUseRates?: {
-            /**
-             * Description of the rate
-             */
-            description?: string;
-            /**
-             * Display name of the rate
-             */
-            displayName: string;
-            /**
-             * Array of controlled load rates in order of usage volume
-             */
-            rates: {
-              /**
-               * The measurement unit of rate. Assumed to be KWH if absent
-               */
-              measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-              /**
-               * Unit price of usage per  measure unit (exclusive of GST)
-               */
-              unitPrice: string;
-              /**
-               * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-               */
-              volume?: number;
-              [k: string]: unknown;
-            }[];
-            /**
-             * Array of times of use
-             */
-            timeOfUse: {
-              /**
-               * The days that the rate applies to
-               */
-              days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-              /**
-               * End of the period
-               */
-              endTime: string;
-              /**
-               * Start of the period
-               */
-              startTime: string;
-              [k: string]: unknown;
-            }[];
-            /**
-             * The type of usage that the rate applies to
-             */
-            type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
-            [k: string]: unknown;
-          }[];
-          /**
-           * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-           */
-          timeZone?: "LOCAL" | "AEST";
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-         */
-        timeZone?: ("LOCAL" | "AEST") | null;
-        /**
-         * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-         */
-        variation?: string | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * An array of additional contacts that are authorised to act on this account
-     */
-    authorisedContacts?: {
-      /**
-       * For people with single names this field need not be present. The single name should be in the lastName field
-       */
-      firstName?: string;
-      /**
-       * For people with single names the single name should be in this field
-       */
-      lastName: string;
-      /**
-       * Field is mandatory but array may be empty
-       */
-      middleNames?: string[];
-      /**
-       * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-       */
-      prefix?: string;
-      /**
-       * Used for a trailing suffix to the name (e.g. Jr)
-       */
-      suffix?: string;
-      [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 
 export interface EnergyAccountDetailV3 extends EnergyAccountBaseV2 {
-  /**
-   * The array of plans containing service points and associated plan details
-   */
-  plans: {
     /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
+     * The array of plans containing service points and associated plan details
      */
-    nickname?: string;
-    /**
-     * An array of servicePointIds, representing NMIs, that this account is linked to
-     */
-    servicePointIds: string[];
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview?: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string;
-      [k: string]: unknown;
-    };
-    /**
-     * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
-     */
-    planDetail?: {
-      /**
-       * The fuel types covered by the plan
-       */
-      fuelType: "ELECTRICITY" | "GAS" | "DUAL";
-      /**
-       * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
-       */
-      isContingentPlan?: boolean;
-      /**
-       * Charges for metering included in the plan
-       */
-      meteringCharges?: {
+    plans: {
         /**
-         * Display name of the charge
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
          */
-        displayName: string;
+        nickname?: string;
         /**
-         * Description of the charge
+         * An array of servicePointIds, representing NMIs, that this account is linked to
          */
-        description?: string;
+        servicePointIds: string[];
         /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+         * Mandatory if openStatus is OPEN
          */
-        minimumValue: string;
+        planOverview?: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string;
+            [k: string]: unknown;
+        };
         /**
-         * The upper limit of the charge if the charge could occur in a range
+         * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
          */
-        maximumValue?: string;
+        planDetail?: {
+            /**
+             * The fuel types covered by the plan
+             */
+            fuelType: 'ELECTRICITY' | 'GAS' | 'DUAL';
+            /**
+             * Flag that indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up). Has no meaning if the plan has a fuelType of DUAL. If absent the value is assumed to be false
+             */
+            isContingentPlan?: boolean;
+            /**
+             * Charges for metering included in the plan
+             */
+            meteringCharges?: {
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * Description of the charge
+                 */
+                description?: string;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
+             */
+            gasContract?: EnergyPlanContractV2;
+            /**
+             * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
+             */
+            electricityContract?: EnergyPlanContractV2;
+            [k: string]: unknown;
+        };
         /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         * An array of additional contacts that are authorised to act on this account
          */
-        period?: string;
+        authorisedContacts?: {
+            /**
+             * For people with single names this field need not be present. The single name should be in the lastName field
+             */
+            firstName?: string;
+            /**
+             * For people with single names the single name should be in this field
+             */
+            lastName: string;
+            /**
+             * Field is mandatory but array may be empty
+             */
+            middleNames?: string[];
+            /**
+             * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+             */
+            prefix?: string;
+            /**
+             * Used for a trailing suffix to the name (e.g. Jr)
+             */
+            suffix?: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
-      }[];
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-       */
-      gasContract?: EnergyPlanContractV2
-      /**
-       * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-       */
-      electricityContract?: EnergyPlanContractV2
-      [k: string]: unknown;
-    };
-    /**
-     * An array of additional contacts that are authorised to act on this account
-     */
-    authorisedContacts?: {
-      /**
-       * For people with single names this field need not be present. The single name should be in the lastName field
-       */
-      firstName?: string;
-      /**
-       * For people with single names the single name should be in this field
-       */
-      lastName: string;
-      /**
-       * Field is mandatory but array may be empty
-       */
-      middleNames?: string[];
-      /**
-       * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-       */
-      prefix?: string;
-      /**
-       * Used for a trailing suffix to the name (e.g. Jr)
-       */
-      suffix?: string;
-      [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccountListResponse {
-  data: {
+    data: {
+        /**
+         * Array of accounts
+         */
+        accounts: ({
+            /**
+             * The ID of the account.  To be created in accordance with CDR ID permanence requirements
+             */
+            accountId: string;
+            /**
+             * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
+             */
+            accountNumber?: string | null;
+            /**
+             * The date that the account was created or opened
+             */
+            creationDate: string;
+            /**
+             * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
+             */
+            displayName?: string | null;
+            [k: string]: unknown;
+        } & {
+            /**
+             * The array of plans containing service points and associated plan details
+             */
+            plans: {
+                /**
+                 * Optional display name for the plan provided by the customer to help differentiate multiple plans
+                 */
+                nickname?: string;
+                /**
+                 * An array of servicePointIds, representing NMIs, that this plan is linked to.  If there are no service points allocated to this plan then an empty array would be expected
+                 */
+                servicePointIds: string[];
+                planOverview: {
+                    /**
+                     * The name of the plan if one exists
+                     */
+                    displayName?: string;
+                    /**
+                     * The start date of the applicability of this plan
+                     */
+                    startDate: string;
+                    /**
+                     * The end date of the applicability of this plan
+                     */
+                    endDate?: string;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        })[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyAccountListResponseV2 {
+    data: EnergyAccountV2[];
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyAccountV2 extends EnergyAccountBaseV2 {
     /**
-     * Array of accounts
+     * The array of plans containing service points and associated plan details
      */
-    accounts: ({
-      /**
-       * The ID of the account.  To be created in accordance with CDR ID permanence requirements
-       */
-      accountId: string;
-      /**
-       * Optional identifier of the account as defined by the data holder.  This must be the value presented on physical statements (if it exists) and must not be used for the value of accountId
-       */
-      accountNumber?: string | null;
-      /**
-       * The date that the account was created or opened
-       */
-      creationDate: string;
-      /**
-       * An optional display name for the account if one exists or can be derived.  The content of this field is at the discretion of the data holder
-       */
-      displayName?: string | null;
-      [k: string]: unknown;
-    } & {
-      /**
-       * The array of plans containing service points and associated plan details
-       */
-      plans: {
+    plans: {
         /**
          * Optional display name for the plan provided by the customer to help differentiate multiple plans
          */
@@ -4793,367 +4887,85 @@ export interface EnergyAccountListResponse {
          * An array of servicePointIds, representing NMIs, that this plan is linked to.  If there are no service points allocated to this plan then an empty array would be expected
          */
         servicePointIds: string[];
-        planOverview: {
-          /**
-           * The name of the plan if one exists
-           */
-          displayName?: string;
-          /**
-           * The start date of the applicability of this plan
-           */
-          startDate: string;
-          /**
-           * The end date of the applicability of this plan
-           */
-          endDate?: string;
-          [k: string]: unknown;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview?: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string;
+            [k: string]: unknown;
         };
         [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
-    })[];
+    }[];
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyAccountListResponseV2 {
-  data: EnergyAccountV2[];
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyAccountV2 extends EnergyAccountBaseV2  {
-  /**
-   * The array of plans containing service points and associated plan details
-   */
-  plans: {
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string;
-    /**
-     * An array of servicePointIds, representing NMIs, that this plan is linked to.  If there are no service points allocated to this plan then an empty array would be expected
-     */
-    servicePointIds: string[];
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview?: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyBalanceListResponse {
-  data: {
-    /**
-     * Array of account balances
-     */
-    balances: {
-      /**
-       * The ID of the account
-       */
-      accountId: string;
-      /**
-       * The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit
-       */
-      balance: string;
-      [k: string]: unknown;
-    }[];
+    data: {
+        /**
+         * Array of account balances
+         */
+        balances: {
+            /**
+             * The ID of the account
+             */
+            accountId: string;
+            /**
+             * The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit
+             */
+            balance: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
     [k: string]: unknown;
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyBalanceResponse {
-  data: {
-    /**
-     * The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit
-     */
-    balance: string;
+    data: {
+        /**
+         * The current balance of the account.  A positive value indicates that amount is owing to be paid.  A negative value indicates that the account is in credit
+         */
+        balance: string;
+        [k: string]: unknown;
+    };
+    links: Links;
+    meta?: Meta;
     [k: string]: unknown;
-  };
-  links: Links;
-  meta?: Meta;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyBillingDemandTransaction {
-  /**
-   * Optional array of adjustments arising for this transaction
-   */
-  adjustments?:
-    | {
-        /**
-         * The amount of the adjustment
-         */
-        amount: string;
-        /**
-         * A free text description of the adjustment
-         */
-        description: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
-   */
-  amount: string;
-  /**
-   * Additional calculation factors that inform the transaction
-   */
-  calculationFactors?:
-    | {
-        /**
-         * The type of the calculation factor
-         */
-        type: "DLF" | "MLF";
-        /**
-         * The value of the calculation factor
-         */
-        value: number;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Optional description of the transaction that can be used for display purposes
-   */
-  description?: string | null;
-  /**
-   * Date and time when the demand period ends
-   */
-  endDate: string;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * Flag indicating if the usage is estimated or actual.  True indicates estimate.  False or absent indicates actual
-   */
-  isEstimate?: boolean | null;
-  /**
-   * The rate for the demand charge in kVA.  A negative value indicates power generated
-   */
-  rate: number;
-  /**
-   * The ID of the service point to which this transaction applies if any
-   */
-  servicePointId?: string | null;
-  /**
-   * Date and time when the demand period starts
-   */
-  startDate: string;
-  /**
-   * The time of use type that the transaction applies to
-   */
-  timeOfUseType:
-    | "PEAK"
-    | "OFF_PEAK"
-    | "OFF_PEAK_DEMAND_CHARGE"
-    | "SHOULDER"
-    | "SHOULDER1"
-    | "SHOULDER2"
-    | "CONTROLLED_LOAD"
-    | "SOLAR"
-    | "AGGREGATE";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingListResponse {
-  data: {
-    /**
-     * Array of transactions sorted by date and time in descending order
-     */
-    transactions: EnergyBillingTransaction[];
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingOnceOffTransaction {
-  /**
-   * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
-   */
-  amount: string;
-  /**
-   * A free text description of the item
-   */
-  description: string;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * The ID of the service point to which this transaction applies if any
-   */
-  servicePointId?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingOtherTransaction {
-  /**
-   * Optional array of adjustments arising for this transaction
-   */
-  adjustments?:
-    | {
-        /**
-         * The amount of the adjustment
-         */
-        amount: string;
-        /**
-         * A free text description of the adjustment
-         */
-        description: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The amount of the charge
-   */
-  amount: string;
-  /**
-   * Additional calculation factors that inform the transaction
-   */
-  calculationFactors?:
-    | {
-        /**
-         * The type of the calculation factor
-         */
-        type: "DLF" | "MLF";
-        /**
-         * The value of the calculation factor
-         */
-        value: number;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * A free text description of the item
-   */
-  description: string;
-  /**
-   * Optional end date for the application of the charge
-   */
-  endDate?: string | null;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * The ID of the service point to which this transaction applies if any
-   */
-  servicePointId?: string | null;
-  /**
-   * Optional start date for the application of the charge
-   */
-  startDate?: string | null;
-  /**
-   * Type of charge. Assumed to be other if absent
-   */
-  type?: ("ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER") | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingPaymentTransaction {
-  /**
-   * The amount paid
-   */
-  amount: string;
-  /**
-   * The method of payment
-   */
-  method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "OTHER";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingTransaction {
-  /**
-   * The ID of the account for which transaction applies
-   */
-  accountId: string;
-  /**
-   * Represents a demand charge or generation credit.  Mandatory if transactionUType is equal to demand
-   */
-  demand?: {
     /**
      * Optional array of adjustments arising for this transaction
      */
     adjustments?:
-      | {
-          /**
-           * The amount of the adjustment
-           */
-          amount: string;
-          /**
-           * A free text description of the adjustment
-           */
-          description: string;
-          [k: string]: unknown;
+        | {
+            /**
+             * The amount of the adjustment
+             */
+            amount: string;
+            /**
+             * A free text description of the adjustment
+             */
+            description: string;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
      */
@@ -5162,18 +4974,18 @@ export interface EnergyBillingTransaction {
      * Additional calculation factors that inform the transaction
      */
     calculationFactors?:
-      | {
-          /**
-           * The type of the calculation factor
-           */
-          type: "DLF" | "MLF";
-          /**
-           * The value of the calculation factor
-           */
-          value: number;
-          [k: string]: unknown;
+        | {
+            /**
+             * The type of the calculation factor
+             */
+            type: 'DLF' | 'MLF';
+            /**
+             * The value of the calculation factor
+             */
+            value: number;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Optional description of the transaction that can be used for display purposes
      */
@@ -5206,29 +5018,33 @@ export interface EnergyBillingTransaction {
      * The time of use type that the transaction applies to
      */
     timeOfUseType:
-      | "PEAK"
-      | "OFF_PEAK"
-      | "OFF_PEAK_DEMAND_CHARGE"
-      | "SHOULDER"
-      | "SHOULDER1"
-      | "SHOULDER2"
-      | "CONTROLLED_LOAD"
-      | "SOLAR"
-      | "AGGREGATE";
+        | 'PEAK'
+        | 'OFF_PEAK'
+        | 'OFF_PEAK_DEMAND_CHARGE'
+        | 'SHOULDER'
+        | 'SHOULDER1'
+        | 'SHOULDER2'
+        | 'CONTROLLED_LOAD'
+        | 'SOLAR'
+        | 'AGGREGATE';
     [k: string]: unknown;
-  };
-  /**
-   * The date and time that the transaction occurred
-   */
-  executionDateTime: string;
-  /**
-   * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
-   */
-  gst?: string | null;
-  /**
-   * Represents a once off charge or credit.  Mandatory if transactionUType is equal to onceOff
-   */
-  onceOff?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingListResponse {
+    data: {
+        /**
+         * Array of transactions sorted by date and time in descending order
+         */
+        transactions: EnergyBillingTransaction[];
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingOnceOffTransaction {
     /**
      * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
      */
@@ -5246,27 +5062,26 @@ export interface EnergyBillingTransaction {
      */
     servicePointId?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * Represents charge other than usage and once off.  Mandatory if transactionUType is equal to otherCharge
-   */
-  otherCharges?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingOtherTransaction {
     /**
      * Optional array of adjustments arising for this transaction
      */
     adjustments?:
-      | {
-          /**
-           * The amount of the adjustment
-           */
-          amount: string;
-          /**
-           * A free text description of the adjustment
-           */
-          description: string;
-          [k: string]: unknown;
+        | {
+            /**
+             * The amount of the adjustment
+             */
+            amount: string;
+            /**
+             * A free text description of the adjustment
+             */
+            description: string;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The amount of the charge
      */
@@ -5275,18 +5090,18 @@ export interface EnergyBillingTransaction {
      * Additional calculation factors that inform the transaction
      */
     calculationFactors?:
-      | {
-          /**
-           * The type of the calculation factor
-           */
-          type: "DLF" | "MLF";
-          /**
-           * The value of the calculation factor
-           */
-          value: number;
-          [k: string]: unknown;
+        | {
+            /**
+             * The type of the calculation factor
+             */
+            type: 'DLF' | 'MLF';
+            /**
+             * The value of the calculation factor
+             */
+            value: number;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * A free text description of the item
      */
@@ -5310,13 +5125,12 @@ export interface EnergyBillingTransaction {
     /**
      * Type of charge. Assumed to be other if absent
      */
-    type?: ("ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER") | null;
+    type?: ('ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER') | null;
     [k: string]: unknown;
-  };
-  /**
-   * Represents a payment to the account.  Mandatory if transactionUType is equal to payment
-   */
-  payment?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingPaymentTransaction {
     /**
      * The amount paid
      */
@@ -5324,33 +5138,321 @@ export interface EnergyBillingTransaction {
     /**
      * The method of payment
      */
-    method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "OTHER";
+    method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'OTHER';
     [k: string]: unknown;
-  };
-  /**
-   * Indicator of the type of transaction object present in this record
-   */
-  transactionUType: "usage" | "demand" | "onceOff" | "otherCharges" | "payment";
-  /**
-   * Represents a usage charge or generation credit.  Mandatory if transactionUType is equal to usage
-   */
-  usage?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingTransaction {
+    /**
+     * The ID of the account for which transaction applies
+     */
+    accountId: string;
+    /**
+     * Represents a demand charge or generation credit.  Mandatory if transactionUType is equal to demand
+     */
+    demand?: {
+        /**
+         * Optional array of adjustments arising for this transaction
+         */
+        adjustments?:
+            | {
+                /**
+                 * The amount of the adjustment
+                 */
+                amount: string;
+                /**
+                 * A free text description of the adjustment
+                 */
+                description: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
+         */
+        amount: string;
+        /**
+         * Additional calculation factors that inform the transaction
+         */
+        calculationFactors?:
+            | {
+                /**
+                 * The type of the calculation factor
+                 */
+                type: 'DLF' | 'MLF';
+                /**
+                 * The value of the calculation factor
+                 */
+                value: number;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Optional description of the transaction that can be used for display purposes
+         */
+        description?: string | null;
+        /**
+         * Date and time when the demand period ends
+         */
+        endDate: string;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * Flag indicating if the usage is estimated or actual.  True indicates estimate.  False or absent indicates actual
+         */
+        isEstimate?: boolean | null;
+        /**
+         * The rate for the demand charge in kVA.  A negative value indicates power generated
+         */
+        rate: number;
+        /**
+         * The ID of the service point to which this transaction applies if any
+         */
+        servicePointId?: string | null;
+        /**
+         * Date and time when the demand period starts
+         */
+        startDate: string;
+        /**
+         * The time of use type that the transaction applies to
+         */
+        timeOfUseType:
+            | 'PEAK'
+            | 'OFF_PEAK'
+            | 'OFF_PEAK_DEMAND_CHARGE'
+            | 'SHOULDER'
+            | 'SHOULDER1'
+            | 'SHOULDER2'
+            | 'CONTROLLED_LOAD'
+            | 'SOLAR'
+            | 'AGGREGATE';
+        [k: string]: unknown;
+    };
+    /**
+     * The date and time that the transaction occurred
+     */
+    executionDateTime: string;
+    /**
+     * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
+     */
+    gst?: string | null;
+    /**
+     * Represents a once off charge or credit.  Mandatory if transactionUType is equal to onceOff
+     */
+    onceOff?: {
+        /**
+         * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
+         */
+        amount: string;
+        /**
+         * A free text description of the item
+         */
+        description: string;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * The ID of the service point to which this transaction applies if any
+         */
+        servicePointId?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Represents charge other than usage and once off.  Mandatory if transactionUType is equal to otherCharge
+     */
+    otherCharges?: {
+        /**
+         * Optional array of adjustments arising for this transaction
+         */
+        adjustments?:
+            | {
+                /**
+                 * The amount of the adjustment
+                 */
+                amount: string;
+                /**
+                 * A free text description of the adjustment
+                 */
+                description: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The amount of the charge
+         */
+        amount: string;
+        /**
+         * Additional calculation factors that inform the transaction
+         */
+        calculationFactors?:
+            | {
+                /**
+                 * The type of the calculation factor
+                 */
+                type: 'DLF' | 'MLF';
+                /**
+                 * The value of the calculation factor
+                 */
+                value: number;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * A free text description of the item
+         */
+        description: string;
+        /**
+         * Optional end date for the application of the charge
+         */
+        endDate?: string | null;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * The ID of the service point to which this transaction applies if any
+         */
+        servicePointId?: string | null;
+        /**
+         * Optional start date for the application of the charge
+         */
+        startDate?: string | null;
+        /**
+         * Type of charge. Assumed to be other if absent
+         */
+        type?: ('ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER') | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Represents a payment to the account.  Mandatory if transactionUType is equal to payment
+     */
+    payment?: {
+        /**
+         * The amount paid
+         */
+        amount: string;
+        /**
+         * The method of payment
+         */
+        method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'OTHER';
+        [k: string]: unknown;
+    };
+    /**
+     * Indicator of the type of transaction object present in this record
+     */
+    transactionUType: 'usage' | 'demand' | 'onceOff' | 'otherCharges' | 'payment';
+    /**
+     * Represents a usage charge or generation credit.  Mandatory if transactionUType is equal to usage
+     */
+    usage?: {
+        /**
+         * Optional array of adjustments arising for this transaction
+         */
+        adjustments?:
+            | {
+                /**
+                 * The amount of the adjustment
+                 */
+                amount: string;
+                /**
+                 * A free text description of the adjustment
+                 */
+                description: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
+         */
+        amount: string;
+        /**
+         * Additional calculation factors that inform the transaction
+         */
+        calculationFactors?:
+            | {
+                /**
+                 * The type of the calculation factor
+                 */
+                type: 'DLF' | 'MLF';
+                /**
+                 * The value of the calculation factor
+                 */
+                value: number;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Optional description of the transaction that can be used for display purposes
+         */
+        description?: string | null;
+        /**
+         * Date and time when the usage period ends
+         */
+        endDate: string;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * Flag indicating if the usage is estimated or actual.  True indicates estimate.  False or absent indicates actual
+         */
+        isEstimate?: boolean | null;
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: ('KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH') | null;
+        /**
+         * The ID of the service point to which this transaction applies if any
+         */
+        servicePointId?: string | null;
+        /**
+         * Date and time when the usage period starts
+         */
+        startDate: string;
+        /**
+         * The time of use type that the transaction applies to
+         */
+        timeOfUseType:
+            | 'PEAK'
+            | 'OFF_PEAK'
+            | 'OFF_PEAK_DEMAND_CHARGE'
+            | 'SHOULDER'
+            | 'SHOULDER1'
+            | 'SHOULDER2'
+            | 'CONTROLLED_LOAD'
+            | 'SOLAR'
+            | 'AGGREGATE';
+        /**
+         * The usage for the period in measure unit.  A negative value indicates power generated
+         */
+        usage: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyBillingUsageTransaction {
     /**
      * Optional array of adjustments arising for this transaction
      */
     adjustments?:
-      | {
-          /**
-           * The amount of the adjustment
-           */
-          amount: string;
-          /**
-           * A free text description of the adjustment
-           */
-          description: string;
-          [k: string]: unknown;
+        | {
+            /**
+             * The amount of the adjustment
+             */
+            amount: string;
+            /**
+             * A free text description of the adjustment
+             */
+            description: string;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
      */
@@ -5359,18 +5461,18 @@ export interface EnergyBillingTransaction {
      * Additional calculation factors that inform the transaction
      */
     calculationFactors?:
-      | {
-          /**
-           * The type of the calculation factor
-           */
-          type: "DLF" | "MLF";
-          /**
-           * The value of the calculation factor
-           */
-          value: number;
-          [k: string]: unknown;
+        | {
+            /**
+             * The type of the calculation factor
+             */
+            type: 'DLF' | 'MLF';
+            /**
+             * The value of the calculation factor
+             */
+            value: number;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Optional description of the transaction that can be used for display purposes
      */
@@ -5390,7 +5492,7 @@ export interface EnergyBillingTransaction {
     /**
      * The measurement unit of rate. Assumed to be KWH if absent
      */
-    measureUnit?: ("KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH") | null;
+    measureUnit?: ('KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH') | null;
     /**
      * The ID of the service point to which this transaction applies if any
      */
@@ -5403,369 +5505,463 @@ export interface EnergyBillingTransaction {
      * The time of use type that the transaction applies to
      */
     timeOfUseType:
-      | "PEAK"
-      | "OFF_PEAK"
-      | "OFF_PEAK_DEMAND_CHARGE"
-      | "SHOULDER"
-      | "SHOULDER1"
-      | "SHOULDER2"
-      | "CONTROLLED_LOAD"
-      | "SOLAR"
-      | "AGGREGATE";
+        | 'PEAK'
+        | 'OFF_PEAK'
+        | 'OFF_PEAK_DEMAND_CHARGE'
+        | 'SHOULDER'
+        | 'SHOULDER1'
+        | 'SHOULDER2'
+        | 'CONTROLLED_LOAD'
+        | 'SOLAR'
+        | 'AGGREGATE';
     /**
      * The usage for the period in measure unit.  A negative value indicates power generated
      */
     usage: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-export interface EnergyBillingUsageTransaction {
-  /**
-   * Optional array of adjustments arising for this transaction
-   */
-  adjustments?:
-    | {
-        /**
-         * The amount of the adjustment
-         */
-        amount: string;
-        /**
-         * A free text description of the adjustment
-         */
-        description: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
-   */
-  amount: string;
-  /**
-   * Additional calculation factors that inform the transaction
-   */
-  calculationFactors?:
-    | {
-        /**
-         * The type of the calculation factor
-         */
-        type: "DLF" | "MLF";
-        /**
-         * The value of the calculation factor
-         */
-        value: number;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Optional description of the transaction that can be used for display purposes
-   */
-  description?: string | null;
-  /**
-   * Date and time when the usage period ends
-   */
-  endDate: string;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * Flag indicating if the usage is estimated or actual.  True indicates estimate.  False or absent indicates actual
-   */
-  isEstimate?: boolean | null;
-  /**
-   * The measurement unit of rate. Assumed to be KWH if absent
-   */
-  measureUnit?: ("KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH") | null;
-  /**
-   * The ID of the service point to which this transaction applies if any
-   */
-  servicePointId?: string | null;
-  /**
-   * Date and time when the usage period starts
-   */
-  startDate: string;
-  /**
-   * The time of use type that the transaction applies to
-   */
-  timeOfUseType:
-    | "PEAK"
-    | "OFF_PEAK"
-    | "OFF_PEAK_DEMAND_CHARGE"
-    | "SHOULDER"
-    | "SHOULDER1"
-    | "SHOULDER2"
-    | "CONTROLLED_LOAD"
-    | "SOLAR"
-    | "AGGREGATE";
-  /**
-   * The usage for the period in measure unit.  A negative value indicates power generated
-   */
-  usage: number;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyConcession {
-  /**
-   * Display text providing more information on the concession. Mandatory if type is VARIABLE
-   */
-  additionalInfo?: string | null;
-  /**
-   * Optional link to additional information regarding the concession
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
-   */
-  amount?: string | null;
-  /**
-   * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
-   */
-  appliedTo?: ("INVOICE" | "USAGE" | "SERVICE_CHARGE" | "CONTROLLED_LOAD")[] | null;
-  /**
-   * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  discountFrequency?: string | null;
-  /**
-   * The display name of the concession
-   */
-  displayName: string;
-  /**
-   * Optional end date for the application of the concession
-   */
-  endDate?: string | null;
-  /**
-   * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
-   */
-  percentage?: string | null;
-  /**
-   * Optional start date for the application of the concession
-   */
-  startDate?: string | null;
-  /**
-   * Indicator of the method of concession calculation
-   */
-  type: "FIXED_AMOUNT" | "FIXED_PERCENTAGE" | "VARIABLE";
-  [k: string]: unknown;
+    /**
+     * Display text providing more information on the concession. Mandatory if type is VARIABLE
+     */
+    additionalInfo?: string | null;
+    /**
+     * Optional link to additional information regarding the concession
+     */
+    additionalInfoUri?: string | null;
+    /**
+     * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
+     */
+    amount?: string | null;
+    /**
+     * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
+     */
+    appliedTo?: ('INVOICE' | 'USAGE' | 'SERVICE_CHARGE' | 'CONTROLLED_LOAD')[] | null;
+    /**
+     * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    discountFrequency?: string | null;
+    /**
+     * The display name of the concession
+     */
+    displayName: string;
+    /**
+     * Optional end date for the application of the concession
+     */
+    endDate?: string | null;
+    /**
+     * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
+     */
+    percentage?: string | null;
+    /**
+     * Optional start date for the application of the concession
+     */
+    startDate?: string | null;
+    /**
+     * Indicator of the method of concession calculation
+     */
+    type: 'FIXED_AMOUNT' | 'FIXED_PERCENTAGE' | 'VARIABLE';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyConcessionsResponse {
-  data: {
-    /**
-     * Array may be empty if no concessions exist
-     */
-    concessions: EnergyConcession[];
+    data: {
+        /**
+         * Array may be empty if no concessions exist
+         */
+        concessions: EnergyConcession[];
+        [k: string]: unknown;
+    };
+    links: Links;
+    meta?: Meta;
     [k: string]: unknown;
-  };
-  links: Links;
-  meta?: Meta;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyDerDetailResponse {
-  data: EnergyDerRecord;
-  links: Links;
-  meta?: Meta;
-  [k: string]: unknown;
+    data: EnergyDerRecord;
+    links: Links;
+    meta?: Meta;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyDerListResponse {
-  data: {
-    /**
-     * Array of meter reads
-     */
-    derRecords: EnergyDerRecord[];
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
+    data: {
+        /**
+         * Array of meter reads
+         */
+        derRecords: EnergyDerRecord[];
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyDerRecord {
-  acConnections: {
-    /**
-     * The date that the DER installation is commissioned
-     */
-    commissioningDate: string;
-    /**
-     * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
-     */
-    connectionIdentifier: number;
-    /**
-     * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
-     */
-    count: number;
-    derDevices: {
-      /**
-       * Number of devices in the group of DER devices
-       */
-      count: number;
-      /**
-       * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
-       */
-      deviceIdentifier: number;
-      /**
-       * The name of the device manufacturer. If absent then assumed to be “unknown”
-       */
-      manufacturer?: string;
-      /**
-       * The model number of the device. If absent then assumed to be “unknown”
-       */
-      modelNumber?: string;
-      /**
-       * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
-       */
-      nominalRatedCapacity: number;
-      /**
-       * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
-       */
-      nominalStorageCapacity?: number;
-      /**
-       * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
-       */
-      status?: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-      /**
-       * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
-       */
-      subtype?: string;
-      /**
-       * Used to indicate the primary technology used in the DER device
-       */
-      type: "FOSSIL" | "HYDRO" | "WIND" | "SOLAR_PV" | "RENEWABLE" | "GEOTHERMAL" | "STORAGE" | "OTHER";
-      [k: string]: unknown;
+    acConnections: {
+        /**
+         * The date that the DER installation is commissioned
+         */
+        commissioningDate: string;
+        /**
+         * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
+         */
+        connectionIdentifier: number;
+        /**
+         * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
+         */
+        count: number;
+        derDevices: {
+            /**
+             * Number of devices in the group of DER devices
+             */
+            count: number;
+            /**
+             * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
+             */
+            deviceIdentifier: number;
+            /**
+             * The name of the device manufacturer. If absent then assumed to be “unknown”
+             */
+            manufacturer?: string;
+            /**
+             * The model number of the device. If absent then assumed to be “unknown”
+             */
+            modelNumber?: string;
+            /**
+             * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
+             */
+            nominalRatedCapacity: number;
+            /**
+             * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
+             */
+            nominalStorageCapacity?: number;
+            /**
+             * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
+             */
+            status?: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+            /**
+             * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
+             */
+            subtype?: string;
+            /**
+             * Used to indicate the primary technology used in the DER device
+             */
+            type: 'FOSSIL' | 'HYDRO' | 'WIND' | 'SOLAR_PV' | 'RENEWABLE' | 'GEOTHERMAL' | 'STORAGE' | 'OTHER';
+            [k: string]: unknown;
+        }[];
+        /**
+         * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
+         */
+        equipmentType?: 'INVERTER' | 'OTHER';
+        /**
+         * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
+         */
+        inverterDeviceCapacity?: number;
+        /**
+         * The inverter model number. Mandatory if equipmentType is INVERTER
+         */
+        inverterModelNumber?: string;
+        /**
+         * The inverter series. Mandatory if equipmentType is INVERTER
+         */
+        inverterSeries?: string;
+        /**
+         * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
+         */
+        manufacturerName?: string;
+        /**
+         * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
+         */
+        status: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+        [k: string]: unknown;
     }[];
     /**
-     * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
+     * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA. Value of 0 indicates no DER record exists for the given servicePointId
      */
-    equipmentType?: "INVERTER" | "OTHER";
+    approvedCapacity: number;
     /**
-     * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
+     * The number of phases available for the installation of DER. Acceptable values are 0, 1, 2 or 3. Value of 0 indicates no DER record exists for the given servicePointId
      */
-    inverterDeviceCapacity?: number;
+    availablePhasesCount: number;
     /**
-     * The inverter model number. Mandatory if equipmentType is INVERTER
+     * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
      */
-    inverterModelNumber?: string;
+    hasCentralProtectionControl?: boolean | null;
     /**
-     * The inverter series. Mandatory if equipmentType is INVERTER
+     * The number of phases that DER is connected to. Acceptable values are 0, 1, 2 or 3. Value of 0 indicates no DER record exists for the given servicePointId
      */
-    inverterSeries?: string;
+    installedPhasesCount: number;
     /**
-     * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
+     * For identification of small generating units designed with the ability to operate in an islanded mode
      */
-    manufacturerName?: string;
+    islandableInstallation: boolean;
     /**
-     * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
+     * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
      */
-    status: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
+    protectionMode?: {
+        /**
+         * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
+         */
+        exportLimitKva?: number | null;
+        /**
+         * Rate of change of frequency trip point (Hz/s).
+         */
+        frequencyRateOfChange?: number | null;
+        /**
+         * Description of the form of inter-trip (e.g. 'from local substation').
+         */
+        interTripScheme?: string | null;
+        /**
+         * Trip voltage.
+         */
+        neutralVoltageDisplacement?: number | null;
+        /**
+         * Protective function limit in Hz.
+         */
+        overFrequencyProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        overFrequencyProtectionDelay?: number | null;
+        /**
+         * Protective function limit in V.
+         */
+        overVoltageProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        overVoltageProtectionDelay?: number | null;
+        /**
+         * Sustained over voltage.
+         */
+        sustainedOverVoltage?: number | null;
+        /**
+         * Sustained Over voltage protection delay in seconds.
+         */
+        sustainedOverVoltageDelay?: number | null;
+        /**
+         * Protective function limit in Hz.
+         */
+        underFrequencyProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        underFrequencyProtectionDelay?: number | null;
+        /**
+         * Protective function limit in V.
+         */
+        underVoltageProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        underVoltageProtectionDelay?: number | null;
+        /**
+         * Trip angle in degrees.
+         */
+        voltageVectorShift?: number | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite.  To be created in accordance with CDR ID permanence requirements
+     */
+    servicePointId: string;
     [k: string]: unknown;
-  }[];
-/**
- * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA. Value of 0 indicates no DER record exists for the given servicePointId
- */
-  approvedCapacity: number;
- /**
-  * The number of phases available for the installation of DER. Acceptable values are 0, 1, 2 or 3. Value of 0 indicates no DER record exists for the given servicePointId
-  */
-  availablePhasesCount: number;
-  /**
-   * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
-   */
-  hasCentralProtectionControl?: boolean | null;
-  /**
-   * The number of phases that DER is connected to. Acceptable values are 0, 1, 2 or 3. Value of 0 indicates no DER record exists for the given servicePointId
-   */
-  installedPhasesCount: number;
-  /**
-   * For identification of small generating units designed with the ability to operate in an islanded mode
-   */
-  islandableInstallation: boolean;
-  /**
-   * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
-   */
-  protectionMode?: {
-    /**
-     * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
-     */
-    exportLimitKva?: number | null;
-    /**
-     * Rate of change of frequency trip point (Hz/s).
-     */
-    frequencyRateOfChange?: number | null;
-    /**
-     * Description of the form of inter-trip (e.g. 'from local substation').
-     */
-    interTripScheme?: string | null;
-    /**
-     * Trip voltage.
-     */
-    neutralVoltageDisplacement?: number | null;
-    /**
-     * Protective function limit in Hz.
-     */
-    overFrequencyProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    overFrequencyProtectionDelay?: number | null;
-    /**
-     * Protective function limit in V.
-     */
-    overVoltageProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    overVoltageProtectionDelay?: number | null;
-    /**
-     * Sustained over voltage.
-     */
-    sustainedOverVoltage?: number | null;
-    /**
-     * Sustained Over voltage protection delay in seconds.
-     */
-    sustainedOverVoltageDelay?: number | null;
-    /**
-     * Protective function limit in Hz.
-     */
-    underFrequencyProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    underFrequencyProtectionDelay?: number | null;
-    /**
-     * Protective function limit in V.
-     */
-    underVoltageProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    underVoltageProtectionDelay?: number | null;
-    /**
-     * Trip angle in degrees.
-     */
-    voltageVectorShift?: number | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite.  To be created in accordance with CDR ID permanence requirements
-   */
-  servicePointId: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyInvoice {
-  /**
-   * Object contain charges and credits related to electricity usage
-   */
-  accountCharges?: {
+    /**
+     * Object contain charges and credits related to electricity usage
+     */
+    accountCharges?: {
+        /**
+         * The aggregate total of account level charges for the period covered by the invoice
+         */
+        totalCharges: string;
+        /**
+         * The aggregate total of account level discounts or credits for the period covered by the invoice
+         */
+        totalDiscounts: string;
+        /**
+         * The total GST for all account level charges.  If absent then zero is assumed
+         */
+        totalGst?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * The ID of the account for which the invoice was issued
+     */
+    accountId: string;
+    /**
+     * The account balance at the time the invoice was issued
+     */
+    balanceAtIssue: string;
+    /**
+     * The date that the invoice is due to be paid
+     */
+    dueDate?: string | null;
+    /**
+     * Object containing charges and credits related to electricity usage
+     */
+    electricity?: {
+        /**
+         * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
+         */
+        otherCharges?:
+            | {
+                /**
+                 * The aggregate total of charges for this item (exclusive of GST)
+                 */
+                amount: string;
+                /**
+                 * A free text description of the type of charge
+                 */
+                description: string;
+                /**
+                 * Type of charge. Assumed to be other if absent
+                 */
+                type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
+         */
+        totalGenerationCredits: string;
+        /**
+         * The total GST for all electricity usage charges.  If absent then zero is assumed
+         */
+        totalGst?: string | null;
+        /**
+         * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
+         */
+        totalOnceOffCharges: string;
+        /**
+         * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
+         */
+        totalOnceOffDiscounts: string;
+        /**
+         * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+         */
+        totalUsageCharges: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Object containing charges and credits related to gas usage
+     */
+    gas?: {
+        /**
+         * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
+         */
+        otherCharges?:
+            | {
+                /**
+                 * The aggregate total of charges for this item (exclusive of GST)
+                 */
+                amount: string;
+                /**
+                 * A free text description of the type of charge
+                 */
+                description: string;
+                /**
+                 * Type of charge. Assumed to be other if absent
+                 */
+                type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
+         */
+        totalGenerationCredits: string;
+        /**
+         * The total GST for all electricity usage charges.  If absent then zero is assumed
+         */
+        totalGst?: string | null;
+        /**
+         * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
+         */
+        totalOnceOffCharges: string;
+        /**
+         * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
+         */
+        totalOnceOffDiscounts: string;
+        /**
+         * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+         */
+        totalUsageCharges: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The total GST amount for this invoice.  If absent then zero is assumed
+     */
+    gstAmount?: string | null;
+    /**
+     * The net amount due for this invoice regardless of previous balance
+     */
+    invoiceAmount?: string | null;
+    /**
+     * The number assigned to this invoice by the energy Retailer
+     */
+    invoiceNumber: string;
+    /**
+     * The date that the invoice was actually issued (as opposed to generated or calculated)
+     */
+    issueDate: string;
+    /**
+     * A discount for on time payment
+     */
+    payOnTimeDiscount?: {
+        /**
+         * The date by which the invoice must be paid to receive the pay on time discount
+         */
+        date: string;
+        /**
+         * The amount that will be discounted if the invoice is paid by the date specified
+         */
+        discountAmount: string;
+        /**
+         * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
+         */
+        gstAmount?: string | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Indicator of the payment status for the invoice
+     */
+    paymentStatus: 'PAID' | 'PARTIALLY_PAID' | 'NOT_PAID';
+    /**
+     * Object containing the start and end date for the period covered by the invoice.  Mandatory if any usage or demand based charges are included in the invoice
+     */
+    period?: {
+        /**
+         * The end date of the period covered by this invoice
+         */
+        endDate: string;
+        /**
+         * The start date of the period covered by this invoice
+         */
+        startDate: string;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Array of service point IDs to which this invoice applies. May be empty if the invoice contains no electricity usage related charges
+     */
+    servicePoints: string[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+/**
+ * Object contains account level charges and credits related to electricity usage
+ */
+export interface EnergyInvoiceAccountCharges {
     /**
      * The aggregate total of account level charges for the period covered by the invoice
      */
@@ -5779,723 +5975,541 @@ export interface EnergyInvoice {
      */
     totalGst?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * The ID of the account for which the invoice was issued
-   */
-  accountId: string;
-  /**
-   * The account balance at the time the invoice was issued
-   */
-  balanceAtIssue: string;
-  /**
-   * The date that the invoice is due to be paid
-   */
-  dueDate?: string | null;
-  /**
-   * Object containing charges and credits related to electricity usage
-   */
-  electricity?: {
-    /**
-     * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
-     */
-    otherCharges?:
-      | {
-          /**
-           * The aggregate total of charges for this item (exclusive of GST)
-           */
-          amount: string;
-          /**
-           * A free text description of the type of charge
-           */
-          description: string;
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[]
-      | null;
-    /**
-     * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
-     */
-    totalGenerationCredits: string;
-    /**
-     * The total GST for all electricity usage charges.  If absent then zero is assumed
-     */
-    totalGst?: string | null;
-    /**
-     * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
-     */
-    totalOnceOffCharges: string;
-    /**
-     * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
-     */
-    totalOnceOffDiscounts: string;
-    /**
-     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-     */
-    totalUsageCharges: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Object containing charges and credits related to gas usage
-   */
-  gas?: {
-    /**
-     * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
-     */
-    otherCharges?:
-      | {
-          /**
-           * The aggregate total of charges for this item (exclusive of GST)
-           */
-          amount: string;
-          /**
-           * A free text description of the type of charge
-           */
-          description: string;
-          /**
-           * Type of charge. Assumed to be other if absent
-           */
-          type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-          [k: string]: unknown;
-        }[]
-      | null;
-    /**
-     * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
-     */
-    totalGenerationCredits: string;
-    /**
-     * The total GST for all electricity usage charges.  If absent then zero is assumed
-     */
-    totalGst?: string | null;
-    /**
-     * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
-     */
-    totalOnceOffCharges: string;
-    /**
-     * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
-     */
-    totalOnceOffDiscounts: string;
-    /**
-     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-     */
-    totalUsageCharges: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The total GST amount for this invoice.  If absent then zero is assumed
-   */
-  gstAmount?: string | null;
-  /**
-   * The net amount due for this invoice regardless of previous balance
-   */
-  invoiceAmount?: string | null;
-  /**
-   * The number assigned to this invoice by the energy Retailer
-   */
-  invoiceNumber: string;
-  /**
-   * The date that the invoice was actually issued (as opposed to generated or calculated)
-   */
-  issueDate: string;
-  /**
-   * A discount for on time payment
-   */
-  payOnTimeDiscount?: {
-    /**
-     * The date by which the invoice must be paid to receive the pay on time discount
-     */
-    date: string;
-    /**
-     * The amount that will be discounted if the invoice is paid by the date specified
-     */
-    discountAmount: string;
-    /**
-     * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
-     */
-    gstAmount?: string | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Indicator of the payment status for the invoice
-   */
-  paymentStatus: "PAID" | "PARTIALLY_PAID" | "NOT_PAID";
-  /**
-   * Object containing the start and end date for the period covered by the invoice.  Mandatory if any usage or demand based charges are included in the invoice
-   */
-  period?: {
-    /**
-     * The end date of the period covered by this invoice
-     */
-    endDate: string;
-    /**
-     * The start date of the period covered by this invoice
-     */
-    startDate: string;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Array of service point IDs to which this invoice applies. May be empty if the invoice contains no electricity usage related charges
-   */
-  servicePoints: string[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
-
-/**
- * Object contains account level charges and credits related to electricity usage
- */
-export interface EnergyInvoiceAccountCharges {
-  /**
-   * The aggregate total of account level charges for the period covered by the invoice
-   */
-  totalCharges: string;
-  /**
-   * The aggregate total of account level discounts or credits for the period covered by the invoice
-   */
-  totalDiscounts: string;
-  /**
-   * The total GST for all account level charges.  If absent then zero is assumed
-   */
-  totalGst?: string | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyInvoiceElectricityUsageCharges {
-  /**
-   * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
-   */
-  otherCharges?:
-    | {
-        /**
-         * The aggregate total of charges for this item (exclusive of GST)
-         */
-        amount: string;
-        /**
-         * A free text description of the type of charge
-         */
-        description: string;
-        /**
-         * Type of charge. Assumed to be other if absent
-         */
-        type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
-   */
-  totalGenerationCredits: string;
-  /**
-   * The total GST for all electricity usage charges.  If absent then zero is assumed
-   */
-  totalGst?: string | null;
-  /**
-   * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
-   */
-  totalOnceOffCharges: string;
-  /**
-   * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
-   */
-  totalOnceOffDiscounts: string;
-  /**
-   * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-   */
-  totalUsageCharges: string;
-  [k: string]: unknown;
+    /**
+     * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
+     */
+    otherCharges?:
+        | {
+            /**
+             * The aggregate total of charges for this item (exclusive of GST)
+             */
+            amount: string;
+            /**
+             * A free text description of the type of charge
+             */
+            description: string;
+            /**
+             * Type of charge. Assumed to be other if absent
+             */
+            type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
+     */
+    totalGenerationCredits: string;
+    /**
+     * The total GST for all electricity usage charges.  If absent then zero is assumed
+     */
+    totalGst?: string | null;
+    /**
+     * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
+     */
+    totalOnceOffCharges: string;
+    /**
+     * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
+     */
+    totalOnceOffDiscounts: string;
+    /**
+     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+     */
+    totalUsageCharges: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyInvoiceGasUsageCharges {
-  /**
-   * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
-   */
-  otherCharges?:
-    | {
-        /**
-         * The aggregate total of charges for this item (exclusive of GST)
-         */
-        amount: string;
-        /**
-         * A free text description of the type of charge
-         */
-        description: string;
-        /**
-         * Type of charge. Assumed to be other if absent
-         */
-        type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
-   */
-  totalGenerationCredits: string;
-  /**
-   * The total GST for all electricity usage charges.  If absent then zero is assumed
-   */
-  totalGst?: string | null;
-  /**
-   * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
-   */
-  totalOnceOffCharges: string;
-  /**
-   * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
-   */
-  totalOnceOffDiscounts: string;
-  /**
-   * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-   */
-  totalUsageCharges: string;
-  [k: string]: unknown;
+    /**
+     * Optional array of charges that may be part of the invoice (for e.g. environmental charges for C&I consumers) (exclusive of GST)
+     */
+    otherCharges?:
+        | {
+            /**
+             * The aggregate total of charges for this item (exclusive of GST)
+             */
+            amount: string;
+            /**
+             * A free text description of the type of charge
+             */
+            description: string;
+            /**
+             * Type of charge. Assumed to be other if absent
+             */
+            type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The aggregate total of generation credits for the period covered by the invoice (exclusive of GST)
+     */
+    totalGenerationCredits: string;
+    /**
+     * The total GST for all electricity usage charges.  If absent then zero is assumed
+     */
+    totalGst?: string | null;
+    /**
+     * The aggregate total of any once off charges arising from electricity usage for the period covered by the invoice (exclusive of GST)
+     */
+    totalOnceOffCharges: string;
+    /**
+     * The aggregate total of any once off discounts or credits arising from electricity usage for the period covered by the invoice (exclusive of GST)
+     */
+    totalOnceOffDiscounts: string;
+    /**
+     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+     */
+    totalUsageCharges: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyInvoiceListResponse {
-  data: {
-    /**
-     * Array of invoices sorted by issue date in descending order
-     */
-    invoices: EnergyInvoice[];
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
+    data: {
+        /**
+         * Array of invoices sorted by issue date in descending order
+         */
+        invoices: EnergyInvoice[];
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPaymentSchedule {
-  /**
-   * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smoothing scenarios)
-   */
-  amount?: string | null;
-  /**
-   * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
-   */
-  cardDebit?: {
     /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+     * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smoothing scenarios)
      */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
+    amount?: string | null;
     /**
-     * The type of credit card held on file
+     * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
      */
-    cardScheme: "VISA" | "MASTERCARD" | "AMEX" | "DINERS" | "OTHER" | "UNKNOWN";
+    cardDebit?: {
+        /**
+         * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+         */
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+        /**
+         * The type of credit card held on file
+         */
+        cardScheme: 'VISA' | 'MASTERCARD' | 'AMEX' | 'DINERS' | 'OTHER' | 'UNKNOWN';
+        /**
+         * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        paymentFrequency: string;
+        [k: string]: unknown;
+    } | null;
     /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
      */
-    paymentFrequency: string;
+    digitalWallet?: {
+        /**
+         * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+         */
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+        /**
+         * The identifier of the digital wallet (dependent on type)
+         */
+        identifier: string;
+        /**
+         * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+         */
+        name: string;
+        /**
+         * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        paymentFrequency: string;
+        /**
+         * The provider of the digital wallet
+         */
+        provider: 'PAYPAL_AU' | 'OTHER';
+        /**
+         * The type of the digital wallet identifier
+         */
+        type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
+     */
+    directDebit?: {
+        /**
+         * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+         */
+        accountNumber?: string | null;
+        /**
+         * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+         */
+        bsb?: string | null;
+        /**
+         * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+         */
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+        /**
+         * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
+         */
+        isTokenised?: boolean | null;
+        /**
+         * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        paymentFrequency: string;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
+     */
+    manualPayment?: {
+        /**
+         * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        billFrequency: string;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * The type of object present in this response
+     */
+    paymentScheduleUType: 'cardDebit' | 'directDebit' | 'manualPayment' | 'digitalWallet';
     [k: string]: unknown;
-  } | null;
-  /**
-   * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
-   */
-  digitalWallet?: {
-    /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-     */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-    /**
-     * The identifier of the digital wallet (dependent on type)
-     */
-    identifier: string;
-    /**
-     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-     */
-    name: string;
-    /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    paymentFrequency: string;
-    /**
-     * The provider of the digital wallet
-     */
-    provider: "PAYPAL_AU" | "OTHER";
-    /**
-     * The type of the digital wallet identifier
-     */
-    type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
-   */
-  directDebit?: {
-    /**
-     * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-     */
-    accountNumber?: string | null;
-    /**
-     * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-     */
-    bsb?: string | null;
-    /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-     */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-    /**
-     * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
-     */
-    isTokenised?: boolean | null;
-    /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    paymentFrequency: string;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
-   */
-  manualPayment?: {
-    /**
-     * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    billFrequency: string;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * The type of object present in this response
-   */
-  paymentScheduleUType: "cardDebit" | "directDebit" | "manualPayment" | "digitalWallet";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPaymentScheduleResponse {
-  data: {
-    /**
-     * Array may be empty if no payment schedule exist
-     */
-    paymentSchedules: EnergyPaymentSchedule[];
+    data: {
+        /**
+         * Array may be empty if no payment schedule exist
+         */
+        paymentSchedules: EnergyPaymentSchedule[];
+        [k: string]: unknown;
+    };
+    links: Links;
+    meta?: Meta;
     [k: string]: unknown;
-  };
-  links: Links;
-  meta?: Meta;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlan {
-  /**
-   * Object that contains links to additional information on specific topics
-   */
-  additionalInformation?: {
     /**
-     * A link to detail on bundles that this plan can be a part of
+     * Object that contains links to additional information on specific topics
      */
-    bundleUri?: string | null;
+    additionalInformation?: {
+        /**
+         * A link to detail on bundles that this plan can be a part of
+         */
+        bundleUri?: string | null;
+        /**
+         * A link to detail on eligibility criteria for the plan
+         */
+        eligibilityUri?: string | null;
+        /**
+         * A link to a general overview of the plan
+         */
+        overviewUri?: string | null;
+        /**
+         * A link to detail on pricing for the plan
+         */
+        pricingUri?: string | null;
+        /**
+         * A link to terms and conditions for the plan
+         */
+        termsUri?: string | null;
+        [k: string]: unknown;
+    } | null;
     /**
-     * A link to detail on eligibility criteria for the plan
+     * A link to an application web page where this plan can be applied for
      */
-    eligibilityUri?: string | null;
+    applicationUri?: string | null;
     /**
-     * A link to a general overview of the plan
+     * The ID of the brand under which this plan is offered
      */
-    overviewUri?: string | null;
+    brand: string;
     /**
-     * A link to detail on pricing for the plan
+     * The display name of the brand under which this plan is offered
      */
-    pricingUri?: string | null;
+    brandName: string;
     /**
-     * A link to terms and conditions for the plan
+     * The type of customer that the plan is offered to.  If absent then the plan is available to all customers
      */
-    termsUri?: string | null;
+    customerType?: ('RESIDENTIAL' | 'BUSINESS') | null;
+    /**
+     * A description of the plan
+     */
+    description?: string | null;
+    /**
+     * The display name of the plan
+     */
+    displayName?: string | null;
+    /**
+     * The date and time from which this plan is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
+     */
+    effectiveFrom?: string | null;
+    /**
+     * The date and time at which this plan will be retired and will no longer be offered. Used to enable the managed deprecation of plans
+     */
+    effectiveTo?: string | null;
+    /**
+     * The fuel types covered by the plan
+     */
+    fuelType: 'ELECTRICITY' | 'GAS' | 'DUAL';
+    /**
+     * Describes the geographical area that the plan is available for.  If absent then it is assumed the plan is not geographically limited
+     */
+    geography?: {
+        /**
+         * Array of distributors for the plan. Must have at least one entry
+         */
+        distributors: string[];
+        /**
+         * Array of valid Australian post codes that are specifically excluded from the plan.  Each element is a single four digit postcode (e.g. 3000) or a range of postcodes defined by two four digit postcodes and a hyphen (e.g. 3000-3999)
+         */
+        excludedPostcodes?: string[] | null;
+        /**
+         * Array of valid Australian post codes that are included from the plan.  If absent defaults to all non-excluded post codes.  Each element is a single four digit postcode (e.g. 3000) or a range of postcodes defined by two four digit postcodes and a hyphen (e.g. 3000-3999)
+         */
+        includedPostcodes?: string[] | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
+     */
+    lastUpdated: string;
+    /**
+     * The ID of the specific plan
+     */
+    planId: string;
+    /**
+     * The type of the plan
+     */
+    type: 'STANDING' | 'MARKET' | 'REGULATED';
     [k: string]: unknown;
-  } | null;
-  /**
-   * A link to an application web page where this plan can be applied for
-   */
-  applicationUri?: string | null;
-  /**
-   * The ID of the brand under which this plan is offered
-   */
-  brand: string;
-  /**
-   * The display name of the brand under which this plan is offered
-   */
-  brandName: string;
-  /**
-   * The type of customer that the plan is offered to.  If absent then the plan is available to all customers
-   */
-  customerType?: ("RESIDENTIAL" | "BUSINESS") | null;
-  /**
-   * A description of the plan
-   */
-  description?: string | null;
-  /**
-   * The display name of the plan
-   */
-  displayName?: string | null;
-  /**
-   * The date and time from which this plan is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
-   */
-  effectiveFrom?: string | null;
-  /**
-   * The date and time at which this plan will be retired and will no longer be offered. Used to enable the managed deprecation of plans
-   */
-  effectiveTo?: string | null;
-  /**
-   * The fuel types covered by the plan
-   */
-  fuelType: "ELECTRICITY" | "GAS" | "DUAL";
-  /**
-   * Describes the geographical area that the plan is available for.  If absent then it is assumed the plan is not geographically limited
-   */
-  geography?: {
-    /**
-     * Array of distributors for the plan. Must have at least one entry
-     */
-    distributors: string[];
-    /**
-     * Array of valid Australian post codes that are specifically excluded from the plan.  Each element is a single four digit postcode (e.g. 3000) or a range of postcodes defined by two four digit postcodes and a hyphen (e.g. 3000-3999)
-     */
-    excludedPostcodes?: string[] | null;
-    /**
-     * Array of valid Australian post codes that are included from the plan.  If absent defaults to all non-excluded post codes.  Each element is a single four digit postcode (e.g. 3000) or a range of postcodes defined by two four digit postcodes and a hyphen (e.g. 3000-3999)
-     */
-    includedPostcodes?: string[] | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
-   */
-  lastUpdated: string;
-  /**
-   * The ID of the specific plan
-   */
-  planId: string;
-  /**
-   * The type of the plan
-   */
-  type: "STANDING" | "MARKET" | "REGULATED";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanContract {
-  /**
-   * Free text field containing additional information of the fees for this contract
-   */
-  additionalFeeInformation?: string | null;
-  /**
-   * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-   */
-  controlledLoad?: EnergyPlanControlledLoad[];
-  /**
-   * Optional list of discounts available for the contract
-   */
-  discounts?: EnergyPlanDiscounts[];
-  /**
-   * Eligibility restrictions or requirements
-   */
-  eligibility?: EnergyPlanEligibility[];
-  /**
-   * An array of fees applicable to the plan
-   */
-  fees?: EnergyPlanFees[];
-  /**
-   * Optional list of charges applicable to green power
-   */
-  greenPowerCharges?: EnergyPlanGreenPowerCharges[];
-  /**
-   * Optional list of incentives available for the contract
-   */
-  incentives?: EnergyPlanIncentives[];
-  /**
-   * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-   */
-  intrinsicGreenPower?: {
     /**
-     * Percentage of green power intrinsically included in the plan
+     * Free text field containing additional information of the fees for this contract
      */
-    greenPercentage: string;
+    additionalFeeInformation?: string | null;
+    /**
+     * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+     */
+    controlledLoad?: EnergyPlanControlledLoad[];
+    /**
+     * Optional list of discounts available for the contract
+     */
+    discounts?: EnergyPlanDiscounts[];
+    /**
+     * Eligibility restrictions or requirements
+     */
+    eligibility?: EnergyPlanEligibility[];
+    /**
+     * An array of fees applicable to the plan
+     */
+    fees?: EnergyPlanFees[];
+    /**
+     * Optional list of charges applicable to green power
+     */
+    greenPowerCharges?: EnergyPlanGreenPowerCharges[];
+    /**
+     * Optional list of incentives available for the contract
+     */
+    incentives?: EnergyPlanIncentives[];
+    /**
+     * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+     */
+    intrinsicGreenPower?: {
+        /**
+         * Percentage of green power intrinsically included in the plan
+         */
+        greenPercentage: string;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Flag indicating whether prices are fixed or variable
+     */
+    isFixed: boolean;
+    /**
+     * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+     */
+    onExpiryDescription?: string | null;
+    /**
+     * Payment options for this contract
+     */
+    paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+    /**
+     * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+     */
+    pricingModel:
+        | 'SINGLE_RATE'
+        | 'SINGLE_RATE_CONT_LOAD'
+        | 'TIME_OF_USE'
+        | 'TIME_OF_USE_CONT_LOAD'
+        | 'FLEXIBLE'
+        | 'FLEXIBLE_CONT_LOAD'
+        | 'QUOTA';
+    /**
+     * Array of feed in tariffs for solar power
+     */
+    solarFeedInTariff?: EnergyPlanSolarFeedInTariff[];
+    /**
+     * Array of tariff periods
+     */
+    tariffPeriod: EnergyPlanTariffPeriod[];
+    /**
+     * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+     */
+    timeZone?: ('LOCAL' | 'AEST') | null;
+    /**
+     * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+     */
+    variation?: string | null;
     [k: string]: unknown;
-  } | null;
-  /**
-   * Flag indicating whether prices are fixed or variable
-   */
-  isFixed: boolean;
-  /**
-   * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-   */
-  onExpiryDescription?: string | null;
-  /**
-   * Payment options for this contract
-   */
-  paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-  /**
-   * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-   */
-  pricingModel:
-    | "SINGLE_RATE"
-    | "SINGLE_RATE_CONT_LOAD"
-    | "TIME_OF_USE"
-    | "TIME_OF_USE_CONT_LOAD"
-    | "FLEXIBLE"
-    | "FLEXIBLE_CONT_LOAD"
-    | "QUOTA";
-  /**
-   * Array of feed in tariffs for solar power
-   */
-  solarFeedInTariff?: EnergyPlanSolarFeedInTariff[];
-  /**
-   * Array of tariff periods
-   */
-  tariffPeriod: EnergyPlanTariffPeriod[];
-  /**
-   * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-   */
-  timeZone?: ("LOCAL" | "AEST") | null;
-  /**
-   * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-   */
-  variation?: string | null;
-  [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanContractV2 {
-  /**
-   * Free text field containing additional information of the fees for this contract
-   */
-  additionalFeeInformation?: string | null;
-  /**
-   * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
-   */
-  controlledLoad?: EnergyPlanControlledLoad[];
-  /**
-   * Optional list of discounts available for the contract
-   */
-  discounts?: EnergyPlanDiscounts[];
-  /**
-   * Eligibility restrictions or requirements
-   */
-  eligibility?: EnergyPlanEligibility[];
-  /**
-   * An array of fees applicable to the plan
-   */
-  fees?: EnergyPlanFees[];
-  /**
-   * Optional list of charges applicable to green power
-   */
-  greenPowerCharges?: EnergyPlanGreenPowerCharges[];
-  /**
-   * Optional list of incentives available for the contract
-   */
-  incentives?: EnergyPlanIncentives[];
-  /**
-   * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
-   */
-  intrinsicGreenPower?: {
     /**
-     * Percentage of green power intrinsically included in the plan
+     * Free text field containing additional information of the fees for this contract
      */
-    greenPercentage: string;
+    additionalFeeInformation?: string | null;
+    /**
+     * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+     */
+    controlledLoad?: EnergyPlanControlledLoad[];
+    /**
+     * Optional list of discounts available for the contract
+     */
+    discounts?: EnergyPlanDiscounts[];
+    /**
+     * Eligibility restrictions or requirements
+     */
+    eligibility?: EnergyPlanEligibility[];
+    /**
+     * An array of fees applicable to the plan
+     */
+    fees?: EnergyPlanFees[];
+    /**
+     * Optional list of charges applicable to green power
+     */
+    greenPowerCharges?: EnergyPlanGreenPowerCharges[];
+    /**
+     * Optional list of incentives available for the contract
+     */
+    incentives?: EnergyPlanIncentives[];
+    /**
+     * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+     */
+    intrinsicGreenPower?: {
+        /**
+         * Percentage of green power intrinsically included in the plan
+         */
+        greenPercentage: string;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Flag indicating whether prices are fixed or variable
+     */
+    isFixed: boolean;
+    /**
+     * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+     */
+    onExpiryDescription?: string | null;
+    /**
+     * Payment options for this contract
+     */
+    paymentOption: ('PAPER_BILL' | 'CREDIT_CARD' | 'DIRECT_DEBIT' | 'BPAY' | 'OTHER')[];
+    /**
+     * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+     */
+    pricingModel:
+        | 'SINGLE_RATE'
+        | 'SINGLE_RATE_CONT_LOAD'
+        | 'TIME_OF_USE'
+        | 'TIME_OF_USE_CONT_LOAD'
+        | 'FLEXIBLE'
+        | 'FLEXIBLE_CONT_LOAD'
+        | 'QUOTA';
+    /**
+     * Array of feed in tariffs for solar power
+     */
+    solarFeedInTariff?: EnergyPlanSolarFeedInTariffV2[];
+    /**
+     * Array of tariff periods
+     */
+    tariffPeriod: EnergyPlanTariffPeriod[];
+    /**
+     * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+     */
+    timeZone?: ('LOCAL' | 'AEST') | null;
+    /**
+     * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+     */
+    variation?: string | null;
     [k: string]: unknown;
-  } | null;
-  /**
-   * Flag indicating whether prices are fixed or variable
-   */
-  isFixed: boolean;
-  /**
-   * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
-   */
-  onExpiryDescription?: string | null;
-  /**
-   * Payment options for this contract
-   */
-  paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
-  /**
-   * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
-   */
-  pricingModel:
-    | "SINGLE_RATE"
-    | "SINGLE_RATE_CONT_LOAD"
-    | "TIME_OF_USE"
-    | "TIME_OF_USE_CONT_LOAD"
-    | "FLEXIBLE"
-    | "FLEXIBLE_CONT_LOAD"
-    | "QUOTA";
-  /**
-   * Array of feed in tariffs for solar power
-   */
-  solarFeedInTariff?: EnergyPlanSolarFeedInTariffV2[];
-  /**
-   * Array of tariff periods
-   */
-  tariffPeriod: EnergyPlanTariffPeriod[];
-  /**
-   * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
-   */
-  timeZone?: ("LOCAL" | "AEST") | null;
-  /**
-   * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
-   */
-  variation?: string | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanContractFull extends EnergyPlanContractV2 {
-  /**
-   * The term for the contract.  If absent assumes no specified term
-   */
-  termType?: "1_YEAR" | "2_YEAR" | "3_YEAR" | "4_YEAR" | "5_YEAR" | "ONGOING" | "OTHER";
-  /**
-   * Description of the benefit period.  Should only be present if termType has the value ONGOING
-   */
-  benefitPeriod?: string;
-  /**
-   * Free text description of the terms for the contract
-   */
-  terms?: string;
-  /**
-   * An array of the meter types that this contract is available for
-   */
-  meterTypes?: string[];
-  /**
-   * Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
-   */
-  coolingOffDays?: number;
-  /**
-   * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  billFrequency: string[];
-  [k: string]: unknown;
+    /**
+     * The term for the contract.  If absent assumes no specified term
+     */
+    termType?: '1_YEAR' | '2_YEAR' | '3_YEAR' | '4_YEAR' | '5_YEAR' | 'ONGOING' | 'OTHER';
+    /**
+     * Description of the benefit period.  Should only be present if termType has the value ONGOING
+     */
+    benefitPeriod?: string;
+    /**
+     * Free text description of the terms for the contract
+     */
+    terms?: string;
+    /**
+     * An array of the meter types that this contract is available for
+     */
+    meterTypes?: string[];
+    /**
+     * Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
+     */
+    coolingOffDays?: number;
+    /**
+     * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    billFrequency: string[];
+    [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanContractFullV2 extends EnergyPlanContractV2 {
-  /**
-   * The term for the contract.  If absent assumes no specified term
-   */
-  termType?: "1_YEAR" | "2_YEAR" | "3_YEAR" | "4_YEAR" | "5_YEAR" | "ONGOING" | "OTHER";
-  /**
-   * Description of the benefit period.  Should only be present if termType has the value ONGOING
-   */
-  benefitPeriod?: string;
-  /**
-   * Free text description of the terms for the contract
-   */
-  terms?: string;
-  /**
-   * An array of the meter types that this contract is available for
-   */
-  meterTypes?: string[];
-  /**
-   * Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
-   */
-  coolingOffDays?: number;
-  /**
-   * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  billFrequency: string[];
-  [k: string]: unknown;
+    /**
+     * The term for the contract.  If absent assumes no specified term
+     */
+    termType?: '1_YEAR' | '2_YEAR' | '3_YEAR' | '4_YEAR' | '5_YEAR' | 'ONGOING' | 'OTHER';
+    /**
+     * Description of the benefit period.  Should only be present if termType has the value ONGOING
+     */
+    benefitPeriod?: string;
+    /**
+     * Free text description of the terms for the contract
+     */
+    terms?: string;
+    /**
+     * An array of the meter types that this contract is available for
+     */
+    meterTypes?: string[];
+    /**
+     * Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
+     */
+    coolingOffDays?: number;
+    /**
+     * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    billFrequency: string[];
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -6503,203 +6517,203 @@ export interface EnergyPlanContractFullV2 extends EnergyPlanContractV2 {
  * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
  */
 export interface EnergyPlanControlledLoad {
-  /**
-   * A display name for the controlled load
-   */
-  displayName: string;
-  /**
-   * Optional end date of the application of the controlled load rate
-   */
-  endDate?: string;
-  /**
-   * Specifies the type of controlloed load rate
-   */
-  rateBlockUType: "singleRate" | "timeOfUseRates";
-  /**
-   * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
-   */
-  singleRate?: {
     /**
-     * The daily supply charge (exclusive of GST) for this controlled load tier
-     */
-    dailySupplyCharge?: string;
-    /**
-     * Description of the controlled load rate
-     */
-    description?: string;
-    /**
-     * Display name of the controlled load rate
+     * A display name for the controlled load
      */
     displayName: string;
     /**
-     * Array of controlled load rates in order of usage volume
+     * Optional end date of the application of the controlled load rate
      */
-    rates: {
-      /**
-       * The measurement unit of rate. Assumed to be KWH if absent
-       */
-      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-      /**
-       * Unit price of usage per  measure unit (exclusive of GST)
-       */
-      unitPrice: string;
-      /**
-       * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-       */
-      volume?: number;
-      [k: string]: unknown;
+    endDate?: string;
+    /**
+     * Specifies the type of controlloed load rate
+     */
+    rateBlockUType: 'singleRate' | 'timeOfUseRates';
+    /**
+     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+     */
+    singleRate?: {
+        /**
+         * The daily supply charge (exclusive of GST) for this controlled load tier
+         */
+        dailySupplyCharge?: string;
+        /**
+         * Description of the controlled load rate
+         */
+        description?: string;
+        /**
+         * Display name of the controlled load rate
+         */
+        displayName: string;
+        /**
+         * Array of controlled load rates in order of usage volume
+         */
+        rates: {
+            /**
+             * The measurement unit of rate. Assumed to be KWH if absent
+             */
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            /**
+             * Unit price of usage per  measure unit (exclusive of GST)
+             */
+            unitPrice: string;
+            /**
+             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+             */
+            volume?: number;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    /**
+     * Optional start date of the application of the controlled load rate
+     */
+    startDate?: string;
+    /**
+     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+     */
+    timeOfUseRates?: {
+        /**
+         * The daily supply charge (exclusive of GST) for this controlled load tier
+         */
+        dailySupplyCharge?: string;
+        /**
+         * Description of the controlled load rate
+         */
+        description?: string;
+        /**
+         * Display name of the controlled load rate
+         */
+        displayName: string;
+        /**
+         * Array of controlled load rates in order of usage volume
+         */
+        rates: {
+            /**
+             * The measurement unit of rate. Assumed to be KWH if absent
+             */
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            /**
+             * Unit price of usage per  measure unit (exclusive of GST)
+             */
+            unitPrice: string;
+            /**
+             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+             */
+            volume?: number;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Array of times of use.
+         */
+        timeOfUse: {
+            /**
+             * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+             */
+            additionalInfo?: string;
+            /**
+             * Optional link to additional information regarding the controlled load
+             */
+            additionalInfoUri?: string;
+            /**
+             * The days that the rate applies to
+             */
+            days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+            /**
+             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+             */
+            endTime?: string;
+            /**
+             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+             */
+            startTime?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The type of usage that the rate applies to
+         */
+        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SOLAR_SPONGE';
+        [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  };
-  /**
-   * Optional start date of the application of the controlled load rate
-   */
-  startDate?: string;
-  /**
-   * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-   */
-  timeOfUseRates?: {
-    /**
-     * The daily supply charge (exclusive of GST) for this controlled load tier
-     */
-    dailySupplyCharge?: string;
-    /**
-     * Description of the controlled load rate
-     */
-    description?: string;
-    /**
-     * Display name of the controlled load rate
-     */
-    displayName: string;
-    /**
-     * Array of controlled load rates in order of usage volume
-     */
-    rates: {
-      /**
-       * The measurement unit of rate. Assumed to be KWH if absent
-       */
-      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-      /**
-       * Unit price of usage per  measure unit (exclusive of GST)
-       */
-      unitPrice: string;
-      /**
-       * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-       */
-      volume?: number;
-      [k: string]: unknown;
-    }[];
-    /**
-     * Array of times of use.
-     */
-    timeOfUse: {
-      /**
-       * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
-       */
-      additionalInfo?: string;
-      /**
-       * Optional link to additional information regarding the controlled load
-       */
-      additionalInfoUri?: string;
-      /**
-       * The days that the rate applies to
-       */
-      days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-      /**
-       * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
-       */
-      endTime?: string;
-      /**
-       * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
-       */
-      startTime?: string;
-      [k: string]: unknown;
-    }[];
-    /**
-     * The type of usage that the rate applies to
-     */
-    type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanDetail extends EnergyPlan {
-  /**
-   * Charges for metering included in the plan
-   */
-  meteringCharges?: {
     /**
-     * Display name of the charge
+     * Charges for metering included in the plan
      */
-    displayName: string;
+    meteringCharges?: {
+        /**
+         * Display name of the charge
+         */
+        displayName: string;
+        /**
+         * Description of the charge
+         */
+        description?: string;
+        /**
+         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+         */
+        minimumValue: string;
+        /**
+         * The upper limit of the charge if the charge could occur in a range
+         */
+        maximumValue?: string;
+        /**
+         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        period?: string;
+        [k: string]: unknown;
+    };
     /**
-     * Description of the charge
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
      */
-    description?: string;
+    gasContract?: EnergyPlanContractFull;
     /**
-     * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
      */
-    minimumValue: string;
-    /**
-     * The upper limit of the charge if the charge could occur in a range
-     */
-    maximumValue?: string;
-    /**
-     * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    period?: string;
+    electricityContract?: EnergyPlanContractFull;
     [k: string]: unknown;
-  };
-  /**
-   * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-   */
-  gasContract?: EnergyPlanContractFull;
-  /**
-   * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-   */
-  electricityContract?: EnergyPlanContractFull;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanDetailV2 extends EnergyPlan {
-  /**
-   * Charges for metering included in the plan
-   */
-  meteringCharges?: {
     /**
-     * Display name of the charge
+     * Charges for metering included in the plan
      */
-    displayName: string;
+    meteringCharges?: {
+        /**
+         * Display name of the charge
+         */
+        displayName: string;
+        /**
+         * Description of the charge
+         */
+        description?: string;
+        /**
+         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+         */
+        minimumValue: string;
+        /**
+         * The upper limit of the charge if the charge could occur in a range
+         */
+        maximumValue?: string;
+        /**
+         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        period?: string;
+        [k: string]: unknown;
+    };
     /**
-     * Description of the charge
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
      */
-    description?: string;
+    gasContract?: EnergyPlanContractFullV2;
     /**
-     * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
      */
-    minimumValue: string;
-    /**
-     * The upper limit of the charge if the charge could occur in a range
-     */
-    maximumValue?: string;
-    /**
-     * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    period?: string;
+    electricityContract?: EnergyPlanContractFullV2;
     [k: string]: unknown;
-  };
-  /**
-   * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
-   */
-  gasContract?: EnergyPlanContractFullV2;
-  /**
-   * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
-   */
-  electricityContract?: EnergyPlanContractFullV2;
-  [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
@@ -6708,75 +6722,75 @@ export interface EnergyPlanDetailV2 extends EnergyPlan {
  * Optional list of discounts available for the contract
  */
 export interface EnergyPlanDiscounts {
-  /**
-   * The type of the discount.  Mandatory if the discount type is CONDITIONAL
-   */
-  category?: "PAY_ON_TIME" | "DIRECT_DEBIT" | "GUARANTEED_DISCOUNT" | "OTHER";
-  /**
-   * The description of the discount
-   */
-  description?: string;
-  /**
-   * The display name of the discount
-   */
-  displayName: string;
-  /**
-   * Optional end date for the discount after which the discount is no longer available
-   */
-  endDate?: string;
-  /**
-   * Required if methodUType is fixedAmount
-   */
-  fixedAmount?: {
     /**
-     * The amount of the discount
+     * The type of the discount.  Mandatory if the discount type is CONDITIONAL
      */
-    amount: string;
+    category?: 'PAY_ON_TIME' | 'DIRECT_DEBIT' | 'GUARANTEED_DISCOUNT' | 'OTHER';
+    /**
+     * The description of the discount
+     */
+    description?: string;
+    /**
+     * The display name of the discount
+     */
+    displayName: string;
+    /**
+     * Optional end date for the discount after which the discount is no longer available
+     */
+    endDate?: string;
+    /**
+     * Required if methodUType is fixedAmount
+     */
+    fixedAmount?: {
+        /**
+         * The amount of the discount
+         */
+        amount: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The method of calculation of the discount
+     */
+    methodUType: 'percentOfBill' | 'percentOfUse' | 'fixedAmount' | 'percentOverThreshold';
+    /**
+     * Required if methodUType is percentOfBill
+     */
+    percentOfBill?: {
+        /**
+         * The rate of the discount applied to the bill amount
+         */
+        rate: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Required if methodUType is percentOfUse
+     */
+    percentOfUse?: {
+        /**
+         * The rate of the discount applied to the usageamount
+         */
+        rate: string;
+        [k: string]: unknown;
+    };
+    /**
+     * Required if methodUType is percentOverThreshold
+     */
+    percentOverThreshold?: {
+        /**
+         * The rate of the discount over the usage amount
+         */
+        rate: string;
+        /**
+         * The usage amount threshold above which the discount applies
+         */
+        usageAmount: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The type of the discount
+     */
+    type: 'CONDITIONAL' | 'GUARANTEED' | 'OTHER';
     [k: string]: unknown;
-  };
-  /**
-   * The method of calculation of the discount
-   */
-  methodUType: "percentOfBill" | "percentOfUse" | "fixedAmount" | "percentOverThreshold";
-  /**
-   * Required if methodUType is percentOfBill
-   */
-  percentOfBill?: {
-    /**
-     * The rate of the discount applied to the bill amount
-     */
-    rate: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Required if methodUType is percentOfUse
-   */
-  percentOfUse?: {
-    /**
-     * The rate of the discount applied to the usageamount
-     */
-    rate: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Required if methodUType is percentOverThreshold
-   */
-  percentOverThreshold?: {
-    /**
-     * The rate of the discount over the usage amount
-     */
-    rate: string;
-    /**
-     * The usage amount threshold above which the discount applies
-     */
-    usageAmount: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The type of the discount
-   */
-  type: "CONDITIONAL" | "GUARANTEED" | "OTHER";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -6784,40 +6798,40 @@ export interface EnergyPlanDiscounts {
  * Eligibility restrictions or requirements
  */
 export interface EnergyPlanEligibility {
-  /**
-   * A description of the eligibility restriction
-   */
-  description?: string;
-  /**
-   * Information of the eligibility restriction specific to the type of the restriction
-   */
-  information: string;
-  /**
-   * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
-   */
-  type:
-    | "EXISTING_CUST"
-    | "EXISTING_POOL"
-    | "EXISTING_SOLAR"
-    | "EXISTING_BATTERY"
-    | "EXISTING_SMART_METER"
-    | "EXISTING_BASIC_METER"
-    | "SENIOR_CARD"
-    | "SMALL_BUSINESS"
-    | "NO_SOLAR_FIT"
-    | "NEW_CUSTOMER"
-    | "ONLINE_ONLY"
-    | "REQ_EQUIP_SUPPLIER"
-    | "THIRD_PARTY_ONLY"
-    | "SPORT_CLUB_MEMBER"
-    | "ORG_MEMBER"
-    | "SPECIFIC_LOCATION"
-    | "MINIMUM_USAGE"
-    | "LOYALTY_MEMBER"
-    | "GROUP_BUY_MEMBER"
-    | "CONTINGENT_PLAN"
-    | "OTHER";
-  [k: string]: unknown;
+    /**
+     * A description of the eligibility restriction
+     */
+    description?: string;
+    /**
+     * Information of the eligibility restriction specific to the type of the restriction
+     */
+    information: string;
+    /**
+     * The type of the eligibility restriction.<br/>The CONTINGENT_PLAN value indicates that the plan is contingent on the customer taking up an alternate fuel plan from the same retailer (for instance, if the fuelType is ELECTRICITY then a GAS plan from the same retailer must be taken up)
+     */
+    type:
+        | 'EXISTING_CUST'
+        | 'EXISTING_POOL'
+        | 'EXISTING_SOLAR'
+        | 'EXISTING_BATTERY'
+        | 'EXISTING_SMART_METER'
+        | 'EXISTING_BASIC_METER'
+        | 'SENIOR_CARD'
+        | 'SMALL_BUSINESS'
+        | 'NO_SOLAR_FIT'
+        | 'NEW_CUSTOMER'
+        | 'ONLINE_ONLY'
+        | 'REQ_EQUIP_SUPPLIER'
+        | 'THIRD_PARTY_ONLY'
+        | 'SPORT_CLUB_MEMBER'
+        | 'ORG_MEMBER'
+        | 'SPECIFIC_LOCATION'
+        | 'MINIMUM_USAGE'
+        | 'LOYALTY_MEMBER'
+        | 'GROUP_BUY_MEMBER'
+        | 'CONTINGENT_PLAN'
+        | 'OTHER';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -6825,104 +6839,104 @@ export interface EnergyPlanEligibility {
  * An array of fees applicable to the plan
  */
 export interface EnergyPlanFees {
-  /**
-   * The fee amount. Required if term is not PERCENT_OF_BILL
-   */
-  amount?: string;
-  /**
-   * A description of the fee
-   */
-  description?: string;
-  /**
-   * The fee rate. Required if term is PERCENT_OF_BILL
-   */
-  rate?: string;
-  /**
-   * The term of the fee
-   */
-  term:
-    | "FIXED"
-    | "1_YEAR"
-    | "2_YEAR"
-    | "3_YEAR"
-    | "4_YEAR"
-    | "5_YEAR"
-    | "PERCENT_OF_BILL"
-    | "ANNUAL"
-    | "DAILY"
-    | "WEEKLY"
-    | "MONTHLY"
-    | "BIANNUAL"
-    | "VARIABLE";
-  /**
-   * The type of the fee
-   */
-  type:
-    | "EXIT"
-    | "ESTABLISHMENT"
-    | "LATE_PAYMENT"
-    | "DISCONNECTION"
-    | "DISCONNECT_MOVE_OUT"
-    | "DISCONNECT_NON_PAY"
-    | "RECONNECTION"
-    | "CONNECTION"
-    | "PAYMENT_PROCESSING"
-    | "CC_PROCESSING"
-    | "CHEQUE_DISHONOUR"
-    | "DD_DISHONOUR"
-    | "MEMBERSHIP"
-    | "CONTRIBUTION"
-    | "PAPER_BILL"
-    | "OTHER";
-  [k: string]: unknown;
+    /**
+     * The fee amount. Required if term is not PERCENT_OF_BILL
+     */
+    amount?: string;
+    /**
+     * A description of the fee
+     */
+    description?: string;
+    /**
+     * The fee rate. Required if term is PERCENT_OF_BILL
+     */
+    rate?: string;
+    /**
+     * The term of the fee
+     */
+    term:
+        | 'FIXED'
+        | '1_YEAR'
+        | '2_YEAR'
+        | '3_YEAR'
+        | '4_YEAR'
+        | '5_YEAR'
+        | 'PERCENT_OF_BILL'
+        | 'ANNUAL'
+        | 'DAILY'
+        | 'WEEKLY'
+        | 'MONTHLY'
+        | 'BIANNUAL'
+        | 'VARIABLE';
+    /**
+     * The type of the fee
+     */
+    type:
+        | 'EXIT'
+        | 'ESTABLISHMENT'
+        | 'LATE_PAYMENT'
+        | 'DISCONNECTION'
+        | 'DISCONNECT_MOVE_OUT'
+        | 'DISCONNECT_NON_PAY'
+        | 'RECONNECTION'
+        | 'CONNECTION'
+        | 'PAYMENT_PROCESSING'
+        | 'CC_PROCESSING'
+        | 'CHEQUE_DISHONOUR'
+        | 'DD_DISHONOUR'
+        | 'MEMBERSHIP'
+        | 'CONTRIBUTION'
+        | 'PAPER_BILL'
+        | 'OTHER';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 /**
  * Optional list of charges applicable to green power
  */
-export interface EnergyPlanGreenPowerCharges  {
-  /**
-   * The description of the charge
-   */
-  description?: string;
-  /**
-   * The display name of the charge
-   */
-  displayName: string;
-  /**
-   * The applicable green power scheme
-   */
-  scheme: "GREENPOWER" | "OTHER";
-  /**
-   * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
-   */
-  tiers: {
+export interface EnergyPlanGreenPowerCharges {
     /**
-     * The amount of the charge if the type implies the application of a fixed amount
+     * The description of the charge
      */
-    amount?: string;
+    description?: string;
     /**
-     * The upper percentage of green power used applicable for this tier
+     * The display name of the charge
      */
-    percentGreen: string;
+    displayName: string;
     /**
-     * The rate of the charge if the type implies the application of a rate
+     * The applicable green power scheme
      */
-    rate?: string;
+    scheme: 'GREENPOWER' | 'OTHER';
+    /**
+     * Array of charge tiers based on the percentage of green power used for the period implied by the type.  Array is in order of increasing percentage of green power
+     */
+    tiers: {
+        /**
+         * The amount of the charge if the type implies the application of a fixed amount
+         */
+        amount?: string;
+        /**
+         * The upper percentage of green power used applicable for this tier
+         */
+        percentGreen: string;
+        /**
+         * The rate of the charge if the type implies the application of a rate
+         */
+        rate?: string;
+        [k: string]: unknown;
+    }[];
+    /**
+     * The type of charge
+     */
+    type:
+        | 'FIXED_PER_DAY'
+        | 'FIXED_PER_WEEK'
+        | 'FIXED_PER_MONTH'
+        | 'FIXED_PER_UNIT'
+        | 'PERCENT_OF_USE'
+        | 'PERCENT_OF_BILL';
     [k: string]: unknown;
-  }[];
-  /**
-   * The type of charge
-   */
-  type:
-    | "FIXED_PER_DAY"
-    | "FIXED_PER_WEEK"
-    | "FIXED_PER_MONTH"
-    | "FIXED_PER_UNIT"
-    | "PERCENT_OF_USE"
-    | "PERCENT_OF_BILL";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -6930,44 +6944,44 @@ export interface EnergyPlanGreenPowerCharges  {
  * Optional list of incentives available for the contract
  */
 export interface EnergyPlanIncentives {
-  /**
-   * The type of the incentive
-   */
-  category: "GIFT" | "ACCOUNT_CREDIT" | "OTHER";
-  /**
-   * The description of the incentive
-   */
-  description: string;
-  /**
-   * The display name of the incentive
-   */
-  displayName: string;
-  /**
-   * A display message outlining an eligibility criteria that may apply
-   */
-  eligibility?: string;
-  [k: string]: unknown;
+    /**
+     * The type of the incentive
+     */
+    category: 'GIFT' | 'ACCOUNT_CREDIT' | 'OTHER';
+    /**
+     * The description of the incentive
+     */
+    description: string;
+    /**
+     * The display name of the incentive
+     */
+    displayName: string;
+    /**
+     * A display message outlining an eligibility criteria that may apply
+     */
+    eligibility?: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanListResponse {
-  data: {
-    /**
-     * Array of plans
-     */
-    plans: EnergyPlan[];
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
+    data: {
+        /**
+         * Array of plans
+         */
+        plans: EnergyPlan[];
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanResponse {
-  data: EnergyPlanDetail;
-  links: LinksPaginated;
-  meta?: MetaPaginated | null;
-  [k: string]: unknown;
+    data: EnergyPlanDetail;
+    links: LinksPaginated;
+    meta?: MetaPaginated | null;
+    [k: string]: unknown;
 }
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
@@ -6975,927 +6989,927 @@ export interface EnergyPlanResponse {
 /**
  * Array of feed in tariffs for solar power
  */
-export interface EnergyPlanSolarFeedInTariff  {
-  /**
-   * A description of the tariff
-   */
-  description?: string;
-  /**
-   * The name of the tariff
-   */
-  displayName: string;
-  /**
-   * The type of the payer
-   */
-  payerType: "GOVERNMENT" | "RETAILER";
-  /**
-   * The applicable scheme
-   */
-  scheme: "PREMIUM" | "OTHER";
-  /**
-   * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-   */
-  singleTariff?: {
+export interface EnergyPlanSolarFeedInTariff {
     /**
-     * The tariff amount
+     * A description of the tariff
      */
-    amount: string;
+    description?: string;
+    /**
+     * The name of the tariff
+     */
+    displayName: string;
+    /**
+     * The type of the payer
+     */
+    payerType: 'GOVERNMENT' | 'RETAILER';
+    /**
+     * The applicable scheme
+     */
+    scheme: 'PREMIUM' | 'OTHER';
+    /**
+     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+     */
+    singleTariff?: {
+        /**
+         * The tariff amount
+         */
+        amount: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The type of the payer
+     */
+    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+    /**
+     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+     */
+    timeVaryingTariffs?: {
+        /**
+         * The tariff amount
+         */
+        amount: string;
+        /**
+         * Array of time periods for which this tariff is applicable
+         */
+        timeVariations: {
+            /**
+             * The days that the tariff applies to. At least one entry required
+             */
+            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+            /**
+             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+             */
+            endTime?: string;
+            /**
+             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+             */
+            startTime?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The type of the charging time period. If absent applies to all periods
+         */
+        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  /**
-   * The type of the payer
-   */
-  tariffUType: "singleTariff" | "timeVaryingTariffs";
-  /**
-   * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-   */
-  timeVaryingTariffs?: {
-    /**
-     * The tariff amount
-     */
-    amount: string;
-    /**
-     * Array of time periods for which this tariff is applicable
-     */
-    timeVariations: {
-      /**
-       * The days that the tariff applies to. At least one entry required
-       */
-      days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-      /**
-       * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-       */
-      endTime?: string;
-      /**
-       * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-       */
-      startTime?: string;
-      [k: string]: unknown;
-    }[];
-    /**
-     * The type of the charging time period. If absent applies to all periods
-     */
-    type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 
 /**
  * Array of feed in tariffs for solar power
  */
-export interface EnergyPlanSolarFeedInTariffV2  {
-  /**
-   * A description of the tariff
-   */
-  description?: string;
-  /**
-   * The name of the tariff
-   */
-  displayName: string;
-  /**
-   * The type of the payer
-   */
-  payerType: "GOVERNMENT" | "RETAILER";
-  /**
-   * The applicable scheme
-   */
-  scheme: "PREMIUM" | "OTHER";
-  /**
-   * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
-   */
-  singleTariff?: {
+export interface EnergyPlanSolarFeedInTariffV2 {
     /**
-     * Array of feed in rates
+     * A description of the tariff
      */
-    rates: {
-      measureUnit?: "KWH"|"KVA"|"KVAR"|"KVARH"|"KW"|"DAYS"|"METER"|"MONTH";
-      unitPrice: string;
-      volume?: number;
-    }[];
+    description?: string;
+    /**
+     * The name of the tariff
+     */
+    displayName: string;
+    /**
+     * The type of the payer
+     */
+    payerType: 'GOVERNMENT' | 'RETAILER';
+    /**
+     * The applicable scheme
+     */
+    scheme: 'PREMIUM' | 'OTHER';
+    /**
+     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+     */
+    singleTariff?: {
+        /**
+         * Array of feed in rates
+         */
+        rates: {
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            unitPrice: string;
+            volume?: number;
+        }[];
+        [k: string]: unknown;
+    };
+    /**
+     * The type of the payer
+     */
+    tariffUType: 'singleTariff' | 'timeVaryingTariffs';
+    /**
+     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+     */
+    timeVaryingTariffs?: {
+        /**
+         * The tariff amount
+         */
+        rates: {
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            unitPrice: string;
+            volume?: number;
+        }[];
+        /**
+         * Array of time periods for which this tariff is applicable
+         */
+        timeVariations: {
+            /**
+             * The days that the tariff applies to. At least one entry required
+             */
+            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+            /**
+             * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
+             */
+            endTime?: string;
+            /**
+             * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
+             */
+            startTime?: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The type of the charging time period. If absent applies to all periods
+         */
+        type?: 'PEAK' | 'OFF_PEAK' | 'SHOULDER';
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  /**
-   * The type of the payer
-   */
-  tariffUType: "singleTariff" | "timeVaryingTariffs";
-  /**
-   * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
-   */
-  timeVaryingTariffs?: {
-    /**
-     * The tariff amount
-     */
-    rates: {
-      measureUnit?: "KWH"|"KVA"|"KVAR"|"KVARH"|"KW"|"DAYS"|"METER"|"MONTH";
-      unitPrice: string;
-      volume?: number;
-    }[];
-    /**
-     * Array of time periods for which this tariff is applicable
-     */
-    timeVariations: {
-      /**
-       * The days that the tariff applies to. At least one entry required
-       */
-      days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-      /**
-       * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight)
-       */
-      endTime?: string;
-      /**
-       * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight)
-       */
-      startTime?: string;
-      [k: string]: unknown;
-    }[];
-    /**
-     * The type of the charging time period. If absent applies to all periods
-     */
-    type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 /**
  * Array of tariff periods
  */
-export interface EnergyPlanTariffPeriod  {
-  /**
-   * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
-   */
-  dailySupplyCharges?: string;
-  /**
-   * Array of demand charges.  Required if rateBlockUType is demandCharges
-   */
-  demandCharges?: {
+export interface EnergyPlanTariffPeriod {
     /**
-     * The charge amount per  measure unit exclusive of GST
+     * The amount of access charge for the tariff period, in dollars per day exclusive of GST.
      */
-    amount: string;
+    dailySupplyCharges?: string;
     /**
-     * Charge period for the demand tariff
+     * Array of demand charges.  Required if rateBlockUType is demandCharges
      */
-    chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
+    demandCharges?: {
+        /**
+         * The charge amount per  measure unit exclusive of GST
+         */
+        amount: string;
+        /**
+         * Charge period for the demand tariff
+         */
+        chargePeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+        /**
+         * The days that the demand tariff applies to
+         */
+        days?: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+        /**
+         * Description of the charge
+         */
+        description?: string;
+        /**
+         * Display name of the charge
+         */
+        displayName: string;
+        /**
+         * End of the period
+         */
+        endTime: string;
+        /**
+         * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+         */
+        maxDemand?: string;
+        /**
+         * The measurement unit of charge amount. Assumed to be KWH if absent
+         */
+        measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+        /**
+         * Application period for the demand tariff
+         */
+        measurementPeriod: 'DAY' | 'MONTH' | 'TARIFF_PERIOD';
+        /**
+         * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+         */
+        minDemand?: string;
+        /**
+         * Start of the period
+         */
+        startTime: string;
+        [k: string]: unknown;
+    }[];
     /**
-     * The days that the demand tariff applies to
-     */
-    days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-    /**
-     * Description of the charge
-     */
-    description?: string;
-    /**
-     * Display name of the charge
+     * The name of the tariff period
      */
     displayName: string;
     /**
-     * End of the period
+     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
      */
-    endTime: string;
+    endDate: string;
     /**
-     * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+     * Specifies the type of rate applicable to this tariff period
      */
-    maxDemand?: string;
+    rateBlockUType: 'singleRate' | 'timeOfUseRates' | 'demandCharges';
     /**
-     * The measurement unit of charge amount. Assumed to be KWH if absent
+     * Object representing a single rate.  Required if rateBlockUType is singleRate
      */
-    measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+    singleRate?: {
+        /**
+         * Description of the rate
+         */
+        description?: string;
+        /**
+         * Display name of the rate
+         */
+        displayName: string;
+        /**
+         * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+         */
+        generalUnitPrice?: string;
+        /**
+         * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        period?: string;
+        /**
+         * Array of controlled load rates in order of usage volume
+         */
+        rates: {
+            /**
+             * The measurement unit of rate. Assumed to be KWH if absent
+             */
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            /**
+             * Unit price of usage per measure unit (exclusive of GST)
+             */
+            unitPrice: string;
+            /**
+             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+             */
+            volume?: number;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
     /**
-     * Application period for the demand tariff
+     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
      */
-    measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
+    startDate: string;
     /**
-     * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
      */
-    minDemand?: string;
-    /**
-     * Start of the period
-     */
-    startTime: string;
-    [k: string]: unknown;
-  }[];
-  /**
-   * The name of the tariff period
-   */
-  displayName: string;
-  /**
-   * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
-   */
-  endDate: string;
-  /**
-   * Specifies the type of rate applicable to this tariff period
-   */
-  rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
-  /**
-   * Object representing a single rate.  Required if rateBlockUType is singleRate
-   */
-  singleRate?: {
-    /**
-     * Description of the rate
-     */
-    description?: string;
-    /**
-     * Display name of the rate
-     */
-    displayName: string;
-    /**
-     * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
-     */
-    generalUnitPrice?: string;
-    /**
-     * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    period?: string;
-    /**
-     * Array of controlled load rates in order of usage volume
-     */
-    rates: {
-      /**
-       * The measurement unit of rate. Assumed to be KWH if absent
-       */
-      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-      /**
-       * Unit price of usage per measure unit (exclusive of GST)
-       */
-      unitPrice: string;
-      /**
-       * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-       */
-      volume?: number;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  /**
-   * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
-   */
-  startDate: string;
-  /**
-   * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
-   */
-  timeOfUseRates?: {
-    /**
-     * Description of the rate
-     */
-    description?: string;
-    /**
-     * Display name of the rate
-     */
-    displayName: string;
-    /**
-     * Array of controlled load rates in order of usage volume
-     */
-    rates: {
-      /**
-       * The measurement unit of rate. Assumed to be KWH if absent
-       */
-      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
-      /**
-       * Unit price of usage per  measure unit (exclusive of GST)
-       */
-      unitPrice: string;
-      /**
-       * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
-       */
-      volume?: number;
-      [k: string]: unknown;
+    timeOfUseRates?: {
+        /**
+         * Description of the rate
+         */
+        description?: string;
+        /**
+         * Display name of the rate
+         */
+        displayName: string;
+        /**
+         * Array of controlled load rates in order of usage volume
+         */
+        rates: {
+            /**
+             * The measurement unit of rate. Assumed to be KWH if absent
+             */
+            measureUnit?: 'KWH' | 'KVA' | 'KVAR' | 'KVARH' | 'KW' | 'DAYS' | 'METER' | 'MONTH';
+            /**
+             * Unit price of usage per  measure unit (exclusive of GST)
+             */
+            unitPrice: string;
+            /**
+             * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+             */
+            volume?: number;
+            [k: string]: unknown;
+        }[];
+        /**
+         * Array of times of use
+         */
+        timeOfUse: {
+            /**
+             * The days that the rate applies to
+             */
+            days: ('SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'PUBLIC_HOLIDAYS')[];
+            /**
+             * End of the period
+             */
+            endTime: string;
+            /**
+             * Start of the period
+             */
+            startTime: string;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The type of usage that the rate applies to
+         */
+        type: 'PEAK' | 'OFF_PEAK' | 'SHOULDER' | 'SHOULDER1' | 'SHOULDER2';
+        [k: string]: unknown;
     }[];
     /**
-     * Array of times of use
+     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
      */
-    timeOfUse: {
-      /**
-       * The days that the rate applies to
-       */
-      days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
-      /**
-       * End of the period
-       */
-      endTime: string;
-      /**
-       * Start of the period
-       */
-      startTime: string;
-      [k: string]: unknown;
-    }[];
+    timeZone?: 'LOCAL' | 'AEST';
     /**
-     * The type of usage that the rate applies to
+     * Type of charge. Assumed to be other if absent
      */
-    type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
+    type?: 'ENVIRONMENTAL' | 'REGULATED' | 'NETWORK' | 'METERING' | 'RETAIL_SERVICE' | 'RCTI' | 'OTHER';
     [k: string]: unknown;
-  }[];
-  /**
-   * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
-   */
-  timeZone?: "LOCAL" | "AEST";
-  /**
-   * Type of charge. Assumed to be other if absent
-   */
-  type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePoint {
-  consumerProfile?: {
+    consumerProfile?: {
+        /**
+         * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+         */
+        classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+        /**
+         * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+         */
+        threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+        [k: string]: unknown;
+    } | null;
     /**
-     * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+     * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
      */
-    classification?: ("BUSINESS" | "RESIDENTIAL") | null;
+    isGenerator?: boolean | null;
     /**
-     * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+     * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
      */
-    threshold?: "LOW" | "MEDIUM" | "HIGH";
+    jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+    /**
+     * The date and time that the information for this service point was modified
+     */
+    lastUpdateDateTime: string;
+    /**
+     * The independent ID of the service point, known in the industry as the NMI
+     */
+    nationalMeteringId: string;
+    /**
+     * The classification of the service point as defined in MSATS procedures
+     */
+    servicePointClassification:
+        | 'EXTERNAL_PROFILE'
+        | 'GENERATOR'
+        | 'LARGE'
+        | 'SMALL'
+        | 'WHOLESALE'
+        | 'NON_CONTEST_UNMETERED_LOAD'
+        | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+        | 'DISTRIBUTION_WHOLESALE';
+    /**
+     * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite. To be created in accordance with CDR ID permanence requirements
+     */
+    servicePointId: string;
+    /**
+     * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
+     */
+    servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
+    /**
+     * The start date from which this service point first became valid
+     */
+    validFromDate: string;
     [k: string]: unknown;
-  } | null;
-  /**
-   * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-   */
-  isGenerator?: boolean | null;
-  /**
-   * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-   */
-  jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-  /**
-   * The date and time that the information for this service point was modified
-   */
-  lastUpdateDateTime: string;
-  /**
-   * The independent ID of the service point, known in the industry as the NMI
-   */
-  nationalMeteringId: string;
-  /**
-   * The classification of the service point as defined in MSATS procedures
-   */
-  servicePointClassification:
-    | "EXTERNAL_PROFILE"
-    | "GENERATOR"
-    | "LARGE"
-    | "SMALL"
-    | "WHOLESALE"
-    | "NON_CONTEST_UNMETERED_LOAD"
-    | "NON_REGISTERED_EMBEDDED_GENERATOR"
-    | "DISTRIBUTION_WHOLESALE";
-  /**
-   * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite. To be created in accordance with CDR ID permanence requirements
-   */
-  servicePointId: string;
-  /**
-   * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
-   */
-  servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
-  /**
-   * The start date from which this service point first became valid
-   */
-  validFromDate: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePointDetail {
-  consumerProfile?: {
-    /**
-     * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
-     */
-    classification?: ("BUSINESS" | "RESIDENTIAL") | null;
-    /**
-     * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
-     */
-    threshold?: "LOW" | "MEDIUM" | "HIGH";
-    [k: string]: unknown;
-  } | null;
-  distributionLossFactor: {
-    /**
-     * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
-     */
-    code: string;
-    /**
-     * Description of the data loss factor code and value
-     */
-    description: string;
-    /**
-     * The value associated with the loss factor code
-     */
-    lossValue: string;
-    [k: string]: unknown;
-  };
-  /**
-   * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-   */
-  isGenerator?: boolean | null;
-  /**
-   * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-   */
-  jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-  /**
-   * The date and time that the information for this service point was modified
-   */
-  lastUpdateDateTime: string;
-  /**
-   * Location of the servicepoint
-   */
-  location: {
-    /**
-     * The type of address object present
-     */
-    addressUType: "paf" | "simple";
-    /**
-     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
-     */
-    paf?: {
-      /**
-       * Building/Property name 1
-       */
-      buildingName1?: string | null;
-      /**
-       * Building/Property name 2
-       */
-      buildingName2?: string | null;
-      /**
-       * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-       */
-      dpid?: string | null;
-      /**
-       * Unit number (including suffix, if applicable)
-       */
-      flatUnitNumber?: string | null;
-      /**
-       * Type of flat or unit for the address
-       */
-      flatUnitType?: string | null;
-      /**
-       * Floor or level number (including alpha characters)
-       */
-      floorLevelNumber?: string | null;
-      /**
-       * Type of floor or level for the address
-       */
-      floorLevelType?: string | null;
-      /**
-       * Full name of locality
-       */
-      localityName: string;
-      /**
-       * Allotment number for the address
-       */
-      lotNumber?: string | null;
-      /**
-       * Postal delivery number if the address is a postal delivery type
-       */
-      postalDeliveryNumber?: number | null;
-      /**
-       * Postal delivery number prefix related to the postal delivery number
-       */
-      postalDeliveryNumberPrefix?: string | null;
-      /**
-       * Postal delivery number suffix related to the postal delivery number
-       */
-      postalDeliveryNumberSuffix?: string | null;
-      /**
-       * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-       */
-      postalDeliveryType?: string | null;
-      /**
-       * Postcode for the locality
-       */
-      postcode: string;
-      /**
-       * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      /**
-       * The name of the street
-       */
-      streetName?: string | null;
-      /**
-       * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetSuffix?: string | null;
-      /**
-       * The street type. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetType?: string | null;
-      /**
-       * Thoroughfare number for a property (first number in a property ranged address)
-       */
-      thoroughfareNumber1?: number | null;
-      /**
-       * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-       */
-      thoroughfareNumber1Suffix?: string | null;
-      /**
-       * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-       */
-      thoroughfareNumber2?: number | null;
-      /**
-       * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-       */
-      thoroughfareNumber2Suffix?: string | null;
-      [k: string]: unknown;
+    consumerProfile?: {
+        /**
+         * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+         */
+        classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+        /**
+         * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+         */
+        threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+        [k: string]: unknown;
+    } | null;
+    distributionLossFactor: {
+        /**
+         * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
+         */
+        code: string;
+        /**
+         * Description of the data loss factor code and value
+         */
+        description: string;
+        /**
+         * The value associated with the loss factor code
+         */
+        lossValue: string;
+        [k: string]: unknown;
     };
     /**
-     * Required if addressUType is set to simple
+     * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
      */
-    simple?: {
-      /**
-       * First line of the standard address object
-       */
-      addressLine1: string;
-      /**
-       * Second line of the standard address object
-       */
-      addressLine2?: string | null;
-      /**
-       * Third line of the standard address object
-       */
-      addressLine3?: string | null;
-      /**
-       * Name of the city or locality
-       */
-      city: string;
-      /**
-       * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-       */
-      country?: string | null;
-      /**
-       * Name of the individual or business formatted for inclusion in an address used for physical mail
-       */
-      mailingName?: string | null;
-      /**
-       * Mandatory for Australian addresses
-       */
-      postcode?: string | null;
-      /**
-       * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
-   */
-  meters?:
-    | {
+    isGenerator?: boolean | null;
+    /**
+     * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+     */
+    jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+    /**
+     * The date and time that the information for this service point was modified
+     */
+    lastUpdateDateTime: string;
+    /**
+     * Location of the servicepoint
+     */
+    location: {
         /**
-         * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
+         * The type of address object present
          */
-        meterId: string;
+        addressUType: 'paf' | 'simple';
         /**
-         * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
+         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
          */
-        registers?: {
-          /**
-           * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
-           */
-          averagedDailyLoad?: number;
-          /**
-           * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
-           */
-          consumptionType?: "ACTUAL" | "CUMULATIVE";
-          /**
-           * Indicates whether the energy recorded by this register is created under a Controlled Load regime
-           */
-          controlledLoad?: boolean;
-          /**
-           * Multiplier required to take a register value and turn it into a value representing billable energy
-           */
-          multiplier?: number;
-          /**
-           * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
-           */
-          networkTariffCode?: string;
-          /**
-           * Indicates the consumption type of register
-           */
-          registerConsumptionType:
-            | "INTERVAL"
-            | "BASIC"
-            | "PROFILE_DATA"
-            | "ACTIVE_IMPORT"
-            | "ACTIVE"
-            | "REACTIVE_IMPORT"
-            | "REACTIVE";
-          /**
-           * Unique identifier of the register within this service point.  Is not globally unique
-           */
-          registerId: string;
-          /**
-           * Register suffix of the meter register where the meter reads are obtained
-           */
-          registerSuffix?: string;
-          /**
-           * Code to identify the time validity of register contents
-           */
-          timeOfDay?:
-            | "ALLDAY"
-            | "INTERVAL"
-            | "PEAK"
-            | "BUSINESS"
-            | "SHOULDER"
-            | "EVENING"
-            | "OFFPEAK"
-            | "CONTROLLED"
-            | "DEMAND";
-          /**
-           * The unit of measure for data held in this register
-           */
-          unitOfMeasure?: string;
-          [k: string]: unknown;
-        }[];
+        paf?: {
+            /**
+             * Building/Property name 1
+             */
+            buildingName1?: string | null;
+            /**
+             * Building/Property name 2
+             */
+            buildingName2?: string | null;
+            /**
+             * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+             */
+            dpid?: string | null;
+            /**
+             * Unit number (including suffix, if applicable)
+             */
+            flatUnitNumber?: string | null;
+            /**
+             * Type of flat or unit for the address
+             */
+            flatUnitType?: string | null;
+            /**
+             * Floor or level number (including alpha characters)
+             */
+            floorLevelNumber?: string | null;
+            /**
+             * Type of floor or level for the address
+             */
+            floorLevelType?: string | null;
+            /**
+             * Full name of locality
+             */
+            localityName: string;
+            /**
+             * Allotment number for the address
+             */
+            lotNumber?: string | null;
+            /**
+             * Postal delivery number if the address is a postal delivery type
+             */
+            postalDeliveryNumber?: number | null;
+            /**
+             * Postal delivery number prefix related to the postal delivery number
+             */
+            postalDeliveryNumberPrefix?: string | null;
+            /**
+             * Postal delivery number suffix related to the postal delivery number
+             */
+            postalDeliveryNumberSuffix?: string | null;
+            /**
+             * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+             */
+            postalDeliveryType?: string | null;
+            /**
+             * Postcode for the locality
+             */
+            postcode: string;
+            /**
+             * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            /**
+             * The name of the street
+             */
+            streetName?: string | null;
+            /**
+             * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetSuffix?: string | null;
+            /**
+             * The street type. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetType?: string | null;
+            /**
+             * Thoroughfare number for a property (first number in a property ranged address)
+             */
+            thoroughfareNumber1?: number | null;
+            /**
+             * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+             */
+            thoroughfareNumber1Suffix?: string | null;
+            /**
+             * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+             */
+            thoroughfareNumber2?: number | null;
+            /**
+             * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+             */
+            thoroughfareNumber2Suffix?: string | null;
+            [k: string]: unknown;
+        };
         /**
-         * Technical characteristics of the meter
+         * Required if addressUType is set to simple
          */
-        specifications: {
-          /**
-           * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
-           */
-          installationType:
-            | "BASIC"
-            | "COMMS1"
-            | "COMMS2"
-            | "COMMS3"
-            | "COMMS4"
-            | "COMMS4C"
-            | "COMMS4D"
-            | "MRAM"
-            | "MRIM"
-            | "PROF"
-            | "SAMPLE"
-            | "UMCP"
-            | "VICAMI"
-            | "NCOLNUML";
-          /**
-           * Free text field to identify the manufacturer of the installed meter
-           */
-          manufacturer?: string;
-          /**
-           * Free text field to identify the meter manufacturer’s designation for the meter model
-           */
-          model?: string;
-          /**
-           * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
-           */
-          nextScheduledReadDate?: string;
-          /**
-           * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
-           */
-          readType?: string;
-          /**
-           * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
-           */
-          status: "CURRENT" | "DISCONNECTED";
-          [k: string]: unknown;
+        simple?: {
+            /**
+             * First line of the standard address object
+             */
+            addressLine1: string;
+            /**
+             * Second line of the standard address object
+             */
+            addressLine2?: string | null;
+            /**
+             * Third line of the standard address object
+             */
+            addressLine3?: string | null;
+            /**
+             * Name of the city or locality
+             */
+            city: string;
+            /**
+             * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+             */
+            country?: string | null;
+            /**
+             * Name of the individual or business formatted for inclusion in an address used for physical mail
+             */
+            mailingName?: string | null;
+            /**
+             * Mandatory for Australian addresses
+             */
+            postcode?: string | null;
+            /**
+             * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            [k: string]: unknown;
         };
         [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The independent ID of the service point, known in the industry as the NMI
-   */
-  nationalMeteringId: string;
-  relatedParticipants: {
+    };
     /**
-     * The name of the party/organisation related to this service point
+     * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
      */
-    party: string;
+    meters?:
+        | {
+            /**
+             * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
+             */
+            meterId: string;
+            /**
+             * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
+             */
+            registers?: {
+                /**
+                 * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
+                 */
+                averagedDailyLoad?: number;
+                /**
+                 * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
+                 */
+                consumptionType?: 'ACTUAL' | 'CUMULATIVE';
+                /**
+                 * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+                 */
+                controlledLoad?: boolean;
+                /**
+                 * Multiplier required to take a register value and turn it into a value representing billable energy
+                 */
+                multiplier?: number;
+                /**
+                 * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
+                 */
+                networkTariffCode?: string;
+                /**
+                 * Indicates the consumption type of register
+                 */
+                registerConsumptionType:
+                    | 'INTERVAL'
+                    | 'BASIC'
+                    | 'PROFILE_DATA'
+                    | 'ACTIVE_IMPORT'
+                    | 'ACTIVE'
+                    | 'REACTIVE_IMPORT'
+                    | 'REACTIVE';
+                /**
+                 * Unique identifier of the register within this service point.  Is not globally unique
+                 */
+                registerId: string;
+                /**
+                 * Register suffix of the meter register where the meter reads are obtained
+                 */
+                registerSuffix?: string;
+                /**
+                 * Code to identify the time validity of register contents
+                 */
+                timeOfDay?:
+                    | 'ALLDAY'
+                    | 'INTERVAL'
+                    | 'PEAK'
+                    | 'BUSINESS'
+                    | 'SHOULDER'
+                    | 'EVENING'
+                    | 'OFFPEAK'
+                    | 'CONTROLLED'
+                    | 'DEMAND';
+                /**
+                 * The unit of measure for data held in this register
+                 */
+                unitOfMeasure?: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * Technical characteristics of the meter
+             */
+            specifications: {
+                /**
+                 * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
+                 */
+                installationType:
+                    | 'BASIC'
+                    | 'COMMS1'
+                    | 'COMMS2'
+                    | 'COMMS3'
+                    | 'COMMS4'
+                    | 'COMMS4C'
+                    | 'COMMS4D'
+                    | 'MRAM'
+                    | 'MRIM'
+                    | 'PROF'
+                    | 'SAMPLE'
+                    | 'UMCP'
+                    | 'VICAMI'
+                    | 'NCOLNUML';
+                /**
+                 * Free text field to identify the manufacturer of the installed meter
+                 */
+                manufacturer?: string;
+                /**
+                 * Free text field to identify the meter manufacturer’s designation for the meter model
+                 */
+                model?: string;
+                /**
+                 * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
+                 */
+                nextScheduledReadDate?: string;
+                /**
+                 * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
+                 */
+                readType?: string;
+                /**
+                 * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
+                 */
+                status: 'CURRENT' | 'DISCONNECTED';
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        }[]
+        | null;
     /**
-     * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
+     * The independent ID of the service point, known in the industry as the NMI
      */
-    role: "FRMP" | "LNSP" | "DRSP";
+    nationalMeteringId: string;
+    relatedParticipants: {
+        /**
+         * The name of the party/organisation related to this service point
+         */
+        party: string;
+        /**
+         * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
+         */
+        role: 'FRMP' | 'LNSP' | 'DRSP';
+        [k: string]: unknown;
+    }[];
+    /**
+     * The classification of the service point as defined in MSATS procedures
+     */
+    servicePointClassification:
+        | 'EXTERNAL_PROFILE'
+        | 'GENERATOR'
+        | 'LARGE'
+        | 'SMALL'
+        | 'WHOLESALE'
+        | 'NON_CONTEST_UNMETERED_LOAD'
+        | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+        | 'DISTRIBUTION_WHOLESALE';
+    /**
+     * The tokenised ID of the service point for use in the CDR APIs.  Created according to the CDR rules for ID permanence
+     */
+    servicePointId: string;
+    /**
+     * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
+     */
+    servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
+    /**
+     * The latest start date from which the constituent data sets of this service point became valid
+     */
+    validFromDate: string;
     [k: string]: unknown;
-  }[];
-  /**
-   * The classification of the service point as defined in MSATS procedures
-   */
-  servicePointClassification:
-    | "EXTERNAL_PROFILE"
-    | "GENERATOR"
-    | "LARGE"
-    | "SMALL"
-    | "WHOLESALE"
-    | "NON_CONTEST_UNMETERED_LOAD"
-    | "NON_REGISTERED_EMBEDDED_GENERATOR"
-    | "DISTRIBUTION_WHOLESALE";
-  /**
-   * The tokenised ID of the service point for use in the CDR APIs.  Created according to the CDR rules for ID permanence
-   */
-  servicePointId: string;
-  /**
-   * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
-   */
-  servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
-  /**
-   * The latest start date from which the constituent data sets of this service point became valid
-   */
-  validFromDate: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePointDetailResponse {
-  data: EnergyServicePointDetail;
-  links: LinksPaginated;
-  meta?: MetaPaginated | null;
-  [k: string]: unknown;
+    data: EnergyServicePointDetail;
+    links: LinksPaginated;
+    meta?: MetaPaginated | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePointListResponse {
-  data: {
-    servicePoints: EnergyServicePoint[];
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
+    data: {
+        servicePoints: EnergyServicePoint[];
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyUsageListResponse {
-  data: {
-    /**
-     * Array of meter reads sorted by NMI in ascending order followed by readStartDate in descending order
-     */
-    reads: EnergyUsageRead[];
+    data: {
+        /**
+         * Array of meter reads sorted by NMI in ascending order followed by readStartDate in descending order
+         */
+        reads: EnergyUsageRead[];
+        [k: string]: unknown;
+    };
+    links: LinksPaginated;
+    meta: MetaPaginated;
     [k: string]: unknown;
-  };
-  links: LinksPaginated;
-  meta: MetaPaginated;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyUsageRead {
-  /**
-   * Mandatory if readUType is set to basicRead
-   */
-  basicRead?: {
     /**
-     * The quality of the read taken.  If absent then assumed to be ACTUAL
+     * Mandatory if readUType is set to basicRead
      */
-    quality?: ("ACTUAL" | "SUBSTITUTE" | "FINAL_SUBSTITUTE") | null;
+    basicRead?: {
+        /**
+         * The quality of the read taken.  If absent then assumed to be ACTUAL
+         */
+        quality?: ('ACTUAL' | 'SUBSTITUTE' | 'FINAL_SUBSTITUTE') | null;
+        /**
+         * Meter read value.  If positive then it means consumption, if negative it means export
+         */
+        value: number;
+        [k: string]: unknown;
+    } | null;
     /**
-     * Meter read value.  If positive then it means consumption, if negative it means export
+     * Indicates whether the energy recorded by this register is created under a Controlled Load regime
      */
-    value: number;
+    controlledLoad?: boolean | null;
+    /**
+     * Mandatory if readUType is set to intervalRead
+     */
+    intervalRead?: {
+        /**
+         * The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export
+         */
+        aggregateValue: number;
+        /**
+         * Array of Interval read values. If positive then it means consumption, if negative it means export. Required when interval-reads query parameter equals FULL or  MIN_30.<br>Each read value indicates the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)
+         */
+        intervalReads?: number[] | null;
+        /**
+         * Read interval length in minutes. Required when interval-reads query parameter equals FULL or MIN_30
+         */
+        readIntervalLength?: number | null;
+        /**
+         *  Specifies quality of reads that are not ACTUAL.  For read indices that are not specified, quality is assumed to be ACTUAL. If not present, all quality of all reads are assumed to be actual. Required when interval-reads query parameter equals FULL or MIN_30
+         */
+        readQualities?: {
+            /**
+             * End interval for read quality flag
+             */
+            endInterval: number;
+            /**
+             * The quality of the read taken
+             */
+            quality: 'SUBSTITUTE' | 'FINAL_SUBSTITUTE';
+            /**
+             * Start interval for read quality flag. First read begins at 1
+             */
+            startInterval: number;
+            [k: string]: unknown;
+        }[] | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
+     */
+    meterId?: string | null;
+    /**
+     * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
+     */
+    readEndDate?: string | null;
+    /**
+     * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
+     */
+    readStartDate: string;
+    /**
+     * Specify the type of the meter read data
+     */
+    readUType: 'basicRead' | 'intervalRead';
+    /**
+     * Register ID of the meter register where the meter reads are obtained
+     */
+    registerId?: string | null;
+    /**
+     * Register suffix of the meter register where the meter reads are obtained
+     */
+    registerSuffix: string;
+    /**
+     * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite.  To be created in accordance with CDR ID permanence requirements
+     */
+    servicePointId: string;
+    /**
+     * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values.
+     */
+    unitOfMeasure?: string | null;
     [k: string]: unknown;
-  } | null;
-  /**
-   * Indicates whether the energy recorded by this register is created under a Controlled Load regime
-   */
-  controlledLoad?: boolean | null;
-  /**
-   * Mandatory if readUType is set to intervalRead
-   */
-  intervalRead?: {
-    /**
-     * The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export
-     */
-    aggregateValue: number;
-    /**
-     * Array of Interval read values. If positive then it means consumption, if negative it means export. Required when interval-reads query parameter equals FULL or  MIN_30.<br>Each read value indicates the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)
-     */
-    intervalReads?: number[] | null;
-    /**
-     * Read interval length in minutes. Required when interval-reads query parameter equals FULL or MIN_30
-     */
-    readIntervalLength?: number | null;
-    /**
-     *  Specifies quality of reads that are not ACTUAL.  For read indices that are not specified, quality is assumed to be ACTUAL. If not present, all quality of all reads are assumed to be actual. Required when interval-reads query parameter equals FULL or MIN_30
-     */
-    readQualities?: | {
-      /**
-       * End interval for read quality flag
-       */
-      endInterval: number;
-      /**
-       * The quality of the read taken
-       */
-      quality: "SUBSTITUTE" | "FINAL_SUBSTITUTE";
-      /**
-       * Start interval for read quality flag. First read begins at 1
-       */
-      startInterval: number;
-      [k: string]: unknown;
-    }[]| null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
-   */
-  meterId?: string | null;
-  /**
-   * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
-   */
-  readEndDate?: string | null;
-  /**
-   * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
-   */
-  readStartDate: string;
-  /**
-   * Specify the type of the meter read data
-   */
-  readUType: "basicRead" | "intervalRead";
-  /**
-   * Register ID of the meter register where the meter reads are obtained
-   */
-  registerId?: string | null;
-  /**
-   * Register suffix of the meter register where the meter reads are obtained
-   */
-  registerSuffix: string;
-  /**
-   * Tokenised ID of the service point to be used for referring to the service point in the CDR API suite.  To be created in accordance with CDR ID permanence requirements
-   */
-  servicePointId: string;
-  /**
-   * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values.
-   */
-  unitOfMeasure?: string | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface Links {
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
+    /**
+     * Fully qualified link that generated the current response document
+     */
+    self: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface LinksPaginated {
-  /**
-   * URI to the first page of this set. Mandatory if this response is not the first page
-   */
-  first?: string | null;
-  /**
-   * URI to the last page of this set. Mandatory if this response is not the last page
-   */
-  last?: string | null;
-  /**
-   * URI to the next page of this set. Mandatory if this response is not the last page
-   */
-  next?: string | null;
-  /**
-   * URI to the previous page of this set. Mandatory if this response is not the first page
-   */
-  prev?: string | null;
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
+    /**
+     * URI to the first page of this set. Mandatory if this response is not the first page
+     */
+    first?: string | null;
+    /**
+     * URI to the last page of this set. Mandatory if this response is not the last page
+     */
+    last?: string | null;
+    /**
+     * URI to the next page of this set. Mandatory if this response is not the last page
+     */
+    next?: string | null;
+    /**
+     * URI to the previous page of this set. Mandatory if this response is not the first page
+     */
+    prev?: string | null;
+    /**
+     * Fully qualified link that generated the current response document
+     */
+    self: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface Meta {
-  [k: string]: unknown;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface MetaPaginated {
-  /**
-   * The total number of pages in the full set. See [pagination](#pagination).
-   */
-  totalPages: number;
-  /**
-   * The total number of records in the full set. See [pagination](#pagination).
-   */
-  totalRecords: number;
-  [k: string]: unknown;
+    /**
+     * The total number of pages in the full set. See [pagination](#pagination).
+     */
+    totalPages: number;
+    /**
+     * The total number of records in the full set. See [pagination](#pagination).
+     */
+    totalRecords: number;
+    [k: string]: unknown;
 }

--- a/types/consumer-data-standards/energy_sdh/index.d.ts
+++ b/types/consumer-data-standards/energy_sdh/index.d.ts
@@ -4,107 +4,6 @@
  * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
  */
 export interface CommonPAFAddress {
-  /**
-   * Building/Property name 1
-   */
-  buildingName1?: string | null;
-  /**
-   * Building/Property name 2
-   */
-  buildingName2?: string | null;
-  /**
-   * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-   */
-  dpid?: string | null;
-  /**
-   * Unit number (including suffix, if applicable)
-   */
-  flatUnitNumber?: string | null;
-  /**
-   * Type of flat or unit for the address
-   */
-  flatUnitType?: string | null;
-  /**
-   * Floor or level number (including alpha characters)
-   */
-  floorLevelNumber?: string | null;
-  /**
-   * Type of floor or level for the address
-   */
-  floorLevelType?: string | null;
-  /**
-   * Full name of locality
-   */
-  localityName: string;
-  /**
-   * Allotment number for the address
-   */
-  lotNumber?: string | null;
-  /**
-   * Postal delivery number if the address is a postal delivery type
-   */
-  postalDeliveryNumber?: number | null;
-  /**
-   * Postal delivery number prefix related to the postal delivery number
-   */
-  postalDeliveryNumberPrefix?: string | null;
-  /**
-   * Postal delivery number suffix related to the postal delivery number
-   */
-  postalDeliveryNumberSuffix?: string | null;
-  /**
-   * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-   */
-  postalDeliveryType?: string | null;
-  /**
-   * Postcode for the locality
-   */
-  postcode: string;
-  /**
-   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  /**
-   * The name of the street
-   */
-  streetName?: string | null;
-  /**
-   * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetSuffix?: string | null;
-  /**
-   * The street type. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetType?: string | null;
-  /**
-   * Thoroughfare number for a property (first number in a property ranged address)
-   */
-  thoroughfareNumber1?: number | null;
-  /**
-   * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-   */
-  thoroughfareNumber1Suffix?: string | null;
-  /**
-   * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-   */
-  thoroughfareNumber2?: number | null;
-  /**
-   * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-   */
-  thoroughfareNumber2Suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface CommonPhysicalAddress {
-  /**
-   * The type of address object present
-   */
-  addressUType: "paf" | "simple";
-  /**
-   * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
-   */
-  paf?: {
     /**
      * Building/Property name 1
      */
@@ -194,1114 +93,18 @@ export interface CommonPhysicalAddress {
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * Required if addressUType is set to simple
-   */
-  simple?: {
-    /**
-     * First line of the standard address object
-     */
-    addressLine1: string;
-    /**
-     * Second line of the standard address object
-     */
-    addressLine2?: string | null;
-    /**
-     * Third line of the standard address object
-     */
-    addressLine3?: string | null;
-    /**
-     * Name of the city or locality
-     */
-    city: string;
-    /**
-     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-     */
-    country?: string | null;
-    /**
-     * Name of the individual or business formatted for inclusion in an address used for physical mail
-     */
-    mailingName?: string | null;
-    /**
-     * Mandatory for Australian addresses
-     */
-    postcode?: string | null;
-    /**
-     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-     */
-    state: string;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
 
-/**
- * Required if addressUType is set to simple
- */
-export interface CommonSimpleAddress {
-  /**
-   * First line of the standard address object
-   */
-  addressLine1: string;
-  /**
-   * Second line of the standard address object
-   */
-  addressLine2?: string | null;
-  /**
-   * Third line of the standard address object
-   */
-  addressLine3?: string | null;
-  /**
-   * Name of the city or locality
-   */
-  city: string;
-  /**
-   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-   */
-  country?: string | null;
-  /**
-   * Name of the individual or business formatted for inclusion in an address used for physical mail
-   */
-  mailingName?: string | null;
-  /**
-   * Mandatory for Australian addresses
-   */
-  postcode?: string | null;
-  /**
-   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyDerDetailResponse {
-  data: {
-    acConnections: {
-      /**
-       * The date that the DER installation is commissioned
-       */
-      commissioningDate: string;
-      /**
-       * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
-       */
-      connectionIdentifier: number;
-      /**
-       * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
-       */
-      count: number;
-      derDevices: {
-        /**
-         * Number of devices in the group of DER devices
-         */
-        count: number;
-        /**
-         * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
-         */
-        deviceIdentifier: number;
-        /**
-         * The name of the device manufacturer. If absent then assumed to be “unknown”
-         */
-        manufacturer?: string;
-        /**
-         * The model number of the device. If absent then assumed to be “unknown”
-         */
-        modelNumber?: string;
-        /**
-         * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
-         */
-        nominalRatedCapacity: number;
-        /**
-         * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
-         */
-        nominalStorageCapacity?: number;
-        /**
-         * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
-         */
-        status?: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-        /**
-         * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
-         */
-        subtype?: string;
-        /**
-         * Used to indicate the primary technology used in the DER device
-         */
-        type: "FOSSIL" | "HYDRO" | "WIND" | "SOLAR_PV" | "RENEWABLE" | "GEOTHERMAL" | "STORAGE" | "OTHER";
-        [k: string]: unknown;
-      }[];
-      /**
-       * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
-       */
-      equipmentType?: "INVERTER" | "OTHER";
-      /**
-       * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
-       */
-      inverterDeviceCapacity?: number;
-      /**
-       * The inverter model number. Mandatory if equipmentType is INVERTER
-       */
-      inverterModelNumber?: string;
-      /**
-       * The inverter series. Mandatory if equipmentType is INVERTER
-       */
-      inverterSeries?: string;
-      /**
-       * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
-       */
-      manufacturerName?: string;
-      /**
-       * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
-       */
-      status: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-      [k: string]: unknown;
-    }[];
-    /**
-     * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
-     */
-    approvedCapacity: number;
-    /**
-     * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
-     */
-    availablePhasesCount: number;
-    /**
-     * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
-     */
-    hasCentralProtectionControl?: boolean | null;
-    /**
-     * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
-     */
-    installedPhasesCount: number;
-    /**
-     * For identification of small generating units designed with the ability to operate in an islanded mode
-     */
-    islandableInstallation: boolean;
-    /**
-     * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
-     */
-    protectionMode?: {
-      /**
-       * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
-       */
-      exportLimitKva?: number | null;
-      /**
-       * Rate of change of frequency trip point (Hz/s).
-       */
-      frequencyRateOfChange?: number | null;
-      /**
-       * Description of the form of inter-trip (e.g. 'from local substation').
-       */
-      interTripScheme?: string | null;
-      /**
-       * Trip voltage.
-       */
-      neutralVoltageDisplacement?: number | null;
-      /**
-       * Protective function limit in Hz.
-       */
-      overFrequencyProtection?: number | null;
-      /**
-       * Trip delay time in seconds.
-       */
-      overFrequencyProtectionDelay?: number | null;
-      /**
-       * Protective function limit in V.
-       */
-      overVoltageProtection?: number | null;
-      /**
-       * Trip delay time in seconds.
-       */
-      overVoltageProtectionDelay?: number | null;
-      /**
-       * Sustained over voltage.
-       */
-      sustainedOverVoltage?: number | null;
-      /**
-       * Sustained Over voltage protection delay in seconds.
-       */
-      sustainedOverVoltageDelay?: number | null;
-      /**
-       * Protective function limit in Hz.
-       */
-      underFrequencyProtection?: number | null;
-      /**
-       * Trip delay time in seconds.
-       */
-      underFrequencyProtectionDelay?: number | null;
-      /**
-       * Protective function limit in V.
-       */
-      underVoltageProtection?: number | null;
-      /**
-       * Trip delay time in seconds.
-       */
-      underVoltageProtectionDelay?: number | null;
-      /**
-       * Trip angle in degrees.
-       */
-      voltageVectorShift?: number | null;
-      [k: string]: unknown;
-    } | null;
-    /**
-     * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-     */
-    servicePointId: string;
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyDerListResponse {
-  data: {
-    /**
-     * Array of meter reads
-     */
-    derRecords: {
-      acConnections: {
-        /**
-         * The date that the DER installation is commissioned
-         */
-        commissioningDate: string;
-        /**
-         * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
-         */
-        connectionIdentifier: number;
-        /**
-         * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
-         */
-        count: number;
-        derDevices: {
-          /**
-           * Number of devices in the group of DER devices
-           */
-          count: number;
-          /**
-           * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
-           */
-          deviceIdentifier: number;
-          /**
-           * The name of the device manufacturer. If absent then assumed to be “unknown”
-           */
-          manufacturer?: string;
-          /**
-           * The model number of the device. If absent then assumed to be “unknown”
-           */
-          modelNumber?: string;
-          /**
-           * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
-           */
-          nominalRatedCapacity: number;
-          /**
-           * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
-           */
-          nominalStorageCapacity?: number;
-          /**
-           * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
-           */
-          status?: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-          /**
-           * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
-           */
-          subtype?: string;
-          /**
-           * Used to indicate the primary technology used in the DER device
-           */
-          type: "FOSSIL" | "HYDRO" | "WIND" | "SOLAR_PV" | "RENEWABLE" | "GEOTHERMAL" | "STORAGE" | "OTHER";
-          [k: string]: unknown;
-        }[];
-        /**
-         * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
-         */
-        equipmentType?: "INVERTER" | "OTHER";
-        /**
-         * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
-         */
-        inverterDeviceCapacity?: number;
-        /**
-         * The inverter model number. Mandatory if equipmentType is INVERTER
-         */
-        inverterModelNumber?: string;
-        /**
-         * The inverter series. Mandatory if equipmentType is INVERTER
-         */
-        inverterSeries?: string;
-        /**
-         * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
-         */
-        manufacturerName?: string;
-        /**
-         * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
-         */
-        status: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-        [k: string]: unknown;
-      }[];
-      /**
-       * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
-       */
-      approvedCapacity: number;
-      /**
-       * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
-       */
-      availablePhasesCount: number;
-      /**
-       * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
-       */
-      hasCentralProtectionControl?: boolean | null;
-      /**
-       * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
-       */
-      installedPhasesCount: number;
-      /**
-       * For identification of small generating units designed with the ability to operate in an islanded mode
-       */
-      islandableInstallation: boolean;
-      /**
-       * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
-       */
-      protectionMode?: {
-        /**
-         * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
-         */
-        exportLimitKva?: number | null;
-        /**
-         * Rate of change of frequency trip point (Hz/s).
-         */
-        frequencyRateOfChange?: number | null;
-        /**
-         * Description of the form of inter-trip (e.g. 'from local substation').
-         */
-        interTripScheme?: string | null;
-        /**
-         * Trip voltage.
-         */
-        neutralVoltageDisplacement?: number | null;
-        /**
-         * Protective function limit in Hz.
-         */
-        overFrequencyProtection?: number | null;
-        /**
-         * Trip delay time in seconds.
-         */
-        overFrequencyProtectionDelay?: number | null;
-        /**
-         * Protective function limit in V.
-         */
-        overVoltageProtection?: number | null;
-        /**
-         * Trip delay time in seconds.
-         */
-        overVoltageProtectionDelay?: number | null;
-        /**
-         * Sustained over voltage.
-         */
-        sustainedOverVoltage?: number | null;
-        /**
-         * Sustained Over voltage protection delay in seconds.
-         */
-        sustainedOverVoltageDelay?: number | null;
-        /**
-         * Protective function limit in Hz.
-         */
-        underFrequencyProtection?: number | null;
-        /**
-         * Trip delay time in seconds.
-         */
-        underFrequencyProtectionDelay?: number | null;
-        /**
-         * Protective function limit in V.
-         */
-        underVoltageProtection?: number | null;
-        /**
-         * Trip delay time in seconds.
-         */
-        underVoltageProtectionDelay?: number | null;
-        /**
-         * Trip angle in degrees.
-         */
-        voltageVectorShift?: number | null;
-        [k: string]: unknown;
-      } | null;
-      /**
-       * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-       */
-      servicePointId: string;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyDerRecord {
-  acConnections: {
-    /**
-     * The date that the DER installation is commissioned
-     */
-    commissioningDate: string;
-    /**
-     * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
-     */
-    connectionIdentifier: number;
-    /**
-     * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
-     */
-    count: number;
-    derDevices: {
-      /**
-       * Number of devices in the group of DER devices
-       */
-      count: number;
-      /**
-       * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
-       */
-      deviceIdentifier: number;
-      /**
-       * The name of the device manufacturer. If absent then assumed to be “unknown”
-       */
-      manufacturer?: string;
-      /**
-       * The model number of the device. If absent then assumed to be “unknown”
-       */
-      modelNumber?: string;
-      /**
-       * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
-       */
-      nominalRatedCapacity: number;
-      /**
-       * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
-       */
-      nominalStorageCapacity?: number;
-      /**
-       * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
-       */
-      status?: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-      /**
-       * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
-       */
-      subtype?: string;
-      /**
-       * Used to indicate the primary technology used in the DER device
-       */
-      type: "FOSSIL" | "HYDRO" | "WIND" | "SOLAR_PV" | "RENEWABLE" | "GEOTHERMAL" | "STORAGE" | "OTHER";
-      [k: string]: unknown;
-    }[];
-    /**
-     * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
-     */
-    equipmentType?: "INVERTER" | "OTHER";
-    /**
-     * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
-     */
-    inverterDeviceCapacity?: number;
-    /**
-     * The inverter model number. Mandatory if equipmentType is INVERTER
-     */
-    inverterModelNumber?: string;
-    /**
-     * The inverter series. Mandatory if equipmentType is INVERTER
-     */
-    inverterSeries?: string;
-    /**
-     * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
-     */
-    manufacturerName?: string;
-    /**
-     * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
-     */
-    status: "ACTIVE" | "INACTIVE" | "DECOMMISSIONED";
-    [k: string]: unknown;
-  }[];
-  /**
-   * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
-   */
-  approvedCapacity: number;
-  /**
-   * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
-   */
-  availablePhasesCount: number;
-  /**
-   * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
-   */
-  hasCentralProtectionControl?: boolean | null;
-  /**
-   * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
-   */
-  installedPhasesCount: number;
-  /**
-   * For identification of small generating units designed with the ability to operate in an islanded mode
-   */
-  islandableInstallation: boolean;
-  /**
-   * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
-   */
-  protectionMode?: {
-    /**
-     * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
-     */
-    exportLimitKva?: number | null;
-    /**
-     * Rate of change of frequency trip point (Hz/s).
-     */
-    frequencyRateOfChange?: number | null;
-    /**
-     * Description of the form of inter-trip (e.g. 'from local substation').
-     */
-    interTripScheme?: string | null;
-    /**
-     * Trip voltage.
-     */
-    neutralVoltageDisplacement?: number | null;
-    /**
-     * Protective function limit in Hz.
-     */
-    overFrequencyProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    overFrequencyProtectionDelay?: number | null;
-    /**
-     * Protective function limit in V.
-     */
-    overVoltageProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    overVoltageProtectionDelay?: number | null;
-    /**
-     * Sustained over voltage.
-     */
-    sustainedOverVoltage?: number | null;
-    /**
-     * Sustained Over voltage protection delay in seconds.
-     */
-    sustainedOverVoltageDelay?: number | null;
-    /**
-     * Protective function limit in Hz.
-     */
-    underFrequencyProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    underFrequencyProtectionDelay?: number | null;
-    /**
-     * Protective function limit in V.
-     */
-    underVoltageProtection?: number | null;
-    /**
-     * Trip delay time in seconds.
-     */
-    underVoltageProtectionDelay?: number | null;
-    /**
-     * Trip angle in degrees.
-     */
-    voltageVectorShift?: number | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-   */
-  servicePointId: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyServicePoint {
-  consumerProfile?: {
-    /**
-     * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
-     */
-    classification?: ("BUSINESS" | "RESIDENTIAL") | null;
-    /**
-     * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
-     */
-    threshold?: "LOW" | "MEDIUM" | "HIGH";
-    [k: string]: unknown;
-  } | null;
-  /**
-   * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-   */
-  isGenerator?: boolean | null;
-  /**
-   * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-   */
-  jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-  /**
-   * The date and time that the information for this service point was modified
-   */
-  lastUpdateDateTime: string;
-  /**
-   * The independent ID of the service point, known in the industry as the NMI
-   */
-  nationalMeteringId: string;
-  /**
-   * The classification of the service point as defined in MSATS procedures
-   */
-  servicePointClassification:
-    | "EXTERNAL_PROFILE"
-    | "GENERATOR"
-    | "LARGE"
-    | "SMALL"
-    | "WHOLESALE"
-    | "NON_CONTEST_UNMETERED_LOAD"
-    | "NON_REGISTERED_EMBEDDED_GENERATOR"
-    | "DISTRIBUTION_WHOLESALE";
-  /**
-   * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-   */
-  servicePointId: string;
-  /**
-   * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
-   */
-  servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
-  /**
-   * The start date from which this service point first became valid
-   */
-  validFromDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyServicePointDetail {
-  consumerProfile?: {
-    /**
-     * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
-     */
-    classification?: ("BUSINESS" | "RESIDENTIAL") | null;
-    /**
-     * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
-     */
-    threshold?: "LOW" | "MEDIUM" | "HIGH";
-    [k: string]: unknown;
-  } | null;
-  distributionLossFactor: {
-    /**
-     * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
-     */
-    code: string;
-    /**
-     * Description of the data loss factor code and value
-     */
-    description: string;
-    /**
-     * The value associated with the loss factor code
-     */
-    lossValue: string;
-    [k: string]: unknown;
-  };
-  /**
-   * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-   */
-  isGenerator?: boolean | null;
-  /**
-   * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-   */
-  jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-  /**
-   * The date and time that the information for this service point was modified
-   */
-  lastUpdateDateTime: string;
-  /**
-   * Location of the servicepoint
-   */
-  location: {
+export interface CommonPhysicalAddress {
     /**
      * The type of address object present
      */
-    addressUType: "paf" | "simple";
+    addressUType: 'paf' | 'simple';
     /**
      * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
      */
     paf?: {
-      /**
-       * Building/Property name 1
-       */
-      buildingName1?: string | null;
-      /**
-       * Building/Property name 2
-       */
-      buildingName2?: string | null;
-      /**
-       * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-       */
-      dpid?: string | null;
-      /**
-       * Unit number (including suffix, if applicable)
-       */
-      flatUnitNumber?: string | null;
-      /**
-       * Type of flat or unit for the address
-       */
-      flatUnitType?: string | null;
-      /**
-       * Floor or level number (including alpha characters)
-       */
-      floorLevelNumber?: string | null;
-      /**
-       * Type of floor or level for the address
-       */
-      floorLevelType?: string | null;
-      /**
-       * Full name of locality
-       */
-      localityName: string;
-      /**
-       * Allotment number for the address
-       */
-      lotNumber?: string | null;
-      /**
-       * Postal delivery number if the address is a postal delivery type
-       */
-      postalDeliveryNumber?: number | null;
-      /**
-       * Postal delivery number prefix related to the postal delivery number
-       */
-      postalDeliveryNumberPrefix?: string | null;
-      /**
-       * Postal delivery number suffix related to the postal delivery number
-       */
-      postalDeliveryNumberSuffix?: string | null;
-      /**
-       * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-       */
-      postalDeliveryType?: string | null;
-      /**
-       * Postcode for the locality
-       */
-      postcode: string;
-      /**
-       * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      /**
-       * The name of the street
-       */
-      streetName?: string | null;
-      /**
-       * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetSuffix?: string | null;
-      /**
-       * The street type. Valid enumeration defined by Australia Post PAF code file
-       */
-      streetType?: string | null;
-      /**
-       * Thoroughfare number for a property (first number in a property ranged address)
-       */
-      thoroughfareNumber1?: number | null;
-      /**
-       * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-       */
-      thoroughfareNumber1Suffix?: string | null;
-      /**
-       * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-       */
-      thoroughfareNumber2?: number | null;
-      /**
-       * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-       */
-      thoroughfareNumber2Suffix?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Required if addressUType is set to simple
-     */
-    simple?: {
-      /**
-       * First line of the standard address object
-       */
-      addressLine1: string;
-      /**
-       * Second line of the standard address object
-       */
-      addressLine2?: string | null;
-      /**
-       * Third line of the standard address object
-       */
-      addressLine3?: string | null;
-      /**
-       * Name of the city or locality
-       */
-      city: string;
-      /**
-       * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-       */
-      country?: string | null;
-      /**
-       * Name of the individual or business formatted for inclusion in an address used for physical mail
-       */
-      mailingName?: string | null;
-      /**
-       * Mandatory for Australian addresses
-       */
-      postcode?: string | null;
-      /**
-       * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-       */
-      state: string;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
-   */
-  meters?:
-    | {
-        /**
-         * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
-         */
-        meterId: string;
-        /**
-         * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
-         */
-        registers?: {
-          /**
-           * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
-           */
-          averagedDailyLoad?: number;
-          /**
-           * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
-           */
-          consumptionType?: "ACTUAL" | "CUMULATIVE";
-          /**
-           * Indicates whether the energy recorded by this register is created under a Controlled Load regime
-           */
-          controlledLoad?: boolean;
-          /**
-           * Multiplier required to take a register value and turn it into a value representing billable energy
-           */
-          multiplier?: number;
-          /**
-           * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
-           */
-          networkTariffCode?: string;
-          /**
-           * Indicates the consumption type of register
-           */
-          registerConsumptionType:
-            | "INTERVAL"
-            | "BASIC"
-            | "PROFILE_DATA"
-            | "ACTIVE_IMPORT"
-            | "ACTIVE"
-            | "REACTIVE_IMPORT"
-            | "REACTIVE";
-          /**
-           * Unique identifier of the register within this service point.  Is not globally unique
-           */
-          registerId: string;
-          /**
-           * Register suffix of the meter register where the meter reads are obtained
-           */
-          registerSuffix?: string;
-          /**
-           * Code to identify the time validity of register contents
-           */
-          timeOfDay?:
-            | "ALLDAY"
-            | "INTERVAL"
-            | "PEAK"
-            | "BUSINESS"
-            | "SHOULDER"
-            | "EVENING"
-            | "OFFPEAK"
-            | "CONTROLLED"
-            | "DEMAND";
-          /**
-           * The unit of measure for data held in this register
-           */
-          unitOfMeasure?: string;
-          [k: string]: unknown;
-        }[];
-        /**
-         * Technical characteristics of the meter
-         */
-        specifications: {
-          /**
-           * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
-           */
-          installationType:
-            | "BASIC"
-            | "COMMS1"
-            | "COMMS2"
-            | "COMMS3"
-            | "COMMS4"
-            | "COMMS4C"
-            | "COMMS4D"
-            | "MRAM"
-            | "MRIM"
-            | "PROF"
-            | "SAMPLE"
-            | "UMCP"
-            | "VICAMI"
-            | "NCOLNUML";
-          /**
-           * Free text field to identify the manufacturer of the installed meter
-           */
-          manufacturer?: string;
-          /**
-           * Free text field to identify the meter manufacturer’s designation for the meter model
-           */
-          model?: string;
-          /**
-           * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
-           */
-          nextScheduledReadDate?: string;
-          /**
-           * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
-           */
-          readType?: string;
-          /**
-           * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
-           */
-          status: "CURRENT" | "DISCONNECTED";
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The independent ID of the service point, known in the industry as the NMI
-   */
-  nationalMeteringId: string;
-  relatedParticipants: {
-    /**
-     * The name of the party/organisation related to this service point
-     */
-    party: string;
-    /**
-     * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
-     */
-    role: "FRMP" | "LNSP" | "DRSP";
-    [k: string]: unknown;
-  }[];
-  /**
-   * The classification of the service point as defined in MSATS procedures
-   */
-  servicePointClassification:
-    | "EXTERNAL_PROFILE"
-    | "GENERATOR"
-    | "LARGE"
-    | "SMALL"
-    | "WHOLESALE"
-    | "NON_CONTEST_UNMETERED_LOAD"
-    | "NON_REGISTERED_EMBEDDED_GENERATOR"
-    | "DISTRIBUTION_WHOLESALE";
-  /**
-   * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-   */
-  servicePointId: string;
-  /**
-   * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
-   */
-  servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
-  /**
-   * The start date from which this service point first became valid
-   */
-  validFromDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyServicePointDetailResponse {
-  data: {
-    consumerProfile?: {
-      /**
-       * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
-       */
-      classification?: ("BUSINESS" | "RESIDENTIAL") | null;
-      /**
-       * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
-       */
-      threshold?: "LOW" | "MEDIUM" | "HIGH";
-      [k: string]: unknown;
-    } | null;
-    distributionLossFactor: {
-      /**
-       * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
-       */
-      code: string;
-      /**
-       * Description of the data loss factor code and value
-       */
-      description: string;
-      /**
-       * The value associated with the loss factor code
-       */
-      lossValue: string;
-      [k: string]: unknown;
-    };
-    /**
-     * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-     */
-    isGenerator?: boolean | null;
-    /**
-     * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-     */
-    jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-    /**
-     * The date and time that the information for this service point was modified
-     */
-    lastUpdateDateTime: string;
-    /**
-     * Location of the servicepoint
-     */
-    location: {
-      /**
-       * The type of address object present
-       */
-      addressUType: "paf" | "simple";
-      /**
-       * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
-       */
-      paf?: {
         /**
          * Building/Property name 1
          */
@@ -1391,11 +194,11 @@ export interface EnergyServicePointDetailResponse {
          */
         thoroughfareNumber2Suffix?: string | null;
         [k: string]: unknown;
-      };
-      /**
-       * Required if addressUType is set to simple
-       */
-      simple?: {
+    };
+    /**
+     * Required if addressUType is set to simple
+     */
+    simple?: {
         /**
          * First line of the standard address object
          */
@@ -1429,154 +232,666 @@ export interface EnergyServicePointDetailResponse {
          */
         state: string;
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+/**
+ * Required if addressUType is set to simple
+ */
+export interface CommonSimpleAddress {
     /**
-     * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
+     * First line of the standard address object
      */
-    meters?:
-      | {
-          /**
-           * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
-           */
-          meterId: string;
-          /**
-           * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
-           */
-          registers?: {
+    addressLine1: string;
+    /**
+     * Second line of the standard address object
+     */
+    addressLine2?: string | null;
+    /**
+     * Third line of the standard address object
+     */
+    addressLine3?: string | null;
+    /**
+     * Name of the city or locality
+     */
+    city: string;
+    /**
+     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+     */
+    country?: string | null;
+    /**
+     * Name of the individual or business formatted for inclusion in an address used for physical mail
+     */
+    mailingName?: string | null;
+    /**
+     * Mandatory for Australian addresses
+     */
+    postcode?: string | null;
+    /**
+     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+     */
+    state: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyDerDetailResponse {
+    data: {
+        acConnections: {
             /**
-             * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
+             * The date that the DER installation is commissioned
              */
-            averagedDailyLoad?: number;
+            commissioningDate: string;
             /**
-             * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
+             * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
              */
-            consumptionType?: "ACTUAL" | "CUMULATIVE";
+            connectionIdentifier: number;
             /**
-             * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+             * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
              */
-            controlledLoad?: boolean;
+            count: number;
+            derDevices: {
+                /**
+                 * Number of devices in the group of DER devices
+                 */
+                count: number;
+                /**
+                 * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
+                 */
+                deviceIdentifier: number;
+                /**
+                 * The name of the device manufacturer. If absent then assumed to be “unknown”
+                 */
+                manufacturer?: string;
+                /**
+                 * The model number of the device. If absent then assumed to be “unknown”
+                 */
+                modelNumber?: string;
+                /**
+                 * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
+                 */
+                nominalRatedCapacity: number;
+                /**
+                 * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
+                 */
+                nominalStorageCapacity?: number;
+                /**
+                 * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
+                 */
+                status?: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+                /**
+                 * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
+                 */
+                subtype?: string;
+                /**
+                 * Used to indicate the primary technology used in the DER device
+                 */
+                type: 'FOSSIL' | 'HYDRO' | 'WIND' | 'SOLAR_PV' | 'RENEWABLE' | 'GEOTHERMAL' | 'STORAGE' | 'OTHER';
+                [k: string]: unknown;
+            }[];
             /**
-             * Multiplier required to take a register value and turn it into a value representing billable energy
+             * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
              */
-            multiplier?: number;
+            equipmentType?: 'INVERTER' | 'OTHER';
             /**
-             * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
+             * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
              */
-            networkTariffCode?: string;
+            inverterDeviceCapacity?: number;
             /**
-             * Indicates the consumption type of register
+             * The inverter model number. Mandatory if equipmentType is INVERTER
              */
-            registerConsumptionType:
-              | "INTERVAL"
-              | "BASIC"
-              | "PROFILE_DATA"
-              | "ACTIVE_IMPORT"
-              | "ACTIVE"
-              | "REACTIVE_IMPORT"
-              | "REACTIVE";
+            inverterModelNumber?: string;
             /**
-             * Unique identifier of the register within this service point.  Is not globally unique
+             * The inverter series. Mandatory if equipmentType is INVERTER
              */
-            registerId: string;
+            inverterSeries?: string;
             /**
-             * Register suffix of the meter register where the meter reads are obtained
+             * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
              */
-            registerSuffix?: string;
+            manufacturerName?: string;
             /**
-             * Code to identify the time validity of register contents
+             * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
              */
-            timeOfDay?:
-              | "ALLDAY"
-              | "INTERVAL"
-              | "PEAK"
-              | "BUSINESS"
-              | "SHOULDER"
-              | "EVENING"
-              | "OFFPEAK"
-              | "CONTROLLED"
-              | "DEMAND";
-            /**
-             * The unit of measure for data held in this register
-             */
-            unitOfMeasure?: string;
+            status: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
             [k: string]: unknown;
-          }[];
-          /**
-           * Technical characteristics of the meter
-           */
-          specifications: {
+        }[];
+        /**
+         * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
+         */
+        approvedCapacity: number;
+        /**
+         * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
+         */
+        availablePhasesCount: number;
+        /**
+         * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
+         */
+        hasCentralProtectionControl?: boolean | null;
+        /**
+         * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
+         */
+        installedPhasesCount: number;
+        /**
+         * For identification of small generating units designed with the ability to operate in an islanded mode
+         */
+        islandableInstallation: boolean;
+        /**
+         * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
+         */
+        protectionMode?: {
             /**
-             * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
+             * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
              */
-            installationType:
-              | "BASIC"
-              | "COMMS1"
-              | "COMMS2"
-              | "COMMS3"
-              | "COMMS4"
-              | "COMMS4C"
-              | "COMMS4D"
-              | "MRAM"
-              | "MRIM"
-              | "PROF"
-              | "SAMPLE"
-              | "UMCP"
-              | "VICAMI"
-              | "NCOLNUML";
+            exportLimitKva?: number | null;
             /**
-             * Free text field to identify the manufacturer of the installed meter
+             * Rate of change of frequency trip point (Hz/s).
+             */
+            frequencyRateOfChange?: number | null;
+            /**
+             * Description of the form of inter-trip (e.g. 'from local substation').
+             */
+            interTripScheme?: string | null;
+            /**
+             * Trip voltage.
+             */
+            neutralVoltageDisplacement?: number | null;
+            /**
+             * Protective function limit in Hz.
+             */
+            overFrequencyProtection?: number | null;
+            /**
+             * Trip delay time in seconds.
+             */
+            overFrequencyProtectionDelay?: number | null;
+            /**
+             * Protective function limit in V.
+             */
+            overVoltageProtection?: number | null;
+            /**
+             * Trip delay time in seconds.
+             */
+            overVoltageProtectionDelay?: number | null;
+            /**
+             * Sustained over voltage.
+             */
+            sustainedOverVoltage?: number | null;
+            /**
+             * Sustained Over voltage protection delay in seconds.
+             */
+            sustainedOverVoltageDelay?: number | null;
+            /**
+             * Protective function limit in Hz.
+             */
+            underFrequencyProtection?: number | null;
+            /**
+             * Trip delay time in seconds.
+             */
+            underFrequencyProtectionDelay?: number | null;
+            /**
+             * Protective function limit in V.
+             */
+            underVoltageProtection?: number | null;
+            /**
+             * Trip delay time in seconds.
+             */
+            underVoltageProtectionDelay?: number | null;
+            /**
+             * Trip angle in degrees.
+             */
+            voltageVectorShift?: number | null;
+            [k: string]: unknown;
+        } | null;
+        /**
+         * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+         */
+        servicePointId: string;
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyDerListResponse {
+    data: {
+        /**
+         * Array of meter reads
+         */
+        derRecords: {
+            acConnections: {
+                /**
+                 * The date that the DER installation is commissioned
+                 */
+                commissioningDate: string;
+                /**
+                 * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
+                 */
+                connectionIdentifier: number;
+                /**
+                 * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
+                 */
+                count: number;
+                derDevices: {
+                    /**
+                     * Number of devices in the group of DER devices
+                     */
+                    count: number;
+                    /**
+                     * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
+                     */
+                    deviceIdentifier: number;
+                    /**
+                     * The name of the device manufacturer. If absent then assumed to be “unknown”
+                     */
+                    manufacturer?: string;
+                    /**
+                     * The model number of the device. If absent then assumed to be “unknown”
+                     */
+                    modelNumber?: string;
+                    /**
+                     * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
+                     */
+                    nominalRatedCapacity: number;
+                    /**
+                     * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
+                     */
+                    nominalStorageCapacity?: number;
+                    /**
+                     * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
+                     */
+                    status?: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+                    /**
+                     * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
+                     */
+                    subtype?: string;
+                    /**
+                     * Used to indicate the primary technology used in the DER device
+                     */
+                    type: 'FOSSIL' | 'HYDRO' | 'WIND' | 'SOLAR_PV' | 'RENEWABLE' | 'GEOTHERMAL' | 'STORAGE' | 'OTHER';
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
+                 */
+                equipmentType?: 'INVERTER' | 'OTHER';
+                /**
+                 * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
+                 */
+                inverterDeviceCapacity?: number;
+                /**
+                 * The inverter model number. Mandatory if equipmentType is INVERTER
+                 */
+                inverterModelNumber?: string;
+                /**
+                 * The inverter series. Mandatory if equipmentType is INVERTER
+                 */
+                inverterSeries?: string;
+                /**
+                 * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
+                 */
+                manufacturerName?: string;
+                /**
+                 * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
+                 */
+                status: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+                [k: string]: unknown;
+            }[];
+            /**
+             * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
+             */
+            approvedCapacity: number;
+            /**
+             * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
+             */
+            availablePhasesCount: number;
+            /**
+             * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
+             */
+            hasCentralProtectionControl?: boolean | null;
+            /**
+             * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
+             */
+            installedPhasesCount: number;
+            /**
+             * For identification of small generating units designed with the ability to operate in an islanded mode
+             */
+            islandableInstallation: boolean;
+            /**
+             * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
+             */
+            protectionMode?: {
+                /**
+                 * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
+                 */
+                exportLimitKva?: number | null;
+                /**
+                 * Rate of change of frequency trip point (Hz/s).
+                 */
+                frequencyRateOfChange?: number | null;
+                /**
+                 * Description of the form of inter-trip (e.g. 'from local substation').
+                 */
+                interTripScheme?: string | null;
+                /**
+                 * Trip voltage.
+                 */
+                neutralVoltageDisplacement?: number | null;
+                /**
+                 * Protective function limit in Hz.
+                 */
+                overFrequencyProtection?: number | null;
+                /**
+                 * Trip delay time in seconds.
+                 */
+                overFrequencyProtectionDelay?: number | null;
+                /**
+                 * Protective function limit in V.
+                 */
+                overVoltageProtection?: number | null;
+                /**
+                 * Trip delay time in seconds.
+                 */
+                overVoltageProtectionDelay?: number | null;
+                /**
+                 * Sustained over voltage.
+                 */
+                sustainedOverVoltage?: number | null;
+                /**
+                 * Sustained Over voltage protection delay in seconds.
+                 */
+                sustainedOverVoltageDelay?: number | null;
+                /**
+                 * Protective function limit in Hz.
+                 */
+                underFrequencyProtection?: number | null;
+                /**
+                 * Trip delay time in seconds.
+                 */
+                underFrequencyProtectionDelay?: number | null;
+                /**
+                 * Protective function limit in V.
+                 */
+                underVoltageProtection?: number | null;
+                /**
+                 * Trip delay time in seconds.
+                 */
+                underVoltageProtectionDelay?: number | null;
+                /**
+                 * Trip angle in degrees.
+                 */
+                voltageVectorShift?: number | null;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+             */
+            servicePointId: string;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyDerRecord {
+    acConnections: {
+        /**
+         * The date that the DER installation is commissioned
+         */
+        commissioningDate: string;
+        /**
+         * AC Connection ID as defined in the DER register.  Does not align with CDR ID permanence standards
+         */
+        connectionIdentifier: number;
+        /**
+         * Number of AC Connections in the group. For the suite of AC Connections to be considered as a group, all of the AC Connections included must have the same attributes
+         */
+        count: number;
+        derDevices: {
+            /**
+             * Number of devices in the group of DER devices
+             */
+            count: number;
+            /**
+             * Unique identifier for a single DER device or a group of DER devices with the same attributes. Does not align with CDR ID permanence standards
+             */
+            deviceIdentifier: number;
+            /**
+             * The name of the device manufacturer. If absent then assumed to be “unknown”
              */
             manufacturer?: string;
             /**
-             * Free text field to identify the meter manufacturer’s designation for the meter model
+             * The model number of the device. If absent then assumed to be “unknown”
              */
-            model?: string;
+            modelNumber?: string;
             /**
-             * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
+             * Maximum output in kVA that is listed in the product specification by the manufacturer. This refers to the capacity of each unit within the device group
              */
-            nextScheduledReadDate?: string;
+            nominalRatedCapacity: number;
             /**
-             * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
+             * Maximum storage capacity in kVAh. This refers to the capacity of each storage module within the device group. Mandatory if type is equal to “STORAGE”
              */
-            readType?: string;
+            nominalStorageCapacity?: number;
             /**
-             * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
+             * Code used to indicate the status of the device. This will be used to identify if an inverter is active or inactive or decommissioned
              */
-            status: "CURRENT" | "DISCONNECTED";
+            status?: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+            /**
+             * Used to indicate the primary technology used in the DER device. This field is also used to record for example the battery chemistry, or the type of PV panel. It is also used to record if a battery is contained in an electric vehicle connected in a vehicle-to-grid arrangement. If absent then assumed to be “other”
+             */
+            subtype?: string;
+            /**
+             * Used to indicate the primary technology used in the DER device
+             */
+            type: 'FOSSIL' | 'HYDRO' | 'WIND' | 'SOLAR_PV' | 'RENEWABLE' | 'GEOTHERMAL' | 'STORAGE' | 'OTHER';
             [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        }[]
-      | null;
+        }[];
+        /**
+         * Indicates whether the DER device is connected via an inverter (and what category of inverter it is) or not (e.g. rotating machine). If absent, assume equipment type to be “OTHER”.
+         */
+        equipmentType?: 'INVERTER' | 'OTHER';
+        /**
+         * The rated AC output power that is listed in the product specified by the manufacturer. Mandatory if equipmentType is INVERTER
+         */
+        inverterDeviceCapacity?: number;
+        /**
+         * The inverter model number. Mandatory if equipmentType is INVERTER
+         */
+        inverterModelNumber?: string;
+        /**
+         * The inverter series. Mandatory if equipmentType is INVERTER
+         */
+        inverterSeries?: string;
+        /**
+         * The name of the inverter manufacturer. Mandatory if equipmentType is INVERTER
+         */
+        manufacturerName?: string;
+        /**
+         * Code used to indicate the status of the Inverter. This will be used to identify if an inverter is active or inactive or decommissioned
+         */
+        status: 'ACTIVE' | 'INACTIVE' | 'DECOMMISSIONED';
+        [k: string]: unknown;
+    }[];
+    /**
+     * Approved small generating unit capacity as agreed with NSP in the connection agreement, expressed in kVA
+     */
+    approvedCapacity: number;
+    /**
+     * The number of phases available for the installation of DER. Acceptable values are 1, 2 or 3.
+     */
+    availablePhasesCount: number;
+    /**
+     * For DER installations where NSPs specify the need for additional forms of protection above those inbuilt in an inverter.  If absent then assumed to be false
+     */
+    hasCentralProtectionControl?: boolean | null;
+    /**
+     * The number of phases that DER is connected to. Acceptable values are 1, 2 or 3.
+     */
+    installedPhasesCount: number;
+    /**
+     * For identification of small generating units designed with the ability to operate in an islanded mode
+     */
+    islandableInstallation: boolean;
+    /**
+     * Required only when the hasCentralProtectionAndControl flag is set to true.  One or more of the object fields will be provided to describe the protection modes in place
+     */
+    protectionMode?: {
+        /**
+         * Maximum amount of power (kVA) that may be exported from a connection point to the grid, as monitored by a control / relay function. An absent value indicates no limit
+         */
+        exportLimitKva?: number | null;
+        /**
+         * Rate of change of frequency trip point (Hz/s).
+         */
+        frequencyRateOfChange?: number | null;
+        /**
+         * Description of the form of inter-trip (e.g. 'from local substation').
+         */
+        interTripScheme?: string | null;
+        /**
+         * Trip voltage.
+         */
+        neutralVoltageDisplacement?: number | null;
+        /**
+         * Protective function limit in Hz.
+         */
+        overFrequencyProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        overFrequencyProtectionDelay?: number | null;
+        /**
+         * Protective function limit in V.
+         */
+        overVoltageProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        overVoltageProtectionDelay?: number | null;
+        /**
+         * Sustained over voltage.
+         */
+        sustainedOverVoltage?: number | null;
+        /**
+         * Sustained Over voltage protection delay in seconds.
+         */
+        sustainedOverVoltageDelay?: number | null;
+        /**
+         * Protective function limit in Hz.
+         */
+        underFrequencyProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        underFrequencyProtectionDelay?: number | null;
+        /**
+         * Protective function limit in V.
+         */
+        underVoltageProtection?: number | null;
+        /**
+         * Trip delay time in seconds.
+         */
+        underVoltageProtectionDelay?: number | null;
+        /**
+         * Trip angle in degrees.
+         */
+        voltageVectorShift?: number | null;
+        [k: string]: unknown;
+    } | null;
+    /**
+     * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+     */
+    servicePointId: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyServicePoint {
+    consumerProfile?: {
+        /**
+         * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+         */
+        classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+        /**
+         * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+         */
+        threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+        [k: string]: unknown;
+    } | null;
+    /**
+     * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
+     */
+    isGenerator?: boolean | null;
+    /**
+     * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+     */
+    jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+    /**
+     * The date and time that the information for this service point was modified
+     */
+    lastUpdateDateTime: string;
     /**
      * The independent ID of the service point, known in the industry as the NMI
      */
     nationalMeteringId: string;
-    relatedParticipants: {
-      /**
-       * The name of the party/organisation related to this service point
-       */
-      party: string;
-      /**
-       * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
-       */
-      role: "FRMP" | "LNSP" | "DRSP";
-      [k: string]: unknown;
-    }[];
     /**
      * The classification of the service point as defined in MSATS procedures
      */
     servicePointClassification:
-      | "EXTERNAL_PROFILE"
-      | "GENERATOR"
-      | "LARGE"
-      | "SMALL"
-      | "WHOLESALE"
-      | "NON_CONTEST_UNMETERED_LOAD"
-      | "NON_REGISTERED_EMBEDDED_GENERATOR"
-      | "DISTRIBUTION_WHOLESALE";
+        | 'EXTERNAL_PROFILE'
+        | 'GENERATOR'
+        | 'LARGE'
+        | 'SMALL'
+        | 'WHOLESALE'
+        | 'NON_CONTEST_UNMETERED_LOAD'
+        | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+        | 'DISTRIBUTION_WHOLESALE';
     /**
      * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
      */
@@ -1584,151 +899,965 @@ export interface EnergyServicePointDetailResponse {
     /**
      * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
      */
-    servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
+    servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
     /**
      * The start date from which this service point first became valid
      */
     validFromDate: string;
     [k: string]: unknown;
-  };
-  links: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyServicePointDetail {
+    consumerProfile?: {
+        /**
+         * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+         */
+        classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+        /**
+         * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+         */
+        threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+        [k: string]: unknown;
+    } | null;
+    distributionLossFactor: {
+        /**
+         * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
+         */
+        code: string;
+        /**
+         * Description of the data loss factor code and value
+         */
+        description: string;
+        /**
+         * The value associated with the loss factor code
+         */
+        lossValue: string;
+        [k: string]: unknown;
+    };
     /**
-     * Fully qualified link that generated the current response document
+     * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
      */
-    self: string;
+    isGenerator?: boolean | null;
+    /**
+     * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+     */
+    jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+    /**
+     * The date and time that the information for this service point was modified
+     */
+    lastUpdateDateTime: string;
+    /**
+     * Location of the servicepoint
+     */
+    location: {
+        /**
+         * The type of address object present
+         */
+        addressUType: 'paf' | 'simple';
+        /**
+         * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
+         */
+        paf?: {
+            /**
+             * Building/Property name 1
+             */
+            buildingName1?: string | null;
+            /**
+             * Building/Property name 2
+             */
+            buildingName2?: string | null;
+            /**
+             * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+             */
+            dpid?: string | null;
+            /**
+             * Unit number (including suffix, if applicable)
+             */
+            flatUnitNumber?: string | null;
+            /**
+             * Type of flat or unit for the address
+             */
+            flatUnitType?: string | null;
+            /**
+             * Floor or level number (including alpha characters)
+             */
+            floorLevelNumber?: string | null;
+            /**
+             * Type of floor or level for the address
+             */
+            floorLevelType?: string | null;
+            /**
+             * Full name of locality
+             */
+            localityName: string;
+            /**
+             * Allotment number for the address
+             */
+            lotNumber?: string | null;
+            /**
+             * Postal delivery number if the address is a postal delivery type
+             */
+            postalDeliveryNumber?: number | null;
+            /**
+             * Postal delivery number prefix related to the postal delivery number
+             */
+            postalDeliveryNumberPrefix?: string | null;
+            /**
+             * Postal delivery number suffix related to the postal delivery number
+             */
+            postalDeliveryNumberSuffix?: string | null;
+            /**
+             * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+             */
+            postalDeliveryType?: string | null;
+            /**
+             * Postcode for the locality
+             */
+            postcode: string;
+            /**
+             * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            /**
+             * The name of the street
+             */
+            streetName?: string | null;
+            /**
+             * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetSuffix?: string | null;
+            /**
+             * The street type. Valid enumeration defined by Australia Post PAF code file
+             */
+            streetType?: string | null;
+            /**
+             * Thoroughfare number for a property (first number in a property ranged address)
+             */
+            thoroughfareNumber1?: number | null;
+            /**
+             * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+             */
+            thoroughfareNumber1Suffix?: string | null;
+            /**
+             * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+             */
+            thoroughfareNumber2?: number | null;
+            /**
+             * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+             */
+            thoroughfareNumber2Suffix?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Required if addressUType is set to simple
+         */
+        simple?: {
+            /**
+             * First line of the standard address object
+             */
+            addressLine1: string;
+            /**
+             * Second line of the standard address object
+             */
+            addressLine2?: string | null;
+            /**
+             * Third line of the standard address object
+             */
+            addressLine3?: string | null;
+            /**
+             * Name of the city or locality
+             */
+            city: string;
+            /**
+             * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+             */
+            country?: string | null;
+            /**
+             * Name of the individual or business formatted for inclusion in an address used for physical mail
+             */
+            mailingName?: string | null;
+            /**
+             * Mandatory for Australian addresses
+             */
+            postcode?: string | null;
+            /**
+             * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+             */
+            state: string;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    /**
+     * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
+     */
+    meters?:
+        | {
+            /**
+             * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
+             */
+            meterId: string;
+            /**
+             * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
+             */
+            registers?: {
+                /**
+                 * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
+                 */
+                averagedDailyLoad?: number;
+                /**
+                 * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
+                 */
+                consumptionType?: 'ACTUAL' | 'CUMULATIVE';
+                /**
+                 * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+                 */
+                controlledLoad?: boolean;
+                /**
+                 * Multiplier required to take a register value and turn it into a value representing billable energy
+                 */
+                multiplier?: number;
+                /**
+                 * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
+                 */
+                networkTariffCode?: string;
+                /**
+                 * Indicates the consumption type of register
+                 */
+                registerConsumptionType:
+                    | 'INTERVAL'
+                    | 'BASIC'
+                    | 'PROFILE_DATA'
+                    | 'ACTIVE_IMPORT'
+                    | 'ACTIVE'
+                    | 'REACTIVE_IMPORT'
+                    | 'REACTIVE';
+                /**
+                 * Unique identifier of the register within this service point.  Is not globally unique
+                 */
+                registerId: string;
+                /**
+                 * Register suffix of the meter register where the meter reads are obtained
+                 */
+                registerSuffix?: string;
+                /**
+                 * Code to identify the time validity of register contents
+                 */
+                timeOfDay?:
+                    | 'ALLDAY'
+                    | 'INTERVAL'
+                    | 'PEAK'
+                    | 'BUSINESS'
+                    | 'SHOULDER'
+                    | 'EVENING'
+                    | 'OFFPEAK'
+                    | 'CONTROLLED'
+                    | 'DEMAND';
+                /**
+                 * The unit of measure for data held in this register
+                 */
+                unitOfMeasure?: string;
+                [k: string]: unknown;
+            }[];
+            /**
+             * Technical characteristics of the meter
+             */
+            specifications: {
+                /**
+                 * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
+                 */
+                installationType:
+                    | 'BASIC'
+                    | 'COMMS1'
+                    | 'COMMS2'
+                    | 'COMMS3'
+                    | 'COMMS4'
+                    | 'COMMS4C'
+                    | 'COMMS4D'
+                    | 'MRAM'
+                    | 'MRIM'
+                    | 'PROF'
+                    | 'SAMPLE'
+                    | 'UMCP'
+                    | 'VICAMI'
+                    | 'NCOLNUML';
+                /**
+                 * Free text field to identify the manufacturer of the installed meter
+                 */
+                manufacturer?: string;
+                /**
+                 * Free text field to identify the meter manufacturer’s designation for the meter model
+                 */
+                model?: string;
+                /**
+                 * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
+                 */
+                nextScheduledReadDate?: string;
+                /**
+                 * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
+                 */
+                readType?: string;
+                /**
+                 * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
+                 */
+                status: 'CURRENT' | 'DISCONNECTED';
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The independent ID of the service point, known in the industry as the NMI
+     */
+    nationalMeteringId: string;
+    relatedParticipants: {
+        /**
+         * The name of the party/organisation related to this service point
+         */
+        party: string;
+        /**
+         * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
+         */
+        role: 'FRMP' | 'LNSP' | 'DRSP';
+        [k: string]: unknown;
+    }[];
+    /**
+     * The classification of the service point as defined in MSATS procedures
+     */
+    servicePointClassification:
+        | 'EXTERNAL_PROFILE'
+        | 'GENERATOR'
+        | 'LARGE'
+        | 'SMALL'
+        | 'WHOLESALE'
+        | 'NON_CONTEST_UNMETERED_LOAD'
+        | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+        | 'DISTRIBUTION_WHOLESALE';
+    /**
+     * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+     */
+    servicePointId: string;
+    /**
+     * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
+     */
+    servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
+    /**
+     * The start date from which this service point first became valid
+     */
+    validFromDate: string;
     [k: string]: unknown;
-  };
-  meta?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyServicePointDetailResponse {
+    data: {
+        consumerProfile?: {
+            /**
+             * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+             */
+            classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+            /**
+             * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+             */
+            threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+            [k: string]: unknown;
+        } | null;
+        distributionLossFactor: {
+            /**
+             * A code used to identify data loss factor for the service point values.  Refer to AEMO distribution loss factor documents for each financial year to interpret
+             */
+            code: string;
+            /**
+             * Description of the data loss factor code and value
+             */
+            description: string;
+            /**
+             * The value associated with the loss factor code
+             */
+            lossValue: string;
+            [k: string]: unknown;
+        };
+        /**
+         * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
+         */
+        isGenerator?: boolean | null;
+        /**
+         * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+         */
+        jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+        /**
+         * The date and time that the information for this service point was modified
+         */
+        lastUpdateDateTime: string;
+        /**
+         * Location of the servicepoint
+         */
+        location: {
+            /**
+             * The type of address object present
+             */
+            addressUType: 'paf' | 'simple';
+            /**
+             * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
+             */
+            paf?: {
+                /**
+                 * Building/Property name 1
+                 */
+                buildingName1?: string | null;
+                /**
+                 * Building/Property name 2
+                 */
+                buildingName2?: string | null;
+                /**
+                 * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+                 */
+                dpid?: string | null;
+                /**
+                 * Unit number (including suffix, if applicable)
+                 */
+                flatUnitNumber?: string | null;
+                /**
+                 * Type of flat or unit for the address
+                 */
+                flatUnitType?: string | null;
+                /**
+                 * Floor or level number (including alpha characters)
+                 */
+                floorLevelNumber?: string | null;
+                /**
+                 * Type of floor or level for the address
+                 */
+                floorLevelType?: string | null;
+                /**
+                 * Full name of locality
+                 */
+                localityName: string;
+                /**
+                 * Allotment number for the address
+                 */
+                lotNumber?: string | null;
+                /**
+                 * Postal delivery number if the address is a postal delivery type
+                 */
+                postalDeliveryNumber?: number | null;
+                /**
+                 * Postal delivery number prefix related to the postal delivery number
+                 */
+                postalDeliveryNumberPrefix?: string | null;
+                /**
+                 * Postal delivery number suffix related to the postal delivery number
+                 */
+                postalDeliveryNumberSuffix?: string | null;
+                /**
+                 * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+                 */
+                postalDeliveryType?: string | null;
+                /**
+                 * Postcode for the locality
+                 */
+                postcode: string;
+                /**
+                 * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                 */
+                state: string;
+                /**
+                 * The name of the street
+                 */
+                streetName?: string | null;
+                /**
+                 * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+                 */
+                streetSuffix?: string | null;
+                /**
+                 * The street type. Valid enumeration defined by Australia Post PAF code file
+                 */
+                streetType?: string | null;
+                /**
+                 * Thoroughfare number for a property (first number in a property ranged address)
+                 */
+                thoroughfareNumber1?: number | null;
+                /**
+                 * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+                 */
+                thoroughfareNumber1Suffix?: string | null;
+                /**
+                 * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+                 */
+                thoroughfareNumber2?: number | null;
+                /**
+                 * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+                 */
+                thoroughfareNumber2Suffix?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Required if addressUType is set to simple
+             */
+            simple?: {
+                /**
+                 * First line of the standard address object
+                 */
+                addressLine1: string;
+                /**
+                 * Second line of the standard address object
+                 */
+                addressLine2?: string | null;
+                /**
+                 * Third line of the standard address object
+                 */
+                addressLine3?: string | null;
+                /**
+                 * Name of the city or locality
+                 */
+                city: string;
+                /**
+                 * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+                 */
+                country?: string | null;
+                /**
+                 * Name of the individual or business formatted for inclusion in an address used for physical mail
+                 */
+                mailingName?: string | null;
+                /**
+                 * Mandatory for Australian addresses
+                 */
+                postcode?: string | null;
+                /**
+                 * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+                 */
+                state: string;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * The meters associated with the service point. This may be empty where there are no meters physically installed at the service point
+         */
+        meters?:
+            | {
+                /**
+                 * The meter ID uniquely identifies a meter for a given service point.  It is unique in the context of the service point.  It is not globally unique
+                 */
+                meterId: string;
+                /**
+                 * Usage data registers available from the meter. This may be empty where there are no meters physically installed at the service point
+                 */
+                registers?: {
+                    /**
+                     * The energy delivered through a connection point or metering point over an extended period normalised to a 'per day' basis (kWh). This value is calculated annually.
+                     */
+                    averagedDailyLoad?: number;
+                    /**
+                     * Actual/Subtractive Indicator. Note the details of enumeration values below: <ul><li>**ACTUAL** implies volume of energy actually metered between two dates</li><li>**CUMULATIVE** indicates a meter reading for a specific date. A second Meter Reading is required to determine the consumption between those two Meter Reading dates</li></ul>
+                     */
+                    consumptionType?: 'ACTUAL' | 'CUMULATIVE';
+                    /**
+                     * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+                     */
+                    controlledLoad?: boolean;
+                    /**
+                     * Multiplier required to take a register value and turn it into a value representing billable energy
+                     */
+                    multiplier?: number;
+                    /**
+                     * The Network Tariff Code is a free text field containing a code supplied and published by the local network service provider
+                     */
+                    networkTariffCode?: string;
+                    /**
+                     * Indicates the consumption type of register
+                     */
+                    registerConsumptionType:
+                        | 'INTERVAL'
+                        | 'BASIC'
+                        | 'PROFILE_DATA'
+                        | 'ACTIVE_IMPORT'
+                        | 'ACTIVE'
+                        | 'REACTIVE_IMPORT'
+                        | 'REACTIVE';
+                    /**
+                     * Unique identifier of the register within this service point.  Is not globally unique
+                     */
+                    registerId: string;
+                    /**
+                     * Register suffix of the meter register where the meter reads are obtained
+                     */
+                    registerSuffix?: string;
+                    /**
+                     * Code to identify the time validity of register contents
+                     */
+                    timeOfDay?:
+                        | 'ALLDAY'
+                        | 'INTERVAL'
+                        | 'PEAK'
+                        | 'BUSINESS'
+                        | 'SHOULDER'
+                        | 'EVENING'
+                        | 'OFFPEAK'
+                        | 'CONTROLLED'
+                        | 'DEMAND';
+                    /**
+                     * The unit of measure for data held in this register
+                     */
+                    unitOfMeasure?: string;
+                    [k: string]: unknown;
+                }[];
+                /**
+                 * Technical characteristics of the meter
+                 */
+                specifications: {
+                    /**
+                     * The metering Installation type code indicates whether the metering installation has to be manually read. Note the details of enumeration values below: <ul><li>**BASIC** - Accumulation Meter – Type 6</li><li>**COMMS1** - Interval Meter with communications – Type 1</li><li>**COMMS2** - Interval Meter with communications – Type 2</li><li>**COMMS3** - Interval Meter with communications – Type 3</li><li>**COMMS4** - Interval Meter with communications – Type 4</li><li>**COMMS4C** - CT connected metering installation that meets the minimum services specifications</li><li>**COMMS4D** - Whole current metering installation that meets the minimum services specifications</li><li>**MRAM** - Small customer metering installation – Type 4A</li><li>**MRIM** - Manually Read Interval Meter – Type 5</li><li>**UMCP** - Unmetered Supply – Type 7</li><li>**VICAMI** - A relevant metering installation as defined in clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load - Introduced as part of Global Settlement</li></ul>
+                     */
+                    installationType:
+                        | 'BASIC'
+                        | 'COMMS1'
+                        | 'COMMS2'
+                        | 'COMMS3'
+                        | 'COMMS4'
+                        | 'COMMS4C'
+                        | 'COMMS4D'
+                        | 'MRAM'
+                        | 'MRIM'
+                        | 'PROF'
+                        | 'SAMPLE'
+                        | 'UMCP'
+                        | 'VICAMI'
+                        | 'NCOLNUML';
+                    /**
+                     * Free text field to identify the manufacturer of the installed meter
+                     */
+                    manufacturer?: string;
+                    /**
+                     * Free text field to identify the meter manufacturer’s designation for the meter model
+                     */
+                    model?: string;
+                    /**
+                     * This date is the next scheduled meter read date (NSRD) if a manual Meter Reading is required
+                     */
+                    nextScheduledReadDate?: string;
+                    /**
+                     * Code to denote the method and frequency of Meter Reading. The value is formatted as follows: <ul><li>First Character = Remote (R) or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 = Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional Fourth Character = to identify what interval length the meter is capable of reading. This includes five, 15 and 30 minute granularity as the following: A – 5 minute B – 15 minute C – 30 minute D – Cannot convert to 5 minute (i.e. due to metering installation de-energised) M - Manually Read Accumulation Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li> <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li> <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>
+                     */
+                    readType?: string;
+                    /**
+                     * A code to denote the status of the meter. Note the details of enumeration values below: <ul><li>**CURRENT** -Applies when a meter is current and not disconnected</li><li>**DISCONNECTED** - Applies when a meter is present but has been remotely disconnected</li></ul>
+                     */
+                    status: 'CURRENT' | 'DISCONNECTED';
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The independent ID of the service point, known in the industry as the NMI
+         */
+        nationalMeteringId: string;
+        relatedParticipants: {
+            /**
+             * The name of the party/organisation related to this service point
+             */
+            party: string;
+            /**
+             * The role performed by this participant in relation to the service point. Note the details of enumeration values below: <ul><li>**FRMP** - Financially Responsible Market Participant</li><li>**LNSP** - Local Network Service Provider or Embedded Network Manager for child connection points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary Service Provider and note that where it is not relevant for a NMI it will not be included</li></ul>
+             */
+            role: 'FRMP' | 'LNSP' | 'DRSP';
+            [k: string]: unknown;
+        }[];
+        /**
+         * The classification of the service point as defined in MSATS procedures
+         */
+        servicePointClassification:
+            | 'EXTERNAL_PROFILE'
+            | 'GENERATOR'
+            | 'LARGE'
+            | 'SMALL'
+            | 'WHOLESALE'
+            | 'NON_CONTEST_UNMETERED_LOAD'
+            | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+            | 'DISTRIBUTION_WHOLESALE';
+        /**
+         * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+         */
+        servicePointId: string;
+        /**
+         * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
+         */
+        servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
+        /**
+         * The start date from which this service point first became valid
+         */
+        validFromDate: string;
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
 
 export interface EnergyServicePointListResponse {
-  data: {
-    servicePoints: {
-      consumerProfile?: {
-        /**
-         * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
-         */
-        classification?: ("BUSINESS" | "RESIDENTIAL") | null;
-        /**
-         * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
-         */
-        threshold?: "LOW" | "MEDIUM" | "HIGH";
+    data: {
+        servicePoints: {
+            consumerProfile?: {
+                /**
+                 * A code that defines the consumer class as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments
+                 */
+                classification?: ('BUSINESS' | 'RESIDENTIAL') | null;
+                /**
+                 * A code that defines the consumption threshold as defined in the National Energy Retail Regulations, or in overriding Jurisdictional instruments. Note the details of enumeration values below: <ul><li>**LOW** - Consumption is less than the ‘lower consumption threshold’ as defined in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption is equal to or greater than the ‘lower consumption threshold’, but less than the ‘upper consumption threshold’, as defined in the National Energy Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater than the ‘upper consumption threshold’ as defined in the National Energy Retail Regulations</li></ul>
+                 */
+                threshold?: 'LOW' | 'MEDIUM' | 'HIGH';
+                [k: string]: unknown;
+            } | null;
+            /**
+             * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
+             */
+            isGenerator?: boolean | null;
+            /**
+             * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+             */
+            jurisdictionCode: 'ALL' | 'ACT' | 'NEM' | 'NSW' | 'QLD' | 'SA' | 'TAS' | 'VIC';
+            /**
+             * The date and time that the information for this service point was modified
+             */
+            lastUpdateDateTime: string;
+            /**
+             * The independent ID of the service point, known in the industry as the NMI
+             */
+            nationalMeteringId: string;
+            /**
+             * The classification of the service point as defined in MSATS procedures
+             */
+            servicePointClassification:
+                | 'EXTERNAL_PROFILE'
+                | 'GENERATOR'
+                | 'LARGE'
+                | 'SMALL'
+                | 'WHOLESALE'
+                | 'NON_CONTEST_UNMETERED_LOAD'
+                | 'NON_REGISTERED_EMBEDDED_GENERATOR'
+                | 'DISTRIBUTION_WHOLESALE';
+            /**
+             * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+             */
+            servicePointId: string;
+            /**
+             * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
+             */
+            servicePointStatus: 'ACTIVE' | 'DE_ENERGISED' | 'EXTINCT' | 'GREENFIELD' | 'OFF_MARKET';
+            /**
+             * The start date from which this service point first became valid
+             */
+            validFromDate: string;
+            [k: string]: unknown;
+        }[];
         [k: string]: unknown;
-      } | null;
-      /**
-       * This flag determines whether the energy at this connection point is to be treated as consumer load or as a generating unit(this may include generator auxiliary loads). If absent defaults to false. <br>**Note:** Only applicable for scheduled or semischeduled generators, does not indicate on site generation by consumer
-       */
-      isGenerator?: boolean | null;
-      /**
-       * Jurisdiction code to which the service point belongs.This code defines the jurisdictional rules which apply to the service point. Note the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT** - Australian Capital Territory</li><li>**NEM** - National Electricity Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA** - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
-       */
-      jurisdictionCode: "ALL" | "ACT" | "NEM" | "NSW" | "QLD" | "SA" | "TAS" | "VIC";
-      /**
-       * The date and time that the information for this service point was modified
-       */
-      lastUpdateDateTime: string;
-      /**
-       * The independent ID of the service point, known in the industry as the NMI
-       */
-      nationalMeteringId: string;
-      /**
-       * The classification of the service point as defined in MSATS procedures
-       */
-      servicePointClassification:
-        | "EXTERNAL_PROFILE"
-        | "GENERATOR"
-        | "LARGE"
-        | "SMALL"
-        | "WHOLESALE"
-        | "NON_CONTEST_UNMETERED_LOAD"
-        | "NON_REGISTERED_EMBEDDED_GENERATOR"
-        | "DISTRIBUTION_WHOLESALE";
-      /**
-       * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-       */
-      servicePointId: string;
-      /**
-       * Code used to indicate the status of the service point. Note the details for the enumeration values below:<ul><li>**ACTIVE** - An active, energised, service point</li><li>**DE_ENERGISED** - The service point exists but is deenergised</li><li>**EXTINCT** - The service point has been permanently decommissioned</li><li>**GREENFIELD** - Applies to a service point that has never been energised</li><li>**OFF_MARKET** - Applies when the service point is no longer settled in the NEM</li></ul>
-       */
-      servicePointStatus: "ACTIVE" | "DE_ENERGISED" | "EXTINCT" | "GREENFIELD" | "OFF_MARKET";
-      /**
-       * The start date from which this service point first became valid
-       */
-      validFromDate: string;
-      [k: string]: unknown;
-    }[];
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
 
 export interface EnergyUsageListResponse {
-  data: {
+    data: {
+        /**
+         * Array of meter reads sorted by NMI in ascending order followed by readStartDate in descending order
+         */
+        reads: {
+            /**
+             * Mandatory if readUType is set to basicRead
+             */
+            basicRead?: {
+                /**
+                 * The quality of the read taken.  If absent then assumed to be ACTUAL
+                 */
+                quality?: ('ACTUAL' | 'SUBSTITUTE' | 'FINAL_SUBSTITUTE') | null;
+                /**
+                 * Meter read value.  If positive then it means consumption, if negative it means export
+                 */
+                value: number;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+             */
+            controlledLoad?: boolean | null;
+            /**
+             * Mandatory if readUType is set to intervalRead
+             */
+            intervalRead?: {
+                /**
+                 * The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export
+                 */
+                aggregateValue: number;
+                /**
+                 * Array of Interval read values. If positive then it means consumption, if negative it means export. Required when interval-reads query parameter equals FULL or  MIN_30.<br>Each read value indicates the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)
+                 */
+                intervalReads?: number[] | null;
+                /**
+                 * Read interval length in minutes. Required when interval-reads query parameter equals FULL or MIN_30
+                 */
+                readIntervalLength?: number | null;
+                /**
+                 *  Specifies quality of reads that are not ACTUAL.  For read indices that are not specified, quality is assumed to be ACTUAL. If not present, all quality of all reads are assumed to be actual. Required when interval-reads query parameter equals FULL or MIN_30
+                 */
+                readQualities?: {
+                    /**
+                     * End interval for read quality flag
+                     */
+                    endInterval: number;
+                    /**
+                     * The quality of the read taken
+                     */
+                    quality: 'SUBSTITUTE' | 'FINAL_SUBSTITUTE';
+                    /**
+                     * Start interval for read quality flag. First read begins at 1
+                     */
+                    startInterval: number;
+                    [k: string]: unknown;
+                } | null;
+                [k: string]: unknown;
+            } | null;
+            /**
+             * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
+             */
+            meterId?: string | null;
+            /**
+             * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
+             */
+            readEndDate?: string | null;
+            /**
+             * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
+             */
+            readStartDate: string;
+            /**
+             * Specify the type of the meter read data
+             */
+            readUType: 'basicRead' | 'intervalRead';
+            /**
+             * Register ID of the meter register where the meter reads are obtained
+             */
+            registerId?: string | null;
+            /**
+             * Register suffix of the meter register where the meter reads are obtained
+             */
+            registerSuffix: string;
+            /**
+             * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+             */
+            servicePointId: string;
+            /**
+             * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values
+             */
+            unitOfMeasure?: string | null;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface EnergyUsageRead {
     /**
-     * Array of meter reads sorted by NMI in ascending order followed by readStartDate in descending order
+     * Mandatory if readUType is set to basicRead
      */
-    reads: {
-      /**
-       * Mandatory if readUType is set to basicRead
-       */
-      basicRead?: {
+    basicRead?: {
         /**
          * The quality of the read taken.  If absent then assumed to be ACTUAL
          */
-        quality?: ("ACTUAL" | "SUBSTITUTE" | "FINAL_SUBSTITUTE") | null;
+        quality?: ('ACTUAL' | 'SUBSTITUTE' | 'FINAL_SUBSTITUTE') | null;
         /**
          * Meter read value.  If positive then it means consumption, if negative it means export
          */
         value: number;
         [k: string]: unknown;
-      } | null;
-      /**
-       * Indicates whether the energy recorded by this register is created under a Controlled Load regime
-       */
-      controlledLoad?: boolean | null;
-      /**
-       * Mandatory if readUType is set to intervalRead
-       */
-      intervalRead?: {
+    } | null;
+    /**
+     * Indicates whether the energy recorded by this register is created under a Controlled Load regime
+     */
+    controlledLoad?: boolean | null;
+    /**
+     * Mandatory if readUType is set to intervalRead
+     */
+    intervalRead?: {
         /**
          * The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export
          */
@@ -1745,59 +1874,70 @@ export interface EnergyUsageListResponse {
          *  Specifies quality of reads that are not ACTUAL.  For read indices that are not specified, quality is assumed to be ACTUAL. If not present, all quality of all reads are assumed to be actual. Required when interval-reads query parameter equals FULL or MIN_30
          */
         readQualities?: {
-          /**
-           * End interval for read quality flag
-           */
-          endInterval: number;
-          /**
-           * The quality of the read taken
-           */
-          quality: "SUBSTITUTE" | "FINAL_SUBSTITUTE";
-          /**
-           * Start interval for read quality flag. First read begins at 1
-           */
-          startInterval: number;
-          [k: string]: unknown;
+            /**
+             * End interval for read quality flag
+             */
+            endInterval: number;
+            /**
+             * The quality of the read taken
+             */
+            quality: 'SUBSTITUTE' | 'FINAL_SUBSTITUTE';
+            /**
+             * Start interval for read quality flag. First read begins at 1
+             */
+            startInterval: number;
+            [k: string]: unknown;
         } | null;
         [k: string]: unknown;
-      } | null;
-      /**
-       * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
-       */
-      meterId?: string | null;
-      /**
-       * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
-       */
-      readEndDate?: string | null;
-      /**
-       * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
-       */
-      readStartDate: string;
-      /**
-       * Specify the type of the meter read data
-       */
-      readUType: "basicRead" | "intervalRead";
-      /**
-       * Register ID of the meter register where the meter reads are obtained
-       */
-      registerId?: string | null;
-      /**
-       * Register suffix of the meter register where the meter reads are obtained
-       */
-      registerSuffix: string;
-      /**
-       * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-       */
-      servicePointId: string;
-      /**
-       * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values
-       */
-      unitOfMeasure?: string | null;
-      [k: string]: unknown;
-    }[];
+    } | null;
+    /**
+     * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
+     */
+    meterId?: string | null;
+    /**
+     * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
+     */
+    readEndDate?: string | null;
+    /**
+     * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
+     */
+    readStartDate: string;
+    /**
+     * Specify the type of the meter read data
+     */
+    readUType: 'basicRead' | 'intervalRead';
+    /**
+     * Register ID of the meter register where the meter reads are obtained
+     */
+    registerId?: string | null;
+    /**
+     * Register suffix of the meter register where the meter reads are obtained
+     */
+    registerSuffix: string;
+    /**
+     * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
+     */
+    servicePointId: string;
+    /**
+     * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values
+     */
+    unitOfMeasure?: string | null;
     [k: string]: unknown;
-  };
-  links: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface Links {
+    /**
+     * Fully qualified link that generated the current response document
+     */
+    self: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface LinksPaginated {
     /**
      * URI to the first page of this set. Mandatory if this response is not the first page
      */
@@ -1819,8 +1959,15 @@ export interface EnergyUsageListResponse {
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface Meta {
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
+
+export interface MetaPaginated {
     /**
      * The total number of pages in the full set. See [pagination](#pagination).
      */
@@ -1830,181 +1977,34 @@ export interface EnergyUsageListResponse {
      */
     totalRecords: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface EnergyUsageRead {
-  /**
-   * Mandatory if readUType is set to basicRead
-   */
-  basicRead?: {
-    /**
-     * The quality of the read taken.  If absent then assumed to be ACTUAL
-     */
-    quality?: ("ACTUAL" | "SUBSTITUTE" | "FINAL_SUBSTITUTE") | null;
-    /**
-     * Meter read value.  If positive then it means consumption, if negative it means export
-     */
-    value: number;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Indicates whether the energy recorded by this register is created under a Controlled Load regime
-   */
-  controlledLoad?: boolean | null;
-  /**
-   * Mandatory if readUType is set to intervalRead
-   */
-  intervalRead?: {
-    /**
-     * The aggregate sum of the interval read values. If positive then it means net consumption, if negative it means net export
-     */
-    aggregateValue: number;
-    /**
-     * Array of Interval read values. If positive then it means consumption, if negative it means export. Required when interval-reads query parameter equals FULL or  MIN_30.<br>Each read value indicates the read for the interval specified by readIntervalLength beginning at midnight of readStartDate (for example 00:00 to 00:30 would be the first reading in a 30 minute Interval)
-     */
-    intervalReads?: number[] | null;
-    /**
-     * Read interval length in minutes. Required when interval-reads query parameter equals FULL or MIN_30
-     */
-    readIntervalLength?: number | null;
-    /**
-     *  Specifies quality of reads that are not ACTUAL.  For read indices that are not specified, quality is assumed to be ACTUAL. If not present, all quality of all reads are assumed to be actual. Required when interval-reads query parameter equals FULL or MIN_30
-     */
-    readQualities?: {
-      /**
-       * End interval for read quality flag
-       */
-      endInterval: number;
-      /**
-       * The quality of the read taken
-       */
-      quality: "SUBSTITUTE" | "FINAL_SUBSTITUTE";
-      /**
-       * Start interval for read quality flag. First read begins at 1
-       */
-      startInterval: number;
-      [k: string]: unknown;
-    } | null;
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Meter id/serial number as it appears in customer’s bill. ID permanence rules do not apply.
-   */
-  meterId?: string | null;
-  /**
-   * Date when the meter reads end in AEST.  If absent then assumed to be equal to readStartDate.  In this case the entry represents data for a single date specified by readStartDate.
-   */
-  readEndDate?: string | null;
-  /**
-   * Date when the meter reads start in AEST and assumed to start from 12:00 am AEST.
-   */
-  readStartDate: string;
-  /**
-   * Specify the type of the meter read data
-   */
-  readUType: "basicRead" | "intervalRead";
-  /**
-   * Register ID of the meter register where the meter reads are obtained
-   */
-  registerId?: string | null;
-  /**
-   * Register suffix of the meter register where the meter reads are obtained
-   */
-  registerSuffix: string;
-  /**
-   * The independent ID of the service point, known in the industry as the National Meter Identifier (NMI). Note that the servicePointId will be replaced with NMI for all interactions between Data Holder and AEMO.
-   */
-  servicePointId: string;
-  /**
-   * Unit of measure of the meter reads. Refer to Appendix B of <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF Specification NEM12 NEM13 v2.1</a> for a list of possible values
-   */
-  unitOfMeasure?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface Links {
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface LinksPaginated {
-  /**
-   * URI to the first page of this set. Mandatory if this response is not the first page
-   */
-  first?: string | null;
-  /**
-   * URI to the last page of this set. Mandatory if this response is not the last page
-   */
-  last?: string | null;
-  /**
-   * URI to the next page of this set. Mandatory if this response is not the last page
-   */
-  next?: string | null;
-  /**
-   * URI to the previous page of this set. Mandatory if this response is not the first page
-   */
-  prev?: string | null;
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface Meta {
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
-
-export interface MetaPaginated {
-  /**
-   * The total number of pages in the full set. See [pagination](#pagination).
-   */
-  totalPages: number;
-  /**
-   * The total number of records in the full set. See [pagination](#pagination).
-   */
-  totalRecords: number;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy_sdh api. */
 
 export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }

--- a/types/consumer-data-standards/index.d.ts
+++ b/types/consumer-data-standards/index.d.ts
@@ -3,13 +3,13 @@
 // Definitions by: Tomas Schier <https://github.com/tom-schier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as admin from './admin';
 import * as banking from './banking';
+import * as common from './common';
 import * as dcr1 from './dcr';
 import * as energy from './energy';
-import * as admin from './admin';
-import * as common from './common';
-import * as register from './register';
 import * as energy_sdh from './energy_sdh';
+import * as register from './register';
 import * as telco from './telco';
 
-export { banking, dcr1, energy, common, admin, energy_sdh, register, telco };
+export { admin, banking, common, dcr1, energy, energy_sdh, register, telco };

--- a/types/consumer-data-standards/register/index.d.ts
+++ b/types/consumer-data-standards/register/index.d.ts
@@ -1,55 +1,80 @@
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
 export interface DataHolderBrandSummary {
-  /**
-   * Australian Business Number for the organisation
-   */
-  abn?: string | null;
-  /**
-   * Australian Company Number for the organisation
-   */
-  acn?: string | null;
-  /**
-   * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
-   */
-  arbn?: string | null;
-  /**
-   * The name of Data Holder Brand
-   */
-  brandName: string;
-  /**
-   * Unique id of the Data Holder Brand issued by the CDR Register
-   */
-  dataHolderBrandId?: string | null;
-  /**
-   * The industries the Data Holder Brand belongs to
-   */
-  industries: ("banking" | "energy" | "telco")[];
-  /**
-   * Interim id of the Data Holder Brand issued by the CDR Register. This is to be used to uniquely identify the record when dataHolderBrandId is not populated and is not to be reused
-   */
-  interimId?: string | null;
-  /**
-   * The date/time that the Data Holder Brand data was last updated in the Register
-   */
-  lastUpdated: string;
-  /**
-   * Brand logo URI
-   */
-  logoUri: string;
-  /**
-   * Base URI for the Data Holder's Consumer Data Standard public endpoints
-   */
-  publicBaseUri: string;
-  [k: string]: unknown;
+    /**
+     * Australian Business Number for the organisation
+     */
+    abn?: string | null;
+    /**
+     * Australian Company Number for the organisation
+     */
+    acn?: string | null;
+    /**
+     * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
+     */
+    arbn?: string | null;
+    /**
+     * The name of Data Holder Brand
+     */
+    brandName: string;
+    /**
+     * Unique id of the Data Holder Brand issued by the CDR Register
+     */
+    dataHolderBrandId?: string | null;
+    /**
+     * The industries the Data Holder Brand belongs to
+     */
+    industries: ('banking' | 'energy' | 'telco')[];
+    /**
+     * Interim id of the Data Holder Brand issued by the CDR Register. This is to be used to uniquely identify the record when dataHolderBrandId is not populated and is not to be reused
+     */
+    interimId?: string | null;
+    /**
+     * The date/time that the Data Holder Brand data was last updated in the Register
+     */
+    lastUpdated: string;
+    /**
+     * Brand logo URI
+     */
+    logoUri: string;
+    /**
+     * Base URI for the Data Holder's Consumer Data Standard public endpoints
+     */
+    publicBaseUri: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
 export interface DataHoldersStatusList {
-  /**
-   * Response data for the query
-   */
-  data: {
+    /**
+     * Response data for the query
+     */
+    data: {
+        /**
+         * Unique id of the Data Holder Legal Entity issued by the CDR Register.
+         */
+        legalEntityId: string;
+        /**
+         * Data Holder status in the CDR Register
+         */
+        status: 'ACTIVE' | 'REMOVED';
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface DataHolderStatus {
     /**
      * Unique id of the Data Holder Legal Entity issued by the CDR Register.
      */
@@ -57,33 +82,8 @@ export interface DataHoldersStatusList {
     /**
      * Data Holder status in the CDR Register
      */
-    status: "ACTIVE" | "REMOVED";
+    status: 'ACTIVE' | 'REMOVED';
     [k: string]: unknown;
-  }[];
-  links: {
-    /**
-     * Fully qualified link to this API call
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface DataHolderStatus {
-  /**
-   * Unique id of the Data Holder Legal Entity issued by the CDR Register.
-   */
-  legalEntityId: string;
-  /**
-   * Data Holder status in the CDR Register
-   */
-  status: "ACTIVE" | "REMOVED";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
@@ -91,56 +91,81 @@ export interface DataHolderStatus {
  * Metadata related to Data Recipient Brand
  */
 export interface DataRecipientBrandMetaData {
-  /**
-   * Data Recipient Brand name
-   */
-  brandName: string;
-  /**
-   * Unique id of the Data Recipient brand issued by the CDR Register
-   */
-  dataRecipientBrandId: string;
-  /**
-   * Data Recipient Brand logo URI
-   */
-  logoUri: string;
-  softwareProducts?:
-    | {
-        /**
-         * Software product logo URI
-         */
-        logoUri: string;
-        /**
-         * Description of the software product
-         */
-        softwareProductDescription?: string | null;
-        /**
-         * Unique id of the Data Recipient software product issued by the CDR Register
-         */
-        softwareProductId: string;
-        /**
-         * Name of the software product
-         */
-        softwareProductName: string;
-        /**
-         * Software Product status in the CDR Register
-         */
-        status: "ACTIVE" | "INACTIVE" | "REMOVED";
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Data Recipient Brand status in the CDR Register
-   */
-  status: "ACTIVE" | "INACTIVE" | "REMOVED";
-  [k: string]: unknown;
+    /**
+     * Data Recipient Brand name
+     */
+    brandName: string;
+    /**
+     * Unique id of the Data Recipient brand issued by the CDR Register
+     */
+    dataRecipientBrandId: string;
+    /**
+     * Data Recipient Brand logo URI
+     */
+    logoUri: string;
+    softwareProducts?:
+        | {
+            /**
+             * Software product logo URI
+             */
+            logoUri: string;
+            /**
+             * Description of the software product
+             */
+            softwareProductDescription?: string | null;
+            /**
+             * Unique id of the Data Recipient software product issued by the CDR Register
+             */
+            softwareProductId: string;
+            /**
+             * Name of the software product
+             */
+            softwareProductName: string;
+            /**
+             * Software Product status in the CDR Register
+             */
+            status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * Data Recipient Brand status in the CDR Register
+     */
+    status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
 export interface DataRecipientsStatusList {
-  /**
-   * Response data for the query
-   */
-  data: {
+    /**
+     * Response data for the query
+     */
+    data: {
+        /**
+         * Unique id of the Data Recipient Legal Entity issued by the CDR Register
+         */
+        legalEntityId: string;
+        /**
+         * Data Recipient status in the CDR Register
+         */
+        status: 'ACTIVE' | 'SUSPENDED' | 'REVOKED' | 'SURRENDERED';
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface DataRecipientStatus {
     /**
      * Unique id of the Data Recipient Legal Entity issued by the CDR Register
      */
@@ -148,33 +173,8 @@ export interface DataRecipientsStatusList {
     /**
      * Data Recipient status in the CDR Register
      */
-    status: "ACTIVE" | "SUSPENDED" | "REVOKED" | "SURRENDERED";
+    status: 'ACTIVE' | 'SUSPENDED' | 'REVOKED' | 'SURRENDERED';
     [k: string]: unknown;
-  }[];
-  links: {
-    /**
-     * Fully qualified link to this API call
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface DataRecipientStatus {
-  /**
-   * Unique id of the Data Recipient Legal Entity issued by the CDR Register
-   */
-  legalEntityId: string;
-  /**
-   * Data Recipient status in the CDR Register
-   */
-  status: "ACTIVE" | "SUSPENDED" | "REVOKED" | "SURRENDERED";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
@@ -182,31 +182,31 @@ export interface DataRecipientStatus {
  * Object representing a JSON Web Key
  */
 export interface JWK {
-  /**
-   * The "alg" (algorithm) parameter identifies the algorithm intended for use with the key
-   */
-  alg: string;
-  /**
-   * The "e" RSA public exponent parameter
-   */
-  e: string;
-  /**
-   * The "key_ops" (key operations) parameter identifies the operation(s) for which the key is intended to be used
-   */
-  key_ops: string[];
-  /**
-   * The "kid" (key ID) parameter is partially used to match a specific key. Note the "kid" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set
-   */
-  kid: string;
-  /**
-   * The "kty" (key type) parameter identifies the cryptographic algorithm family used with the key
-   */
-  kty: string;
-  /**
-   * The "n" RSA public modulus parameter
-   */
-  n: string;
-  [k: string]: unknown;
+    /**
+     * The "alg" (algorithm) parameter identifies the algorithm intended for use with the key
+     */
+    alg: string;
+    /**
+     * The "e" RSA public exponent parameter
+     */
+    e: string;
+    /**
+     * The "key_ops" (key operations) parameter identifies the operation(s) for which the key is intended to be used
+     */
+    key_ops: string[];
+    /**
+     * The "kid" (key ID) parameter is partially used to match a specific key. Note the "kid" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set
+     */
+    kid: string;
+    /**
+     * The "kty" (key type) parameter identifies the cryptographic algorithm family used with the key
+     */
+    kty: string;
+    /**
+     * The "n" RSA public modulus parameter
+     */
+    n: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
@@ -214,197 +214,6 @@ export interface JWK {
  * The data that is common to all organisations, regardless of the type (e.g. company, trust, partnership, government)
  */
 export interface LegalEntityDetail {
-  /**
-   * Australian Business Number for the organisation
-   */
-  abn?: string | null;
-  /**
-   * Australian Company Number for the organisation
-   */
-  acn?: string | null;
-  /**
-   * ANZSIC division of the organisation. **[[ANZSIC-2006]](#iref-ANZSIC-2006)**
-   */
-  anzsicDivision?: string | null;
-  /**
-   * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
-   */
-  arbn?: string | null;
-  /**
-   * Unique id of the organisation issued by the CDR Register
-   */
-  legalEntityId: string;
-  /**
-   * Unique legal name of the organisation
-   */
-  legalEntityName: string;
-  /**
-   * Legal Entity logo URI
-   */
-  logoUri: string;
-  /**
-   * Legal organisation type
-   */
-  organisationType?: ("SOLE_TRADER" | "COMPANY" | "PARTNERSHIP" | "TRUST" | "GOVERNMENT_ENTITY" | "OTHER") | null;
-  /**
-   * Country of registeration (if the company is registered outside Australia)
-   */
-  registeredCountry?: string | null;
-  /**
-   * Date of registration (if the company is registered outside Australia)
-   */
-  registrationDate?: string | null;
-  /**
-   * Unique registration number (if the company is registered outside Australia)
-   */
-  registrationNumber?: string | null;
-  status: "ACTIVE" | "REMOVED";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface Links {
-  /**
-   * Fully qualified link to this API call
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface LinksPaginated {
-  /**
-   * URI to the first page of this set. Mandatory if this response is not the first page
-   */
-  first?: string | null;
-  /**
-   * URI to the last page of this set. Mandatory if this response is not the last page
-   */
-  last?: string | null;
-  /**
-   * URI to the next page of this set. Mandatory if this response is not the last page
-   */
-  next?: string | null;
-  /**
-   * URI to the previous page of this set. Mandatory if this response is not the first page
-   */
-  prev?: string | null;
-  /**
-   * Fully qualified link to this API call
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface Meta {
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-/**
- * Additional data for customised error codes
- */
-export interface MetaError {
-  /**
-   * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-   */
-  urn?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface MetaPaginated {
-  /**
-   * The total number of pages in the full set
-   */
-  totalPages: number;
-  /**
-   * The total number of records in the full set
-   */
-  totalRecords: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-/**
- * Defines the mechanism used and associated endpoints for Data Holder to Data Recipient authentication
- */
-export interface RegisterDataHolderAuth {
-  /**
-   * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
-   */
-  jwksEndpoint: string;
-  /**
-   * The type of authentication and authorisation mechanism in use
-   */
-  registerUType: "SIGNED-JWT";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface RegisterDataHolderBrand {
-  authDetails: {
-    /**
-     * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
-     */
-    jwksEndpoint: string;
-    /**
-     * The type of authentication and authorisation mechanism in use
-     */
-    registerUType: "SIGNED-JWT";
-    [k: string]: unknown;
-  }[];
-  /**
-   * The name of Data Holder Brand
-   */
-  brandName: string;
-  /**
-   * Unique id of the Data Holder Brand issued by the CDR Register
-   */
-  dataHolderBrandId: string;
-  /**
-   * Endpoints related to Data Holder Brand services
-   */
-  endpointDetail: {
-    /**
-     * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
-     */
-    extensionBaseUri?: string | null;
-    /**
-     * Base URI for the Data Holder's Consumer Data Standard information security endpoints
-     */
-    infosecBaseUri: string;
-    /**
-     * Base URI for the Data Holder's Consumer Data Standard public endpoints
-     */
-    publicBaseUri: string;
-    /**
-     * Base URI for the Data Holder's Consumer Data Standard resource endpoints
-     */
-    resourceBaseUri: string;
-    /**
-     * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
-     */
-    version: string;
-    /**
-     * Publicly available website or web resource URI
-     */
-    websiteUri: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The industries the Data Holder Brand belongs to
-   */
-  industries: ("banking" | "energy" | "telco")[];
-  /**
-   * The date/time that the Data Holder Brand data was last updated in the Register
-   */
-  lastUpdated: string;
-  /**
-   * The data that is common to all organisations, regardless of the type (e.g. company, trust, partnership, government)
-   */
-  legalEntity: {
     /**
      * Australian Business Number for the organisation
      */
@@ -436,7 +245,7 @@ export interface RegisterDataHolderBrand {
     /**
      * Legal organisation type
      */
-    organisationType?: ("SOLE_TRADER" | "COMPANY" | "PARTNERSHIP" | "TRUST" | "GOVERNMENT_ENTITY" | "OTHER") | null;
+    organisationType?: ('SOLE_TRADER' | 'COMPANY' | 'PARTNERSHIP' | 'TRUST' | 'GOVERNMENT_ENTITY' | 'OTHER') | null;
     /**
      * Country of registeration (if the company is registered outside Australia)
      */
@@ -449,469 +258,21 @@ export interface RegisterDataHolderBrand {
      * Unique registration number (if the company is registered outside Australia)
      */
     registrationNumber?: string | null;
-    status: "ACTIVE" | "REMOVED";
+    status: 'ACTIVE' | 'REMOVED';
     [k: string]: unknown;
-  };
-  /**
-   * Brand logo URI
-   */
-  logoUri: string;
-  status: "ACTIVE" | "INACTIVE" | "REMOVED";
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
-/**
- * Endpoints related to Data Holder Brand services
- */
-export interface RegisterDataHolderBrandServiceEndpoint {
-  /**
-   * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
-   */
-  extensionBaseUri?: string | null;
-  /**
-   * Base URI for the Data Holder's Consumer Data Standard information security endpoints
-   */
-  infosecBaseUri: string;
-  /**
-   * Base URI for the Data Holder's Consumer Data Standard public endpoints
-   */
-  publicBaseUri: string;
-  /**
-   * Base URI for the Data Holder's Consumer Data Standard resource endpoints
-   */
-  resourceBaseUri: string;
-  /**
-   * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
-   */
-  version: string;
-  /**
-   * Publicly available website or web resource URI
-   */
-  websiteUri: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface RegisterDataRecipient {
-  /**
-   * Accreditation level of the Data Recipient in the CDR Register
-   */
-  accreditationLevel: "UNRESTRICTED" | "SPONSORED";
-  /**
-   * CDR Register issued human readable unique number given to Data Recipients upon accreditation
-   */
-  accreditationNumber: string;
-  dataRecipientBrands?:
-    | {
-        /**
-         * Data Recipient Brand name
-         */
-        brandName: string;
-        /**
-         * Unique id of the Data Recipient brand issued by the CDR Register
-         */
-        dataRecipientBrandId: string;
-        /**
-         * Data Recipient Brand logo URI
-         */
-        logoUri: string;
-        softwareProducts?:
-          | {
-              /**
-               * Software product logo URI
-               */
-              logoUri: string;
-              /**
-               * Description of the software product
-               */
-              softwareProductDescription?: string | null;
-              /**
-               * Unique id of the Data Recipient software product issued by the CDR Register
-               */
-              softwareProductId: string;
-              /**
-               * Name of the software product
-               */
-              softwareProductName: string;
-              /**
-               * Software Product status in the CDR Register
-               */
-              status: "ACTIVE" | "INACTIVE" | "REMOVED";
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * Data Recipient Brand status in the CDR Register
-         */
-        status: "ACTIVE" | "INACTIVE" | "REMOVED";
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The date/time that the Legal Entity was last updated in the CDR Register
-   */
-  lastUpdated: string;
-  /**
-   * Unique id of the Data Recipient Legal Entity issued by the CDR Register.
-   */
-  legalEntityId: string;
-  /**
-   * Legal name of the Data Recipient
-   */
-  legalEntityName: string;
-  /**
-   * Legal Entity logo URI
-   */
-  logoUri: string;
-  /**
-   * Data Recipient status in the CDR Register
-   */
-  status: "ACTIVE" | "SUSPENDED" | "REVOKED" | "SURRENDERED";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface ResponseDataHoldersBrandSummaryList {
-  /**
-   * Response data for the query
-   */
-  data: {
-    /**
-     * Australian Business Number for the organisation
-     */
-    abn?: string | null;
-    /**
-     * Australian Company Number for the organisation
-     */
-    acn?: string | null;
-    /**
-     * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
-     */
-    arbn?: string | null;
-    /**
-     * The name of Data Holder Brand
-     */
-    brandName: string;
-    /**
-     * Unique id of the Data Holder Brand issued by the CDR Register
-     */
-    dataHolderBrandId?: string | null;
-    /**
-     * The industries the Data Holder Brand belongs to
-     */
-    industries: ("banking" | "energy" | "telco")[];
-    /**
-     * Interim id of the Data Holder Brand issued by the CDR Register. This is to be used to uniquely identify the record when dataHolderBrandId is not populated and is not to be reused
-     */
-    interimId?: string | null;
-    /**
-     * The date/time that the Data Holder Brand data was last updated in the Register
-     */
-    lastUpdated: string;
-    /**
-     * Brand logo URI
-     */
-    logoUri: string;
-    /**
-     * Base URI for the Data Holder's Consumer Data Standard public endpoints
-     */
-    publicBaseUri: string;
-    [k: string]: unknown;
-  }[];
-  links: {
+export interface Links {
     /**
      * Fully qualified link to this API call
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
-export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface ResponseErrorListV2Errors {
-  /**
-   * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-   */
-  code: string;
-  /**
-   * A human-readable explanation specific to this occurrence of the problem.
-   */
-  detail: string;
-  /**
-   * Additional data for customised error codes
-   */
-  meta?: {
-    /**
-     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-     */
-    urn?: string | null;
-    [k: string]: unknown;
-  };
-  /**
-   * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-   */
-  title: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-/**
- * Response containing the JSON Web Key Set
- */
-export interface ResponseJWKS {
-  /**
-   * The value of the "keys" parameter is an array of JWK values
-   */
-  keys: {
-    /**
-     * The "alg" (algorithm) parameter identifies the algorithm intended for use with the key
-     */
-    alg: string;
-    /**
-     * The "e" RSA public exponent parameter
-     */
-    e: string;
-    /**
-     * The "key_ops" (key operations) parameter identifies the operation(s) for which the key is intended to be used
-     */
-    key_ops: string[];
-    /**
-     * The "kid" (key ID) parameter is partially used to match a specific key. Note the "kid" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set
-     */
-    kid: string;
-    /**
-     * The "kty" (key type) parameter identifies the cryptographic algorithm family used with the key
-     */
-    kty: string;
-    /**
-     * The "n" RSA public modulus parameter
-     */
-    n: string;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-/**
- * Response containing the Open ID Provider Configuration Metadata
- */
-export interface ResponseOpenIDProviderConfigMetadata {
-  /**
-   * JSON array containing a list of the Claim Names of the Claims that the CDR Register supplies values for
-   */
-  claims_supported: string[];
-  /**
-   * JSON array containing a list of Proof Key for Code Exchange (PKCE) **[[RFC7636]](#nref-RFC7636)** code challenge methods supported by this authorization server. Given the CDR Register does not support PKCE, this field can be safely ignored
-   */
-  code_challenge_methods_supported: string[];
-  /**
-   * JSON array containing a list of the OAuth 2.0 Grant Type values that the CDR Register supports
-   */
-  grant_types_supported: string[];
-  /**
-   * JSON array containing a list of the JWS signing algorithms (alg values) supported by the CDR Register for the ID Token to encode the Claims in a JWT. Given the CDR Register does not issue ID tokens, this field can be safely ignored
-   */
-  id_token_signing_alg_values_supported: string[];
-  /**
-   * URL using the https scheme with no query or fragment component that the CDR Register asserts as its Issuer Identifier
-   */
-  issuer: string;
-  /**
-   * URL of the CDR Register's JSON Web Key Set **[[JWK]](#nref-JWK)** document. This contains the signing key(s) used to validate access tokens issued from the CDR Register. Note that this differs from the JWKS endpoint used to validate SSAs and CDR Register client authentication
-   */
-  jwks_uri: string;
-  /**
-   * JSON array containing a list of the OAuth 2.0 response_type values that the CDR Registrer supports
-   */
-  response_types_supported: string[];
-  /**
-   * JSON array containing a list of the OAuth 2.0 **[[RFC6749]](#nref-RFC6749)** scope values that the CDR Register supports
-   */
-  scopes_supported: string[];
-  /**
-   * JSON array containing a list of the Subject Identifier types that the CDR Register supports. Given the CDR Register does not issue ID tokens, this field can be safely ignored
-   */
-  subject_types_supported: string[];
-  /**
-   * Boolean value indicating server support for mutual TLS client certificate bound access tokens
-   */
-  tls_client_certificate_bound_access_tokens: boolean;
-  /**
-   * URL of the CDR Register's OAuth 2.0 Token Endpoint
-   */
-  token_endpoint: string;
-  /**
-   * JSON array containing a list of Client Authentication methods supported by this Token Endpoint
-   */
-  token_endpoint_auth_methods_supported: string[];
-  /**
-   * JSON array containing a list of the JWS signing algorithms (alg values) supported by the token endpoint for the signature on the JWT **[[JWT]](#nref-JWT)** used to authenticate the client at the token endpoint for the \"private_key_jwt\" authentication method
-   */
-  token_endpoint_auth_signing_alg_values_supported: string[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-/**
- * Response containing a list of CDR Register Data Holder Brand objects
- */
-export interface ResponseRegisterDataHolderBrandList {
-  /**
-   * Response data for the query
-   */
-  data: {
-    authDetails: {
-      /**
-       * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
-       */
-      jwksEndpoint: string;
-      /**
-       * The type of authentication and authorisation mechanism in use
-       */
-      registerUType: "SIGNED-JWT";
-      [k: string]: unknown;
-    }[];
-    /**
-     * The name of Data Holder Brand
-     */
-    brandName: string;
-    /**
-     * Unique id of the Data Holder Brand issued by the CDR Register
-     */
-    dataHolderBrandId: string;
-    /**
-     * Endpoints related to Data Holder Brand services
-     */
-    endpointDetail: {
-      /**
-       * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
-       */
-      extensionBaseUri?: string | null;
-      /**
-       * Base URI for the Data Holder's Consumer Data Standard information security endpoints
-       */
-      infosecBaseUri: string;
-      /**
-       * Base URI for the Data Holder's Consumer Data Standard public endpoints
-       */
-      publicBaseUri: string;
-      /**
-       * Base URI for the Data Holder's Consumer Data Standard resource endpoints
-       */
-      resourceBaseUri: string;
-      /**
-       * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
-       */
-      version: string;
-      /**
-       * Publicly available website or web resource URI
-       */
-      websiteUri: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The industries the Data Holder Brand belongs to
-     */
-    industries: ("banking" | "energy" | "telco")[];
-    /**
-     * The date/time that the Data Holder Brand data was last updated in the Register
-     */
-    lastUpdated: string;
-    /**
-     * The data that is common to all organisations, regardless of the type (e.g. company, trust, partnership, government)
-     */
-    legalEntity: {
-      /**
-       * Australian Business Number for the organisation
-       */
-      abn?: string | null;
-      /**
-       * Australian Company Number for the organisation
-       */
-      acn?: string | null;
-      /**
-       * ANZSIC division of the organisation. **[[ANZSIC-2006]](#iref-ANZSIC-2006)**
-       */
-      anzsicDivision?: string | null;
-      /**
-       * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
-       */
-      arbn?: string | null;
-      /**
-       * Unique id of the organisation issued by the CDR Register
-       */
-      legalEntityId: string;
-      /**
-       * Unique legal name of the organisation
-       */
-      legalEntityName: string;
-      /**
-       * Legal Entity logo URI
-       */
-      logoUri: string;
-      /**
-       * Legal organisation type
-       */
-      organisationType?: ("SOLE_TRADER" | "COMPANY" | "PARTNERSHIP" | "TRUST" | "GOVERNMENT_ENTITY" | "OTHER") | null;
-      /**
-       * Country of registeration (if the company is registered outside Australia)
-       */
-      registeredCountry?: string | null;
-      /**
-       * Date of registration (if the company is registered outside Australia)
-       */
-      registrationDate?: string | null;
-      /**
-       * Unique registration number (if the company is registered outside Australia)
-       */
-      registrationNumber?: string | null;
-      status: "ACTIVE" | "REMOVED";
-      [k: string]: unknown;
-    };
-    /**
-     * Brand logo URI
-     */
-    logoUri: string;
-    status: "ACTIVE" | "INACTIVE" | "REMOVED";
-    [k: string]: unknown;
-  }[];
-  links: {
+export interface LinksPaginated {
     /**
      * URI to the first page of this set. Mandatory if this response is not the first page
      */
@@ -933,8 +294,27 @@ export interface ResponseRegisterDataHolderBrandList {
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface Meta {
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Additional data for customised error codes
+ */
+export interface MetaError {
+    /**
+     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+     */
+    urn?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface MetaPaginated {
     /**
      * The total number of pages in the full set
      */
@@ -944,73 +324,230 @@ export interface ResponseRegisterDataHolderBrandList {
      */
     totalRecords: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
 /**
- * Response containing a list of Data Recipients in the CDR Register
+ * Defines the mechanism used and associated endpoints for Data Holder to Data Recipient authentication
  */
-export interface ResponseRegisterDataRecipientList {
-  /**
-   * Response data for the query
-   */
-  data: {
+export interface RegisterDataHolderAuth {
+    /**
+     * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
+     */
+    jwksEndpoint: string;
+    /**
+     * The type of authentication and authorisation mechanism in use
+     */
+    registerUType: 'SIGNED-JWT';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface RegisterDataHolderBrand {
+    authDetails: {
+        /**
+         * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
+         */
+        jwksEndpoint: string;
+        /**
+         * The type of authentication and authorisation mechanism in use
+         */
+        registerUType: 'SIGNED-JWT';
+        [k: string]: unknown;
+    }[];
+    /**
+     * The name of Data Holder Brand
+     */
+    brandName: string;
+    /**
+     * Unique id of the Data Holder Brand issued by the CDR Register
+     */
+    dataHolderBrandId: string;
+    /**
+     * Endpoints related to Data Holder Brand services
+     */
+    endpointDetail: {
+        /**
+         * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
+         */
+        extensionBaseUri?: string | null;
+        /**
+         * Base URI for the Data Holder's Consumer Data Standard information security endpoints
+         */
+        infosecBaseUri: string;
+        /**
+         * Base URI for the Data Holder's Consumer Data Standard public endpoints
+         */
+        publicBaseUri: string;
+        /**
+         * Base URI for the Data Holder's Consumer Data Standard resource endpoints
+         */
+        resourceBaseUri: string;
+        /**
+         * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
+         */
+        version: string;
+        /**
+         * Publicly available website or web resource URI
+         */
+        websiteUri: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The industries the Data Holder Brand belongs to
+     */
+    industries: ('banking' | 'energy' | 'telco')[];
+    /**
+     * The date/time that the Data Holder Brand data was last updated in the Register
+     */
+    lastUpdated: string;
+    /**
+     * The data that is common to all organisations, regardless of the type (e.g. company, trust, partnership, government)
+     */
+    legalEntity: {
+        /**
+         * Australian Business Number for the organisation
+         */
+        abn?: string | null;
+        /**
+         * Australian Company Number for the organisation
+         */
+        acn?: string | null;
+        /**
+         * ANZSIC division of the organisation. **[[ANZSIC-2006]](#iref-ANZSIC-2006)**
+         */
+        anzsicDivision?: string | null;
+        /**
+         * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
+         */
+        arbn?: string | null;
+        /**
+         * Unique id of the organisation issued by the CDR Register
+         */
+        legalEntityId: string;
+        /**
+         * Unique legal name of the organisation
+         */
+        legalEntityName: string;
+        /**
+         * Legal Entity logo URI
+         */
+        logoUri: string;
+        /**
+         * Legal organisation type
+         */
+        organisationType?: ('SOLE_TRADER' | 'COMPANY' | 'PARTNERSHIP' | 'TRUST' | 'GOVERNMENT_ENTITY' | 'OTHER') | null;
+        /**
+         * Country of registeration (if the company is registered outside Australia)
+         */
+        registeredCountry?: string | null;
+        /**
+         * Date of registration (if the company is registered outside Australia)
+         */
+        registrationDate?: string | null;
+        /**
+         * Unique registration number (if the company is registered outside Australia)
+         */
+        registrationNumber?: string | null;
+        status: 'ACTIVE' | 'REMOVED';
+        [k: string]: unknown;
+    };
+    /**
+     * Brand logo URI
+     */
+    logoUri: string;
+    status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Endpoints related to Data Holder Brand services
+ */
+export interface RegisterDataHolderBrandServiceEndpoint {
+    /**
+     * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
+     */
+    extensionBaseUri?: string | null;
+    /**
+     * Base URI for the Data Holder's Consumer Data Standard information security endpoints
+     */
+    infosecBaseUri: string;
+    /**
+     * Base URI for the Data Holder's Consumer Data Standard public endpoints
+     */
+    publicBaseUri: string;
+    /**
+     * Base URI for the Data Holder's Consumer Data Standard resource endpoints
+     */
+    resourceBaseUri: string;
+    /**
+     * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
+     */
+    version: string;
+    /**
+     * Publicly available website or web resource URI
+     */
+    websiteUri: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface RegisterDataRecipient {
     /**
      * Accreditation level of the Data Recipient in the CDR Register
      */
-    accreditationLevel: "UNRESTRICTED" | "SPONSORED";
+    accreditationLevel: 'UNRESTRICTED' | 'SPONSORED';
     /**
      * CDR Register issued human readable unique number given to Data Recipients upon accreditation
      */
     accreditationNumber: string;
     dataRecipientBrands?:
-      | {
-          /**
-           * Data Recipient Brand name
-           */
-          brandName: string;
-          /**
-           * Unique id of the Data Recipient brand issued by the CDR Register
-           */
-          dataRecipientBrandId: string;
-          /**
-           * Data Recipient Brand logo URI
-           */
-          logoUri: string;
-          softwareProducts?:
-            | {
-                /**
-                 * Software product logo URI
-                 */
-                logoUri: string;
-                /**
-                 * Description of the software product
-                 */
-                softwareProductDescription?: string | null;
-                /**
-                 * Unique id of the Data Recipient software product issued by the CDR Register
-                 */
-                softwareProductId: string;
-                /**
-                 * Name of the software product
-                 */
-                softwareProductName: string;
-                /**
-                 * Software Product status in the CDR Register
-                 */
-                status: "ACTIVE" | "INACTIVE" | "REMOVED";
-                [k: string]: unknown;
-              }[]
-            | null;
-          /**
-           * Data Recipient Brand status in the CDR Register
-           */
-          status: "ACTIVE" | "INACTIVE" | "REMOVED";
-          [k: string]: unknown;
+        | {
+            /**
+             * Data Recipient Brand name
+             */
+            brandName: string;
+            /**
+             * Unique id of the Data Recipient brand issued by the CDR Register
+             */
+            dataRecipientBrandId: string;
+            /**
+             * Data Recipient Brand logo URI
+             */
+            logoUri: string;
+            softwareProducts?:
+                | {
+                    /**
+                     * Software product logo URI
+                     */
+                    logoUri: string;
+                    /**
+                     * Description of the software product
+                     */
+                    softwareProductDescription?: string | null;
+                    /**
+                     * Unique id of the Data Recipient software product issued by the CDR Register
+                     */
+                    softwareProductId: string;
+                    /**
+                     * Name of the software product
+                     */
+                    softwareProductName: string;
+                    /**
+                     * Software Product status in the CDR Register
+                     */
+                    status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * Data Recipient Brand status in the CDR Register
+             */
+            status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The date/time that the Legal Entity was last updated in the CDR Register
      */
@@ -1030,20 +567,485 @@ export interface ResponseRegisterDataRecipientList {
     /**
      * Data Recipient status in the CDR Register
      */
-    status: "ACTIVE" | "SUSPENDED" | "REVOKED" | "SURRENDERED";
+    status: 'ACTIVE' | 'SUSPENDED' | 'REVOKED' | 'SURRENDERED';
     [k: string]: unknown;
-  }[];
-  links: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface ResponseDataHoldersBrandSummaryList {
     /**
-     * Fully qualified link to this API call
+     * Response data for the query
      */
-    self: string;
+    data: {
+        /**
+         * Australian Business Number for the organisation
+         */
+        abn?: string | null;
+        /**
+         * Australian Company Number for the organisation
+         */
+        acn?: string | null;
+        /**
+         * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
+         */
+        arbn?: string | null;
+        /**
+         * The name of Data Holder Brand
+         */
+        brandName: string;
+        /**
+         * Unique id of the Data Holder Brand issued by the CDR Register
+         */
+        dataHolderBrandId?: string | null;
+        /**
+         * The industries the Data Holder Brand belongs to
+         */
+        industries: ('banking' | 'energy' | 'telco')[];
+        /**
+         * Interim id of the Data Holder Brand issued by the CDR Register. This is to be used to uniquely identify the record when dataHolderBrandId is not populated and is not to be reused
+         */
+        interimId?: string | null;
+        /**
+         * The date/time that the Data Holder Brand data was last updated in the Register
+         */
+        lastUpdated: string;
+        /**
+         * Brand logo URI
+         */
+        logoUri: string;
+        /**
+         * Base URI for the Data Holder's Consumer Data Standard public endpoints
+         */
+        publicBaseUri: string;
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface ResponseErrorListV2 {
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface ResponseErrorListV2Errors {
+    /**
+     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+     */
+    code: string;
+    /**
+     * A human-readable explanation specific to this occurrence of the problem.
+     */
+    detail: string;
+    /**
+     * Additional data for customised error codes
+     */
+    meta?: {
+        /**
+         * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+         */
+        urn?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+     */
+    title: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Response containing the JSON Web Key Set
+ */
+export interface ResponseJWKS {
+    /**
+     * The value of the "keys" parameter is an array of JWK values
+     */
+    keys: {
+        /**
+         * The "alg" (algorithm) parameter identifies the algorithm intended for use with the key
+         */
+        alg: string;
+        /**
+         * The "e" RSA public exponent parameter
+         */
+        e: string;
+        /**
+         * The "key_ops" (key operations) parameter identifies the operation(s) for which the key is intended to be used
+         */
+        key_ops: string[];
+        /**
+         * The "kid" (key ID) parameter is partially used to match a specific key. Note the "kid" parameter is not guaranteed unique and additional parameters should be used to progressively to identify a key within a set
+         */
+        kid: string;
+        /**
+         * The "kty" (key type) parameter identifies the cryptographic algorithm family used with the key
+         */
+        kty: string;
+        /**
+         * The "n" RSA public modulus parameter
+         */
+        n: string;
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Response containing the Open ID Provider Configuration Metadata
+ */
+export interface ResponseOpenIDProviderConfigMetadata {
+    /**
+     * JSON array containing a list of the Claim Names of the Claims that the CDR Register supplies values for
+     */
+    claims_supported: string[];
+    /**
+     * JSON array containing a list of Proof Key for Code Exchange (PKCE) **[[RFC7636]](#nref-RFC7636)** code challenge methods supported by this authorization server. Given the CDR Register does not support PKCE, this field can be safely ignored
+     */
+    code_challenge_methods_supported: string[];
+    /**
+     * JSON array containing a list of the OAuth 2.0 Grant Type values that the CDR Register supports
+     */
+    grant_types_supported: string[];
+    /**
+     * JSON array containing a list of the JWS signing algorithms (alg values) supported by the CDR Register for the ID Token to encode the Claims in a JWT. Given the CDR Register does not issue ID tokens, this field can be safely ignored
+     */
+    id_token_signing_alg_values_supported: string[];
+    /**
+     * URL using the https scheme with no query or fragment component that the CDR Register asserts as its Issuer Identifier
+     */
+    issuer: string;
+    /**
+     * URL of the CDR Register's JSON Web Key Set **[[JWK]](#nref-JWK)** document. This contains the signing key(s) used to validate access tokens issued from the CDR Register. Note that this differs from the JWKS endpoint used to validate SSAs and CDR Register client authentication
+     */
+    jwks_uri: string;
+    /**
+     * JSON array containing a list of the OAuth 2.0 response_type values that the CDR Registrer supports
+     */
+    response_types_supported: string[];
+    /**
+     * JSON array containing a list of the OAuth 2.0 **[[RFC6749]](#nref-RFC6749)** scope values that the CDR Register supports
+     */
+    scopes_supported: string[];
+    /**
+     * JSON array containing a list of the Subject Identifier types that the CDR Register supports. Given the CDR Register does not issue ID tokens, this field can be safely ignored
+     */
+    subject_types_supported: string[];
+    /**
+     * Boolean value indicating server support for mutual TLS client certificate bound access tokens
+     */
+    tls_client_certificate_bound_access_tokens: boolean;
+    /**
+     * URL of the CDR Register's OAuth 2.0 Token Endpoint
+     */
+    token_endpoint: string;
+    /**
+     * JSON array containing a list of Client Authentication methods supported by this Token Endpoint
+     */
+    token_endpoint_auth_methods_supported: string[];
+    /**
+     * JSON array containing a list of the JWS signing algorithms (alg values) supported by the token endpoint for the signature on the JWT **[[JWT]](#nref-JWT)** used to authenticate the client at the token endpoint for the \"private_key_jwt\" authentication method
+     */
+    token_endpoint_auth_signing_alg_values_supported: string[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Response containing a list of CDR Register Data Holder Brand objects
+ */
+export interface ResponseRegisterDataHolderBrandList {
+    /**
+     * Response data for the query
+     */
+    data: {
+        authDetails: {
+            /**
+             * JWKS endpoint used for authentication by the Data Holder with the Data Recipient
+             */
+            jwksEndpoint: string;
+            /**
+             * The type of authentication and authorisation mechanism in use
+             */
+            registerUType: 'SIGNED-JWT';
+            [k: string]: unknown;
+        }[];
+        /**
+         * The name of Data Holder Brand
+         */
+        brandName: string;
+        /**
+         * Unique id of the Data Holder Brand issued by the CDR Register
+         */
+        dataHolderBrandId: string;
+        /**
+         * Endpoints related to Data Holder Brand services
+         */
+        endpointDetail: {
+            /**
+             * Base URI for the Data Holder extension endpoints to the Consumer Data Standard (optional)
+             */
+            extensionBaseUri?: string | null;
+            /**
+             * Base URI for the Data Holder's Consumer Data Standard information security endpoints
+             */
+            infosecBaseUri: string;
+            /**
+             * Base URI for the Data Holder's Consumer Data Standard public endpoints
+             */
+            publicBaseUri: string;
+            /**
+             * Base URI for the Data Holder's Consumer Data Standard resource endpoints
+             */
+            resourceBaseUri: string;
+            /**
+             * The major version of the high level standards. This is not the version of the endpoint or the payload being requested but the version of the overall standards being applied. This version number will be "v" followed by the major version of the standards as a positive integer (e.g. v1, v12 or v76)
+             */
+            version: string;
+            /**
+             * Publicly available website or web resource URI
+             */
+            websiteUri: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The industries the Data Holder Brand belongs to
+         */
+        industries: ('banking' | 'energy' | 'telco')[];
+        /**
+         * The date/time that the Data Holder Brand data was last updated in the Register
+         */
+        lastUpdated: string;
+        /**
+         * The data that is common to all organisations, regardless of the type (e.g. company, trust, partnership, government)
+         */
+        legalEntity: {
+            /**
+             * Australian Business Number for the organisation
+             */
+            abn?: string | null;
+            /**
+             * Australian Company Number for the organisation
+             */
+            acn?: string | null;
+            /**
+             * ANZSIC division of the organisation. **[[ANZSIC-2006]](#iref-ANZSIC-2006)**
+             */
+            anzsicDivision?: string | null;
+            /**
+             * Australian Registered Body Number.  ARBNs are issued to registrable Australian bodies and foreign companies
+             */
+            arbn?: string | null;
+            /**
+             * Unique id of the organisation issued by the CDR Register
+             */
+            legalEntityId: string;
+            /**
+             * Unique legal name of the organisation
+             */
+            legalEntityName: string;
+            /**
+             * Legal Entity logo URI
+             */
+            logoUri: string;
+            /**
+             * Legal organisation type
+             */
+            organisationType?:
+                | ('SOLE_TRADER' | 'COMPANY' | 'PARTNERSHIP' | 'TRUST' | 'GOVERNMENT_ENTITY' | 'OTHER')
+                | null;
+            /**
+             * Country of registeration (if the company is registered outside Australia)
+             */
+            registeredCountry?: string | null;
+            /**
+             * Date of registration (if the company is registered outside Australia)
+             */
+            registrationDate?: string | null;
+            /**
+             * Unique registration number (if the company is registered outside Australia)
+             */
+            registrationNumber?: string | null;
+            status: 'ACTIVE' | 'REMOVED';
+            [k: string]: unknown;
+        };
+        /**
+         * Brand logo URI
+         */
+        logoUri: string;
+        status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+/**
+ * Response containing a list of Data Recipients in the CDR Register
+ */
+export interface ResponseRegisterDataRecipientList {
+    /**
+     * Response data for the query
+     */
+    data: {
+        /**
+         * Accreditation level of the Data Recipient in the CDR Register
+         */
+        accreditationLevel: 'UNRESTRICTED' | 'SPONSORED';
+        /**
+         * CDR Register issued human readable unique number given to Data Recipients upon accreditation
+         */
+        accreditationNumber: string;
+        dataRecipientBrands?:
+            | {
+                /**
+                 * Data Recipient Brand name
+                 */
+                brandName: string;
+                /**
+                 * Unique id of the Data Recipient brand issued by the CDR Register
+                 */
+                dataRecipientBrandId: string;
+                /**
+                 * Data Recipient Brand logo URI
+                 */
+                logoUri: string;
+                softwareProducts?:
+                    | {
+                        /**
+                         * Software product logo URI
+                         */
+                        logoUri: string;
+                        /**
+                         * Description of the software product
+                         */
+                        softwareProductDescription?: string | null;
+                        /**
+                         * Unique id of the Data Recipient software product issued by the CDR Register
+                         */
+                        softwareProductId: string;
+                        /**
+                         * Name of the software product
+                         */
+                        softwareProductName: string;
+                        /**
+                         * Software Product status in the CDR Register
+                         */
+                        status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * Data Recipient Brand status in the CDR Register
+                 */
+                status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The date/time that the Legal Entity was last updated in the CDR Register
+         */
+        lastUpdated: string;
+        /**
+         * Unique id of the Data Recipient Legal Entity issued by the CDR Register.
+         */
+        legalEntityId: string;
+        /**
+         * Legal name of the Data Recipient
+         */
+        legalEntityName: string;
+        /**
+         * Legal Entity logo URI
+         */
+        logoUri: string;
+        /**
+         * Data Recipient status in the CDR Register
+         */
+        status: 'ACTIVE' | 'SUSPENDED' | 'REVOKED' | 'SURRENDERED';
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
@@ -1051,35 +1053,60 @@ export interface ResponseRegisterDataRecipientList {
  * Data Recipient Brand Software Products
  */
 export interface SoftwareProductMetaData {
-  /**
-   * Software product logo URI
-   */
-  logoUri: string;
-  /**
-   * Description of the software product
-   */
-  softwareProductDescription?: string | null;
-  /**
-   * Unique id of the Data Recipient software product issued by the CDR Register
-   */
-  softwareProductId: string;
-  /**
-   * Name of the software product
-   */
-  softwareProductName: string;
-  /**
-   * Software Product status in the CDR Register
-   */
-  status: "ACTIVE" | "INACTIVE" | "REMOVED";
-  [k: string]: unknown;
+    /**
+     * Software product logo URI
+     */
+    logoUri: string;
+    /**
+     * Description of the software product
+     */
+    softwareProductDescription?: string | null;
+    /**
+     * Unique id of the Data Recipient software product issued by the CDR Register
+     */
+    softwareProductId: string;
+    /**
+     * Name of the software product
+     */
+    softwareProductName: string;
+    /**
+     * Software Product status in the CDR Register
+     */
+    status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the register api. */
 
 export interface SoftwareProductsStatusList {
-  /**
-   * Response data for the query
-   */
-  data: {
+    /**
+     * Response data for the query
+     */
+    data: {
+        /**
+         * Unique id of the software product issued by the CDR Register
+         */
+        softwareProductId: string;
+        /**
+         * Software product status in the CDR Register
+         */
+        status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * Fully qualified link to this API call
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
+
+export interface SoftwareProductStatus {
     /**
      * Unique id of the software product issued by the CDR Register
      */
@@ -1087,31 +1114,6 @@ export interface SoftwareProductsStatusList {
     /**
      * Software product status in the CDR Register
      */
-    status: "ACTIVE" | "INACTIVE" | "REMOVED";
+    status: 'ACTIVE' | 'INACTIVE' | 'REMOVED';
     [k: string]: unknown;
-  }[];
-  links: {
-    /**
-     * Fully qualified link to this API call
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the register api. */
-
-export interface SoftwareProductStatus {
-  /**
-   * Unique id of the software product issued by the CDR Register
-   */
-  softwareProductId: string;
-  /**
-   * Software product status in the CDR Register
-   */
-  status: "ACTIVE" | "INACTIVE" | "REMOVED";
-  [k: string]: unknown;
 }

--- a/types/consumer-data-standards/telco/index.d.ts
+++ b/types/consumer-data-standards/telco/index.d.ts
@@ -4,107 +4,6 @@
  * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
  */
 export interface CommonPAFAddress {
-  /**
-   * Building/Property name 1
-   */
-  buildingName1?: string | null;
-  /**
-   * Building/Property name 2
-   */
-  buildingName2?: string | null;
-  /**
-   * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
-   */
-  dpid?: string | null;
-  /**
-   * Unit number (including suffix, if applicable)
-   */
-  flatUnitNumber?: string | null;
-  /**
-   * Type of flat or unit for the address
-   */
-  flatUnitType?: string | null;
-  /**
-   * Floor or level number (including alpha characters)
-   */
-  floorLevelNumber?: string | null;
-  /**
-   * Type of floor or level for the address
-   */
-  floorLevelType?: string | null;
-  /**
-   * Full name of locality
-   */
-  localityName: string;
-  /**
-   * Allotment number for the address
-   */
-  lotNumber?: string | null;
-  /**
-   * Postal delivery number if the address is a postal delivery type
-   */
-  postalDeliveryNumber?: number | null;
-  /**
-   * Postal delivery number prefix related to the postal delivery number
-   */
-  postalDeliveryNumberPrefix?: string | null;
-  /**
-   * Postal delivery number suffix related to the postal delivery number
-   */
-  postalDeliveryNumberSuffix?: string | null;
-  /**
-   * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
-   */
-  postalDeliveryType?: string | null;
-  /**
-   * Postcode for the locality
-   */
-  postcode: string;
-  /**
-   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  /**
-   * The name of the street
-   */
-  streetName?: string | null;
-  /**
-   * The street type suffix. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetSuffix?: string | null;
-  /**
-   * The street type. Valid enumeration defined by Australia Post PAF code file
-   */
-  streetType?: string | null;
-  /**
-   * Thoroughfare number for a property (first number in a property ranged address)
-   */
-  thoroughfareNumber1?: number | null;
-  /**
-   * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
-   */
-  thoroughfareNumber1Suffix?: string | null;
-  /**
-   * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
-   */
-  thoroughfareNumber2?: number | null;
-  /**
-   * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
-   */
-  thoroughfareNumber2Suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface CommonPhysicalAddress {
-  /**
-   * The type of address object present
-   */
-  addressUType: "paf" | "simple";
-  /**
-   * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
-   */
-  paf?: {
     /**
      * Building/Property name 1
      */
@@ -194,11 +93,154 @@ export interface CommonPhysicalAddress {
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
-  };
-  /**
-   * Required if addressUType is set to simple
-   */
-  simple?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface CommonPhysicalAddress {
+    /**
+     * The type of address object present
+     */
+    addressUType: 'paf' | 'simple';
+    /**
+     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). Required if addressUType is set to paf
+     */
+    paf?: {
+        /**
+         * Building/Property name 1
+         */
+        buildingName1?: string | null;
+        /**
+         * Building/Property name 2
+         */
+        buildingName2?: string | null;
+        /**
+         * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+         */
+        dpid?: string | null;
+        /**
+         * Unit number (including suffix, if applicable)
+         */
+        flatUnitNumber?: string | null;
+        /**
+         * Type of flat or unit for the address
+         */
+        flatUnitType?: string | null;
+        /**
+         * Floor or level number (including alpha characters)
+         */
+        floorLevelNumber?: string | null;
+        /**
+         * Type of floor or level for the address
+         */
+        floorLevelType?: string | null;
+        /**
+         * Full name of locality
+         */
+        localityName: string;
+        /**
+         * Allotment number for the address
+         */
+        lotNumber?: string | null;
+        /**
+         * Postal delivery number if the address is a postal delivery type
+         */
+        postalDeliveryNumber?: number | null;
+        /**
+         * Postal delivery number prefix related to the postal delivery number
+         */
+        postalDeliveryNumberPrefix?: string | null;
+        /**
+         * Postal delivery number suffix related to the postal delivery number
+         */
+        postalDeliveryNumberSuffix?: string | null;
+        /**
+         * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+         */
+        postalDeliveryType?: string | null;
+        /**
+         * Postcode for the locality
+         */
+        postcode: string;
+        /**
+         * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        /**
+         * The name of the street
+         */
+        streetName?: string | null;
+        /**
+         * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetSuffix?: string | null;
+        /**
+         * The street type. Valid enumeration defined by Australia Post PAF code file
+         */
+        streetType?: string | null;
+        /**
+         * Thoroughfare number for a property (first number in a property ranged address)
+         */
+        thoroughfareNumber1?: number | null;
+        /**
+         * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+         */
+        thoroughfareNumber1Suffix?: string | null;
+        /**
+         * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+         */
+        thoroughfareNumber2?: number | null;
+        /**
+         * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+         */
+        thoroughfareNumber2Suffix?: string | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Required if addressUType is set to simple
+     */
+    simple?: {
+        /**
+         * First line of the standard address object
+         */
+        addressLine1: string;
+        /**
+         * Second line of the standard address object
+         */
+        addressLine2?: string | null;
+        /**
+         * Third line of the standard address object
+         */
+        addressLine3?: string | null;
+        /**
+         * Name of the city or locality
+         */
+        city: string;
+        /**
+         * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+         */
+        country?: string | null;
+        /**
+         * Name of the individual or business formatted for inclusion in an address used for physical mail
+         */
+        mailingName?: string | null;
+        /**
+         * Mandatory for Australian addresses
+         */
+        postcode?: string | null;
+        /**
+         * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+         */
+        state: string;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Required if addressUType is set to simple
+ */
+export interface CommonSimpleAddress {
     /**
      * First line of the standard address object
      */
@@ -232,720 +274,19 @@ export interface CommonPhysicalAddress {
      */
     state: string;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Required if addressUType is set to simple
- */
-export interface CommonSimpleAddress {
-  /**
-   * First line of the standard address object
-   */
-  addressLine1: string;
-  /**
-   * Second line of the standard address object
-   */
-  addressLine2?: string | null;
-  /**
-   * Third line of the standard address object
-   */
-  addressLine3?: string | null;
-  /**
-   * Name of the city or locality
-   */
-  city: string;
-  /**
-   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
-   */
-  country?: string | null;
-  /**
-   * Name of the individual or business formatted for inclusion in an address used for physical mail
-   */
-  mailingName?: string | null;
-  /**
-   * Mandatory for Australian addresses
-   */
-  postcode?: string | null;
-  /**
-   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
-   */
-  state: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface Links {
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface LinksPaginated {
-  /**
-   * URI to the first page of this set. Mandatory if this response is not the first page
-   */
-  first?: string | null;
-  /**
-   * URI to the last page of this set. Mandatory if this response is not the last page
-   */
-  last?: string | null;
-  /**
-   * URI to the next page of this set. Mandatory if this response is not the last page
-   */
-  next?: string | null;
-  /**
-   * URI to the previous page of this set. Mandatory if this response is not the first page
-   */
-  prev?: string | null;
-  /**
-   * Fully qualified link that generated the current response document
-   */
-  self: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface Meta {
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Additional data for customised error codes
- */
-export interface MetaError {
-  /**
-   * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-   */
-  urn?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface MetaPaginated {
-  /**
-   * The total number of pages in the full set. See [pagination](#pagination).
-   */
-  totalPages: number;
-  /**
-   * The total number of records in the full set. See [pagination](#pagination).
-   */
-  totalRecords: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface ResponseErrorListV2 {
-  errors: {
-    /**
-     * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
-     */
-    code: string;
-    /**
-     * A human-readable explanation specific to this occurrence of the problem.
-     */
-    detail: string;
-    /**
-     * Additional data for customised error codes
-     */
-    meta?: {
-      /**
-       * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
-       */
-      urn?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
-     */
-    title: string;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * The array of plans containing services and associated plan details
- */
-export interface TelcoAccount {
-  /**
-   * The array of plans containing service and associated plan details
-   */
-  plans: {
-    /**
-     * The billing type of then plan
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string | null;
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string | null;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string | null;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-     */
-    serviceIds: string[];
-    /**
-     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-     */
-    type: "MOBILE" | "BROADBAND";
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoAccountBase {
-  /**
-   * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  accountId?: string | null;
-  /**
-   * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
-   */
-  accountNumber?: string | null;
-  /**
-   * The retail name of the brand
-   */
-  brand?: string | null;
-  /**
-   * The date that the account was created or opened. Mandatory if openStatus is OPEN
-   */
-  creationDate?: string | null;
-  /**
-   * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
-   */
-  displayName?: string | null;
-  /**
-   * The date and time which the account was last updated
-   */
-  lastUpdated?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * The array of plans containing services and associated plan details
- */
-export interface TelcoAccountDetail {
-  /**
-   * The array of plans containing services and associated plan details
-   */
-  plans: ({
-    /**
-     * The billing type of then plan
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string | null;
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string | null;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string | null;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-     */
-    serviceIds: string[];
-    /**
-     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-     */
-    type: "MOBILE" | "BROADBAND";
-    [k: string]: unknown;
-  } & {
-    planDetail: {
-      /**
-       * Charges for metering included in the plan
-       */
-      charges: {
-        /**
-         * Description of the charge
-         */
-        description?: string | null;
-        /**
-         * Display name of the charge
-         */
-        displayName: string;
-        /**
-         * The upper limit of the charge if the charge could occur in a range
-         */
-        maximumValue?: string | null;
-        /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-         */
-        minimumValue: string;
-        /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-         */
-        period?: string | null;
-        [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  })[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoAccountDetailAuthorisedContacts {
-  /**
-   * For people with single names this field need not be present. The single name should be in the lastName field
-   */
-  firstName?: string | null;
-  /**
-   * For people with single names the single name should be in this field
-   */
-  lastName: string;
-  /**
-   * Field is mandatory but array may be empty
-   */
-  middleNames?: string[] | null;
-  /**
-   * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
-   */
-  prefix?: string | null;
-  /**
-   * Used for a trailing suffix to the name (e.g. Jr)
-   */
-  suffix?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoAccountDetailResponse {
-  data: {
-    /**
-     * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    accountId?: string | null;
-    /**
-     * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
-     */
-    accountNumber?: string | null;
-    /**
-     * The retail name of the brand
-     */
-    brand?: string | null;
-    /**
-     * The date that the account was created or opened. Mandatory if openStatus is OPEN
-     */
-    creationDate?: string | null;
-    /**
-     * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
-     */
-    displayName?: string | null;
-    /**
-     * The date and time which the account was last updated
-     */
-    lastUpdated?: string | null;
-    /**
-     * Open or closed status for the account. If not present then OPEN is assumed
-     */
-    openStatus?: ("CLOSED" | "OPEN") | null;
-    [k: string]: unknown;
-  } & {
-    /**
-     * The array of plans containing service and associated plan details
-     */
-    plans: {
-      /**
-       * The billing type of then plan
-       */
-      billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-      /**
-       * Optional display name for the plan provided by the customer to help differentiate multiple plans
-       */
-      nickname?: string | null;
-      /**
-       * Mandatory if openStatus is OPEN
-       */
-      planOverview: {
-        /**
-         * The name of the plan if one exists
-         */
-        displayName?: string | null;
-        /**
-         * The end date of the applicability of this plan
-         */
-        endDate?: string | null;
-        /**
-         * The start date of the applicability of this plan
-         */
-        startDate: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-       */
-      serviceIds: string[];
-      /**
-       * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-       */
-      type: "MOBILE" | "BROADBAND";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  } & {
-    /**
-     * The array of plans containing services and associated plan details
-     */
-    plans: ({
-      /**
-       * The billing type of then plan
-       */
-      billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-      /**
-       * Optional display name for the plan provided by the customer to help differentiate multiple plans
-       */
-      nickname?: string | null;
-      /**
-       * Mandatory if openStatus is OPEN
-       */
-      planOverview: {
-        /**
-         * The name of the plan if one exists
-         */
-        displayName?: string | null;
-        /**
-         * The end date of the applicability of this plan
-         */
-        endDate?: string | null;
-        /**
-         * The start date of the applicability of this plan
-         */
-        startDate: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-       */
-      serviceIds: string[];
-      /**
-       * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-       */
-      type: "MOBILE" | "BROADBAND";
-      [k: string]: unknown;
-    } & {
-      planDetail: {
-        /**
-         * Charges for metering included in the plan
-         */
-        charges: {
-          /**
-           * Description of the charge
-           */
-          description?: string | null;
-          /**
-           * Display name of the charge
-           */
-          displayName: string;
-          /**
-           * The upper limit of the charge if the charge could occur in a range
-           */
-          maximumValue?: string | null;
-          /**
-           * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-           */
-          minimumValue: string;
-          /**
-           * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-           */
-          period?: string | null;
-          [k: string]: unknown;
-        }[];
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    })[];
-    [k: string]: unknown;
-  };
-  links: {
     /**
      * Fully qualified link that generated the current response document
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export type TelcoAccountDetailResponseData = {
-  /**
-   * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  accountId?: string | null;
-  /**
-   * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
-   */
-  accountNumber?: string | null;
-  /**
-   * The retail name of the brand
-   */
-  brand?: string | null;
-  /**
-   * The date that the account was created or opened. Mandatory if openStatus is OPEN
-   */
-  creationDate?: string | null;
-  /**
-   * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
-   */
-  displayName?: string | null;
-  /**
-   * The date and time which the account was last updated
-   */
-  lastUpdated?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  [k: string]: unknown;
-} & {
-  /**
-   * The array of plans containing service and associated plan details
-   */
-  plans: {
-    /**
-     * The billing type of then plan
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string | null;
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string | null;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string | null;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-     */
-    serviceIds: string[];
-    /**
-     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-     */
-    type: "MOBILE" | "BROADBAND";
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-} & {
-  /**
-   * The array of plans containing services and associated plan details
-   */
-  plans: ({
-    /**
-     * The billing type of then plan
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
-     */
-    nickname?: string | null;
-    /**
-     * Mandatory if openStatus is OPEN
-     */
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string | null;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string | null;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-     */
-    serviceIds: string[];
-    /**
-     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-     */
-    type: "MOBILE" | "BROADBAND";
-    [k: string]: unknown;
-  } & {
-    planDetail: {
-      /**
-       * Charges for metering included in the plan
-       */
-      charges: {
-        /**
-         * Description of the charge
-         */
-        description?: string | null;
-        /**
-         * Display name of the charge
-         */
-        displayName: string;
-        /**
-         * The upper limit of the charge if the charge could occur in a range
-         */
-        maximumValue?: string | null;
-        /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-         */
-        minimumValue: string;
-        /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-         */
-        period?: string | null;
-        [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  })[];
-  [k: string]: unknown;
-};
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoAccountListResponse {
-  data: {
-    /**
-     * Array of accounts
-     */
-    accounts: ({
-      /**
-       * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      accountId?: string | null;
-      /**
-       * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
-       */
-      accountNumber?: string | null;
-      /**
-       * The retail name of the brand
-       */
-      brand?: string | null;
-      /**
-       * The date that the account was created or opened. Mandatory if openStatus is OPEN
-       */
-      creationDate?: string | null;
-      /**
-       * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
-       */
-      displayName?: string | null;
-      /**
-       * The date and time which the account was last updated
-       */
-      lastUpdated?: string | null;
-      /**
-       * Open or closed status for the account. If not present then OPEN is assumed
-       */
-      openStatus?: ("CLOSED" | "OPEN") | null;
-      [k: string]: unknown;
-    } & {
-      /**
-       * The array of plans containing service and associated plan details
-       */
-      plans: {
-        /**
-         * The billing type of then plan
-         */
-        billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-        /**
-         * Optional display name for the plan provided by the customer to help differentiate multiple plans
-         */
-        nickname?: string | null;
-        /**
-         * Mandatory if openStatus is OPEN
-         */
-        planOverview: {
-          /**
-           * The name of the plan if one exists
-           */
-          displayName?: string | null;
-          /**
-           * The end date of the applicability of this plan
-           */
-          endDate?: string | null;
-          /**
-           * The start date of the applicability of this plan
-           */
-          startDate: string;
-          [k: string]: unknown;
-        };
-        /**
-         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-         */
-        serviceIds: string[];
-        /**
-         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-         */
-        type: "MOBILE" | "BROADBAND";
-        [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
-    })[];
-    [k: string]: unknown;
-  };
-  links: {
+export interface LinksPaginated {
     /**
      * URI to the first page of this set. Mandatory if this response is not the first page
      */
@@ -967,8 +308,27 @@ export interface TelcoAccountListResponse {
      */
     self: string;
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface Meta {
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Additional data for customised error codes
+ */
+export interface MetaError {
+    /**
+     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+     */
+    urn?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface MetaPaginated {
     /**
      * The total number of pages in the full set. See [pagination](#pagination).
      */
@@ -978,16 +338,88 @@ export interface TelcoAccountListResponse {
      */
     totalRecords: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export interface TelcoAccountListResponseData {
-  /**
-   * Array of accounts
-   */
-  accounts: ({
+export interface ResponseErrorListV2 {
+    errors: {
+        /**
+         * The code of the error encountered. Where the error is specific to the respondent, an application-specific error code, expressed as a string value. If the error is application-specific, the URN code that the specific error extends must be provided in the meta object. Otherwise, the value is the error code URN.
+         */
+        code: string;
+        /**
+         * A human-readable explanation specific to this occurrence of the problem.
+         */
+        detail: string;
+        /**
+         * Additional data for customised error codes
+         */
+        meta?: {
+            /**
+             * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+             */
+            urn?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A short, human-readable summary of the problem that MUST NOT change from occurrence to occurrence of the problem represented by the error code.
+         */
+        title: string;
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * The array of plans containing services and associated plan details
+ */
+export interface TelcoAccount {
+    /**
+     * The array of plans containing service and associated plan details
+     */
+    plans: {
+        /**
+         * The billing type of then plan
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string | null;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string | null;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string | null;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+         */
+        serviceIds: string[];
+        /**
+         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountBase {
     /**
      * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
      */
@@ -1015,25 +447,636 @@ export interface TelcoAccountListResponseData {
     /**
      * Open or closed status for the account. If not present then OPEN is assumed
      */
-    openStatus?: ("CLOSED" | "OPEN") | null;
+    openStatus?: ('CLOSED' | 'OPEN') | null;
     [k: string]: unknown;
-  } & {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * The array of plans containing services and associated plan details
+ */
+export interface TelcoAccountDetail {
+    /**
+     * The array of plans containing services and associated plan details
+     */
+    plans: ({
+        /**
+         * The billing type of then plan
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string | null;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string | null;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string | null;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+         */
+        serviceIds: string[];
+        /**
+         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    } & {
+        planDetail: {
+            /**
+             * Charges for metering included in the plan
+             */
+            charges: {
+                /**
+                 * Description of the charge
+                 */
+                description?: string | null;
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string | null;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string | null;
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    })[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountDetailAuthorisedContacts {
+    /**
+     * For people with single names this field need not be present. The single name should be in the lastName field
+     */
+    firstName?: string | null;
+    /**
+     * For people with single names the single name should be in this field
+     */
+    lastName: string;
+    /**
+     * Field is mandatory but array may be empty
+     */
+    middleNames?: string[] | null;
+    /**
+     * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+     */
+    prefix?: string | null;
+    /**
+     * Used for a trailing suffix to the name (e.g. Jr)
+     */
+    suffix?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountDetailResponse {
+    data: {
+        /**
+         * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        accountId?: string | null;
+        /**
+         * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
+         */
+        accountNumber?: string | null;
+        /**
+         * The retail name of the brand
+         */
+        brand?: string | null;
+        /**
+         * The date that the account was created or opened. Mandatory if openStatus is OPEN
+         */
+        creationDate?: string | null;
+        /**
+         * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
+         */
+        displayName?: string | null;
+        /**
+         * The date and time which the account was last updated
+         */
+        lastUpdated?: string | null;
+        /**
+         * Open or closed status for the account. If not present then OPEN is assumed
+         */
+        openStatus?: ('CLOSED' | 'OPEN') | null;
+        [k: string]: unknown;
+    } & {
+        /**
+         * The array of plans containing service and associated plan details
+         */
+        plans: {
+            /**
+             * The billing type of then plan
+             */
+            billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+            /**
+             * Optional display name for the plan provided by the customer to help differentiate multiple plans
+             */
+            nickname?: string | null;
+            /**
+             * Mandatory if openStatus is OPEN
+             */
+            planOverview: {
+                /**
+                 * The name of the plan if one exists
+                 */
+                displayName?: string | null;
+                /**
+                 * The end date of the applicability of this plan
+                 */
+                endDate?: string | null;
+                /**
+                 * The start date of the applicability of this plan
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+             */
+            serviceIds: string[];
+            /**
+             * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+             */
+            type: 'MOBILE' | 'BROADBAND';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    } & {
+        /**
+         * The array of plans containing services and associated plan details
+         */
+        plans: ({
+            /**
+             * The billing type of then plan
+             */
+            billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+            /**
+             * Optional display name for the plan provided by the customer to help differentiate multiple plans
+             */
+            nickname?: string | null;
+            /**
+             * Mandatory if openStatus is OPEN
+             */
+            planOverview: {
+                /**
+                 * The name of the plan if one exists
+                 */
+                displayName?: string | null;
+                /**
+                 * The end date of the applicability of this plan
+                 */
+                endDate?: string | null;
+                /**
+                 * The start date of the applicability of this plan
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+             */
+            serviceIds: string[];
+            /**
+             * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+             */
+            type: 'MOBILE' | 'BROADBAND';
+            [k: string]: unknown;
+        } & {
+            planDetail: {
+                /**
+                 * Charges for metering included in the plan
+                 */
+                charges: {
+                    /**
+                     * Description of the charge
+                     */
+                    description?: string | null;
+                    /**
+                     * Display name of the charge
+                     */
+                    displayName: string;
+                    /**
+                     * The upper limit of the charge if the charge could occur in a range
+                     */
+                    maximumValue?: string | null;
+                    /**
+                     * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                     */
+                    minimumValue: string;
+                    /**
+                     * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                     */
+                    period?: string | null;
+                    [k: string]: unknown;
+                }[];
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        })[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export type TelcoAccountDetailResponseData = {
+    /**
+     * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+     */
+    accountId?: string | null;
+    /**
+     * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
+     */
+    accountNumber?: string | null;
+    /**
+     * The retail name of the brand
+     */
+    brand?: string | null;
+    /**
+     * The date that the account was created or opened. Mandatory if openStatus is OPEN
+     */
+    creationDate?: string | null;
+    /**
+     * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
+     */
+    displayName?: string | null;
+    /**
+     * The date and time which the account was last updated
+     */
+    lastUpdated?: string | null;
+    /**
+     * Open or closed status for the account. If not present then OPEN is assumed
+     */
+    openStatus?: ('CLOSED' | 'OPEN') | null;
+    [k: string]: unknown;
+} & {
     /**
      * The array of plans containing service and associated plan details
      */
     plans: {
-      /**
-       * The billing type of then plan
-       */
-      billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-      /**
-       * Optional display name for the plan provided by the customer to help differentiate multiple plans
-       */
-      nickname?: string | null;
-      /**
-       * Mandatory if openStatus is OPEN
-       */
-      planOverview: {
+        /**
+         * The billing type of then plan
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string | null;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string | null;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string | null;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+         */
+        serviceIds: string[];
+        /**
+         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+} & {
+    /**
+     * The array of plans containing services and associated plan details
+     */
+    plans: ({
+        /**
+         * The billing type of then plan
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string | null;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string | null;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string | null;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+         */
+        serviceIds: string[];
+        /**
+         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    } & {
+        planDetail: {
+            /**
+             * Charges for metering included in the plan
+             */
+            charges: {
+                /**
+                 * Description of the charge
+                 */
+                description?: string | null;
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string | null;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string | null;
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    })[];
+    [k: string]: unknown;
+};
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountListResponse {
+    data: {
+        /**
+         * Array of accounts
+         */
+        accounts: ({
+            /**
+             * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            accountId?: string | null;
+            /**
+             * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
+             */
+            accountNumber?: string | null;
+            /**
+             * The retail name of the brand
+             */
+            brand?: string | null;
+            /**
+             * The date that the account was created or opened. Mandatory if openStatus is OPEN
+             */
+            creationDate?: string | null;
+            /**
+             * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
+             */
+            displayName?: string | null;
+            /**
+             * The date and time which the account was last updated
+             */
+            lastUpdated?: string | null;
+            /**
+             * Open or closed status for the account. If not present then OPEN is assumed
+             */
+            openStatus?: ('CLOSED' | 'OPEN') | null;
+            [k: string]: unknown;
+        } & {
+            /**
+             * The array of plans containing service and associated plan details
+             */
+            plans: {
+                /**
+                 * The billing type of then plan
+                 */
+                billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+                /**
+                 * Optional display name for the plan provided by the customer to help differentiate multiple plans
+                 */
+                nickname?: string | null;
+                /**
+                 * Mandatory if openStatus is OPEN
+                 */
+                planOverview: {
+                    /**
+                     * The name of the plan if one exists
+                     */
+                    displayName?: string | null;
+                    /**
+                     * The end date of the applicability of this plan
+                     */
+                    endDate?: string | null;
+                    /**
+                     * The start date of the applicability of this plan
+                     */
+                    startDate: string;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+                 */
+                serviceIds: string[];
+                /**
+                 * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+                 */
+                type: 'MOBILE' | 'BROADBAND';
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        })[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountListResponseData {
+    /**
+     * Array of accounts
+     */
+    accounts: ({
+        /**
+         * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        accountId?: string | null;
+        /**
+         * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
+         */
+        accountNumber?: string | null;
+        /**
+         * The retail name of the brand
+         */
+        brand?: string | null;
+        /**
+         * The date that the account was created or opened. Mandatory if openStatus is OPEN
+         */
+        creationDate?: string | null;
+        /**
+         * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
+         */
+        displayName?: string | null;
+        /**
+         * The date and time which the account was last updated
+         */
+        lastUpdated?: string | null;
+        /**
+         * Open or closed status for the account. If not present then OPEN is assumed
+         */
+        openStatus?: ('CLOSED' | 'OPEN') | null;
+        [k: string]: unknown;
+    } & {
+        /**
+         * The array of plans containing service and associated plan details
+         */
+        plans: {
+            /**
+             * The billing type of then plan
+             */
+            billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+            /**
+             * Optional display name for the plan provided by the customer to help differentiate multiple plans
+             */
+            nickname?: string | null;
+            /**
+             * Mandatory if openStatus is OPEN
+             */
+            planOverview: {
+                /**
+                 * The name of the plan if one exists
+                 */
+                displayName?: string | null;
+                /**
+                 * The end date of the applicability of this plan
+                 */
+                endDate?: string | null;
+                /**
+                 * The start date of the applicability of this plan
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+             */
+            serviceIds: string[];
+            /**
+             * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+             */
+            type: 'MOBILE' | 'BROADBAND';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    })[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoAccountPlan {
+    /**
+     * The billing type of then plan
+     */
+    billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+    /**
+     * Optional display name for the plan provided by the customer to help differentiate multiple plans
+     */
+    nickname?: string | null;
+    /**
+     * Mandatory if openStatus is OPEN
+     */
+    planOverview: {
         /**
          * The name of the plan if one exists
          */
@@ -1047,36 +1090,60 @@ export interface TelcoAccountListResponseData {
          */
         startDate: string;
         [k: string]: unknown;
-      };
-      /**
-       * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-       */
-      serviceIds: string[];
-      /**
-       * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-       */
-      type: "MOBILE" | "BROADBAND";
-      [k: string]: unknown;
-    }[];
+    };
+    /**
+     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+     */
+    serviceIds: string[];
+    /**
+     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+     */
+    type: 'MOBILE' | 'BROADBAND';
     [k: string]: unknown;
-  })[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export interface TelcoAccountPlan {
-  /**
-   * The billing type of then plan
-   */
-  billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-  /**
-   * Optional display name for the plan provided by the customer to help differentiate multiple plans
-   */
-  nickname?: string | null;
-  /**
-   * Mandatory if openStatus is OPEN
-   */
-  planOverview: {
+/**
+ * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
+ */
+export interface TelcoAccountPlanDetail {
+    planDetail: {
+        /**
+         * Charges for metering included in the plan
+         */
+        charges: {
+            /**
+             * Description of the charge
+             */
+            description?: string | null;
+            /**
+             * Display name of the charge
+             */
+            displayName: string;
+            /**
+             * The upper limit of the charge if the charge could occur in a range
+             */
+            maximumValue?: string | null;
+            /**
+             * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+             */
+            minimumValue: string;
+            /**
+             * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            period?: string | null;
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Mandatory if openStatus is OPEN
+ */
+export interface TelcoAccountPlanOverview {
     /**
      * The name of the plan if one exists
      */
@@ -1090,518 +1157,451 @@ export interface TelcoAccountPlan {
      */
     startDate: string;
     [k: string]: unknown;
-  };
-  /**
-   * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
-   */
-  serviceIds: string[];
-  /**
-   * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-   */
-  type: "MOBILE" | "BROADBAND";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
- */
-export interface TelcoAccountPlanDetail {
-  planDetail: {
-    /**
-     * Charges for metering included in the plan
-     */
-    charges: {
-      /**
-       * Description of the charge
-       */
-      description?: string | null;
-      /**
-       * Display name of the charge
-       */
-      displayName: string;
-      /**
-       * The upper limit of the charge if the charge could occur in a range
-       */
-      maximumValue?: string | null;
-      /**
-       * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-       */
-      minimumValue: string;
-      /**
-       * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      period?: string | null;
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Mandatory if openStatus is OPEN
- */
-export interface TelcoAccountPlanOverview {
-  /**
-   * The name of the plan if one exists
-   */
-  displayName?: string | null;
-  /**
-   * The end date of the applicability of this plan
-   */
-  endDate?: string | null;
-  /**
-   * The start date of the applicability of this plan
-   */
-  startDate: string;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export type TelcoAccountResponseData = {
-  /**
-   * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  accountId?: string | null;
-  /**
-   * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
-   */
-  accountNumber?: string | null;
-  /**
-   * The retail name of the brand
-   */
-  brand?: string | null;
-  /**
-   * The date that the account was created or opened. Mandatory if openStatus is OPEN
-   */
-  creationDate?: string | null;
-  /**
-   * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
-   */
-  displayName?: string | null;
-  /**
-   * The date and time which the account was last updated
-   */
-  lastUpdated?: string | null;
-  /**
-   * Open or closed status for the account. If not present then OPEN is assumed
-   */
-  openStatus?: ("CLOSED" | "OPEN") | null;
-  [k: string]: unknown;
-} & {
-  /**
-   * The array of plans containing service and associated plan details
-   */
-  plans: {
     /**
-     * The billing type of then plan
+     * The ID of the account. To be created in accordance with [CDR ID permanence](#id-permanence) requirements
      */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
+    accountId?: string | null;
     /**
-     * Optional display name for the plan provided by the customer to help differentiate multiple plans
+     * Masked identifier of the account as defined by the data holder. This must be the value presented on physical statements (required if it exists) and must not be used for the value of the accountId
      */
-    nickname?: string | null;
+    accountNumber?: string | null;
     /**
-     * Mandatory if openStatus is OPEN
+     * The retail name of the brand
      */
-    planOverview: {
-      /**
-       * The name of the plan if one exists
-       */
-      displayName?: string | null;
-      /**
-       * The end date of the applicability of this plan
-       */
-      endDate?: string | null;
-      /**
-       * The start date of the applicability of this plan
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
+    brand?: string | null;
     /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+     * The date that the account was created or opened. Mandatory if openStatus is OPEN
      */
-    serviceIds: string[];
+    creationDate?: string | null;
     /**
-     * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+     * An optional display name for the account if one exists or can be derived. The content of this field is at the discretion of the data holder
      */
-    type: "MOBILE" | "BROADBAND";
+    displayName?: string | null;
+    /**
+     * The date and time which the account was last updated
+     */
+    lastUpdated?: string | null;
+    /**
+     * Open or closed status for the account. If not present then OPEN is assumed
+     */
+    openStatus?: ('CLOSED' | 'OPEN') | null;
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
+} & {
+    /**
+     * The array of plans containing service and associated plan details
+     */
+    plans: {
+        /**
+         * The billing type of then plan
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * Optional display name for the plan provided by the customer to help differentiate multiple plans
+         */
+        nickname?: string | null;
+        /**
+         * Mandatory if openStatus is OPEN
+         */
+        planOverview: {
+            /**
+             * The name of the plan if one exists
+             */
+            displayName?: string | null;
+            /**
+             * The end date of the applicability of this plan
+             */
+            endDate?: string | null;
+            /**
+             * The start date of the applicability of this plan
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirement
+         */
+        serviceIds: string[];
+        /**
+         * The type of the plan. The type of plan. A [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
 };
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoAccountUsage {
-  /**
-   * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  accountId: string;
-  /**
-   * List of services that are part of the account
-   */
-  services: {
-    service: {
-      /**
-       * Optional description of the service used for display purposes
-       */
-      displayName?: string | null;
-      /**
-       * Date when the usage period ends
-       */
-      endDate?: string | null;
-      /**
-       * Required if the service includes a phone number
-       */
-      phoneNumber?: string | null;
-      /**
-       * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceId: string;
-      /**
-       * Date when the usage period started
-       */
-      startDate: string;
-      /**
-       * Object containing usage summary
-       */
-      usage?: {
-        /**
-         * Summary of data usage
-         */
-        data?: {
-          /**
-           * Cost amount of data usage
-           */
-          amount: string;
-          /**
-           * Amount of data downloaded in megabytes (MB)
-           */
-          download: number;
-          /**
-           * Required if roaming is suipported
-           */
-          roaming?: {
+    /**
+     * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
+     */
+    accountId: string;
+    /**
+     * List of services that are part of the account
+     */
+    services: {
+        service: {
             /**
-             * Amount value of data roaming charges
+             * Optional description of the service used for display purposes
              */
-            amount?: string | null;
+            displayName?: string | null;
             /**
-             * Amount of data used while roaming in megabytes (MB)
+             * Date when the usage period ends
              */
-            download?: number | null;
+            endDate?: string | null;
+            /**
+             * Required if the service includes a phone number
+             */
+            phoneNumber?: string | null;
+            /**
+             * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            serviceId: string;
+            /**
+             * Date when the usage period started
+             */
+            startDate: string;
+            /**
+             * Object containing usage summary
+             */
+            usage?: {
+                /**
+                 * Summary of data usage
+                 */
+                data?: {
+                    /**
+                     * Cost amount of data usage
+                     */
+                    amount: string;
+                    /**
+                     * Amount of data downloaded in megabytes (MB)
+                     */
+                    download: number;
+                    /**
+                     * Required if roaming is suipported
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of data roaming charges
+                         */
+                        amount?: string | null;
+                        /**
+                         * Amount of data used while roaming in megabytes (MB)
+                         */
+                        download?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Number of data sessions
+                     */
+                    sessions?: number | null;
+                    /**
+                     * Amount of data uploaded in megabytes (MB)
+                     */
+                    upload: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of messaging. Required if messaging services is included in the product plan
+                 */
+                messaging?: {
+                    /**
+                     * Summary of MMS usage
+                     */
+                    mms: {
+                        /**
+                         * Cost amount of MMS messages
+                         */
+                        amount: string;
+                        /**
+                         * ber of international MMS messages sent
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national MMS messages sent
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of SMS usage
+                     */
+                    sms: {
+                        /**
+                         * Cost amount of SMS messages. Including premium SMS services
+                         */
+                        amount: string;
+                        /**
+                         * Number of international SMS messages sent. Including premium SMS services
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national SMS messages sent. Including premium SMS services
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of voice calls. Required if voice calls are included in product plan
+                 */
+                voice?: {
+                    /**
+                     * International voice calls. Requied if international calling is supported
+                     */
+                    international: {
+                        /**
+                         * Cost amount of international voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of international voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * National voice calls
+                     */
+                    national: {
+                        /**
+                         * Cost amount of national calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of national voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Roaming voice calls, Required if roaming is supported
+                     */
+                    roaming: {
+                        /**
+                         * Cost amount of roaming voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of roaming voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
             [k: string]: unknown;
-          };
-          /**
-           * Number of data sessions
-           */
-          sessions?: number | null;
-          /**
-           * Amount of data uploaded in megabytes (MB)
-           */
-          upload: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of messaging. Required if messaging services is included in the product plan
-         */
-        messaging?: {
-          /**
-           * Summary of MMS usage
-           */
-          mms: {
-            /**
-             * Cost amount of MMS messages
-             */
-            amount: string;
-            /**
-             * ber of international MMS messages sent
-             */
-            international?: number | null;
-            /**
-             * Number of national MMS messages sent
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of SMS usage
-           */
-          sms: {
-            /**
-             * Cost amount of SMS messages. Including premium SMS services
-             */
-            amount: string;
-            /**
-             * Number of international SMS messages sent. Including premium SMS services
-             */
-            international?: number | null;
-            /**
-             * Number of national SMS messages sent. Including premium SMS services
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of voice calls. Required if voice calls are included in product plan
-         */
-        voice?: {
-          /**
-           * International voice calls. Requied if international calling is supported
-           */
-          international: {
-            /**
-             * Cost amount of international voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of international voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * National voice calls
-           */
-          national: {
-            /**
-             * Cost amount of national calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of national voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * Roaming voice calls, Required if roaming is supported
-           */
-          roaming: {
-            /**
-             * Cost amount of roaming voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of roaming voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
         };
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
+    }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoAccountUsageServices {
-  service: {
-    /**
-     * Optional description of the service used for display purposes
-     */
-    displayName?: string | null;
-    /**
-     * Date when the usage period ends
-     */
-    endDate?: string | null;
-    /**
-     * Required if the service includes a phone number
-     */
-    phoneNumber?: string | null;
-    /**
-     * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    serviceId: string;
-    /**
-     * Date when the usage period started
-     */
-    startDate: string;
-    /**
-     * Object containing usage summary
-     */
-    usage?: {
-      /**
-       * Summary of data usage
-       */
-      data?: {
+    service: {
         /**
-         * Cost amount of data usage
+         * Optional description of the service used for display purposes
          */
-        amount: string;
+        displayName?: string | null;
         /**
-         * Amount of data downloaded in megabytes (MB)
+         * Date when the usage period ends
          */
-        download: number;
+        endDate?: string | null;
         /**
-         * Required if roaming is suipported
+         * Required if the service includes a phone number
          */
-        roaming?: {
-          /**
-           * Amount value of data roaming charges
-           */
-          amount?: string | null;
-          /**
-           * Amount of data used while roaming in megabytes (MB)
-           */
-          download?: number | null;
-          [k: string]: unknown;
+        phoneNumber?: string | null;
+        /**
+         * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        serviceId: string;
+        /**
+         * Date when the usage period started
+         */
+        startDate: string;
+        /**
+         * Object containing usage summary
+         */
+        usage?: {
+            /**
+             * Summary of data usage
+             */
+            data?: {
+                /**
+                 * Cost amount of data usage
+                 */
+                amount: string;
+                /**
+                 * Amount of data downloaded in megabytes (MB)
+                 */
+                download: number;
+                /**
+                 * Required if roaming is suipported
+                 */
+                roaming?: {
+                    /**
+                     * Amount value of data roaming charges
+                     */
+                    amount?: string | null;
+                    /**
+                     * Amount of data used while roaming in megabytes (MB)
+                     */
+                    download?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Number of data sessions
+                 */
+                sessions?: number | null;
+                /**
+                 * Amount of data uploaded in megabytes (MB)
+                 */
+                upload: number;
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of messaging. Required if messaging services is included in the product plan
+             */
+            messaging?: {
+                /**
+                 * Summary of MMS usage
+                 */
+                mms: {
+                    /**
+                     * Cost amount of MMS messages
+                     */
+                    amount: string;
+                    /**
+                     * ber of international MMS messages sent
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national MMS messages sent
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of SMS usage
+                 */
+                sms: {
+                    /**
+                     * Cost amount of SMS messages. Including premium SMS services
+                     */
+                    amount: string;
+                    /**
+                     * Number of international SMS messages sent. Including premium SMS services
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national SMS messages sent. Including premium SMS services
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of voice calls. Required if voice calls are included in product plan
+             */
+            voice?: {
+                /**
+                 * International voice calls. Requied if international calling is supported
+                 */
+                international: {
+                    /**
+                     * Cost amount of international voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of international voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * National voice calls
+                 */
+                national: {
+                    /**
+                     * Cost amount of national calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of national voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Roaming voice calls, Required if roaming is supported
+                 */
+                roaming: {
+                    /**
+                     * Cost amount of roaming voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of roaming voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
         };
-        /**
-         * Number of data sessions
-         */
-        sessions?: number | null;
-        /**
-         * Amount of data uploaded in megabytes (MB)
-         */
-        upload: number;
         [k: string]: unknown;
-      };
-      /**
-       * Summary of messaging. Required if messaging services is included in the product plan
-       */
-      messaging?: {
-        /**
-         * Summary of MMS usage
-         */
-        mms: {
-          /**
-           * Cost amount of MMS messages
-           */
-          amount: string;
-          /**
-           * ber of international MMS messages sent
-           */
-          international?: number | null;
-          /**
-           * Number of national MMS messages sent
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of SMS usage
-         */
-        sms: {
-          /**
-           * Cost amount of SMS messages. Including premium SMS services
-           */
-          amount: string;
-          /**
-           * Number of international SMS messages sent. Including premium SMS services
-           */
-          international?: number | null;
-          /**
-           * Number of national SMS messages sent. Including premium SMS services
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of voice calls. Required if voice calls are included in product plan
-       */
-      voice?: {
-        /**
-         * International voice calls. Requied if international calling is supported
-         */
-        international: {
-          /**
-           * Cost amount of international voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of international voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * National voice calls
-         */
-        national: {
-          /**
-           * Cost amount of national calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of national voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Roaming voice calls, Required if roaming is supported
-         */
-        roaming: {
-          /**
-           * Cost amount of roaming voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of roaming voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -1609,27 +1609,27 @@ export interface TelcoAccountUsageServices {
  * Object that contains links to additional information on specific topics
  */
 export interface TelcoAdditionalInformation {
-  /**
-   * A link to detail on bundles that this plan can be a part of
-   */
-  bundleUri?: string | null;
-  /**
-   * A link to detail on eligibility criteria for the plan
-   */
-  eligibilityUri?: string | null;
-  /**
-   * A link to a general overview of the plan
-   */
-  overviewUri?: string | null;
-  /**
-   * A link to detail on pricing for the plan
-   */
-  pricingUri?: string | null;
-  /**
-   * A link to terms and conditions for the plan
-   */
-  termsUri?: string | null;
-  [k: string]: unknown;
+    /**
+     * A link to detail on bundles that this plan can be a part of
+     */
+    bundleUri?: string | null;
+    /**
+     * A link to detail on eligibility criteria for the plan
+     */
+    eligibilityUri?: string | null;
+    /**
+     * A link to a general overview of the plan
+     */
+    overviewUri?: string | null;
+    /**
+     * A link to detail on pricing for the plan
+     */
+    pricingUri?: string | null;
+    /**
+     * A link to terms and conditions for the plan
+     */
+    termsUri?: string | null;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -1637,272 +1637,20 @@ export interface TelcoAdditionalInformation {
  * Object containing account service usage summary
  */
 export interface TelcoBalance {
-  /**
-   * Summary of balances
-   */
-  services: {
     /**
-     * A summary of Service balances
+     * Summary of balances
      */
-    balance?: {
-      /**
-       * Summary of data balances
-       */
-      data?: {
+    services: {
         /**
-         * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+         * A summary of Service balances
          */
-        amount?: string | null;
-        /**
-         * An overview of plan limits. Required unless planType is UNSUPPORTED
-         */
-        description?: string | null;
-        /**
-         * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        download?: number | null;
-        /**
-         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-         */
-        planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-        /**
-         * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-         */
-        roaming?: {
-          /**
-           * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
-           */
-          download?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        upload?: number | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of messaging. Required if messaging services is included in the product plan
-       */
-      messaging?: {
-        /**
-         * Summary of MMS Balance. Required if the service plan supports MMS messaging
-         */
-        mms: {
-          /**
-           * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          international?: number | null;
-          /**
-           * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          national?: number | null;
-          /**
-           * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-         */
-        planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-        /**
-         * Summary of SMS Balance. Required if the service plan supports SMS messaging
-         */
-        sms: {
-          /**
-           * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          international?: number | null;
-          /**
-           * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          national?: number | null;
-          /**
-           * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of voice balances. Required if voice calls are included in product plan
-       */
-      voice?: {
-        /**
-         * International voice calls
-         */
-        international?: {
-          /**
-           * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          duration?: string | null;
-          /**
-           * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          number?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * National voice calls
-         */
-        national?: {
-          /**
-           * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          duration?: string | null;
-          /**
-           * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          number?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-         */
-        planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-        /**
-         * Roaming voice calls
-         */
-        roaming?: {
-          /**
-           * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          duration?: string | null;
-          /**
-           * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          number?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Optional description of the service used for display purposes
-     */
-    displayName?: string | null;
-    /**
-     * Date when the balance period ends
-     */
-    endDate?: string | null;
-    /**
-     * Required if the service includes a phone number
-     */
-    phoneNumber?: string | null;
-    /**
-     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    serviceId?: string | null;
-    /**
-     * Date when the balance period started
-     */
-    startDate?: string | null;
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBalanceListResponse {
-  data: {
-    /**
-     * Array of account balances
-     */
-    balances: {
-      /**
-       * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      accountId?: string | null;
-      /**
-       * Object containing account service usage summary
-       */
-      balance?: {
-        /**
-         * Summary of balances
-         */
-        services: {
-          /**
-           * A summary of Service balances
-           */
-          balance?: {
+        balance?: {
             /**
              * Summary of data balances
              */
             data?: {
-              /**
-               * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              download?: number | null;
-              /**
-               * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-               */
-              planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-              /**
-               * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-               */
-              roaming?: {
                 /**
-                 * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                 * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
                  */
                 amount?: string | null;
                 /**
@@ -1910,427 +1658,176 @@ export interface TelcoBalanceListResponse {
                  */
                 description?: string | null;
                 /**
-                 * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                 * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
                  */
                 download?: number | null;
+                /**
+                 * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                 */
+                planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                /**
+                 * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+                 */
+                roaming?: {
+                    /**
+                     * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                     */
+                    download?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                upload?: number | null;
                 [k: string]: unknown;
-              };
-              /**
-               * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              upload?: number | null;
-              [k: string]: unknown;
             };
             /**
              * Summary of messaging. Required if messaging services is included in the product plan
              */
             messaging?: {
-              /**
-               * Summary of MMS Balance. Required if the service plan supports MMS messaging
-               */
-              mms: {
                 /**
-                 * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 * Summary of MMS Balance. Required if the service plan supports MMS messaging
                  */
-                amount?: string | null;
+                mms: {
+                    /**
+                     * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    national?: number | null;
+                    /**
+                     * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
                 /**
-                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
                  */
-                description?: string | null;
+                planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
                 /**
-                 * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 * Summary of SMS Balance. Required if the service plan supports SMS messaging
                  */
-                international?: number | null;
-                /**
-                 * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                national?: number | null;
-                /**
-                 * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                roaming?: number | null;
+                sms: {
+                    /**
+                     * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    national?: number | null;
+                    /**
+                     * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
                 [k: string]: unknown;
-              };
-              /**
-               * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-               */
-              planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-              /**
-               * Summary of SMS Balance. Required if the service plan supports SMS messaging
-               */
-              sms: {
-                /**
-                 * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                amount?: string | null;
-                /**
-                 * An overview of plan limits. Required unless planType is UNSUPPORTED
-                 */
-                description?: string | null;
-                /**
-                 * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                international?: number | null;
-                /**
-                 * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                national?: number | null;
-                /**
-                 * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                roaming?: number | null;
-                [k: string]: unknown;
-              };
-              [k: string]: unknown;
             };
             /**
              * Summary of voice balances. Required if voice calls are included in product plan
              */
             voice?: {
-              /**
-               * International voice calls
-               */
-              international?: {
                 /**
-                 * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                 * International voice calls
                  */
-                amount?: string | null;
+                international?: {
+                    /**
+                     * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    duration?: string | null;
+                    /**
+                     * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    number?: number | null;
+                    [k: string]: unknown;
+                };
                 /**
-                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 * National voice calls
                  */
-                description?: string | null;
+                national?: {
+                    /**
+                     * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    duration?: string | null;
+                    /**
+                     * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    number?: number | null;
+                    [k: string]: unknown;
+                };
                 /**
-                 * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                 * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
                  */
-                duration?: string | null;
+                planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
                 /**
-                 * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                 * Roaming voice calls
                  */
-                number?: number | null;
+                roaming?: {
+                    /**
+                     * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    duration?: string | null;
+                    /**
+                     * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    number?: number | null;
+                    [k: string]: unknown;
+                };
                 [k: string]: unknown;
-              };
-              /**
-               * National voice calls
-               */
-              national?: {
-                /**
-                 * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                amount?: string | null;
-                /**
-                 * An overview of plan limits. Required unless planType is UNSUPPORTED
-                 */
-                description?: string | null;
-                /**
-                 * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                duration?: string | null;
-                /**
-                 * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                number?: number | null;
-                [k: string]: unknown;
-              };
-              /**
-               * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-               */
-              planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-              /**
-               * Roaming voice calls
-               */
-              roaming?: {
-                /**
-                 * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                amount?: string | null;
-                /**
-                 * An overview of plan limits. Required unless planType is UNSUPPORTED
-                 */
-                description?: string | null;
-                /**
-                 * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                duration?: string | null;
-                /**
-                 * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-                 */
-                number?: number | null;
-                [k: string]: unknown;
-              };
-              [k: string]: unknown;
             };
             [k: string]: unknown;
-          };
-          /**
-           * Optional description of the service used for display purposes
-           */
-          displayName?: string | null;
-          /**
-           * Date when the balance period ends
-           */
-          endDate?: string | null;
-          /**
-           * Required if the service includes a phone number
-           */
-          phoneNumber?: string | null;
-          /**
-           * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-           */
-          serviceId?: string | null;
-          /**
-           * Date when the balance period started
-           */
-          startDate?: string | null;
-          [k: string]: unknown;
-        }[];
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBalanceListResponseData {
-  /**
-   * Array of account balances
-   */
-  balances: {
-    /**
-     * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    accountId?: string | null;
-    /**
-     * Object containing account service usage summary
-     */
-    balance?: {
-      /**
-       * Summary of balances
-       */
-      services: {
-        /**
-         * A summary of Service balances
-         */
-        balance?: {
-          /**
-           * Summary of data balances
-           */
-          data?: {
-            /**
-             * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            download?: number | null;
-            /**
-             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-             */
-            planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-            /**
-             * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-             */
-            roaming?: {
-              /**
-               * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
-               */
-              download?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            upload?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of messaging. Required if messaging services is included in the product plan
-           */
-          messaging?: {
-            /**
-             * Summary of MMS Balance. Required if the service plan supports MMS messaging
-             */
-            mms: {
-              /**
-               * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              international?: number | null;
-              /**
-               * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              national?: number | null;
-              /**
-               * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-             */
-            planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-            /**
-             * Summary of SMS Balance. Required if the service plan supports SMS messaging
-             */
-            sms: {
-              /**
-               * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              international?: number | null;
-              /**
-               * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              national?: number | null;
-              /**
-               * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of voice balances. Required if voice calls are included in product plan
-           */
-          voice?: {
-            /**
-             * International voice calls
-             */
-            international?: {
-              /**
-               * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              duration?: string | null;
-              /**
-               * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              number?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * National voice calls
-             */
-            national?: {
-              /**
-               * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              duration?: string | null;
-              /**
-               * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              number?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-             */
-            planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-            /**
-             * Roaming voice calls
-             */
-            roaming?: {
-              /**
-               * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              amount?: string | null;
-              /**
-               * An overview of plan limits. Required unless planType is UNSUPPORTED
-               */
-              description?: string | null;
-              /**
-               * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              duration?: string | null;
-              /**
-               * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-               */
-              number?: number | null;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
         };
         /**
          * Optional description of the service used for display purposes
@@ -2353,638 +1850,999 @@ export interface TelcoBalanceListResponseData {
          */
         startDate?: string | null;
         [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBalanceListResponse {
+    data: {
+        /**
+         * Array of account balances
+         */
+        balances: {
+            /**
+             * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            accountId?: string | null;
+            /**
+             * Object containing account service usage summary
+             */
+            balance?: {
+                /**
+                 * Summary of balances
+                 */
+                services: {
+                    /**
+                     * A summary of Service balances
+                     */
+                    balance?: {
+                        /**
+                         * Summary of data balances
+                         */
+                        data?: {
+                            /**
+                             * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            download?: number | null;
+                            /**
+                             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                             */
+                            planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                            /**
+                             * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+                             */
+                            roaming?: {
+                                /**
+                                 * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                                 */
+                                download?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            upload?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of messaging. Required if messaging services is included in the product plan
+                         */
+                        messaging?: {
+                            /**
+                             * Summary of MMS Balance. Required if the service plan supports MMS messaging
+                             */
+                            mms: {
+                                /**
+                                 * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                international?: number | null;
+                                /**
+                                 * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                national?: number | null;
+                                /**
+                                 * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                roaming?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                             */
+                            planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                            /**
+                             * Summary of SMS Balance. Required if the service plan supports SMS messaging
+                             */
+                            sms: {
+                                /**
+                                 * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                international?: number | null;
+                                /**
+                                 * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                national?: number | null;
+                                /**
+                                 * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                roaming?: number | null;
+                                [k: string]: unknown;
+                            };
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of voice balances. Required if voice calls are included in product plan
+                         */
+                        voice?: {
+                            /**
+                             * International voice calls
+                             */
+                            international?: {
+                                /**
+                                 * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                duration?: string | null;
+                                /**
+                                 * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                number?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * National voice calls
+                             */
+                            national?: {
+                                /**
+                                 * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                duration?: string | null;
+                                /**
+                                 * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                number?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                             */
+                            planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                            /**
+                             * Roaming voice calls
+                             */
+                            roaming?: {
+                                /**
+                                 * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                                 */
+                                description?: string | null;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                duration?: string | null;
+                                /**
+                                 * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                                 */
+                                number?: number | null;
+                                [k: string]: unknown;
+                            };
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Optional description of the service used for display purposes
+                     */
+                    displayName?: string | null;
+                    /**
+                     * Date when the balance period ends
+                     */
+                    endDate?: string | null;
+                    /**
+                     * Required if the service includes a phone number
+                     */
+                    phoneNumber?: string | null;
+                    /**
+                     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+                     */
+                    serviceId?: string | null;
+                    /**
+                     * Date when the balance period started
+                     */
+                    startDate?: string | null;
+                    [k: string]: unknown;
+                }[];
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
     };
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBalanceListResponseData {
+    /**
+     * Array of account balances
+     */
+    balances: {
+        /**
+         * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        accountId?: string | null;
+        /**
+         * Object containing account service usage summary
+         */
+        balance?: {
+            /**
+             * Summary of balances
+             */
+            services: {
+                /**
+                 * A summary of Service balances
+                 */
+                balance?: {
+                    /**
+                     * Summary of data balances
+                     */
+                    data?: {
+                        /**
+                         * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        download?: number | null;
+                        /**
+                         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                         */
+                        planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                        /**
+                         * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+                         */
+                        roaming?: {
+                            /**
+                             * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                             */
+                            download?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        upload?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of messaging. Required if messaging services is included in the product plan
+                     */
+                    messaging?: {
+                        /**
+                         * Summary of MMS Balance. Required if the service plan supports MMS messaging
+                         */
+                        mms: {
+                            /**
+                             * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            national?: number | null;
+                            /**
+                             * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                         */
+                        planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                        /**
+                         * Summary of SMS Balance. Required if the service plan supports SMS messaging
+                         */
+                        sms: {
+                            /**
+                             * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            national?: number | null;
+                            /**
+                             * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of voice balances. Required if voice calls are included in product plan
+                     */
+                    voice?: {
+                        /**
+                         * International voice calls
+                         */
+                        international?: {
+                            /**
+                             * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            duration?: string | null;
+                            /**
+                             * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            number?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * National voice calls
+                         */
+                        national?: {
+                            /**
+                             * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            duration?: string | null;
+                            /**
+                             * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            number?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                         */
+                        planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                        /**
+                         * Roaming voice calls
+                         */
+                        roaming?: {
+                            /**
+                             * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            amount?: string | null;
+                            /**
+                             * An overview of plan limits. Required unless planType is UNSUPPORTED
+                             */
+                            description?: string | null;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            duration?: string | null;
+                            /**
+                             * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                             */
+                            number?: number | null;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Optional description of the service used for display purposes
+                 */
+                displayName?: string | null;
+                /**
+                 * Date when the balance period ends
+                 */
+                endDate?: string | null;
+                /**
+                 * Required if the service includes a phone number
+                 */
+                phoneNumber?: string | null;
+                /**
+                 * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceId?: string | null;
+                /**
+                 * Date when the balance period started
+                 */
+                startDate?: string | null;
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoBalanceResponse {
-  /**
-   * Object containing account service usage summary
-   */
-  data: {
     /**
-     * Summary of balances
+     * Object containing account service usage summary
      */
-    services: {
-      /**
-       * A summary of Service balances
-       */
-      balance?: {
+    data: {
         /**
-         * Summary of data balances
+         * Summary of balances
          */
-        data?: {
-          /**
-           * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          download?: number | null;
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-           */
-          roaming?: {
+        services: {
             /**
-             * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+             * A summary of Service balances
              */
-            amount?: string | null;
+            balance?: {
+                /**
+                 * Summary of data balances
+                 */
+                data?: {
+                    /**
+                     * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    download?: number | null;
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                         */
+                        download?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    upload?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of messaging. Required if messaging services is included in the product plan
+                 */
+                messaging?: {
+                    /**
+                     * Summary of MMS Balance. Required if the service plan supports MMS messaging
+                     */
+                    mms: {
+                        /**
+                         * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        national?: number | null;
+                        /**
+                         * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Summary of SMS Balance. Required if the service plan supports SMS messaging
+                     */
+                    sms: {
+                        /**
+                         * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        national?: number | null;
+                        /**
+                         * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of voice balances. Required if voice calls are included in product plan
+                 */
+                voice?: {
+                    /**
+                     * International voice calls
+                     */
+                    international?: {
+                        /**
+                         * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * National voice calls
+                     */
+                    national?: {
+                        /**
+                         * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Roaming voice calls
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
             /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             * Optional description of the service used for display purposes
              */
-            description?: string | null;
+            displayName?: string | null;
             /**
-             * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+             * Date when the balance period ends
              */
-            download?: number | null;
+            endDate?: string | null;
+            /**
+             * Required if the service includes a phone number
+             */
+            phoneNumber?: string | null;
+            /**
+             * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            serviceId?: string | null;
+            /**
+             * Date when the balance period started
+             */
+            startDate?: string | null;
             [k: string]: unknown;
-          };
-          /**
-           * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          upload?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of messaging. Required if messaging services is included in the product plan
-         */
-        messaging?: {
-          /**
-           * Summary of MMS Balance. Required if the service plan supports MMS messaging
-           */
-          mms: {
-            /**
-             * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            international?: number | null;
-            /**
-             * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            national?: number | null;
-            /**
-             * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Summary of SMS Balance. Required if the service plan supports SMS messaging
-           */
-          sms: {
-            /**
-             * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            international?: number | null;
-            /**
-             * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            national?: number | null;
-            /**
-             * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of voice balances. Required if voice calls are included in product plan
-         */
-        voice?: {
-          /**
-           * International voice calls
-           */
-          international?: {
-            /**
-             * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * National voice calls
-           */
-          national?: {
-            /**
-             * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Roaming voice calls
-           */
-          roaming?: {
-            /**
-             * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
+        }[];
         [k: string]: unknown;
-      };
-      /**
-       * Optional description of the service used for display purposes
-       */
-      displayName?: string | null;
-      /**
-       * Date when the balance period ends
-       */
-      endDate?: string | null;
-      /**
-       * Required if the service includes a phone number
-       */
-      phoneNumber?: string | null;
-      /**
-       * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceId?: string | null;
-      /**
-       * Date when the balance period started
-       */
-      startDate?: string | null;
-      [k: string]: unknown;
-    }[];
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoBalanceResponseData {
-  /**
-   * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  accountId?: string | null;
-  /**
-   * Object containing account service usage summary
-   */
-  balance?: {
     /**
-     * Summary of balances
+     * The ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
      */
-    services: {
-      /**
-       * A summary of Service balances
-       */
-      balance?: {
+    accountId?: string | null;
+    /**
+     * Object containing account service usage summary
+     */
+    balance?: {
         /**
-         * Summary of data balances
+         * Summary of balances
          */
-        data?: {
-          /**
-           * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          amount?: string | null;
-          /**
-           * An overview of plan limits. Required unless planType is UNSUPPORTED
-           */
-          description?: string | null;
-          /**
-           * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          download?: number | null;
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-           */
-          roaming?: {
+        services: {
             /**
-             * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+             * A summary of Service balances
              */
-            amount?: string | null;
+            balance?: {
+                /**
+                 * Summary of data balances
+                 */
+                data?: {
+                    /**
+                     * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    amount?: string | null;
+                    /**
+                     * An overview of plan limits. Required unless planType is UNSUPPORTED
+                     */
+                    description?: string | null;
+                    /**
+                     * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    download?: number | null;
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                         */
+                        download?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+                     */
+                    upload?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of messaging. Required if messaging services is included in the product plan
+                 */
+                messaging?: {
+                    /**
+                     * Summary of MMS Balance. Required if the service plan supports MMS messaging
+                     */
+                    mms: {
+                        /**
+                         * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        national?: number | null;
+                        /**
+                         * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Summary of SMS Balance. Required if the service plan supports SMS messaging
+                     */
+                    sms: {
+                        /**
+                         * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        national?: number | null;
+                        /**
+                         * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of voice balances. Required if voice calls are included in product plan
+                 */
+                voice?: {
+                    /**
+                     * International voice calls
+                     */
+                    international?: {
+                        /**
+                         * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * National voice calls
+                     */
+                    national?: {
+                        /**
+                         * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+                     */
+                    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+                    /**
+                     * Roaming voice calls
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        amount?: string | null;
+                        /**
+                         * An overview of plan limits. Required unless planType is UNSUPPORTED
+                         */
+                        description?: string | null;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        duration?: string | null;
+                        /**
+                         * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                         */
+                        number?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
             /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             * Optional description of the service used for display purposes
              */
-            description?: string | null;
+            displayName?: string | null;
             /**
-             * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+             * Date when the balance period ends
              */
-            download?: number | null;
+            endDate?: string | null;
+            /**
+             * Required if the service includes a phone number
+             */
+            phoneNumber?: string | null;
+            /**
+             * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            serviceId?: string | null;
+            /**
+             * Date when the balance period started
+             */
+            startDate?: string | null;
             [k: string]: unknown;
-          };
-          /**
-           * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-           */
-          upload?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of messaging. Required if messaging services is included in the product plan
-         */
-        messaging?: {
-          /**
-           * Summary of MMS Balance. Required if the service plan supports MMS messaging
-           */
-          mms: {
-            /**
-             * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            international?: number | null;
-            /**
-             * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            national?: number | null;
-            /**
-             * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Summary of SMS Balance. Required if the service plan supports SMS messaging
-           */
-          sms: {
-            /**
-             * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            international?: number | null;
-            /**
-             * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            national?: number | null;
-            /**
-             * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of voice balances. Required if voice calls are included in product plan
-         */
-        voice?: {
-          /**
-           * International voice calls
-           */
-          international?: {
-            /**
-             * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * National voice calls
-           */
-          national?: {
-            /**
-             * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-           */
-          planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-          /**
-           * Roaming voice calls
-           */
-          roaming?: {
-            /**
-             * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            amount?: string | null;
-            /**
-             * An overview of plan limits. Required unless planType is UNSUPPORTED
-             */
-            description?: string | null;
-            /**
-             * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            duration?: string | null;
-            /**
-             * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-             */
-            number?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
+        }[];
         [k: string]: unknown;
-      };
-      /**
-       * Optional description of the service used for display purposes
-       */
-      displayName?: string | null;
-      /**
-       * Date when the balance period ends
-       */
-      endDate?: string | null;
-      /**
-       * Required if the service includes a phone number
-       */
-      phoneNumber?: string | null;
-      /**
-       * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceId?: string | null;
-      /**
-       * Date when the balance period started
-       */
-      startDate?: string | null;
-      [k: string]: unknown;
-    }[];
+    };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoBillingAccountTransaction {
-  /**
-   * Optional array of adjustments arising for this transaction
-   */
-  adjustments?:
-    | {
-        /**
-         * The amount of the adjustment
-         */
-        amount: string;
-        /**
-         * A free text description of the adjustment
-         */
-        description: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
-   */
-  amount: string;
-  /**
-   * Optional description of the transaction that can be used for display purposes
-   */
-  description?: string | null;
-  /**
-   * Date and time when the usage period ends
-   */
-  endDate: string;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  serviceIds?: string | null;
-  /**
-   * Date and time when the usage period starts
-   */
-  startDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBillingAccountTransactionAdjustments {
-  /**
-   * The amount of the adjustment
-   */
-  amount: string;
-  /**
-   * A free text description of the adjustment
-   */
-  description: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBillingOnceOffTransaction {
-  /**
-   * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
-   */
-  amount: string;
-  /**
-   * A free text description of the item
-   */
-  description: string;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  serviceId?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBillingOtherTransaction {
-  /**
-   * Optional array of adjustments arising for this transaction
-   */
-  adjustments?:
-    | {
-        /**
-         * The amount of the adjustment
-         */
-        amount: string;
-        /**
-         * A free text description of the adjustment
-         */
-        description: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The amount of the charge
-   */
-  amount: string;
-  /**
-   * A free text description of the item
-   */
-  description: string;
-  /**
-   * Optional end date for the application of the charge
-   */
-  endDate?: string | null;
-  /**
-   * The number of the invoice in which this transaction is included if it has been issued
-   */
-  invoiceNumber?: string | null;
-  /**
-   * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  serviceId?: string | null;
-  /**
-   * Optional start date for the application of the charge
-   */
-  startDate?: string | null;
-  /**
-   * Type of charge. Assumed to be OTHER if absent
-   */
-  type?: ("SERVICE" | "NETWORK" | "EQUIPMENT" | "METERING" | "OTHER") | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBillingPaymentTransaction {
-  /**
-   * The amount paid
-   */
-  amount: string;
-  /**
-   * The method of payment
-   */
-  method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "VOUCHER" | "OTHER";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoBillingTransaction {
-  account?: {
     /**
      * Optional array of adjustments arising for this transaction
      */
     adjustments?:
-      | {
-          /**
-           * The amount of the adjustment
-           */
-          amount: string;
-          /**
-           * A free text description of the adjustment
-           */
-          description: string;
-          [k: string]: unknown;
+        | {
+            /**
+             * The amount of the adjustment
+             */
+            amount: string;
+            /**
+             * A free text description of the adjustment
+             */
+            description: string;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
      */
@@ -3010,20 +2868,23 @@ export interface TelcoBillingTransaction {
      */
     startDate: string;
     [k: string]: unknown;
-  };
-  /**
-   * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-   */
-  accountId: string;
-  /**
-   * The date and time that the transaction occurred
-   */
-  executionDateTime: string;
-  /**
-   * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
-   */
-  gst?: string | null;
-  onceOff?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBillingAccountTransactionAdjustments {
+    /**
+     * The amount of the adjustment
+     */
+    amount: string;
+    /**
+     * A free text description of the adjustment
+     */
+    description: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBillingOnceOffTransaction {
     /**
      * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
      */
@@ -3041,24 +2902,26 @@ export interface TelcoBillingTransaction {
      */
     serviceId?: string | null;
     [k: string]: unknown;
-  };
-  otherCharges?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBillingOtherTransaction {
     /**
      * Optional array of adjustments arising for this transaction
      */
     adjustments?:
-      | {
-          /**
-           * The amount of the adjustment
-           */
-          amount: string;
-          /**
-           * A free text description of the adjustment
-           */
-          description: string;
-          [k: string]: unknown;
+        | {
+            /**
+             * The amount of the adjustment
+             */
+            amount: string;
+            /**
+             * A free text description of the adjustment
+             */
+            description: string;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * The amount of the charge
      */
@@ -3086,10 +2949,12 @@ export interface TelcoBillingTransaction {
     /**
      * Type of charge. Assumed to be OTHER if absent
      */
-    type?: ("SERVICE" | "NETWORK" | "EQUIPMENT" | "METERING" | "OTHER") | null;
+    type?: ('SERVICE' | 'NETWORK' | 'EQUIPMENT' | 'METERING' | 'OTHER') | null;
     [k: string]: unknown;
-  };
-  payment?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBillingPaymentTransaction {
     /**
      * The amount paid
      */
@@ -3097,155 +2962,153 @@ export interface TelcoBillingTransaction {
     /**
      * The method of payment
      */
-    method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "VOUCHER" | "OTHER";
+    method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'VOUCHER' | 'OTHER';
     [k: string]: unknown;
-  };
-  /**
-   * Indicator of the type of transaction object present in this record
-   */
-  transactionUType: "account" | "onceOff" | "otherCharges" | "payment";
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoBillingTransaction {
+    account?: {
+        /**
+         * Optional array of adjustments arising for this transaction
+         */
+        adjustments?:
+            | {
+                /**
+                 * The amount of the adjustment
+                 */
+                amount: string;
+                /**
+                 * A free text description of the adjustment
+                 */
+                description: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
+         */
+        amount: string;
+        /**
+         * Optional description of the transaction that can be used for display purposes
+         */
+        description?: string | null;
+        /**
+         * Date and time when the usage period ends
+         */
+        endDate: string;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        serviceIds?: string | null;
+        /**
+         * Date and time when the usage period starts
+         */
+        startDate: string;
+        [k: string]: unknown;
+    };
+    /**
+     * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+     */
+    accountId: string;
+    /**
+     * The date and time that the transaction occurred
+     */
+    executionDateTime: string;
+    /**
+     * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
+     */
+    gst?: string | null;
+    onceOff?: {
+        /**
+         * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
+         */
+        amount: string;
+        /**
+         * A free text description of the item
+         */
+        description: string;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        serviceId?: string | null;
+        [k: string]: unknown;
+    };
+    otherCharges?: {
+        /**
+         * Optional array of adjustments arising for this transaction
+         */
+        adjustments?:
+            | {
+                /**
+                 * The amount of the adjustment
+                 */
+                amount: string;
+                /**
+                 * A free text description of the adjustment
+                 */
+                description: string;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * The amount of the charge
+         */
+        amount: string;
+        /**
+         * A free text description of the item
+         */
+        description: string;
+        /**
+         * Optional end date for the application of the charge
+         */
+        endDate?: string | null;
+        /**
+         * The number of the invoice in which this transaction is included if it has been issued
+         */
+        invoiceNumber?: string | null;
+        /**
+         * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        serviceId?: string | null;
+        /**
+         * Optional start date for the application of the charge
+         */
+        startDate?: string | null;
+        /**
+         * Type of charge. Assumed to be OTHER if absent
+         */
+        type?: ('SERVICE' | 'NETWORK' | 'EQUIPMENT' | 'METERING' | 'OTHER') | null;
+        [k: string]: unknown;
+    };
+    payment?: {
+        /**
+         * The amount paid
+         */
+        amount: string;
+        /**
+         * The method of payment
+         */
+        method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'VOUCHER' | 'OTHER';
+        [k: string]: unknown;
+    };
+    /**
+     * Indicator of the type of transaction object present in this record
+     */
+    transactionUType: 'account' | 'onceOff' | 'otherCharges' | 'payment';
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoConcession {
-  /**
-   * Display text providing more information on the concession
-   */
-  additionalInfo?: string | null;
-  /**
-   * Optional link to additional information regarding the concession
-   */
-  additionalInfoUri?: string | null;
-  /**
-   * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
-   */
-  amount?: string | null;
-  /**
-   * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
-   */
-  appliedTo?: ("INVOICE" | "USAGE")[] | null;
-  /**
-   * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  discountFrequency?: string | null;
-  /**
-   * The display name of the concession
-   */
-  displayName: string;
-  /**
-   * Optional end date for the application of the concession
-   */
-  endDate?: string | null;
-  /**
-   * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
-   */
-  percentage?: string | null;
-  /**
-   * Optional start date for the application of the concession
-   */
-  startDate: string;
-  /**
-   * The concession type
-   */
-  type: "CONCESSION" | "REBATE" | "GRANT";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoConcessionsResponse {
-  data: {
-    /**
-     * Array may be empty if no concessions exist
-     */
-    concessions: {
-      /**
-       * Display text providing more information on the concession
-       */
-      additionalInfo?: string | null;
-      /**
-       * Optional link to additional information regarding the concession
-       */
-      additionalInfoUri?: string | null;
-      /**
-       * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
-       */
-      amount?: string | null;
-      /**
-       * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
-       */
-      appliedTo?: ("INVOICE" | "USAGE")[] | null;
-      /**
-       * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      discountFrequency?: string | null;
-      /**
-       * The display name of the concession
-       */
-      displayName: string;
-      /**
-       * Optional end date for the application of the concession
-       */
-      endDate?: string | null;
-      /**
-       * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
-       */
-      percentage?: string | null;
-      /**
-       * Optional start date for the application of the concession
-       */
-      startDate: string;
-      /**
-       * The concession type
-       */
-      type: "CONCESSION" | "REBATE" | "GRANT";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoConcessionsResponseData {
-  /**
-   * Array may be empty if no concessions exist
-   */
-  concessions: {
     /**
      * Display text providing more information on the concession
      */
@@ -3261,7 +3124,7 @@ export interface TelcoConcessionsResponseData {
     /**
      * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
      */
-    appliedTo?: ("INVOICE" | "USAGE")[] | null;
+    appliedTo?: ('INVOICE' | 'USAGE')[] | null;
     /**
      * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
      */
@@ -3285,10 +3148,147 @@ export interface TelcoConcessionsResponseData {
     /**
      * The concession type
      */
-    type: "CONCESSION" | "REBATE" | "GRANT";
+    type: 'CONCESSION' | 'REBATE' | 'GRANT';
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoConcessionsResponse {
+    data: {
+        /**
+         * Array may be empty if no concessions exist
+         */
+        concessions: {
+            /**
+             * Display text providing more information on the concession
+             */
+            additionalInfo?: string | null;
+            /**
+             * Optional link to additional information regarding the concession
+             */
+            additionalInfoUri?: string | null;
+            /**
+             * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
+             */
+            amount?: string | null;
+            /**
+             * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
+             */
+            appliedTo?: ('INVOICE' | 'USAGE')[] | null;
+            /**
+             * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            discountFrequency?: string | null;
+            /**
+             * The display name of the concession
+             */
+            displayName: string;
+            /**
+             * Optional end date for the application of the concession
+             */
+            endDate?: string | null;
+            /**
+             * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
+             */
+            percentage?: string | null;
+            /**
+             * Optional start date for the application of the concession
+             */
+            startDate: string;
+            /**
+             * The concession type
+             */
+            type: 'CONCESSION' | 'REBATE' | 'GRANT';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoConcessionsResponseData {
+    /**
+     * Array may be empty if no concessions exist
+     */
+    concessions: {
+        /**
+         * Display text providing more information on the concession
+         */
+        additionalInfo?: string | null;
+        /**
+         * Optional link to additional information regarding the concession
+         */
+        additionalInfoUri?: string | null;
+        /**
+         * Conditional attribute for the amount of discount for the concession- required if type is FIXED_AMOUNT
+         */
+        amount?: string | null;
+        /**
+         * Array of ENUM's to specify what the concession applies to. Multiple ENUM values can be provided. If absent, USAGE is assumed
+         */
+        appliedTo?: ('INVOICE' | 'USAGE')[] | null;
+        /**
+         * Conditional attribute for frequency at which a concession is applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        discountFrequency?: string | null;
+        /**
+         * The display name of the concession
+         */
+        displayName: string;
+        /**
+         * Optional end date for the application of the concession
+         */
+        endDate?: string | null;
+        /**
+         * Conditional attribute for the percentage of discount of concession - required if type is FIXED_PERCENTAGE
+         */
+        percentage?: string | null;
+        /**
+         * Optional start date for the application of the concession
+         */
+        startDate: string;
+        /**
+         * The concession type
+         */
+        type: 'CONCESSION' | 'REBATE' | 'GRANT';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -3296,428 +3296,60 @@ export interface TelcoConcessionsResponseData {
  * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
  */
 export interface TelcoContract {
-  /**
-   * URI of the contract conditions
-   */
-  contractUri?: string | null;
-  /**
-   * Description of the contract
-   */
-  description?: string | null;
-  /**
-   * Minimum contract duration in months
-   */
-  duration: number;
-  /**
-   * Name of the contract
-   */
-  name: string;
-  [k: string]: unknown;
+    /**
+     * URI of the contract conditions
+     */
+    contractUri?: string | null;
+    /**
+     * Description of the contract
+     */
+    description?: string | null;
+    /**
+     * Minimum contract duration in months
+     */
+    duration: number;
+    /**
+     * Name of the contract
+     */
+    name: string;
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoInvoice {
-  /**
-   * Object contain charges and credits related to usage
-   */
-  accountCharges?: {
     /**
-     * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+     * Object contain charges and credits related to usage
      */
-    otherCharges?: {
-      /**
-       * The aggregate total of charges for this item (exclusive of GST)
-       */
-      amount: string;
-      /**
-       * A free text description of the charge
-       */
-      description: string;
-      /**
-       * A free text description of the charge
-       */
-      type?:
-        | (
-            | "SERVICE"
-            | "EQUIPMENT"
-            | "NETWORK"
-            | "HANDSET"
-            | "DEVICE"
-            | "ENTERTAINMENT"
-            | "SUBSCRIPTION"
-            | "SOFTWARE"
-            | "OTHER"
-          )
-        | null;
-      [k: string]: unknown;
-    };
-    /**
-     * The aggregate total of account level discounts or credits for the period covered by the invoice
-     */
-    totalDiscounts: string;
-    /**
-     * The total GST for all account level charges.  If absent then zero is assumed
-     */
-    totalGst?: string | null;
-    /**
-     * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
-     */
-    totalOnceOffCharges: string;
-    /**
-     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-     */
-    totalUsageCharges: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-   */
-  accountId: string;
-  /**
-   * Object containing usage summary
-   */
-  accountUsage?: {
-    /**
-     * Summary of data usage
-     */
-    data?: {
-      /**
-       * Cost amount of data usage
-       */
-      amount: string;
-      /**
-       * Amount of data downloaded in megabytes (MB)
-       */
-      download: number;
-      /**
-       * Required if roaming is suipported
-       */
-      roaming?: {
-        /**
-         * Amount value of data roaming charges
-         */
-        amount?: string | null;
-        /**
-         * Amount of data used while roaming in megabytes (MB)
-         */
-        download?: number | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Number of data sessions
-       */
-      sessions?: number | null;
-      /**
-       * Amount of data uploaded in megabytes (MB)
-       */
-      upload: number;
-      [k: string]: unknown;
-    };
-    /**
-     * Summary of messaging. Required if messaging services is included in the product plan
-     */
-    messaging?: {
-      /**
-       * Summary of MMS usage
-       */
-      mms: {
-        /**
-         * Cost amount of MMS messages
-         */
-        amount: string;
-        /**
-         * ber of international MMS messages sent
-         */
-        international?: number | null;
-        /**
-         * Number of national MMS messages sent
-         */
-        national: number;
-        /**
-         * Number of roaming SMS messages sent. Including premium SMS services
-         */
-        roaming?: number | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of SMS usage
-       */
-      sms: {
-        /**
-         * Cost amount of SMS messages. Including premium SMS services
-         */
-        amount: string;
-        /**
-         * Number of international SMS messages sent. Including premium SMS services
-         */
-        international?: number | null;
-        /**
-         * Number of national SMS messages sent. Including premium SMS services
-         */
-        national: number;
-        /**
-         * Number of roaming SMS messages sent. Including premium SMS services
-         */
-        roaming?: number | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Summary of voice calls. Required if voice calls are included in product plan
-     */
-    voice?: {
-      /**
-       * International voice calls. Requied if international calling is supported
-       */
-      international: {
-        /**
-         * Cost amount of international voice calls
-         */
-        amount: string;
-        /**
-         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-         */
-        duration: string;
-        /**
-         * Number of international voice calls
-         */
-        number: number;
-        [k: string]: unknown;
-      };
-      /**
-       * National voice calls
-       */
-      national: {
-        /**
-         * Cost amount of national calls
-         */
-        amount: string;
-        /**
-         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-         */
-        duration: string;
-        /**
-         * Number of national voice calls
-         */
-        number: number;
-        [k: string]: unknown;
-      };
-      /**
-       * Roaming voice calls, Required if roaming is supported
-       */
-      roaming: {
-        /**
-         * Cost amount of roaming voice calls
-         */
-        amount: string;
-        /**
-         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-         */
-        duration: string;
-        /**
-         * Number of roaming voice calls
-         */
-        number: number;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * The account balance at the time the invoice was issued
-   */
-  balanceAtIssue: string;
-  /**
-   * The date that the invoice is due to be paid
-   */
-  dueDate?: string | null;
-  /**
-   * The total GST amount for this invoice.  If absent then zero is assumed
-   */
-  gstAmount?: string | null;
-  /**
-   * The net amount due for this invoice regardless of previous balance
-   */
-  invoiceAmount?: string | null;
-  /**
-   * The number assigned to this invoice by the telco Retailer
-   */
-  invoiceNumber: string;
-  /**
-   * The date that the invoice was actually issued (as opposed to generated or calculated)
-   */
-  issueDate: string;
-  /**
-   * A discount for on time payment
-   */
-  payOnTimeDiscount?: {
-    /**
-     * The date by which the invoice must be paid to receive the pay on time discount
-     */
-    date: string;
-    /**
-     * The amount that will be discounted if the invoice is paid by the date specified
-     */
-    discountAmount: string;
-    /**
-     * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
-     */
-    gstAmount?: string | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Indicator of the payment status for the invoice
-   */
-  paymentStatus: "PAID" | "PARTIALLY_PAID" | "NOT_PAID";
-  /**
-   * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
-   */
-  period?: {
-    /**
-     * The end date of the period covered by this invoice
-     */
-    endDate: string;
-    /**
-     * The start date of the period covered by this invoice
-     */
-    startDate: string;
-    [k: string]: unknown;
-  };
-  /**
-   * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
-   */
-  services: string[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Object contain charges and credits related to usage
- */
-export interface TelcoInvoiceAccountCharges {
-  /**
-   * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
-   */
-  otherCharges?: {
-    /**
-     * The aggregate total of charges for this item (exclusive of GST)
-     */
-    amount: string;
-    /**
-     * A free text description of the charge
-     */
-    description: string;
-    /**
-     * A free text description of the charge
-     */
-    type?:
-      | (
-          | "SERVICE"
-          | "EQUIPMENT"
-          | "NETWORK"
-          | "HANDSET"
-          | "DEVICE"
-          | "ENTERTAINMENT"
-          | "SUBSCRIPTION"
-          | "SOFTWARE"
-          | "OTHER"
-        )
-      | null;
-    [k: string]: unknown;
-  };
-  /**
-   * The aggregate total of account level discounts or credits for the period covered by the invoice
-   */
-  totalDiscounts: string;
-  /**
-   * The total GST for all account level charges.  If absent then zero is assumed
-   */
-  totalGst?: string | null;
-  /**
-   * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
-   */
-  totalOnceOffCharges: string;
-  /**
-   * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-   */
-  totalUsageCharges: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
- */
-export interface TelcoInvoiceAccountChargesOtherCharges {
-  /**
-   * The aggregate total of charges for this item (exclusive of GST)
-   */
-  amount: string;
-  /**
-   * A free text description of the charge
-   */
-  description: string;
-  /**
-   * A free text description of the charge
-   */
-  type?:
-    | (
-        | "SERVICE"
-        | "EQUIPMENT"
-        | "NETWORK"
-        | "HANDSET"
-        | "DEVICE"
-        | "ENTERTAINMENT"
-        | "SUBSCRIPTION"
-        | "SOFTWARE"
-        | "OTHER"
-      )
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoInvoiceListResponse {
-  data: {
-    /**
-     * Array of invoices sorted by issue date in descending order
-     */
-    invoices: {
-      /**
-       * Object contain charges and credits related to usage
-       */
-      accountCharges?: {
+    accountCharges?: {
         /**
          * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
          */
         otherCharges?: {
-          /**
-           * The aggregate total of charges for this item (exclusive of GST)
-           */
-          amount: string;
-          /**
-           * A free text description of the charge
-           */
-          description: string;
-          /**
-           * A free text description of the charge
-           */
-          type?:
-            | (
-                | "SERVICE"
-                | "EQUIPMENT"
-                | "NETWORK"
-                | "HANDSET"
-                | "DEVICE"
-                | "ENTERTAINMENT"
-                | "SUBSCRIPTION"
-                | "SOFTWARE"
-                | "OTHER"
-              )
-            | null;
-          [k: string]: unknown;
+            /**
+             * The aggregate total of charges for this item (exclusive of GST)
+             */
+            amount: string;
+            /**
+             * A free text description of the charge
+             */
+            description: string;
+            /**
+             * A free text description of the charge
+             */
+            type?:
+                | (
+                    | 'SERVICE'
+                    | 'EQUIPMENT'
+                    | 'NETWORK'
+                    | 'HANDSET'
+                    | 'DEVICE'
+                    | 'ENTERTAINMENT'
+                    | 'SUBSCRIPTION'
+                    | 'SOFTWARE'
+                    | 'OTHER'
+                )
+                | null;
+            [k: string]: unknown;
         };
         /**
          * The aggregate total of account level discounts or credits for the period covered by the invoice
@@ -3736,325 +3368,6 @@ export interface TelcoInvoiceListResponse {
          */
         totalUsageCharges: string;
         [k: string]: unknown;
-      };
-      /**
-       * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-       */
-      accountId: string;
-      /**
-       * Object containing usage summary
-       */
-      accountUsage?: {
-        /**
-         * Summary of data usage
-         */
-        data?: {
-          /**
-           * Cost amount of data usage
-           */
-          amount: string;
-          /**
-           * Amount of data downloaded in megabytes (MB)
-           */
-          download: number;
-          /**
-           * Required if roaming is suipported
-           */
-          roaming?: {
-            /**
-             * Amount value of data roaming charges
-             */
-            amount?: string | null;
-            /**
-             * Amount of data used while roaming in megabytes (MB)
-             */
-            download?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Number of data sessions
-           */
-          sessions?: number | null;
-          /**
-           * Amount of data uploaded in megabytes (MB)
-           */
-          upload: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of messaging. Required if messaging services is included in the product plan
-         */
-        messaging?: {
-          /**
-           * Summary of MMS usage
-           */
-          mms: {
-            /**
-             * Cost amount of MMS messages
-             */
-            amount: string;
-            /**
-             * ber of international MMS messages sent
-             */
-            international?: number | null;
-            /**
-             * Number of national MMS messages sent
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of SMS usage
-           */
-          sms: {
-            /**
-             * Cost amount of SMS messages. Including premium SMS services
-             */
-            amount: string;
-            /**
-             * Number of international SMS messages sent. Including premium SMS services
-             */
-            international?: number | null;
-            /**
-             * Number of national SMS messages sent. Including premium SMS services
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of voice calls. Required if voice calls are included in product plan
-         */
-        voice?: {
-          /**
-           * International voice calls. Requied if international calling is supported
-           */
-          international: {
-            /**
-             * Cost amount of international voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of international voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * National voice calls
-           */
-          national: {
-            /**
-             * Cost amount of national calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of national voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * Roaming voice calls, Required if roaming is supported
-           */
-          roaming: {
-            /**
-             * Cost amount of roaming voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of roaming voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * The account balance at the time the invoice was issued
-       */
-      balanceAtIssue: string;
-      /**
-       * The date that the invoice is due to be paid
-       */
-      dueDate?: string | null;
-      /**
-       * The total GST amount for this invoice.  If absent then zero is assumed
-       */
-      gstAmount?: string | null;
-      /**
-       * The net amount due for this invoice regardless of previous balance
-       */
-      invoiceAmount?: string | null;
-      /**
-       * The number assigned to this invoice by the telco Retailer
-       */
-      invoiceNumber: string;
-      /**
-       * The date that the invoice was actually issued (as opposed to generated or calculated)
-       */
-      issueDate: string;
-      /**
-       * A discount for on time payment
-       */
-      payOnTimeDiscount?: {
-        /**
-         * The date by which the invoice must be paid to receive the pay on time discount
-         */
-        date: string;
-        /**
-         * The amount that will be discounted if the invoice is paid by the date specified
-         */
-        discountAmount: string;
-        /**
-         * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
-         */
-        gstAmount?: string | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Indicator of the payment status for the invoice
-       */
-      paymentStatus: "PAID" | "PARTIALLY_PAID" | "NOT_PAID";
-      /**
-       * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
-       */
-      period?: {
-        /**
-         * The end date of the period covered by this invoice
-         */
-        endDate: string;
-        /**
-         * The start date of the period covered by this invoice
-         */
-        startDate: string;
-        [k: string]: unknown;
-      };
-      /**
-       * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
-       */
-      services: string[];
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoInvoiceListResponseData {
-  /**
-   * Array of invoices sorted by issue date in descending order
-   */
-  invoices: {
-    /**
-     * Object contain charges and credits related to usage
-     */
-    accountCharges?: {
-      /**
-       * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
-       */
-      otherCharges?: {
-        /**
-         * The aggregate total of charges for this item (exclusive of GST)
-         */
-        amount: string;
-        /**
-         * A free text description of the charge
-         */
-        description: string;
-        /**
-         * A free text description of the charge
-         */
-        type?:
-          | (
-              | "SERVICE"
-              | "EQUIPMENT"
-              | "NETWORK"
-              | "HANDSET"
-              | "DEVICE"
-              | "ENTERTAINMENT"
-              | "SUBSCRIPTION"
-              | "SOFTWARE"
-              | "OTHER"
-            )
-          | null;
-        [k: string]: unknown;
-      };
-      /**
-       * The aggregate total of account level discounts or credits for the period covered by the invoice
-       */
-      totalDiscounts: string;
-      /**
-       * The total GST for all account level charges.  If absent then zero is assumed
-       */
-      totalGst?: string | null;
-      /**
-       * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
-       */
-      totalOnceOffCharges: string;
-      /**
-       * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-       */
-      totalUsageCharges: string;
-      [k: string]: unknown;
     };
     /**
      * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
@@ -4064,153 +3377,153 @@ export interface TelcoInvoiceListResponseData {
      * Object containing usage summary
      */
     accountUsage?: {
-      /**
-       * Summary of data usage
-       */
-      data?: {
         /**
-         * Cost amount of data usage
+         * Summary of data usage
          */
-        amount: string;
-        /**
-         * Amount of data downloaded in megabytes (MB)
-         */
-        download: number;
-        /**
-         * Required if roaming is suipported
-         */
-        roaming?: {
-          /**
-           * Amount value of data roaming charges
-           */
-          amount?: string | null;
-          /**
-           * Amount of data used while roaming in megabytes (MB)
-           */
-          download?: number | null;
-          [k: string]: unknown;
+        data?: {
+            /**
+             * Cost amount of data usage
+             */
+            amount: string;
+            /**
+             * Amount of data downloaded in megabytes (MB)
+             */
+            download: number;
+            /**
+             * Required if roaming is suipported
+             */
+            roaming?: {
+                /**
+                 * Amount value of data roaming charges
+                 */
+                amount?: string | null;
+                /**
+                 * Amount of data used while roaming in megabytes (MB)
+                 */
+                download?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Number of data sessions
+             */
+            sessions?: number | null;
+            /**
+             * Amount of data uploaded in megabytes (MB)
+             */
+            upload: number;
+            [k: string]: unknown;
         };
         /**
-         * Number of data sessions
+         * Summary of messaging. Required if messaging services is included in the product plan
          */
-        sessions?: number | null;
+        messaging?: {
+            /**
+             * Summary of MMS usage
+             */
+            mms: {
+                /**
+                 * Cost amount of MMS messages
+                 */
+                amount: string;
+                /**
+                 * ber of international MMS messages sent
+                 */
+                international?: number | null;
+                /**
+                 * Number of national MMS messages sent
+                 */
+                national: number;
+                /**
+                 * Number of roaming SMS messages sent. Including premium SMS services
+                 */
+                roaming?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of SMS usage
+             */
+            sms: {
+                /**
+                 * Cost amount of SMS messages. Including premium SMS services
+                 */
+                amount: string;
+                /**
+                 * Number of international SMS messages sent. Including premium SMS services
+                 */
+                international?: number | null;
+                /**
+                 * Number of national SMS messages sent. Including premium SMS services
+                 */
+                national: number;
+                /**
+                 * Number of roaming SMS messages sent. Including premium SMS services
+                 */
+                roaming?: number | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
         /**
-         * Amount of data uploaded in megabytes (MB)
+         * Summary of voice calls. Required if voice calls are included in product plan
          */
-        upload: number;
+        voice?: {
+            /**
+             * International voice calls. Requied if international calling is supported
+             */
+            international: {
+                /**
+                 * Cost amount of international voice calls
+                 */
+                amount: string;
+                /**
+                 * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                 */
+                duration: string;
+                /**
+                 * Number of international voice calls
+                 */
+                number: number;
+                [k: string]: unknown;
+            };
+            /**
+             * National voice calls
+             */
+            national: {
+                /**
+                 * Cost amount of national calls
+                 */
+                amount: string;
+                /**
+                 * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                 */
+                duration: string;
+                /**
+                 * Number of national voice calls
+                 */
+                number: number;
+                [k: string]: unknown;
+            };
+            /**
+             * Roaming voice calls, Required if roaming is supported
+             */
+            roaming: {
+                /**
+                 * Cost amount of roaming voice calls
+                 */
+                amount: string;
+                /**
+                 * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                 */
+                duration: string;
+                /**
+                 * Number of roaming voice calls
+                 */
+                number: number;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
-      };
-      /**
-       * Summary of messaging. Required if messaging services is included in the product plan
-       */
-      messaging?: {
-        /**
-         * Summary of MMS usage
-         */
-        mms: {
-          /**
-           * Cost amount of MMS messages
-           */
-          amount: string;
-          /**
-           * ber of international MMS messages sent
-           */
-          international?: number | null;
-          /**
-           * Number of national MMS messages sent
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of SMS usage
-         */
-        sms: {
-          /**
-           * Cost amount of SMS messages. Including premium SMS services
-           */
-          amount: string;
-          /**
-           * Number of international SMS messages sent. Including premium SMS services
-           */
-          international?: number | null;
-          /**
-           * Number of national SMS messages sent. Including premium SMS services
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of voice calls. Required if voice calls are included in product plan
-       */
-      voice?: {
-        /**
-         * International voice calls. Requied if international calling is supported
-         */
-        international: {
-          /**
-           * Cost amount of international voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of international voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * National voice calls
-         */
-        national: {
-          /**
-           * Cost amount of national calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of national voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Roaming voice calls, Required if roaming is supported
-         */
-        roaming: {
-          /**
-           * Cost amount of roaming voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of roaming voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     /**
      * The account balance at the time the invoice was issued
@@ -4240,326 +3553,6 @@ export interface TelcoInvoiceListResponseData {
      * A discount for on time payment
      */
     payOnTimeDiscount?: {
-      /**
-       * The date by which the invoice must be paid to receive the pay on time discount
-       */
-      date: string;
-      /**
-       * The amount that will be discounted if the invoice is paid by the date specified
-       */
-      discountAmount: string;
-      /**
-       * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
-       */
-      gstAmount?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Indicator of the payment status for the invoice
-     */
-    paymentStatus: "PAID" | "PARTIALLY_PAID" | "NOT_PAID";
-    /**
-     * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
-     */
-    period?: {
-      /**
-       * The end date of the period covered by this invoice
-       */
-      endDate: string;
-      /**
-       * The start date of the period covered by this invoice
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
-     */
-    services: string[];
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * A discount for on time payment
- */
-export interface TelcoInvoicePayOnTimeDiscount {
-  /**
-   * The date by which the invoice must be paid to receive the pay on time discount
-   */
-  date: string;
-  /**
-   * The amount that will be discounted if the invoice is paid by the date specified
-   */
-  discountAmount: string;
-  /**
-   * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
-   */
-  gstAmount?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
- */
-export interface TelcoInvoicePeriod {
-  /**
-   * The end date of the period covered by this invoice
-   */
-  endDate: string;
-  /**
-   * The start date of the period covered by this invoice
-   */
-  startDate: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoInvoiceResponse {
-  data: {
-    /**
-     * Array of invoices sorted by issue date in descending order
-     */
-    invoices: {
-      /**
-       * Object contain charges and credits related to usage
-       */
-      accountCharges?: {
-        /**
-         * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
-         */
-        otherCharges?: {
-          /**
-           * The aggregate total of charges for this item (exclusive of GST)
-           */
-          amount: string;
-          /**
-           * A free text description of the charge
-           */
-          description: string;
-          /**
-           * A free text description of the charge
-           */
-          type?:
-            | (
-                | "SERVICE"
-                | "EQUIPMENT"
-                | "NETWORK"
-                | "HANDSET"
-                | "DEVICE"
-                | "ENTERTAINMENT"
-                | "SUBSCRIPTION"
-                | "SOFTWARE"
-                | "OTHER"
-              )
-            | null;
-          [k: string]: unknown;
-        };
-        /**
-         * The aggregate total of account level discounts or credits for the period covered by the invoice
-         */
-        totalDiscounts: string;
-        /**
-         * The total GST for all account level charges.  If absent then zero is assumed
-         */
-        totalGst?: string | null;
-        /**
-         * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
-         */
-        totalOnceOffCharges: string;
-        /**
-         * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
-         */
-        totalUsageCharges: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-       */
-      accountId: string;
-      /**
-       * Object containing usage summary
-       */
-      accountUsage?: {
-        /**
-         * Summary of data usage
-         */
-        data?: {
-          /**
-           * Cost amount of data usage
-           */
-          amount: string;
-          /**
-           * Amount of data downloaded in megabytes (MB)
-           */
-          download: number;
-          /**
-           * Required if roaming is suipported
-           */
-          roaming?: {
-            /**
-             * Amount value of data roaming charges
-             */
-            amount?: string | null;
-            /**
-             * Amount of data used while roaming in megabytes (MB)
-             */
-            download?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Number of data sessions
-           */
-          sessions?: number | null;
-          /**
-           * Amount of data uploaded in megabytes (MB)
-           */
-          upload: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of messaging. Required if messaging services is included in the product plan
-         */
-        messaging?: {
-          /**
-           * Summary of MMS usage
-           */
-          mms: {
-            /**
-             * Cost amount of MMS messages
-             */
-            amount: string;
-            /**
-             * ber of international MMS messages sent
-             */
-            international?: number | null;
-            /**
-             * Number of national MMS messages sent
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of SMS usage
-           */
-          sms: {
-            /**
-             * Cost amount of SMS messages. Including premium SMS services
-             */
-            amount: string;
-            /**
-             * Number of international SMS messages sent. Including premium SMS services
-             */
-            international?: number | null;
-            /**
-             * Number of national SMS messages sent. Including premium SMS services
-             */
-            national: number;
-            /**
-             * Number of roaming SMS messages sent. Including premium SMS services
-             */
-            roaming?: number | null;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of voice calls. Required if voice calls are included in product plan
-         */
-        voice?: {
-          /**
-           * International voice calls. Requied if international calling is supported
-           */
-          international: {
-            /**
-             * Cost amount of international voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of international voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * National voice calls
-           */
-          national: {
-            /**
-             * Cost amount of national calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of national voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          /**
-           * Roaming voice calls, Required if roaming is supported
-           */
-          roaming: {
-            /**
-             * Cost amount of roaming voice calls
-             */
-            amount: string;
-            /**
-             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-             */
-            duration: string;
-            /**
-             * Number of roaming voice calls
-             */
-            number: number;
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * The account balance at the time the invoice was issued
-       */
-      balanceAtIssue: string;
-      /**
-       * The date that the invoice is due to be paid
-       */
-      dueDate?: string | null;
-      /**
-       * The total GST amount for this invoice.  If absent then zero is assumed
-       */
-      gstAmount?: string | null;
-      /**
-       * The net amount due for this invoice regardless of previous balance
-       */
-      invoiceAmount?: string | null;
-      /**
-       * The number assigned to this invoice by the telco Retailer
-       */
-      invoiceNumber: string;
-      /**
-       * The date that the invoice was actually issued (as opposed to generated or calculated)
-       */
-      issueDate: string;
-      /**
-       * A discount for on time payment
-       */
-      payOnTimeDiscount?: {
         /**
          * The date by which the invoice must be paid to receive the pay on time discount
          */
@@ -4573,15 +3566,15 @@ export interface TelcoInvoiceResponse {
          */
         gstAmount?: string | null;
         [k: string]: unknown;
-      };
-      /**
-       * Indicator of the payment status for the invoice
-       */
-      paymentStatus: "PAID" | "PARTIALLY_PAID" | "NOT_PAID";
-      /**
-       * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
-       */
-      period?: {
+    };
+    /**
+     * Indicator of the payment status for the invoice
+     */
+    paymentStatus: 'PAID' | 'PARTIALLY_PAID' | 'NOT_PAID';
+    /**
+     * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
+     */
+    period?: {
         /**
          * The end date of the period covered by this invoice
          */
@@ -4591,254 +3584,1067 @@ export interface TelcoInvoiceResponse {
          */
         startDate: string;
         [k: string]: unknown;
-      };
-      /**
-       * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
-       */
-      services: string[];
-      [k: string]: unknown;
+    };
+    /**
+     * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
+     */
+    services: string[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Object contain charges and credits related to usage
+ */
+export interface TelcoInvoiceAccountCharges {
+    /**
+     * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+     */
+    otherCharges?: {
+        /**
+         * The aggregate total of charges for this item (exclusive of GST)
+         */
+        amount: string;
+        /**
+         * A free text description of the charge
+         */
+        description: string;
+        /**
+         * A free text description of the charge
+         */
+        type?:
+            | (
+                | 'SERVICE'
+                | 'EQUIPMENT'
+                | 'NETWORK'
+                | 'HANDSET'
+                | 'DEVICE'
+                | 'ENTERTAINMENT'
+                | 'SUBSCRIPTION'
+                | 'SOFTWARE'
+                | 'OTHER'
+            )
+            | null;
+        [k: string]: unknown;
+    };
+    /**
+     * The aggregate total of account level discounts or credits for the period covered by the invoice
+     */
+    totalDiscounts: string;
+    /**
+     * The total GST for all account level charges.  If absent then zero is assumed
+     */
+    totalGst?: string | null;
+    /**
+     * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
+     */
+    totalOnceOffCharges: string;
+    /**
+     * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+     */
+    totalUsageCharges: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+ */
+export interface TelcoInvoiceAccountChargesOtherCharges {
+    /**
+     * The aggregate total of charges for this item (exclusive of GST)
+     */
+    amount: string;
+    /**
+     * A free text description of the charge
+     */
+    description: string;
+    /**
+     * A free text description of the charge
+     */
+    type?:
+        | (
+            | 'SERVICE'
+            | 'EQUIPMENT'
+            | 'NETWORK'
+            | 'HANDSET'
+            | 'DEVICE'
+            | 'ENTERTAINMENT'
+            | 'SUBSCRIPTION'
+            | 'SOFTWARE'
+            | 'OTHER'
+        )
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoInvoiceListResponse {
+    data: {
+        /**
+         * Array of invoices sorted by issue date in descending order
+         */
+        invoices: {
+            /**
+             * Object contain charges and credits related to usage
+             */
+            accountCharges?: {
+                /**
+                 * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+                 */
+                otherCharges?: {
+                    /**
+                     * The aggregate total of charges for this item (exclusive of GST)
+                     */
+                    amount: string;
+                    /**
+                     * A free text description of the charge
+                     */
+                    description: string;
+                    /**
+                     * A free text description of the charge
+                     */
+                    type?:
+                        | (
+                            | 'SERVICE'
+                            | 'EQUIPMENT'
+                            | 'NETWORK'
+                            | 'HANDSET'
+                            | 'DEVICE'
+                            | 'ENTERTAINMENT'
+                            | 'SUBSCRIPTION'
+                            | 'SOFTWARE'
+                            | 'OTHER'
+                        )
+                        | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The aggregate total of account level discounts or credits for the period covered by the invoice
+                 */
+                totalDiscounts: string;
+                /**
+                 * The total GST for all account level charges.  If absent then zero is assumed
+                 */
+                totalGst?: string | null;
+                /**
+                 * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
+                 */
+                totalOnceOffCharges: string;
+                /**
+                 * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+                 */
+                totalUsageCharges: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+             */
+            accountId: string;
+            /**
+             * Object containing usage summary
+             */
+            accountUsage?: {
+                /**
+                 * Summary of data usage
+                 */
+                data?: {
+                    /**
+                     * Cost amount of data usage
+                     */
+                    amount: string;
+                    /**
+                     * Amount of data downloaded in megabytes (MB)
+                     */
+                    download: number;
+                    /**
+                     * Required if roaming is suipported
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of data roaming charges
+                         */
+                        amount?: string | null;
+                        /**
+                         * Amount of data used while roaming in megabytes (MB)
+                         */
+                        download?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Number of data sessions
+                     */
+                    sessions?: number | null;
+                    /**
+                     * Amount of data uploaded in megabytes (MB)
+                     */
+                    upload: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of messaging. Required if messaging services is included in the product plan
+                 */
+                messaging?: {
+                    /**
+                     * Summary of MMS usage
+                     */
+                    mms: {
+                        /**
+                         * Cost amount of MMS messages
+                         */
+                        amount: string;
+                        /**
+                         * ber of international MMS messages sent
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national MMS messages sent
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of SMS usage
+                     */
+                    sms: {
+                        /**
+                         * Cost amount of SMS messages. Including premium SMS services
+                         */
+                        amount: string;
+                        /**
+                         * Number of international SMS messages sent. Including premium SMS services
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national SMS messages sent. Including premium SMS services
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of voice calls. Required if voice calls are included in product plan
+                 */
+                voice?: {
+                    /**
+                     * International voice calls. Requied if international calling is supported
+                     */
+                    international: {
+                        /**
+                         * Cost amount of international voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of international voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * National voice calls
+                     */
+                    national: {
+                        /**
+                         * Cost amount of national calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of national voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Roaming voice calls, Required if roaming is supported
+                     */
+                    roaming: {
+                        /**
+                         * Cost amount of roaming voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of roaming voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * The account balance at the time the invoice was issued
+             */
+            balanceAtIssue: string;
+            /**
+             * The date that the invoice is due to be paid
+             */
+            dueDate?: string | null;
+            /**
+             * The total GST amount for this invoice.  If absent then zero is assumed
+             */
+            gstAmount?: string | null;
+            /**
+             * The net amount due for this invoice regardless of previous balance
+             */
+            invoiceAmount?: string | null;
+            /**
+             * The number assigned to this invoice by the telco Retailer
+             */
+            invoiceNumber: string;
+            /**
+             * The date that the invoice was actually issued (as opposed to generated or calculated)
+             */
+            issueDate: string;
+            /**
+             * A discount for on time payment
+             */
+            payOnTimeDiscount?: {
+                /**
+                 * The date by which the invoice must be paid to receive the pay on time discount
+                 */
+                date: string;
+                /**
+                 * The amount that will be discounted if the invoice is paid by the date specified
+                 */
+                discountAmount: string;
+                /**
+                 * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
+                 */
+                gstAmount?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Indicator of the payment status for the invoice
+             */
+            paymentStatus: 'PAID' | 'PARTIALLY_PAID' | 'NOT_PAID';
+            /**
+             * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
+             */
+            period?: {
+                /**
+                 * The end date of the period covered by this invoice
+                 */
+                endDate: string;
+                /**
+                 * The start date of the period covered by this invoice
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
+             */
+            services: string[];
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoInvoiceListResponseData {
+    /**
+     * Array of invoices sorted by issue date in descending order
+     */
+    invoices: {
+        /**
+         * Object contain charges and credits related to usage
+         */
+        accountCharges?: {
+            /**
+             * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+             */
+            otherCharges?: {
+                /**
+                 * The aggregate total of charges for this item (exclusive of GST)
+                 */
+                amount: string;
+                /**
+                 * A free text description of the charge
+                 */
+                description: string;
+                /**
+                 * A free text description of the charge
+                 */
+                type?:
+                    | (
+                        | 'SERVICE'
+                        | 'EQUIPMENT'
+                        | 'NETWORK'
+                        | 'HANDSET'
+                        | 'DEVICE'
+                        | 'ENTERTAINMENT'
+                        | 'SUBSCRIPTION'
+                        | 'SOFTWARE'
+                        | 'OTHER'
+                    )
+                    | null;
+                [k: string]: unknown;
+            };
+            /**
+             * The aggregate total of account level discounts or credits for the period covered by the invoice
+             */
+            totalDiscounts: string;
+            /**
+             * The total GST for all account level charges.  If absent then zero is assumed
+             */
+            totalGst?: string | null;
+            /**
+             * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
+             */
+            totalOnceOffCharges: string;
+            /**
+             * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+             */
+            totalUsageCharges: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+         */
+        accountId: string;
+        /**
+         * Object containing usage summary
+         */
+        accountUsage?: {
+            /**
+             * Summary of data usage
+             */
+            data?: {
+                /**
+                 * Cost amount of data usage
+                 */
+                amount: string;
+                /**
+                 * Amount of data downloaded in megabytes (MB)
+                 */
+                download: number;
+                /**
+                 * Required if roaming is suipported
+                 */
+                roaming?: {
+                    /**
+                     * Amount value of data roaming charges
+                     */
+                    amount?: string | null;
+                    /**
+                     * Amount of data used while roaming in megabytes (MB)
+                     */
+                    download?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Number of data sessions
+                 */
+                sessions?: number | null;
+                /**
+                 * Amount of data uploaded in megabytes (MB)
+                 */
+                upload: number;
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of messaging. Required if messaging services is included in the product plan
+             */
+            messaging?: {
+                /**
+                 * Summary of MMS usage
+                 */
+                mms: {
+                    /**
+                     * Cost amount of MMS messages
+                     */
+                    amount: string;
+                    /**
+                     * ber of international MMS messages sent
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national MMS messages sent
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of SMS usage
+                 */
+                sms: {
+                    /**
+                     * Cost amount of SMS messages. Including premium SMS services
+                     */
+                    amount: string;
+                    /**
+                     * Number of international SMS messages sent. Including premium SMS services
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national SMS messages sent. Including premium SMS services
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of voice calls. Required if voice calls are included in product plan
+             */
+            voice?: {
+                /**
+                 * International voice calls. Requied if international calling is supported
+                 */
+                international: {
+                    /**
+                     * Cost amount of international voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of international voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * National voice calls
+                 */
+                national: {
+                    /**
+                     * Cost amount of national calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of national voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Roaming voice calls, Required if roaming is supported
+                 */
+                roaming: {
+                    /**
+                     * Cost amount of roaming voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of roaming voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * The account balance at the time the invoice was issued
+         */
+        balanceAtIssue: string;
+        /**
+         * The date that the invoice is due to be paid
+         */
+        dueDate?: string | null;
+        /**
+         * The total GST amount for this invoice.  If absent then zero is assumed
+         */
+        gstAmount?: string | null;
+        /**
+         * The net amount due for this invoice regardless of previous balance
+         */
+        invoiceAmount?: string | null;
+        /**
+         * The number assigned to this invoice by the telco Retailer
+         */
+        invoiceNumber: string;
+        /**
+         * The date that the invoice was actually issued (as opposed to generated or calculated)
+         */
+        issueDate: string;
+        /**
+         * A discount for on time payment
+         */
+        payOnTimeDiscount?: {
+            /**
+             * The date by which the invoice must be paid to receive the pay on time discount
+             */
+            date: string;
+            /**
+             * The amount that will be discounted if the invoice is paid by the date specified
+             */
+            discountAmount: string;
+            /**
+             * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
+             */
+            gstAmount?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Indicator of the payment status for the invoice
+         */
+        paymentStatus: 'PAID' | 'PARTIALLY_PAID' | 'NOT_PAID';
+        /**
+         * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
+         */
+        period?: {
+            /**
+             * The end date of the period covered by this invoice
+             */
+            endDate: string;
+            /**
+             * The start date of the period covered by this invoice
+             */
+            startDate: string;
+            [k: string]: unknown;
+        };
+        /**
+         * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
+         */
+        services: string[];
+        [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  };
-  links: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * A discount for on time payment
+ */
+export interface TelcoInvoicePayOnTimeDiscount {
     /**
-     * Fully qualified link that generated the current response document
+     * The date by which the invoice must be paid to receive the pay on time discount
      */
-    self: string;
+    date: string;
+    /**
+     * The amount that will be discounted if the invoice is paid by the date specified
+     */
+    discountAmount: string;
+    /**
+     * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
+     */
+    gstAmount?: string | null;
     [k: string]: unknown;
-  };
-  meta: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
+ */
+export interface TelcoInvoicePeriod {
+    /**
+     * The end date of the period covered by this invoice
+     */
+    endDate: string;
+    /**
+     * The start date of the period covered by this invoice
+     */
+    startDate: string;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoInvoiceResponse {
+    data: {
+        /**
+         * Array of invoices sorted by issue date in descending order
+         */
+        invoices: {
+            /**
+             * Object contain charges and credits related to usage
+             */
+            accountCharges?: {
+                /**
+                 * Optional array of charges that may be part of the invoice (for example services fees) (exclusive of GST)
+                 */
+                otherCharges?: {
+                    /**
+                     * The aggregate total of charges for this item (exclusive of GST)
+                     */
+                    amount: string;
+                    /**
+                     * A free text description of the charge
+                     */
+                    description: string;
+                    /**
+                     * A free text description of the charge
+                     */
+                    type?:
+                        | (
+                            | 'SERVICE'
+                            | 'EQUIPMENT'
+                            | 'NETWORK'
+                            | 'HANDSET'
+                            | 'DEVICE'
+                            | 'ENTERTAINMENT'
+                            | 'SUBSCRIPTION'
+                            | 'SOFTWARE'
+                            | 'OTHER'
+                        )
+                        | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * The aggregate total of account level discounts or credits for the period covered by the invoice
+                 */
+                totalDiscounts: string;
+                /**
+                 * The total GST for all account level charges.  If absent then zero is assumed
+                 */
+                totalGst?: string | null;
+                /**
+                 * The aggregate total of any once off charges arising from usage for the period covered by the invoice (exclusive of GST)
+                 */
+                totalOnceOffCharges: string;
+                /**
+                 * The aggregate total of usage charges for the period covered by the invoice (exclusive of GST)
+                 */
+                totalUsageCharges: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The ID of the account for which the invoice was issued. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+             */
+            accountId: string;
+            /**
+             * Object containing usage summary
+             */
+            accountUsage?: {
+                /**
+                 * Summary of data usage
+                 */
+                data?: {
+                    /**
+                     * Cost amount of data usage
+                     */
+                    amount: string;
+                    /**
+                     * Amount of data downloaded in megabytes (MB)
+                     */
+                    download: number;
+                    /**
+                     * Required if roaming is suipported
+                     */
+                    roaming?: {
+                        /**
+                         * Amount value of data roaming charges
+                         */
+                        amount?: string | null;
+                        /**
+                         * Amount of data used while roaming in megabytes (MB)
+                         */
+                        download?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Number of data sessions
+                     */
+                    sessions?: number | null;
+                    /**
+                     * Amount of data uploaded in megabytes (MB)
+                     */
+                    upload: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of messaging. Required if messaging services is included in the product plan
+                 */
+                messaging?: {
+                    /**
+                     * Summary of MMS usage
+                     */
+                    mms: {
+                        /**
+                         * Cost amount of MMS messages
+                         */
+                        amount: string;
+                        /**
+                         * ber of international MMS messages sent
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national MMS messages sent
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of SMS usage
+                     */
+                    sms: {
+                        /**
+                         * Cost amount of SMS messages. Including premium SMS services
+                         */
+                        amount: string;
+                        /**
+                         * Number of international SMS messages sent. Including premium SMS services
+                         */
+                        international?: number | null;
+                        /**
+                         * Number of national SMS messages sent. Including premium SMS services
+                         */
+                        national: number;
+                        /**
+                         * Number of roaming SMS messages sent. Including premium SMS services
+                         */
+                        roaming?: number | null;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of voice calls. Required if voice calls are included in product plan
+                 */
+                voice?: {
+                    /**
+                     * International voice calls. Requied if international calling is supported
+                     */
+                    international: {
+                        /**
+                         * Cost amount of international voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of international voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * National voice calls
+                     */
+                    national: {
+                        /**
+                         * Cost amount of national calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of national voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Roaming voice calls, Required if roaming is supported
+                     */
+                    roaming: {
+                        /**
+                         * Cost amount of roaming voice calls
+                         */
+                        amount: string;
+                        /**
+                         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                         */
+                        duration: string;
+                        /**
+                         * Number of roaming voice calls
+                         */
+                        number: number;
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * The account balance at the time the invoice was issued
+             */
+            balanceAtIssue: string;
+            /**
+             * The date that the invoice is due to be paid
+             */
+            dueDate?: string | null;
+            /**
+             * The total GST amount for this invoice.  If absent then zero is assumed
+             */
+            gstAmount?: string | null;
+            /**
+             * The net amount due for this invoice regardless of previous balance
+             */
+            invoiceAmount?: string | null;
+            /**
+             * The number assigned to this invoice by the telco Retailer
+             */
+            invoiceNumber: string;
+            /**
+             * The date that the invoice was actually issued (as opposed to generated or calculated)
+             */
+            issueDate: string;
+            /**
+             * A discount for on time payment
+             */
+            payOnTimeDiscount?: {
+                /**
+                 * The date by which the invoice must be paid to receive the pay on time discount
+                 */
+                date: string;
+                /**
+                 * The amount that will be discounted if the invoice is paid by the date specified
+                 */
+                discountAmount: string;
+                /**
+                 * The GST amount that will be discounted if the invoice is paid by the date specified.  If absent then zero is assumed
+                 */
+                gstAmount?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Indicator of the payment status for the invoice
+             */
+            paymentStatus: 'PAID' | 'PARTIALLY_PAID' | 'NOT_PAID';
+            /**
+             * Object containing the start and end date for the period covered by the invoice. Mandatory if any usage based charges are included in the invoice
+             */
+            period?: {
+                /**
+                 * The end date of the period covered by this invoice
+                 */
+                endDate: string;
+                /**
+                 * The start date of the period covered by this invoice
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * An array of service IDs to which this invoice applies. May be empty if the invoice contains no usage related charges
+             */
+            services: string[];
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoPaymentSchedule {
-  /**
-   * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
-   */
-  amount?: string | null;
-  /**
-   * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
-   */
-  cardDebit?: {
     /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+     * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
      */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
+    amount?: string | null;
     /**
-     * The type of credit card held on file
+     * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
      */
-    cardScheme: "VISA" | "MASTERCARD" | "AMEX" | "DINERS" | "OTHER" | "UNKNOWN";
-    /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    paymentFrequency: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
-   */
-  digitalWallet?: {
-    /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-     */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-    /**
-     * The identifier of the digital wallet (dependent on type)
-     */
-    identifier: string;
-    /**
-     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-     */
-    name: string;
-    /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    paymentFrequency: string;
-    /**
-     * The provider of the digital wallet
-     */
-    provider: "PAYPAL_AU" | "OTHER";
-    /**
-     * The type of the digital wallet identifier
-     */
-    type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-    [k: string]: unknown;
-  };
-  /**
-   * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
-   */
-  directDebit?: {
-    /**
-     * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-     */
-    accountNumber?: string | null;
-    /**
-     * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-     */
-    bsb?: string | null;
-    /**
-     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-     */
-    calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-    /**
-     * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
-     */
-    isTokenised?: boolean | null;
-    /**
-     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    paymentFrequency: string;
-    [k: string]: unknown;
-  };
-  /**
-   * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
-   */
-  manualPayment?: {
-    /**
-     * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    billFrequency: string;
-    [k: string]: unknown;
-  };
-  /**
-   * The type of object present in this response
-   */
-  paymentScheduleUType: "cardDebit" | "directDebit" | "manualPayment" | "digitalWallet";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
- */
-export interface TelcoPaymentScheduleCardDebit {
-  /**
-   * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-   */
-  calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-  /**
-   * The type of credit card held on file
-   */
-  cardScheme: "VISA" | "MASTERCARD" | "AMEX" | "DINERS" | "OTHER" | "UNKNOWN";
-  /**
-   * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  paymentFrequency: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
- */
-export interface TelcoPaymentScheduleDigitalWallet {
-  /**
-   * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-   */
-  calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-  /**
-   * The identifier of the digital wallet (dependent on type)
-   */
-  identifier: string;
-  /**
-   * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-   */
-  name: string;
-  /**
-   * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  paymentFrequency: string;
-  /**
-   * The provider of the digital wallet
-   */
-  provider: "PAYPAL_AU" | "OTHER";
-  /**
-   * The type of the digital wallet identifier
-   */
-  type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
- */
-export interface TelcoPaymentScheduleDirectDebit {
-  /**
-   * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-   */
-  accountNumber?: string | null;
-  /**
-   * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-   */
-  bsb?: string | null;
-  /**
-   * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-   */
-  calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-  /**
-   * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
-   */
-  isTokenised?: boolean | null;
-  /**
-   * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  paymentFrequency: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
- */
-export interface TelcoPaymentScheduleManualPayment {
-  /**
-   * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  billFrequency: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoPaymentScheduleResponse {
-  data: {
-    /**
-     * Array may be empty if no payment schedule exist
-     */
-    paymentSchedules: {
-      /**
-       * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
-       */
-      amount?: string | null;
-      /**
-       * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
-       */
-      cardDebit?: {
+    cardDebit?: {
         /**
          * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
          */
-        calculationType: "STATIC" | "BALANCE" | "CALCULATED";
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
         /**
          * The type of credit card held on file
          */
-        cardScheme: "VISA" | "MASTERCARD" | "AMEX" | "DINERS" | "OTHER" | "UNKNOWN";
+        cardScheme: 'VISA' | 'MASTERCARD' | 'AMEX' | 'DINERS' | 'OTHER' | 'UNKNOWN';
         /**
          * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
          */
         paymentFrequency: string;
         [k: string]: unknown;
-      };
-      /**
-       * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
-       */
-      digitalWallet?: {
+    };
+    /**
+     * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
+     */
+    digitalWallet?: {
         /**
          * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
          */
-        calculationType: "STATIC" | "BALANCE" | "CALCULATED";
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
         /**
          * The identifier of the digital wallet (dependent on type)
          */
@@ -4854,17 +4660,17 @@ export interface TelcoPaymentScheduleResponse {
         /**
          * The provider of the digital wallet
          */
-        provider: "PAYPAL_AU" | "OTHER";
+        provider: 'PAYPAL_AU' | 'OTHER';
         /**
          * The type of the digital wallet identifier
          */
-        type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
+        type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
         [k: string]: unknown;
-      };
-      /**
-       * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
-       */
-      directDebit?: {
+    };
+    /**
+     * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
+     */
+    directDebit?: {
         /**
          * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
          */
@@ -4876,7 +4682,7 @@ export interface TelcoPaymentScheduleResponse {
         /**
          * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
          */
-        calculationType: "STATIC" | "BALANCE" | "CALCULATED";
+        calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
         /**
          * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
          */
@@ -4886,754 +4692,371 @@ export interface TelcoPaymentScheduleResponse {
          */
         paymentFrequency: string;
         [k: string]: unknown;
-      };
-      /**
-       * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
-       */
-      manualPayment?: {
-        /**
-         * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-         */
-        billFrequency: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The type of object present in this response
-       */
-      paymentScheduleUType: "cardDebit" | "directDebit" | "manualPayment" | "digitalWallet";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoPaymentScheduleResponseData {
-  /**
-   * Array may be empty if no payment schedule exist
-   */
-  paymentSchedules: {
-    /**
-     * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
-     */
-    amount?: string | null;
-    /**
-     * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
-     */
-    cardDebit?: {
-      /**
-       * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-       */
-      calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-      /**
-       * The type of credit card held on file
-       */
-      cardScheme: "VISA" | "MASTERCARD" | "AMEX" | "DINERS" | "OTHER" | "UNKNOWN";
-      /**
-       * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      paymentFrequency: string;
-      [k: string]: unknown;
-    };
-    /**
-     * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
-     */
-    digitalWallet?: {
-      /**
-       * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-       */
-      calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-      /**
-       * The identifier of the digital wallet (dependent on type)
-       */
-      identifier: string;
-      /**
-       * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
-       */
-      name: string;
-      /**
-       * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      paymentFrequency: string;
-      /**
-       * The provider of the digital wallet
-       */
-      provider: "PAYPAL_AU" | "OTHER";
-      /**
-       * The type of the digital wallet identifier
-       */
-      type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
-      [k: string]: unknown;
-    };
-    /**
-     * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
-     */
-    directDebit?: {
-      /**
-       * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-       */
-      accountNumber?: string | null;
-      /**
-       * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
-       */
-      bsb?: string | null;
-      /**
-       * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
-       */
-      calculationType: "STATIC" | "BALANCE" | "CALCULATED";
-      /**
-       * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
-       */
-      isTokenised?: boolean | null;
-      /**
-       * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      paymentFrequency: string;
-      [k: string]: unknown;
     };
     /**
      * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
      */
     manualPayment?: {
-      /**
-       * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      billFrequency: string;
-      [k: string]: unknown;
+        /**
+         * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+         */
+        billFrequency: string;
+        [k: string]: unknown;
     };
     /**
      * The type of object present in this response
      */
-    paymentScheduleUType: "cardDebit" | "directDebit" | "manualPayment" | "digitalWallet";
+    paymentScheduleUType: 'cardDebit' | 'directDebit' | 'manualPayment' | 'digitalWallet';
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
+ */
+export interface TelcoPaymentScheduleCardDebit {
+    /**
+     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+     */
+    calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+    /**
+     * The type of credit card held on file
+     */
+    cardScheme: 'VISA' | 'MASTERCARD' | 'AMEX' | 'DINERS' | 'OTHER' | 'UNKNOWN';
+    /**
+     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    paymentFrequency: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
+ */
+export interface TelcoPaymentScheduleDigitalWallet {
+    /**
+     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+     */
+    calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+    /**
+     * The identifier of the digital wallet (dependent on type)
+     */
+    identifier: string;
+    /**
+     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+     */
+    name: string;
+    /**
+     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    paymentFrequency: string;
+    /**
+     * The provider of the digital wallet
+     */
+    provider: 'PAYPAL_AU' | 'OTHER';
+    /**
+     * The type of the digital wallet identifier
+     */
+    type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
+ */
+export interface TelcoPaymentScheduleDirectDebit {
+    /**
+     * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+     */
+    accountNumber?: string | null;
+    /**
+     * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+     */
+    bsb?: string | null;
+    /**
+     * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+     */
+    calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+    /**
+     * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
+     */
+    isTokenised?: boolean | null;
+    /**
+     * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    paymentFrequency: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
+ */
+export interface TelcoPaymentScheduleManualPayment {
+    /**
+     * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    billFrequency: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoPaymentScheduleResponse {
+    data: {
+        /**
+         * Array may be empty if no payment schedule exist
+         */
+        paymentSchedules: {
+            /**
+             * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
+             */
+            amount?: string | null;
+            /**
+             * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
+             */
+            cardDebit?: {
+                /**
+                 * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+                 */
+                calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+                /**
+                 * The type of credit card held on file
+                 */
+                cardScheme: 'VISA' | 'MASTERCARD' | 'AMEX' | 'DINERS' | 'OTHER' | 'UNKNOWN';
+                /**
+                 * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                paymentFrequency: string;
+                [k: string]: unknown;
+            };
+            /**
+             * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
+             */
+            digitalWallet?: {
+                /**
+                 * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+                 */
+                calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+                /**
+                 * The identifier of the digital wallet (dependent on type)
+                 */
+                identifier: string;
+                /**
+                 * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+                 */
+                name: string;
+                /**
+                 * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                paymentFrequency: string;
+                /**
+                 * The provider of the digital wallet
+                 */
+                provider: 'PAYPAL_AU' | 'OTHER';
+                /**
+                 * The type of the digital wallet identifier
+                 */
+                type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+                [k: string]: unknown;
+            };
+            /**
+             * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
+             */
+            directDebit?: {
+                /**
+                 * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+                 */
+                accountNumber?: string | null;
+                /**
+                 * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+                 */
+                bsb?: string | null;
+                /**
+                 * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+                 */
+                calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+                /**
+                 * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
+                 */
+                isTokenised?: boolean | null;
+                /**
+                 * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                paymentFrequency: string;
+                [k: string]: unknown;
+            };
+            /**
+             * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
+             */
+            manualPayment?: {
+                /**
+                 * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                billFrequency: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The type of object present in this response
+             */
+            paymentScheduleUType: 'cardDebit' | 'directDebit' | 'manualPayment' | 'digitalWallet';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoPaymentScheduleResponseData {
+    /**
+     * Array may be empty if no payment schedule exist
+     */
+    paymentSchedules: {
+        /**
+         * Optional payment amount indicating that a constant payment amount is scheduled to be paid (used in bill smooting scenarios)
+         */
+        amount?: string | null;
+        /**
+         * Represents a regular credit card payment schedule. Mandatory if paymentScheduleUType is set to cardDebit
+         */
+        cardDebit?: {
+            /**
+             * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+             */
+            calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+            /**
+             * The type of credit card held on file
+             */
+            cardScheme: 'VISA' | 'MASTERCARD' | 'AMEX' | 'DINERS' | 'OTHER' | 'UNKNOWN';
+            /**
+             * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            paymentFrequency: string;
+            [k: string]: unknown;
+        };
+        /**
+         * Represents a regular payment from a digital wallet. Mandatory if paymentScheduleUType is set to digitalWallet
+         */
+        digitalWallet?: {
+            /**
+             * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+             */
+            calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+            /**
+             * The identifier of the digital wallet (dependent on type)
+             */
+            identifier: string;
+            /**
+             * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+             */
+            name: string;
+            /**
+             * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            paymentFrequency: string;
+            /**
+             * The provider of the digital wallet
+             */
+            provider: 'PAYPAL_AU' | 'OTHER';
+            /**
+             * The type of the digital wallet identifier
+             */
+            type: 'EMAIL' | 'CONTACT_NAME' | 'TELEPHONE';
+            [k: string]: unknown;
+        };
+        /**
+         * Represents a regular direct debit from a specified bank account. Mandatory if paymentScheduleUType is set to directDebit
+         */
+        directDebit?: {
+            /**
+             * The unmasked account number for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+             */
+            accountNumber?: string | null;
+            /**
+             * The unmasked BSB for the account to be debited. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.  Is required if isTokenised is absent or false
+             */
+            bsb?: string | null;
+            /**
+             * The mechanism by which the payment amount is calculated.  Explanation of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent, static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding balance for the account is paid per period</li><li>**CALCULATED** - Indicates that the payment amount is variable and calculated using a pre-defined algorithm</li></ul>
+             */
+            calculationType: 'STATIC' | 'BALANCE' | 'CALCULATED';
+            /**
+             * Flag indicating that the account details are tokenised and cannot be shared.  False if absent
+             */
+            isTokenised?: boolean | null;
+            /**
+             * The frequency that payments will occur.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            paymentFrequency: string;
+            [k: string]: unknown;
+        };
+        /**
+         * Represents a manual payment schedule where the customer pays in response to a delivered statement. Mandatory if paymentScheduleUType is set to manualPayment
+         */
+        manualPayment?: {
+            /**
+             * The frequency with which a bill will be issued.  Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            billFrequency: string;
+            [k: string]: unknown;
+        };
+        /**
+         * The type of object present in this response
+         */
+        paymentScheduleUType: 'cardDebit' | 'directDebit' | 'manualPayment' | 'digitalWallet';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 /**
  * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
  */
-export type TelcoPlanType = "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
+export type TelcoPlanType = 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoProduct {
-  /**
-   * Object that contains links to additional information on specific topics
-   */
-  additionalInformation?: {
     /**
-     * A link to detail on bundles that this plan can be a part of
+     * Object that contains links to additional information on specific topics
      */
-    bundleUri?: string | null;
-    /**
-     * A link to detail on eligibility criteria for the plan
-     */
-    eligibilityUri?: string | null;
-    /**
-     * A link to a general overview of the plan
-     */
-    overviewUri?: string | null;
-    /**
-     * A link to detail on pricing for the plan
-     */
-    pricingUri?: string | null;
-    /**
-     * A link to terms and conditions for the plan
-     */
-    termsUri?: string | null;
-    [k: string]: unknown;
-  };
-  /**
-   * A link to an application web page where this plan can be applied for
-   */
-  applicationUri?: string | null;
-  /**
-   * The type of product
-   */
-  billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-  /**
-   * The ID of the brand under which this product is offered
-   */
-  brand: string;
-  /**
-   * The display name of the brand under which this product is offered
-   */
-  brandName: string;
-  /**
-   * Required if part of a bundle. If not present FALSE is assumed
-   */
-  bundle?: boolean | null;
-  /**
-   * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
-   */
-  contract?: {
-    /**
-     * URI of the contract conditions
-     */
-    contractUri?: string | null;
-    /**
-     * Description of the contract
-     */
-    description?: string | null;
-    /**
-     * Minimum contract duration in months
-     */
-    duration: number;
-    /**
-     * Name of the contract
-     */
-    name: string;
-    [k: string]: unknown;
-  };
-  /**
-   * A description of the product
-   */
-  description?: string | null;
-  /**
-   * The display name of the product
-   */
-  displayName?: string | null;
-  /**
-   * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
-   */
-  effectiveFrom?: string | null;
-  /**
-   * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
-   */
-  effectiveTo?: string | null;
-  /**
-   * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
-   */
-  lastUpdated?: string | null;
-  /**
-   * List of pricing details for the product plan
-   */
-  pricing: {
-    /**
-     * The amount charged for the duration period
-     */
-    amount: string;
-    /**
-     * The description of the pricing
-     */
-    description: string;
-    /**
-     * The display name of the pricing
-     */
-    name: string;
-    /**
-     * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-     */
-    period?: string | null;
-    [k: string]: unknown;
-  }[];
-  /**
-   * The ID of the specific product
-   */
-  productId: string;
-  /**
-   * The purpose type of the product. If absent, then the value PERSONAL is assumed
-   */
-  purpose?: ("PERSONAL" | "BUSINESS" | "ALL") | null;
-  /**
-   * The ID of the Third Party through which this product may be originated
-   */
-  thirdPartyAgentId?: string | null;
-  /**
-   * The display name of the Third Party through which this product may be originated
-   */
-  thirdPartyAgentName?: string | null;
-  /**
-   * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-   */
-  type: "MOBILE" | "BROADBAND";
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetail {
-  /**
-   * Bundles the product can be part of
-   */
-  bundles?:
-    | {
-        /**
-         * The URI of the product bundle
-         */
-        bundleUri?: string | null;
-        /**
-         * The description of the product bundle
-         */
-        description?: string | null;
-        /**
-         * The display name of the product bundle
-         */
-        displayName: string;
-        /**
-         * Optional list of features of the bundle
-         */
-        features?:
-          | {
-              /**
-               * The type of the feature
-               */
-              category?:
-                | (
-                    | "DATA"
-                    | "VOICE"
-                    | "MESSAGING"
-                    | "HANDSET"
-                    | "DEVICE"
-                    | "NETWORK"
-                    | "ENTERTAINMENT"
-                    | "SUBSCRIPTION"
-                    | "SOFTWARE"
-                    | "OTHER"
-                  )
-                | null;
-              /**
-               * The description of the feature
-               */
-              description?: string | null;
-              /**
-               * The display name of the feature
-               */
-              displayName: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Discounts associated to the product
-   */
-  discounts?:
-    | {
-        /**
-         * The description name of the product plan
-         */
-        description?: string | null;
-        /**
-         * The URI of the discount
-         */
-        discountUri?: string | null;
-        /**
-         * The display name of the product plan
-         */
-        displayName: string;
-        /**
-         * Optional list of features of the discount
-         */
-        features?:
-          | {
-              /**
-               * The description of the discount feature
-               */
-              description?: string | null;
-              /**
-               * The display name of the discount feature
-               */
-              displayName: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Incentives associated to the product
-   */
-  incentives?:
-    | {
-        /**
-         * The description of the incentive
-         */
-        description?: string | null;
-        /**
-         * The display name of the incentive
-         */
-        displayName: string;
-        /**
-         * Optional list of features of the incentive
-         */
-        features?:
-          | {
-              /**
-               * The description of the incentive feature
-               */
-              description?: string | null;
-              /**
-               * The display name of the incentive feature
-               */
-              displayName: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * The URI of the incentive
-         */
-        incentiveUri?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Charges for metering included in the plan
-   */
-  meteringCharges?:
-    | {
-        /**
-         * Description of the charge
-         */
-        description?: string | null;
-        /**
-         * Display name of the charge
-         */
-        displayName: string;
-        /**
-         * The upper limit of the charge if the charge could occur in a range
-         */
-        maximumValue?: string | null;
-        /**
-         * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-         */
-        minimumValue: string;
-        /**
-         * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-         */
-        period?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * Plans associated to the product
-   */
-  plans?:
-    | {
-        /**
-         * The display name of the product plan
-         */
-        description?: string | null;
-        /**
-         * The display name of the product plan
-         */
-        displayName: string;
-        /**
-         * Optional list of features of the plan
-         */
-        features?:
-          | {
-              /**
-               * The description of the feature
-               */
-              description?: string | null;
-              /**
-               * The display name of the feature
-               */
-              displayName: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * The URI of the product plan
-         */
-        planUri?: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailBundles {
-  /**
-   * The URI of the product bundle
-   */
-  bundleUri?: string | null;
-  /**
-   * The description of the product bundle
-   */
-  description?: string | null;
-  /**
-   * The display name of the product bundle
-   */
-  displayName: string;
-  /**
-   * Optional list of features of the bundle
-   */
-  features?:
-    | {
-        /**
-         * The type of the feature
-         */
-        category?:
-          | (
-              | "DATA"
-              | "VOICE"
-              | "MESSAGING"
-              | "HANDSET"
-              | "DEVICE"
-              | "NETWORK"
-              | "ENTERTAINMENT"
-              | "SUBSCRIPTION"
-              | "SOFTWARE"
-              | "OTHER"
-            )
-          | null;
-        /**
-         * The description of the feature
-         */
-        description?: string | null;
-        /**
-         * The display name of the feature
-         */
-        displayName: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailDiscountFeature {
-  /**
-   * The description of the discount feature
-   */
-  description?: string | null;
-  /**
-   * The display name of the discount feature
-   */
-  displayName: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailDiscounts {
-  /**
-   * The description name of the product plan
-   */
-  description?: string | null;
-  /**
-   * The URI of the discount
-   */
-  discountUri?: string | null;
-  /**
-   * The display name of the product plan
-   */
-  displayName: string;
-  /**
-   * Optional list of features of the discount
-   */
-  features?:
-    | {
-        /**
-         * The description of the discount feature
-         */
-        description?: string | null;
-        /**
-         * The display name of the discount feature
-         */
-        displayName: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailFeature {
-  /**
-   * The type of the feature
-   */
-  category?:
-    | (
-        | "DATA"
-        | "VOICE"
-        | "MESSAGING"
-        | "HANDSET"
-        | "DEVICE"
-        | "NETWORK"
-        | "ENTERTAINMENT"
-        | "SUBSCRIPTION"
-        | "SOFTWARE"
-        | "OTHER"
-      )
-    | null;
-  /**
-   * The description of the feature
-   */
-  description?: string | null;
-  /**
-   * The display name of the feature
-   */
-  displayName: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailIncentiveFeature {
-  /**
-   * The description of the incentive feature
-   */
-  description?: string | null;
-  /**
-   * The display name of the incentive feature
-   */
-  displayName: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailIncentives {
-  /**
-   * The description of the incentive
-   */
-  description?: string | null;
-  /**
-   * The display name of the incentive
-   */
-  displayName: string;
-  /**
-   * Optional list of features of the incentive
-   */
-  features?:
-    | {
-        /**
-         * The description of the incentive feature
-         */
-        description?: string | null;
-        /**
-         * The display name of the incentive feature
-         */
-        displayName: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The URI of the incentive
-   */
-  incentiveUri?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailMeteringCharges {
-  /**
-   * Description of the charge
-   */
-  description?: string | null;
-  /**
-   * Display name of the charge
-   */
-  displayName: string;
-  /**
-   * The upper limit of the charge if the charge could occur in a range
-   */
-  maximumValue?: string | null;
-  /**
-   * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-   */
-  minimumValue: string;
-  /**
-   * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  period?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailPlan {
-  /**
-   * The display name of the product plan
-   */
-  description?: string | null;
-  /**
-   * The display name of the product plan
-   */
-  displayName: string;
-  /**
-   * Optional list of features of the plan
-   */
-  features?:
-    | {
-        /**
-         * The description of the feature
-         */
-        description?: string | null;
-        /**
-         * The display name of the feature
-         */
-        displayName: string;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * The URI of the product plan
-   */
-  planUri?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductDetailPlanFeature {
-  /**
-   * The description of the feature
-   */
-  description?: string | null;
-  /**
-   * The display name of the feature
-   */
-  displayName: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductListResponse {
-  data: {
-    /**
-     * Array of Products
-     */
-    plans: {
-      /**
-       * Object that contains links to additional information on specific topics
-       */
-      additionalInformation?: {
+    additionalInformation?: {
         /**
          * A link to detail on bundles that this plan can be a part of
          */
@@ -5655,31 +5078,31 @@ export interface TelcoProductListResponse {
          */
         termsUri?: string | null;
         [k: string]: unknown;
-      };
-      /**
-       * A link to an application web page where this plan can be applied for
-       */
-      applicationUri?: string | null;
-      /**
-       * The type of product
-       */
-      billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-      /**
-       * The ID of the brand under which this product is offered
-       */
-      brand: string;
-      /**
-       * The display name of the brand under which this product is offered
-       */
-      brandName: string;
-      /**
-       * Required if part of a bundle. If not present FALSE is assumed
-       */
-      bundle?: boolean | null;
-      /**
-       * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
-       */
-      contract?: {
+    };
+    /**
+     * A link to an application web page where this plan can be applied for
+     */
+    applicationUri?: string | null;
+    /**
+     * The type of product
+     */
+    billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+    /**
+     * The ID of the brand under which this product is offered
+     */
+    brand: string;
+    /**
+     * The display name of the brand under which this product is offered
+     */
+    brandName: string;
+    /**
+     * Required if part of a bundle. If not present FALSE is assumed
+     */
+    bundle?: boolean | null;
+    /**
+     * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
+     */
+    contract?: {
         /**
          * URI of the contract conditions
          */
@@ -5697,31 +5120,31 @@ export interface TelcoProductListResponse {
          */
         name: string;
         [k: string]: unknown;
-      };
-      /**
-       * A description of the product
-       */
-      description?: string | null;
-      /**
-       * The display name of the product
-       */
-      displayName?: string | null;
-      /**
-       * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
-       */
-      effectiveFrom?: string | null;
-      /**
-       * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
-       */
-      effectiveTo?: string | null;
-      /**
-       * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
-       */
-      lastUpdated?: string | null;
-      /**
-       * List of pricing details for the product plan
-       */
-      pricing: {
+    };
+    /**
+     * A description of the product
+     */
+    description?: string | null;
+    /**
+     * The display name of the product
+     */
+    displayName?: string | null;
+    /**
+     * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
+     */
+    effectiveFrom?: string | null;
+    /**
+     * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
+     */
+    effectiveTo?: string | null;
+    /**
+     * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
+     */
+    lastUpdated?: string | null;
+    /**
+     * List of pricing details for the product plan
+     */
+    pricing: {
         /**
          * The amount charged for the duration period
          */
@@ -5739,183 +5162,6 @@ export interface TelcoProductListResponse {
          */
         period?: string | null;
         [k: string]: unknown;
-      }[];
-      /**
-       * The ID of the specific product
-       */
-      productId: string;
-      /**
-       * The purpose type of the product. If absent, then the value PERSONAL is assumed
-       */
-      purpose?: ("PERSONAL" | "BUSINESS" | "ALL") | null;
-      /**
-       * The ID of the Third Party through which this product may be originated
-       */
-      thirdPartyAgentId?: string | null;
-      /**
-       * The display name of the Third Party through which this product may be originated
-       */
-      thirdPartyAgentName?: string | null;
-      /**
-       * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-       */
-      type: "MOBILE" | "BROADBAND";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductListResponseData {
-  /**
-   * Array of Products
-   */
-  plans: {
-    /**
-     * Object that contains links to additional information on specific topics
-     */
-    additionalInformation?: {
-      /**
-       * A link to detail on bundles that this plan can be a part of
-       */
-      bundleUri?: string | null;
-      /**
-       * A link to detail on eligibility criteria for the plan
-       */
-      eligibilityUri?: string | null;
-      /**
-       * A link to a general overview of the plan
-       */
-      overviewUri?: string | null;
-      /**
-       * A link to detail on pricing for the plan
-       */
-      pricingUri?: string | null;
-      /**
-       * A link to terms and conditions for the plan
-       */
-      termsUri?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A link to an application web page where this plan can be applied for
-     */
-    applicationUri?: string | null;
-    /**
-     * The type of product
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * The ID of the brand under which this product is offered
-     */
-    brand: string;
-    /**
-     * The display name of the brand under which this product is offered
-     */
-    brandName: string;
-    /**
-     * Required if part of a bundle. If not present FALSE is assumed
-     */
-    bundle?: boolean | null;
-    /**
-     * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
-     */
-    contract?: {
-      /**
-       * URI of the contract conditions
-       */
-      contractUri?: string | null;
-      /**
-       * Description of the contract
-       */
-      description?: string | null;
-      /**
-       * Minimum contract duration in months
-       */
-      duration: number;
-      /**
-       * Name of the contract
-       */
-      name: string;
-      [k: string]: unknown;
-    };
-    /**
-     * A description of the product
-     */
-    description?: string | null;
-    /**
-     * The display name of the product
-     */
-    displayName?: string | null;
-    /**
-     * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
-     */
-    effectiveFrom?: string | null;
-    /**
-     * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
-     */
-    effectiveTo?: string | null;
-    /**
-     * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
-     */
-    lastUpdated?: string | null;
-    /**
-     * List of pricing details for the product plan
-     */
-    pricing: {
-      /**
-       * The amount charged for the duration period
-       */
-      amount: string;
-      /**
-       * The description of the pricing
-       */
-      description: string;
-      /**
-       * The display name of the pricing
-       */
-      name: string;
-      /**
-       * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      period?: string | null;
-      [k: string]: unknown;
     }[];
     /**
      * The ID of the specific product
@@ -5924,7 +5170,7 @@ export interface TelcoProductListResponseData {
     /**
      * The purpose type of the product. If absent, then the value PERSONAL is assumed
      */
-    purpose?: ("PERSONAL" | "BUSINESS" | "ALL") | null;
+    purpose?: ('PERSONAL' | 'BUSINESS' | 'ALL') | null;
     /**
      * The ID of the Third Party through which this product may be originated
      */
@@ -5936,370 +5182,1124 @@ export interface TelcoProductListResponseData {
     /**
      * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
      */
-    type: "MOBILE" | "BROADBAND";
+    type: 'MOBILE' | 'BROADBAND';
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export interface TelcoProductPricing {
-  /**
-   * The amount charged for the duration period
-   */
-  amount: string;
-  /**
-   * The description of the pricing
-   */
-  description: string;
-  /**
-   * The display name of the pricing
-   */
-  name: string;
-  /**
-   * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-   */
-  period?: string | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoProductResponse {
-  data: {
-    /**
-     * Object that contains links to additional information on specific topics
-     */
-    additionalInformation?: {
-      /**
-       * A link to detail on bundles that this plan can be a part of
-       */
-      bundleUri?: string | null;
-      /**
-       * A link to detail on eligibility criteria for the plan
-       */
-      eligibilityUri?: string | null;
-      /**
-       * A link to a general overview of the plan
-       */
-      overviewUri?: string | null;
-      /**
-       * A link to detail on pricing for the plan
-       */
-      pricingUri?: string | null;
-      /**
-       * A link to terms and conditions for the plan
-       */
-      termsUri?: string | null;
-      [k: string]: unknown;
-    };
-    /**
-     * A link to an application web page where this plan can be applied for
-     */
-    applicationUri?: string | null;
-    /**
-     * The type of product
-     */
-    billingType: "PRE_PAID" | "POST_PAID" | "UPFRONT_PAID" | "OTHER";
-    /**
-     * The ID of the brand under which this product is offered
-     */
-    brand: string;
-    /**
-     * The display name of the brand under which this product is offered
-     */
-    brandName: string;
-    /**
-     * Required if part of a bundle. If not present FALSE is assumed
-     */
-    bundle?: boolean | null;
-    /**
-     * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
-     */
-    contract?: {
-      /**
-       * URI of the contract conditions
-       */
-      contractUri?: string | null;
-      /**
-       * Description of the contract
-       */
-      description?: string | null;
-      /**
-       * Minimum contract duration in months
-       */
-      duration: number;
-      /**
-       * Name of the contract
-       */
-      name: string;
-      [k: string]: unknown;
-    };
-    /**
-     * A description of the product
-     */
-    description?: string | null;
-    /**
-     * The display name of the product
-     */
-    displayName?: string | null;
-    /**
-     * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
-     */
-    effectiveFrom?: string | null;
-    /**
-     * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
-     */
-    effectiveTo?: string | null;
-    /**
-     * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
-     */
-    lastUpdated?: string | null;
-    /**
-     * List of pricing details for the product plan
-     */
-    pricing: {
-      /**
-       * The amount charged for the duration period
-       */
-      amount: string;
-      /**
-       * The description of the pricing
-       */
-      description: string;
-      /**
-       * The display name of the pricing
-       */
-      name: string;
-      /**
-       * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-       */
-      period?: string | null;
-      [k: string]: unknown;
-    }[];
-    /**
-     * The ID of the specific product
-     */
-    productId: string;
-    /**
-     * The purpose type of the product. If absent, then the value PERSONAL is assumed
-     */
-    purpose?: ("PERSONAL" | "BUSINESS" | "ALL") | null;
-    /**
-     * The ID of the Third Party through which this product may be originated
-     */
-    thirdPartyAgentId?: string | null;
-    /**
-     * The display name of the Third Party through which this product may be originated
-     */
-    thirdPartyAgentName?: string | null;
-    /**
-     * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
-     */
-    type: "MOBILE" | "BROADBAND";
-    [k: string]: unknown;
-  } & {
+export interface TelcoProductDetail {
     /**
      * Bundles the product can be part of
      */
     bundles?:
-      | {
-          /**
-           * The URI of the product bundle
-           */
-          bundleUri?: string | null;
-          /**
-           * The description of the product bundle
-           */
-          description?: string | null;
-          /**
-           * The display name of the product bundle
-           */
-          displayName: string;
-          /**
-           * Optional list of features of the bundle
-           */
-          features?:
-            | {
-                /**
-                 * The type of the feature
-                 */
-                category?:
-                  | (
-                      | "DATA"
-                      | "VOICE"
-                      | "MESSAGING"
-                      | "HANDSET"
-                      | "DEVICE"
-                      | "NETWORK"
-                      | "ENTERTAINMENT"
-                      | "SUBSCRIPTION"
-                      | "SOFTWARE"
-                      | "OTHER"
-                    )
-                  | null;
-                /**
-                 * The description of the feature
-                 */
-                description?: string | null;
-                /**
-                 * The display name of the feature
-                 */
-                displayName: string;
-                [k: string]: unknown;
-              }[]
-            | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The URI of the product bundle
+             */
+            bundleUri?: string | null;
+            /**
+             * The description of the product bundle
+             */
+            description?: string | null;
+            /**
+             * The display name of the product bundle
+             */
+            displayName: string;
+            /**
+             * Optional list of features of the bundle
+             */
+            features?:
+                | {
+                    /**
+                     * The type of the feature
+                     */
+                    category?:
+                        | (
+                            | 'DATA'
+                            | 'VOICE'
+                            | 'MESSAGING'
+                            | 'HANDSET'
+                            | 'DEVICE'
+                            | 'NETWORK'
+                            | 'ENTERTAINMENT'
+                            | 'SUBSCRIPTION'
+                            | 'SOFTWARE'
+                            | 'OTHER'
+                        )
+                        | null;
+                    /**
+                     * The description of the feature
+                     */
+                    description?: string | null;
+                    /**
+                     * The display name of the feature
+                     */
+                    displayName: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Discounts associated to the product
      */
     discounts?:
-      | {
-          /**
-           * The description name of the product plan
-           */
-          description?: string | null;
-          /**
-           * The URI of the discount
-           */
-          discountUri?: string | null;
-          /**
-           * The display name of the product plan
-           */
-          displayName: string;
-          /**
-           * Optional list of features of the discount
-           */
-          features?:
-            | {
-                /**
-                 * The description of the discount feature
-                 */
-                description?: string | null;
-                /**
-                 * The display name of the discount feature
-                 */
-                displayName: string;
-                [k: string]: unknown;
-              }[]
-            | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The description name of the product plan
+             */
+            description?: string | null;
+            /**
+             * The URI of the discount
+             */
+            discountUri?: string | null;
+            /**
+             * The display name of the product plan
+             */
+            displayName: string;
+            /**
+             * Optional list of features of the discount
+             */
+            features?:
+                | {
+                    /**
+                     * The description of the discount feature
+                     */
+                    description?: string | null;
+                    /**
+                     * The display name of the discount feature
+                     */
+                    displayName: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Incentives associated to the product
      */
     incentives?:
-      | {
-          /**
-           * The description of the incentive
-           */
-          description?: string | null;
-          /**
-           * The display name of the incentive
-           */
-          displayName: string;
-          /**
-           * Optional list of features of the incentive
-           */
-          features?:
-            | {
-                /**
-                 * The description of the incentive feature
-                 */
-                description?: string | null;
-                /**
-                 * The display name of the incentive feature
-                 */
-                displayName: string;
-                [k: string]: unknown;
-              }[]
-            | null;
-          /**
-           * The URI of the incentive
-           */
-          incentiveUri?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * The description of the incentive
+             */
+            description?: string | null;
+            /**
+             * The display name of the incentive
+             */
+            displayName: string;
+            /**
+             * Optional list of features of the incentive
+             */
+            features?:
+                | {
+                    /**
+                     * The description of the incentive feature
+                     */
+                    description?: string | null;
+                    /**
+                     * The display name of the incentive feature
+                     */
+                    displayName: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The URI of the incentive
+             */
+            incentiveUri?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Charges for metering included in the plan
      */
     meteringCharges?:
-      | {
-          /**
-           * Description of the charge
-           */
-          description?: string | null;
-          /**
-           * Display name of the charge
-           */
-          displayName: string;
-          /**
-           * The upper limit of the charge if the charge could occur in a range
-           */
-          maximumValue?: string | null;
-          /**
-           * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
-           */
-          minimumValue: string;
-          /**
-           * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
-           */
-          period?: string | null;
-          [k: string]: unknown;
+        | {
+            /**
+             * Description of the charge
+             */
+            description?: string | null;
+            /**
+             * Display name of the charge
+             */
+            displayName: string;
+            /**
+             * The upper limit of the charge if the charge could occur in a range
+             */
+            maximumValue?: string | null;
+            /**
+             * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+             */
+            minimumValue: string;
+            /**
+             * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            period?: string | null;
+            [k: string]: unknown;
         }[]
-      | null;
+        | null;
     /**
      * Plans associated to the product
      */
     plans?:
-      | {
-          /**
-           * The display name of the product plan
-           */
-          description?: string | null;
-          /**
-           * The display name of the product plan
-           */
-          displayName: string;
-          /**
-           * Optional list of features of the plan
-           */
-          features?:
-            | {
+        | {
+            /**
+             * The display name of the product plan
+             */
+            description?: string | null;
+            /**
+             * The display name of the product plan
+             */
+            displayName: string;
+            /**
+             * Optional list of features of the plan
+             */
+            features?:
+                | {
+                    /**
+                     * The description of the feature
+                     */
+                    description?: string | null;
+                    /**
+                     * The display name of the feature
+                     */
+                    displayName: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The URI of the product plan
+             */
+            planUri?: string | null;
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailBundles {
+    /**
+     * The URI of the product bundle
+     */
+    bundleUri?: string | null;
+    /**
+     * The description of the product bundle
+     */
+    description?: string | null;
+    /**
+     * The display name of the product bundle
+     */
+    displayName: string;
+    /**
+     * Optional list of features of the bundle
+     */
+    features?:
+        | {
+            /**
+             * The type of the feature
+             */
+            category?:
+                | (
+                    | 'DATA'
+                    | 'VOICE'
+                    | 'MESSAGING'
+                    | 'HANDSET'
+                    | 'DEVICE'
+                    | 'NETWORK'
+                    | 'ENTERTAINMENT'
+                    | 'SUBSCRIPTION'
+                    | 'SOFTWARE'
+                    | 'OTHER'
+                )
+                | null;
+            /**
+             * The description of the feature
+             */
+            description?: string | null;
+            /**
+             * The display name of the feature
+             */
+            displayName: string;
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailDiscountFeature {
+    /**
+     * The description of the discount feature
+     */
+    description?: string | null;
+    /**
+     * The display name of the discount feature
+     */
+    displayName: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailDiscounts {
+    /**
+     * The description name of the product plan
+     */
+    description?: string | null;
+    /**
+     * The URI of the discount
+     */
+    discountUri?: string | null;
+    /**
+     * The display name of the product plan
+     */
+    displayName: string;
+    /**
+     * Optional list of features of the discount
+     */
+    features?:
+        | {
+            /**
+             * The description of the discount feature
+             */
+            description?: string | null;
+            /**
+             * The display name of the discount feature
+             */
+            displayName: string;
+            [k: string]: unknown;
+        }[]
+        | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailFeature {
+    /**
+     * The type of the feature
+     */
+    category?:
+        | (
+            | 'DATA'
+            | 'VOICE'
+            | 'MESSAGING'
+            | 'HANDSET'
+            | 'DEVICE'
+            | 'NETWORK'
+            | 'ENTERTAINMENT'
+            | 'SUBSCRIPTION'
+            | 'SOFTWARE'
+            | 'OTHER'
+        )
+        | null;
+    /**
+     * The description of the feature
+     */
+    description?: string | null;
+    /**
+     * The display name of the feature
+     */
+    displayName: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailIncentiveFeature {
+    /**
+     * The description of the incentive feature
+     */
+    description?: string | null;
+    /**
+     * The display name of the incentive feature
+     */
+    displayName: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailIncentives {
+    /**
+     * The description of the incentive
+     */
+    description?: string | null;
+    /**
+     * The display name of the incentive
+     */
+    displayName: string;
+    /**
+     * Optional list of features of the incentive
+     */
+    features?:
+        | {
+            /**
+             * The description of the incentive feature
+             */
+            description?: string | null;
+            /**
+             * The display name of the incentive feature
+             */
+            displayName: string;
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The URI of the incentive
+     */
+    incentiveUri?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailMeteringCharges {
+    /**
+     * Description of the charge
+     */
+    description?: string | null;
+    /**
+     * Display name of the charge
+     */
+    displayName: string;
+    /**
+     * The upper limit of the charge if the charge could occur in a range
+     */
+    maximumValue?: string | null;
+    /**
+     * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+     */
+    minimumValue: string;
+    /**
+     * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    period?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailPlan {
+    /**
+     * The display name of the product plan
+     */
+    description?: string | null;
+    /**
+     * The display name of the product plan
+     */
+    displayName: string;
+    /**
+     * Optional list of features of the plan
+     */
+    features?:
+        | {
+            /**
+             * The description of the feature
+             */
+            description?: string | null;
+            /**
+             * The display name of the feature
+             */
+            displayName: string;
+            [k: string]: unknown;
+        }[]
+        | null;
+    /**
+     * The URI of the product plan
+     */
+    planUri?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductDetailPlanFeature {
+    /**
+     * The description of the feature
+     */
+    description?: string | null;
+    /**
+     * The display name of the feature
+     */
+    displayName: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductListResponse {
+    data: {
+        /**
+         * Array of Products
+         */
+        plans: {
+            /**
+             * Object that contains links to additional information on specific topics
+             */
+            additionalInformation?: {
                 /**
-                 * The description of the feature
+                 * A link to detail on bundles that this plan can be a part of
+                 */
+                bundleUri?: string | null;
+                /**
+                 * A link to detail on eligibility criteria for the plan
+                 */
+                eligibilityUri?: string | null;
+                /**
+                 * A link to a general overview of the plan
+                 */
+                overviewUri?: string | null;
+                /**
+                 * A link to detail on pricing for the plan
+                 */
+                pricingUri?: string | null;
+                /**
+                 * A link to terms and conditions for the plan
+                 */
+                termsUri?: string | null;
+                [k: string]: unknown;
+            };
+            /**
+             * A link to an application web page where this plan can be applied for
+             */
+            applicationUri?: string | null;
+            /**
+             * The type of product
+             */
+            billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+            /**
+             * The ID of the brand under which this product is offered
+             */
+            brand: string;
+            /**
+             * The display name of the brand under which this product is offered
+             */
+            brandName: string;
+            /**
+             * Required if part of a bundle. If not present FALSE is assumed
+             */
+            bundle?: boolean | null;
+            /**
+             * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
+             */
+            contract?: {
+                /**
+                 * URI of the contract conditions
+                 */
+                contractUri?: string | null;
+                /**
+                 * Description of the contract
                  */
                 description?: string | null;
                 /**
-                 * The display name of the feature
+                 * Minimum contract duration in months
+                 */
+                duration: number;
+                /**
+                 * Name of the contract
+                 */
+                name: string;
+                [k: string]: unknown;
+            };
+            /**
+             * A description of the product
+             */
+            description?: string | null;
+            /**
+             * The display name of the product
+             */
+            displayName?: string | null;
+            /**
+             * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
+             */
+            effectiveFrom?: string | null;
+            /**
+             * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
+             */
+            effectiveTo?: string | null;
+            /**
+             * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
+             */
+            lastUpdated?: string | null;
+            /**
+             * List of pricing details for the product plan
+             */
+            pricing: {
+                /**
+                 * The amount charged for the duration period
+                 */
+                amount: string;
+                /**
+                 * The description of the pricing
+                 */
+                description: string;
+                /**
+                 * The display name of the pricing
+                 */
+                name: string;
+                /**
+                 * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string | null;
+                [k: string]: unknown;
+            }[];
+            /**
+             * The ID of the specific product
+             */
+            productId: string;
+            /**
+             * The purpose type of the product. If absent, then the value PERSONAL is assumed
+             */
+            purpose?: ('PERSONAL' | 'BUSINESS' | 'ALL') | null;
+            /**
+             * The ID of the Third Party through which this product may be originated
+             */
+            thirdPartyAgentId?: string | null;
+            /**
+             * The display name of the Third Party through which this product may be originated
+             */
+            thirdPartyAgentName?: string | null;
+            /**
+             * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+             */
+            type: 'MOBILE' | 'BROADBAND';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductListResponseData {
+    /**
+     * Array of Products
+     */
+    plans: {
+        /**
+         * Object that contains links to additional information on specific topics
+         */
+        additionalInformation?: {
+            /**
+             * A link to detail on bundles that this plan can be a part of
+             */
+            bundleUri?: string | null;
+            /**
+             * A link to detail on eligibility criteria for the plan
+             */
+            eligibilityUri?: string | null;
+            /**
+             * A link to a general overview of the plan
+             */
+            overviewUri?: string | null;
+            /**
+             * A link to detail on pricing for the plan
+             */
+            pricingUri?: string | null;
+            /**
+             * A link to terms and conditions for the plan
+             */
+            termsUri?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A link to an application web page where this plan can be applied for
+         */
+        applicationUri?: string | null;
+        /**
+         * The type of product
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * The ID of the brand under which this product is offered
+         */
+        brand: string;
+        /**
+         * The display name of the brand under which this product is offered
+         */
+        brandName: string;
+        /**
+         * Required if part of a bundle. If not present FALSE is assumed
+         */
+        bundle?: boolean | null;
+        /**
+         * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
+         */
+        contract?: {
+            /**
+             * URI of the contract conditions
+             */
+            contractUri?: string | null;
+            /**
+             * Description of the contract
+             */
+            description?: string | null;
+            /**
+             * Minimum contract duration in months
+             */
+            duration: number;
+            /**
+             * Name of the contract
+             */
+            name: string;
+            [k: string]: unknown;
+        };
+        /**
+         * A description of the product
+         */
+        description?: string | null;
+        /**
+         * The display name of the product
+         */
+        displayName?: string | null;
+        /**
+         * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
+         */
+        effectiveFrom?: string | null;
+        /**
+         * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
+         */
+        effectiveTo?: string | null;
+        /**
+         * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
+         */
+        lastUpdated?: string | null;
+        /**
+         * List of pricing details for the product plan
+         */
+        pricing: {
+            /**
+             * The amount charged for the duration period
+             */
+            amount: string;
+            /**
+             * The description of the pricing
+             */
+            description: string;
+            /**
+             * The display name of the pricing
+             */
+            name: string;
+            /**
+             * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            period?: string | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The ID of the specific product
+         */
+        productId: string;
+        /**
+         * The purpose type of the product. If absent, then the value PERSONAL is assumed
+         */
+        purpose?: ('PERSONAL' | 'BUSINESS' | 'ALL') | null;
+        /**
+         * The ID of the Third Party through which this product may be originated
+         */
+        thirdPartyAgentId?: string | null;
+        /**
+         * The display name of the Third Party through which this product may be originated
+         */
+        thirdPartyAgentName?: string | null;
+        /**
+         * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductPricing {
+    /**
+     * The amount charged for the duration period
+     */
+    amount: string;
+    /**
+     * The description of the pricing
+     */
+    description: string;
+    /**
+     * The display name of the pricing
+     */
+    name: string;
+    /**
+     * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    period?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoProductResponse {
+    data: {
+        /**
+         * Object that contains links to additional information on specific topics
+         */
+        additionalInformation?: {
+            /**
+             * A link to detail on bundles that this plan can be a part of
+             */
+            bundleUri?: string | null;
+            /**
+             * A link to detail on eligibility criteria for the plan
+             */
+            eligibilityUri?: string | null;
+            /**
+             * A link to a general overview of the plan
+             */
+            overviewUri?: string | null;
+            /**
+             * A link to detail on pricing for the plan
+             */
+            pricingUri?: string | null;
+            /**
+             * A link to terms and conditions for the plan
+             */
+            termsUri?: string | null;
+            [k: string]: unknown;
+        };
+        /**
+         * A link to an application web page where this plan can be applied for
+         */
+        applicationUri?: string | null;
+        /**
+         * The type of product
+         */
+        billingType: 'PRE_PAID' | 'POST_PAID' | 'UPFRONT_PAID' | 'OTHER';
+        /**
+         * The ID of the brand under which this product is offered
+         */
+        brand: string;
+        /**
+         * The display name of the brand under which this product is offered
+         */
+        brandName: string;
+        /**
+         * Required if part of a bundle. If not present FALSE is assumed
+         */
+        bundle?: boolean | null;
+        /**
+         * Summary of the contract details. Mandatory if the billing type is POST_PAID and a contract agreement is required with the service provider for the plan
+         */
+        contract?: {
+            /**
+             * URI of the contract conditions
+             */
+            contractUri?: string | null;
+            /**
+             * Description of the contract
+             */
+            description?: string | null;
+            /**
+             * Minimum contract duration in months
+             */
+            duration: number;
+            /**
+             * Name of the contract
+             */
+            name: string;
+            [k: string]: unknown;
+        };
+        /**
+         * A description of the product
+         */
+        description?: string | null;
+        /**
+         * The display name of the product
+         */
+        displayName?: string | null;
+        /**
+         * The date and time from which this product is effective (ie. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate
+         */
+        effectiveFrom?: string | null;
+        /**
+         * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of plans
+         */
+        effectiveTo?: string | null;
+        /**
+         * The last date and time that the information for this plan was changed (or the creation date for the plan if it has never been altered)
+         */
+        lastUpdated?: string | null;
+        /**
+         * List of pricing details for the product plan
+         */
+        pricing: {
+            /**
+             * The amount charged for the duration period
+             */
+            amount: string;
+            /**
+             * The description of the pricing
+             */
+            description: string;
+            /**
+             * The display name of the pricing
+             */
+            name: string;
+            /**
+             * The duration that occurs on a pricing schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+             */
+            period?: string | null;
+            [k: string]: unknown;
+        }[];
+        /**
+         * The ID of the specific product
+         */
+        productId: string;
+        /**
+         * The purpose type of the product. If absent, then the value PERSONAL is assumed
+         */
+        purpose?: ('PERSONAL' | 'BUSINESS' | 'ALL') | null;
+        /**
+         * The ID of the Third Party through which this product may be originated
+         */
+        thirdPartyAgentId?: string | null;
+        /**
+         * The display name of the Third Party through which this product may be originated
+         */
+        thirdPartyAgentName?: string | null;
+        /**
+         * The type of product. [MOBILE](https://www.legislation.gov.au/Details/C2022C00170/Html/Volume_1#_Toc95898745) service or BROADBAND fixed internet service
+         */
+        type: 'MOBILE' | 'BROADBAND';
+        [k: string]: unknown;
+    } & {
+        /**
+         * Bundles the product can be part of
+         */
+        bundles?:
+            | {
+                /**
+                 * The URI of the product bundle
+                 */
+                bundleUri?: string | null;
+                /**
+                 * The description of the product bundle
+                 */
+                description?: string | null;
+                /**
+                 * The display name of the product bundle
                  */
                 displayName: string;
+                /**
+                 * Optional list of features of the bundle
+                 */
+                features?:
+                    | {
+                        /**
+                         * The type of the feature
+                         */
+                        category?:
+                            | (
+                                | 'DATA'
+                                | 'VOICE'
+                                | 'MESSAGING'
+                                | 'HANDSET'
+                                | 'DEVICE'
+                                | 'NETWORK'
+                                | 'ENTERTAINMENT'
+                                | 'SUBSCRIPTION'
+                                | 'SOFTWARE'
+                                | 'OTHER'
+                            )
+                            | null;
+                        /**
+                         * The description of the feature
+                         */
+                        description?: string | null;
+                        /**
+                         * The display name of the feature
+                         */
+                        displayName: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
                 [k: string]: unknown;
-              }[]
+            }[]
             | null;
-          /**
-           * The URI of the product plan
-           */
-          planUri?: string | null;
-          [k: string]: unknown;
-        }[]
-      | null;
+        /**
+         * Discounts associated to the product
+         */
+        discounts?:
+            | {
+                /**
+                 * The description name of the product plan
+                 */
+                description?: string | null;
+                /**
+                 * The URI of the discount
+                 */
+                discountUri?: string | null;
+                /**
+                 * The display name of the product plan
+                 */
+                displayName: string;
+                /**
+                 * Optional list of features of the discount
+                 */
+                features?:
+                    | {
+                        /**
+                         * The description of the discount feature
+                         */
+                        description?: string | null;
+                        /**
+                         * The display name of the discount feature
+                         */
+                        displayName: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Incentives associated to the product
+         */
+        incentives?:
+            | {
+                /**
+                 * The description of the incentive
+                 */
+                description?: string | null;
+                /**
+                 * The display name of the incentive
+                 */
+                displayName: string;
+                /**
+                 * Optional list of features of the incentive
+                 */
+                features?:
+                    | {
+                        /**
+                         * The description of the incentive feature
+                         */
+                        description?: string | null;
+                        /**
+                         * The display name of the incentive feature
+                         */
+                        displayName: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * The URI of the incentive
+                 */
+                incentiveUri?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Charges for metering included in the plan
+         */
+        meteringCharges?:
+            | {
+                /**
+                 * Description of the charge
+                 */
+                description?: string | null;
+                /**
+                 * Display name of the charge
+                 */
+                displayName: string;
+                /**
+                 * The upper limit of the charge if the charge could occur in a range
+                 */
+                maximumValue?: string | null;
+                /**
+                 * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+                 */
+                minimumValue: string;
+                /**
+                 * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+                 */
+                period?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        /**
+         * Plans associated to the product
+         */
+        plans?:
+            | {
+                /**
+                 * The display name of the product plan
+                 */
+                description?: string | null;
+                /**
+                 * The display name of the product plan
+                 */
+                displayName: string;
+                /**
+                 * Optional list of features of the plan
+                 */
+                features?:
+                    | {
+                        /**
+                         * The description of the feature
+                         */
+                        description?: string | null;
+                        /**
+                         * The display name of the feature
+                         */
+                        displayName: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * The URI of the product plan
+                 */
+                planUri?: string | null;
+                [k: string]: unknown;
+            }[]
+            | null;
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -6307,34 +6307,242 @@ export interface TelcoProductResponse {
  * Telco balances for a service
  */
 export interface TelcoServiceBalance {
-  /**
-   * A summary of Service balances
-   */
-  balance?: {
     /**
-     * Summary of data balances
+     * A summary of Service balances
      */
-    data?: {
-      /**
-       * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      download?: number | null;
-      /**
-       * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-       */
-      planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-      /**
-       * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-       */
-      roaming?: {
+    balance?: {
+        /**
+         * Summary of data balances
+         */
+        data?: {
+            /**
+             * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            download?: number | null;
+            /**
+             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+             */
+            planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+            /**
+             * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+             */
+            roaming?: {
+                /**
+                 * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+                 */
+                download?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            upload?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Summary of messaging. Required if messaging services is included in the product plan
+         */
+        messaging?: {
+            /**
+             * Summary of MMS Balance. Required if the service plan supports MMS messaging
+             */
+            mms: {
+                /**
+                 * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                international?: number | null;
+                /**
+                 * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                national?: number | null;
+                /**
+                 * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                roaming?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+             */
+            planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+            /**
+             * Summary of SMS Balance. Required if the service plan supports SMS messaging
+             */
+            sms: {
+                /**
+                 * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                international?: number | null;
+                /**
+                 * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                national?: number | null;
+                /**
+                 * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                roaming?: number | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        /**
+         * Summary of voice balances. Required if voice calls are included in product plan
+         */
+        voice?: {
+            /**
+             * International voice calls
+             */
+            international?: {
+                /**
+                 * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                duration?: string | null;
+                /**
+                 * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                number?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * National voice calls
+             */
+            national?: {
+                /**
+                 * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                duration?: string | null;
+                /**
+                 * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                number?: number | null;
+                [k: string]: unknown;
+            };
+            /**
+             * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+             */
+            planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+            /**
+             * Roaming voice calls
+             */
+            roaming?: {
+                /**
+                 * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                amount?: string | null;
+                /**
+                 * An overview of plan limits. Required unless planType is UNSUPPORTED
+                 */
+                description?: string | null;
+                /**
+                 * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                duration?: string | null;
+                /**
+                 * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+                 */
+                number?: number | null;
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    /**
+     * Optional description of the service used for display purposes
+     */
+    displayName?: string | null;
+    /**
+     * Date when the balance period ends
+     */
+    endDate?: string | null;
+    /**
+     * Required if the service includes a phone number
+     */
+    phoneNumber?: string | null;
+    /**
+     * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+     */
+    serviceId?: string | null;
+    /**
+     * Date when the balance period started
+     */
+    startDate?: string | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of data balances
+ */
+export interface TelcoServiceBalanceData {
+    /**
+     * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
+     */
+    amount?: string | null;
+    /**
+     * An overview of plan limits. Required unless planType is UNSUPPORTED
+     */
+    description?: string | null;
+    /**
+     * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+     */
+    download?: number | null;
+    /**
+     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+     */
+    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+    /**
+     * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+     */
+    roaming?: {
         /**
          * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
          */
@@ -6348,21 +6556,43 @@ export interface TelcoServiceBalance {
          */
         download?: number | null;
         [k: string]: unknown;
-      };
-      /**
-       * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      upload?: number | null;
-      [k: string]: unknown;
     };
     /**
-     * Summary of messaging. Required if messaging services is included in the product plan
+     * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
      */
-    messaging?: {
-      /**
-       * Summary of MMS Balance. Required if the service plan supports MMS messaging
-       */
-      mms: {
+    upload?: number | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+ */
+export interface TelcoServiceBalanceDataRoaming {
+    /**
+     * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+     */
+    amount?: string | null;
+    /**
+     * An overview of plan limits. Required unless planType is UNSUPPORTED
+     */
+    description?: string | null;
+    /**
+     * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+     */
+    download?: number | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of messaging. Required if messaging services is included in the product plan
+ */
+export interface TelcoServiceBalanceMessaging {
+    /**
+     * Summary of MMS Balance. Required if the service plan supports MMS messaging
+     */
+    mms: {
         /**
          * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
          */
@@ -6384,15 +6614,15 @@ export interface TelcoServiceBalance {
          */
         roaming?: number | null;
         [k: string]: unknown;
-      };
-      /**
-       * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-       */
-      planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-      /**
-       * Summary of SMS Balance. Required if the service plan supports SMS messaging
-       */
-      sms: {
+    };
+    /**
+     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+     */
+    planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+    /**
+     * Summary of SMS Balance. Required if the service plan supports SMS messaging
+     */
+    sms: {
         /**
          * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
          */
@@ -6414,185 +6644,15 @@ export interface TelcoServiceBalance {
          */
         roaming?: number | null;
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    /**
-     * Summary of voice balances. Required if voice calls are included in product plan
-     */
-    voice?: {
-      /**
-       * International voice calls
-       */
-      international?: {
-        /**
-         * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        amount?: string | null;
-        /**
-         * An overview of plan limits. Required unless planType is UNSUPPORTED
-         */
-        description?: string | null;
-        /**
-         * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        duration?: string | null;
-        /**
-         * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        number?: number | null;
-        [k: string]: unknown;
-      };
-      /**
-       * National voice calls
-       */
-      national?: {
-        /**
-         * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        amount?: string | null;
-        /**
-         * An overview of plan limits. Required unless planType is UNSUPPORTED
-         */
-        description?: string | null;
-        /**
-         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        duration?: string | null;
-        /**
-         * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        number?: number | null;
-        [k: string]: unknown;
-      };
-      /**
-       * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-       */
-      planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-      /**
-       * Roaming voice calls
-       */
-      roaming?: {
-        /**
-         * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        amount?: string | null;
-        /**
-         * An overview of plan limits. Required unless planType is UNSUPPORTED
-         */
-        description?: string | null;
-        /**
-         * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        duration?: string | null;
-        /**
-         * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-         */
-        number?: number | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  /**
-   * Optional description of the service used for display purposes
-   */
-  displayName?: string | null;
-  /**
-   * Date when the balance period ends
-   */
-  endDate?: string | null;
-  /**
-   * Required if the service includes a phone number
-   */
-  phoneNumber?: string | null;
-  /**
-   * The serviceId representing a unique service identifier such as a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  serviceId?: string | null;
-  /**
-   * Date when the balance period started
-   */
-  startDate?: string | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 /**
- * Summary of data balances
+ * Summary of MMS Balance. Required if the service plan supports MMS messaging
  */
-export interface TelcoServiceBalanceData {
-  /**
-   * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  download?: number | null;
-  /**
-   * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-   */
-  planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-  /**
-   * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-   */
-  roaming?: {
-    /**
-     * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
-     */
-    amount?: string | null;
-    /**
-     * An overview of plan limits. Required unless planType is UNSUPPORTED
-     */
-    description?: string | null;
-    /**
-     * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
-     */
-    download?: number | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  upload?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Balance of data roaming charges. Required unless planType is UNSUPPORTED
- */
-export interface TelcoServiceBalanceDataRoaming {
-  /**
-   * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
-   */
-  download?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of messaging. Required if messaging services is included in the product plan
- */
-export interface TelcoServiceBalanceMessaging {
-  /**
-   * Summary of MMS Balance. Required if the service plan supports MMS messaging
-   */
-  mms: {
+export interface TelcoServiceBalanceMessagingMms {
     /**
      * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
      */
@@ -6614,15 +6674,13 @@ export interface TelcoServiceBalanceMessaging {
      */
     roaming?: number | null;
     [k: string]: unknown;
-  };
-  /**
-   * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-   */
-  planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-  /**
-   * Summary of SMS Balance. Required if the service plan supports SMS messaging
-   */
-  sms: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of SMS Balance. Required if the service plan supports SMS messaging
+ */
+export interface TelcoServiceBalanceMessagingSms {
     /**
      * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
      */
@@ -6644,64 +6702,6 @@ export interface TelcoServiceBalanceMessaging {
      */
     roaming?: number | null;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of MMS Balance. Required if the service plan supports MMS messaging
- */
-export interface TelcoServiceBalanceMessagingMms {
-  /**
-   * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  international?: number | null;
-  /**
-   * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  national?: number | null;
-  /**
-   * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  roaming?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of SMS Balance. Required if the service plan supports SMS messaging
- */
-export interface TelcoServiceBalanceMessagingSms {
-  /**
-   * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  international?: number | null;
-  /**
-   * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  national?: number | null;
-  /**
-   * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  roaming?: number | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -6709,10 +6709,84 @@ export interface TelcoServiceBalanceMessagingSms {
  * Summary of voice balances. Required if voice calls are included in product plan
  */
 export interface TelcoServiceBalanceVoice {
-  /**
-   * International voice calls
-   */
-  international?: {
+    /**
+     * International voice calls
+     */
+    international?: {
+        /**
+         * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        amount?: string | null;
+        /**
+         * An overview of plan limits. Required unless planType is UNSUPPORTED
+         */
+        description?: string | null;
+        /**
+         * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        duration?: string | null;
+        /**
+         * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        number?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * National voice calls
+     */
+    national?: {
+        /**
+         * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        amount?: string | null;
+        /**
+         * An overview of plan limits. Required unless planType is UNSUPPORTED
+         */
+        description?: string | null;
+        /**
+         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        duration?: string | null;
+        /**
+         * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        number?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+     */
+    planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+    /**
+     * Roaming voice calls
+     */
+    roaming?: {
+        /**
+         * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        amount?: string | null;
+        /**
+         * An overview of plan limits. Required unless planType is UNSUPPORTED
+         */
+        description?: string | null;
+        /**
+         * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        duration?: string | null;
+        /**
+         * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        number?: number | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * International voice calls
+ */
+export interface TelcoServiceBalanceVoiceInternational {
     /**
      * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
      */
@@ -6730,11 +6804,13 @@ export interface TelcoServiceBalanceVoice {
      */
     number?: number | null;
     [k: string]: unknown;
-  };
-  /**
-   * National voice calls
-   */
-  national?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * National voice calls
+ */
+export interface TelcoServiceBalanceVoiceNational {
     /**
      * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
      */
@@ -6752,15 +6828,13 @@ export interface TelcoServiceBalanceVoice {
      */
     number?: number | null;
     [k: string]: unknown;
-  };
-  /**
-   * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-   */
-  planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-  /**
-   * Roaming voice calls
-   */
-  roaming?: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Roaming voice calls
+ */
+export interface TelcoServiceBalanceVoiceRoaming {
     /**
      * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
      */
@@ -6778,80 +6852,6 @@ export interface TelcoServiceBalanceVoice {
      */
     number?: number | null;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * International voice calls
- */
-export interface TelcoServiceBalanceVoiceInternational {
-  /**
-   * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  duration?: string | null;
-  /**
-   * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  number?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * National voice calls
- */
-export interface TelcoServiceBalanceVoiceNational {
-  /**
-   * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  duration?: string | null;
-  /**
-   * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  number?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Roaming voice calls
- */
-export interface TelcoServiceBalanceVoiceRoaming {
-  /**
-   * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  amount?: string | null;
-  /**
-   * An overview of plan limits. Required unless planType is UNSUPPORTED
-   */
-  description?: string | null;
-  /**
-   * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  duration?: string | null;
-  /**
-   * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-   */
-  number?: number | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -6859,380 +6859,202 @@ export interface TelcoServiceBalanceVoiceRoaming {
  * A summary of Service balances
  */
 export interface TelcoServiceBalances {
-  /**
-   * Summary of data balances
-   */
-  data?: {
     /**
-     * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
-     */
-    amount?: string | null;
-    /**
-     * An overview of plan limits. Required unless planType is UNSUPPORTED
-     */
-    description?: string | null;
-    /**
-     * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-     */
-    download?: number | null;
-    /**
-     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-     */
-    planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-    /**
-     * Balance of data roaming charges. Required unless planType is UNSUPPORTED
-     */
-    roaming?: {
-      /**
-       * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
-       */
-      download?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
-     */
-    upload?: number | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Summary of messaging. Required if messaging services is included in the product plan
-   */
-  messaging?: {
-    /**
-     * Summary of MMS Balance. Required if the service plan supports MMS messaging
-     */
-    mms: {
-      /**
-       * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      international?: number | null;
-      /**
-       * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      national?: number | null;
-      /**
-       * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      roaming?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-     */
-    planType?: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-    /**
-     * Summary of SMS Balance. Required if the service plan supports SMS messaging
-     */
-    sms: {
-      /**
-       * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      international?: number | null;
-      /**
-       * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      national?: number | null;
-      /**
-       * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      roaming?: number | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * Summary of voice balances. Required if voice calls are included in product plan
-   */
-  voice?: {
-    /**
-     * International voice calls
-     */
-    international?: {
-      /**
-       * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      duration?: string | null;
-      /**
-       * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      number?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * National voice calls
-     */
-    national?: {
-      /**
-       * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      duration?: string | null;
-      /**
-       * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      number?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
-     */
-    planType: "METERED" | "UNMETERED" | "LIMITED" | "UNSUPPORTED";
-    /**
-     * Roaming voice calls
-     */
-    roaming?: {
-      /**
-       * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      amount?: string | null;
-      /**
-       * An overview of plan limits. Required unless planType is UNSUPPORTED
-       */
-      description?: string | null;
-      /**
-       * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      duration?: string | null;
-      /**
-       * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
-       */
-      number?: number | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoServiceDetail {
-  /**
-   * The tokenised ID of the service identifier for use in the CDR APIs. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf).  Created according to the CDR rules for [CDR ID permanence](#id-permanence)
-   */
-  serviceId: string;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoServiceUsage {
-  /**
-   * Optional description of the service used for display purposes
-   */
-  displayName?: string | null;
-  /**
-   * Date when the usage period ends
-   */
-  endDate?: string | null;
-  /**
-   * Required if the service includes a phone number
-   */
-  phoneNumber?: string | null;
-  /**
-   * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-   */
-  serviceId: string;
-  /**
-   * Date when the usage period started
-   */
-  startDate: string;
-  /**
-   * Object containing usage summary
-   */
-  usage?: {
-    /**
-     * Summary of data usage
+     * Summary of data balances
      */
     data?: {
-      /**
-       * Cost amount of data usage
-       */
-      amount: string;
-      /**
-       * Amount of data downloaded in megabytes (MB)
-       */
-      download: number;
-      /**
-       * Required if roaming is suipported
-       */
-      roaming?: {
         /**
-         * Amount value of data roaming charges
+         * Remaining value amount of data available. Required unless planType is UNSUPPORTED or UNMETERED
          */
         amount?: string | null;
         /**
-         * Amount of data used while roaming in megabytes (MB)
+         * An overview of plan limits. Required unless planType is UNSUPPORTED
+         */
+        description?: string | null;
+        /**
+         * Remaining download data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
          */
         download?: number | null;
+        /**
+         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
+         */
+        planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+        /**
+         * Balance of data roaming charges. Required unless planType is UNSUPPORTED
+         */
+        roaming?: {
+            /**
+             * Amount value of data roaming charges. Required unless planType is UNSUPPORTED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Amount of data used overseas in megabytes (MB). Required unless planType is UNSUPPORTED
+             */
+            download?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Remaining upload data in megabytes (MB). Required unless planType is UNSUPPORTED or UNMETERED
+         */
+        upload?: number | null;
         [k: string]: unknown;
-      };
-      /**
-       * Number of data sessions
-       */
-      sessions?: number | null;
-      /**
-       * Amount of data uploaded in megabytes (MB)
-       */
-      upload: number;
-      [k: string]: unknown;
     };
     /**
      * Summary of messaging. Required if messaging services is included in the product plan
      */
     messaging?: {
-      /**
-       * Summary of MMS usage
-       */
-      mms: {
         /**
-         * Cost amount of MMS messages
+         * Summary of MMS Balance. Required if the service plan supports MMS messaging
          */
-        amount: string;
+        mms: {
+            /**
+             * Amount value of MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Number of international MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            international?: number | null;
+            /**
+             * Number of national MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            national?: number | null;
+            /**
+             * Number of roaming MMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            roaming?: number | null;
+            [k: string]: unknown;
+        };
         /**
-         * ber of international MMS messages sent
+         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
          */
-        international?: number | null;
+        planType?: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
         /**
-         * Number of national MMS messages sent
+         * Summary of SMS Balance. Required if the service plan supports SMS messaging
          */
-        national: number;
-        /**
-         * Number of roaming SMS messages sent. Including premium SMS services
-         */
-        roaming?: number | null;
+        sms: {
+            /**
+             * Amount value of SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Number of international SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            international?: number | null;
+            /**
+             * Number of national SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            national?: number | null;
+            /**
+             * Number of roaming SMS messages remaining. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            roaming?: number | null;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
-      };
-      /**
-       * Summary of SMS usage
-       */
-      sms: {
-        /**
-         * Cost amount of SMS messages. Including premium SMS services
-         */
-        amount: string;
-        /**
-         * Number of international SMS messages sent. Including premium SMS services
-         */
-        international?: number | null;
-        /**
-         * Number of national SMS messages sent. Including premium SMS services
-         */
-        national: number;
-        /**
-         * Number of roaming SMS messages sent. Including premium SMS services
-         */
-        roaming?: number | null;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     /**
-     * Summary of voice calls. Required if voice calls are included in product plan
+     * Summary of voice balances. Required if voice calls are included in product plan
      */
     voice?: {
-      /**
-       * International voice calls. Requied if international calling is supported
-       */
-      international: {
         /**
-         * Cost amount of international voice calls
+         * International voice calls
          */
-        amount: string;
+        international?: {
+            /**
+             * Amount value of international calls available. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Total duration (hours, minutes, and seconds) of international voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            duration?: string | null;
+            /**
+             * Number of international voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            number?: number | null;
+            [k: string]: unknown;
+        };
         /**
-         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+         * National voice calls
          */
-        duration: string;
+        national?: {
+            /**
+             * Amount balance of national calls. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            duration?: string | null;
+            /**
+             * Number of national voice calls. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            number?: number | null;
+            [k: string]: unknown;
+        };
         /**
-         * Number of international voice calls
+         * Plan type for this feature. METERED: A plan is charged by usage for the feature. UNMETERED: A plan with no limits for a feature. LIMITED: Where plan limit inclusions apply. UNSUPPORTED: Feature is not supported
          */
-        number: number;
+        planType: 'METERED' | 'UNMETERED' | 'LIMITED' | 'UNSUPPORTED';
+        /**
+         * Roaming voice calls
+         */
+        roaming?: {
+            /**
+             * Amount value of roaming calls available. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            amount?: string | null;
+            /**
+             * An overview of plan limits. Required unless planType is UNSUPPORTED
+             */
+            description?: string | null;
+            /**
+             * Total duration (hours, minutes, and seconds) of roaming voice calls available. Not limited to 24hrs. Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            duration?: string | null;
+            /**
+             * Number of roaming voice calls available Required unless planType is UNSUPPORTED or UNMETERED
+             */
+            number?: number | null;
+            [k: string]: unknown;
+        };
         [k: string]: unknown;
-      };
-      /**
-       * National voice calls
-       */
-      national: {
-        /**
-         * Cost amount of national calls
-         */
-        amount: string;
-        /**
-         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-         */
-        duration: string;
-        /**
-         * Number of national voice calls
-         */
-        number: number;
-        [k: string]: unknown;
-      };
-      /**
-       * Roaming voice calls, Required if roaming is supported
-       */
-      roaming: {
-        /**
-         * Cost amount of roaming voice calls
-         */
-        amount: string;
-        /**
-         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-         */
-        duration: string;
-        /**
-         * Number of roaming voice calls
-         */
-        number: number;
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
     };
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export interface TelcoServiceUsageListResponse {
-  data: {
+export interface TelcoServiceDetail {
+    /**
+     * The tokenised ID of the service identifier for use in the CDR APIs. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf).  Created according to the CDR rules for [CDR ID permanence](#id-permanence)
+     */
+    serviceId: string;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoServiceUsage {
     /**
      * Optional description of the service used for display purposes
      */
@@ -7257,978 +7079,22 @@ export interface TelcoServiceUsageListResponse {
      * Object containing usage summary
      */
     usage?: {
-      /**
-       * Summary of data usage
-       */
-      data?: {
         /**
-         * Cost amount of data usage
+         * Summary of data usage
          */
-        amount: string;
-        /**
-         * Amount of data downloaded in megabytes (MB)
-         */
-        download: number;
-        /**
-         * Required if roaming is suipported
-         */
-        roaming?: {
-          /**
-           * Amount value of data roaming charges
-           */
-          amount?: string | null;
-          /**
-           * Amount of data used while roaming in megabytes (MB)
-           */
-          download?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Number of data sessions
-         */
-        sessions?: number | null;
-        /**
-         * Amount of data uploaded in megabytes (MB)
-         */
-        upload: number;
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of messaging. Required if messaging services is included in the product plan
-       */
-      messaging?: {
-        /**
-         * Summary of MMS usage
-         */
-        mms: {
-          /**
-           * Cost amount of MMS messages
-           */
-          amount: string;
-          /**
-           * ber of international MMS messages sent
-           */
-          international?: number | null;
-          /**
-           * Number of national MMS messages sent
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of SMS usage
-         */
-        sms: {
-          /**
-           * Cost amount of SMS messages. Including premium SMS services
-           */
-          amount: string;
-          /**
-           * Number of international SMS messages sent. Including premium SMS services
-           */
-          international?: number | null;
-          /**
-           * Number of national SMS messages sent. Including premium SMS services
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of voice calls. Required if voice calls are included in product plan
-       */
-      voice?: {
-        /**
-         * International voice calls. Requied if international calling is supported
-         */
-        international: {
-          /**
-           * Cost amount of international voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of international voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * National voice calls
-         */
-        national: {
-          /**
-           * Cost amount of national calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of national voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Roaming voice calls, Required if roaming is supported
-         */
-        roaming: {
-          /**
-           * Cost amount of roaming voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of roaming voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  }[];
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoServiceUsageResponse {
-  data: {
-    /**
-     * Optional description of the service used for display purposes
-     */
-    displayName?: string | null;
-    /**
-     * Date when the usage period ends
-     */
-    endDate?: string | null;
-    /**
-     * Required if the service includes a phone number
-     */
-    phoneNumber?: string | null;
-    /**
-     * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    serviceId: string;
-    /**
-     * Date when the usage period started
-     */
-    startDate: string;
-    /**
-     * Object containing usage summary
-     */
-    usage?: {
-      /**
-       * Summary of data usage
-       */
-      data?: {
-        /**
-         * Cost amount of data usage
-         */
-        amount: string;
-        /**
-         * Amount of data downloaded in megabytes (MB)
-         */
-        download: number;
-        /**
-         * Required if roaming is suipported
-         */
-        roaming?: {
-          /**
-           * Amount value of data roaming charges
-           */
-          amount?: string | null;
-          /**
-           * Amount of data used while roaming in megabytes (MB)
-           */
-          download?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Number of data sessions
-         */
-        sessions?: number | null;
-        /**
-         * Amount of data uploaded in megabytes (MB)
-         */
-        upload: number;
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of messaging. Required if messaging services is included in the product plan
-       */
-      messaging?: {
-        /**
-         * Summary of MMS usage
-         */
-        mms: {
-          /**
-           * Cost amount of MMS messages
-           */
-          amount: string;
-          /**
-           * ber of international MMS messages sent
-           */
-          international?: number | null;
-          /**
-           * Number of national MMS messages sent
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        /**
-         * Summary of SMS usage
-         */
-        sms: {
-          /**
-           * Cost amount of SMS messages. Including premium SMS services
-           */
-          amount: string;
-          /**
-           * Number of international SMS messages sent. Including premium SMS services
-           */
-          international?: number | null;
-          /**
-           * Number of national SMS messages sent. Including premium SMS services
-           */
-          national: number;
-          /**
-           * Number of roaming SMS messages sent. Including premium SMS services
-           */
-          roaming?: number | null;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      /**
-       * Summary of voice calls. Required if voice calls are included in product plan
-       */
-      voice?: {
-        /**
-         * International voice calls. Requied if international calling is supported
-         */
-        international: {
-          /**
-           * Cost amount of international voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of international voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * National voice calls
-         */
-        national: {
-          /**
-           * Cost amount of national calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of national voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        /**
-         * Roaming voice calls, Required if roaming is supported
-         */
-        roaming: {
-          /**
-           * Cost amount of roaming voice calls
-           */
-          amount: string;
-          /**
-           * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-           */
-          duration: string;
-          /**
-           * Number of roaming voice calls
-           */
-          number: number;
-          [k: string]: unknown;
-        };
-        [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoTransactionListResponse {
-  data: {
-    /**
-     * Array of transactions sorted by date and time in descending order
-     */
-    transactions: {
-      account?: {
-        /**
-         * Optional array of adjustments arising for this transaction
-         */
-        adjustments?:
-          | {
-              /**
-               * The amount of the adjustment
-               */
-              amount: string;
-              /**
-               * A free text description of the adjustment
-               */
-              description: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
-         */
-        amount: string;
-        /**
-         * Optional description of the transaction that can be used for display purposes
-         */
-        description?: string | null;
-        /**
-         * Date and time when the usage period ends
-         */
-        endDate: string;
-        /**
-         * The number of the invoice in which this transaction is included if it has been issued
-         */
-        invoiceNumber?: string | null;
-        /**
-         * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-         */
-        serviceIds?: string | null;
-        /**
-         * Date and time when the usage period starts
-         */
-        startDate: string;
-        [k: string]: unknown;
-      };
-      /**
-       * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-       */
-      accountId: string;
-      /**
-       * The date and time that the transaction occurred
-       */
-      executionDateTime: string;
-      /**
-       * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
-       */
-      gst?: string | null;
-      onceOff?: {
-        /**
-         * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
-         */
-        amount: string;
-        /**
-         * A free text description of the item
-         */
-        description: string;
-        /**
-         * The number of the invoice in which this transaction is included if it has been issued
-         */
-        invoiceNumber?: string | null;
-        /**
-         * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-         */
-        serviceId?: string | null;
-        [k: string]: unknown;
-      };
-      otherCharges?: {
-        /**
-         * Optional array of adjustments arising for this transaction
-         */
-        adjustments?:
-          | {
-              /**
-               * The amount of the adjustment
-               */
-              amount: string;
-              /**
-               * A free text description of the adjustment
-               */
-              description: string;
-              [k: string]: unknown;
-            }[]
-          | null;
-        /**
-         * The amount of the charge
-         */
-        amount: string;
-        /**
-         * A free text description of the item
-         */
-        description: string;
-        /**
-         * Optional end date for the application of the charge
-         */
-        endDate?: string | null;
-        /**
-         * The number of the invoice in which this transaction is included if it has been issued
-         */
-        invoiceNumber?: string | null;
-        /**
-         * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-         */
-        serviceId?: string | null;
-        /**
-         * Optional start date for the application of the charge
-         */
-        startDate?: string | null;
-        /**
-         * Type of charge. Assumed to be OTHER if absent
-         */
-        type?: ("SERVICE" | "NETWORK" | "EQUIPMENT" | "METERING" | "OTHER") | null;
-        [k: string]: unknown;
-      };
-      payment?: {
-        /**
-         * The amount paid
-         */
-        amount: string;
-        /**
-         * The method of payment
-         */
-        method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "VOUCHER" | "OTHER";
-        [k: string]: unknown;
-      };
-      /**
-       * Indicator of the type of transaction object present in this record
-       */
-      transactionUType: "account" | "onceOff" | "otherCharges" | "payment";
-      [k: string]: unknown;
-    }[];
-    [k: string]: unknown;
-  };
-  links: {
-    /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
-     */
-    first?: string | null;
-    /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
-     */
-    last?: string | null;
-    /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
-     */
-    next?: string | null;
-    /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
-     */
-    prev?: string | null;
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    /**
-     * The total number of pages in the full set. See [pagination](#pagination).
-     */
-    totalPages: number;
-    /**
-     * The total number of records in the full set. See [pagination](#pagination).
-     */
-    totalRecords: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoTransactionListResponseData {
-  /**
-   * Array of transactions sorted by date and time in descending order
-   */
-  transactions: {
-    account?: {
-      /**
-       * Optional array of adjustments arising for this transaction
-       */
-      adjustments?:
-        | {
+        data?: {
             /**
-             * The amount of the adjustment
+             * Cost amount of data usage
              */
             amount: string;
             /**
-             * A free text description of the adjustment
+             * Amount of data downloaded in megabytes (MB)
              */
-            description: string;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
-       */
-      amount: string;
-      /**
-       * Optional description of the transaction that can be used for display purposes
-       */
-      description?: string | null;
-      /**
-       * Date and time when the usage period ends
-       */
-      endDate: string;
-      /**
-       * The number of the invoice in which this transaction is included if it has been issued
-       */
-      invoiceNumber?: string | null;
-      /**
-       * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceIds?: string | null;
-      /**
-       * Date and time when the usage period starts
-       */
-      startDate: string;
-      [k: string]: unknown;
-    };
-    /**
-     * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
-     */
-    accountId: string;
-    /**
-     * The date and time that the transaction occurred
-     */
-    executionDateTime: string;
-    /**
-     * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
-     */
-    gst?: string | null;
-    onceOff?: {
-      /**
-       * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
-       */
-      amount: string;
-      /**
-       * A free text description of the item
-       */
-      description: string;
-      /**
-       * The number of the invoice in which this transaction is included if it has been issued
-       */
-      invoiceNumber?: string | null;
-      /**
-       * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceId?: string | null;
-      [k: string]: unknown;
-    };
-    otherCharges?: {
-      /**
-       * Optional array of adjustments arising for this transaction
-       */
-      adjustments?:
-        | {
+            download: number;
             /**
-             * The amount of the adjustment
+             * Required if roaming is suipported
              */
-            amount: string;
-            /**
-             * A free text description of the adjustment
-             */
-            description: string;
-            [k: string]: unknown;
-          }[]
-        | null;
-      /**
-       * The amount of the charge
-       */
-      amount: string;
-      /**
-       * A free text description of the item
-       */
-      description: string;
-      /**
-       * Optional end date for the application of the charge
-       */
-      endDate?: string | null;
-      /**
-       * The number of the invoice in which this transaction is included if it has been issued
-       */
-      invoiceNumber?: string | null;
-      /**
-       * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      serviceId?: string | null;
-      /**
-       * Optional start date for the application of the charge
-       */
-      startDate?: string | null;
-      /**
-       * Type of charge. Assumed to be OTHER if absent
-       */
-      type?: ("SERVICE" | "NETWORK" | "EQUIPMENT" | "METERING" | "OTHER") | null;
-      [k: string]: unknown;
-    };
-    payment?: {
-      /**
-       * The amount paid
-       */
-      amount: string;
-      /**
-       * The method of payment
-       */
-      method: "DIRECT_DEBIT" | "CARD" | "TRANSFER" | "BPAY" | "CASH" | "CHEQUE" | "VOUCHER" | "OTHER";
-      [k: string]: unknown;
-    };
-    /**
-     * Indicator of the type of transaction object present in this record
-     */
-    transactionUType: "account" | "onceOff" | "otherCharges" | "payment";
-    [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Object containing usage summary
- */
-export interface TelcoUsage {
-  /**
-   * Summary of data usage
-   */
-  data?: {
-    /**
-     * Cost amount of data usage
-     */
-    amount: string;
-    /**
-     * Amount of data downloaded in megabytes (MB)
-     */
-    download: number;
-    /**
-     * Required if roaming is suipported
-     */
-    roaming?: {
-      /**
-       * Amount value of data roaming charges
-       */
-      amount?: string | null;
-      /**
-       * Amount of data used while roaming in megabytes (MB)
-       */
-      download?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Number of data sessions
-     */
-    sessions?: number | null;
-    /**
-     * Amount of data uploaded in megabytes (MB)
-     */
-    upload: number;
-    [k: string]: unknown;
-  };
-  /**
-   * Summary of messaging. Required if messaging services is included in the product plan
-   */
-  messaging?: {
-    /**
-     * Summary of MMS usage
-     */
-    mms: {
-      /**
-       * Cost amount of MMS messages
-       */
-      amount: string;
-      /**
-       * ber of international MMS messages sent
-       */
-      international?: number | null;
-      /**
-       * Number of national MMS messages sent
-       */
-      national: number;
-      /**
-       * Number of roaming SMS messages sent. Including premium SMS services
-       */
-      roaming?: number | null;
-      [k: string]: unknown;
-    };
-    /**
-     * Summary of SMS usage
-     */
-    sms: {
-      /**
-       * Cost amount of SMS messages. Including premium SMS services
-       */
-      amount: string;
-      /**
-       * Number of international SMS messages sent. Including premium SMS services
-       */
-      international?: number | null;
-      /**
-       * Number of national SMS messages sent. Including premium SMS services
-       */
-      national: number;
-      /**
-       * Number of roaming SMS messages sent. Including premium SMS services
-       */
-      roaming?: number | null;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  /**
-   * Summary of voice calls. Required if voice calls are included in product plan
-   */
-  voice?: {
-    /**
-     * International voice calls. Requied if international calling is supported
-     */
-    international: {
-      /**
-       * Cost amount of international voice calls
-       */
-      amount: string;
-      /**
-       * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-       */
-      duration: string;
-      /**
-       * Number of international voice calls
-       */
-      number: number;
-      [k: string]: unknown;
-    };
-    /**
-     * National voice calls
-     */
-    national: {
-      /**
-       * Cost amount of national calls
-       */
-      amount: string;
-      /**
-       * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-       */
-      duration: string;
-      /**
-       * Number of national voice calls
-       */
-      number: number;
-      [k: string]: unknown;
-    };
-    /**
-     * Roaming voice calls, Required if roaming is supported
-     */
-    roaming: {
-      /**
-       * Cost amount of roaming voice calls
-       */
-      amount: string;
-      /**
-       * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-       */
-      duration: string;
-      /**
-       * Number of roaming voice calls
-       */
-      number: number;
-      [k: string]: unknown;
-    };
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Roaming Data Usage
- */
-export interface TelcoUsageDatRoaming {
-  /**
-   * Amount value of data roaming charges
-   */
-  amount?: string | null;
-  /**
-   * Amount of data used while roaming in megabytes (MB)
-   */
-  download?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of data usage
- */
-export interface TelcoUsageData {
-  /**
-   * Cost amount of data usage
-   */
-  amount: string;
-  /**
-   * Amount of data downloaded in megabytes (MB)
-   */
-  download: number;
-  /**
-   * Required if roaming is suipported
-   */
-  roaming?: {
-    /**
-     * Amount value of data roaming charges
-     */
-    amount?: string | null;
-    /**
-     * Amount of data used while roaming in megabytes (MB)
-     */
-    download?: number | null;
-    [k: string]: unknown;
-  };
-  /**
-   * Number of data sessions
-   */
-  sessions?: number | null;
-  /**
-   * Amount of data uploaded in megabytes (MB)
-   */
-  upload: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-export interface TelcoUsageListResponse {
-  data: {
-    /**
-     * Array of usage on accounts
-     */
-    accounts: {
-      /**
-       * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-       */
-      accountId: string;
-      /**
-       * List of services that are part of the account
-       */
-      services: {
-        service: {
-          /**
-           * Optional description of the service used for display purposes
-           */
-          displayName?: string | null;
-          /**
-           * Date when the usage period ends
-           */
-          endDate?: string | null;
-          /**
-           * Required if the service includes a phone number
-           */
-          phoneNumber?: string | null;
-          /**
-           * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-           */
-          serviceId: string;
-          /**
-           * Date when the usage period started
-           */
-          startDate: string;
-          /**
-           * Object containing usage summary
-           */
-          usage?: {
-            /**
-             * Summary of data usage
-             */
-            data?: {
-              /**
-               * Cost amount of data usage
-               */
-              amount: string;
-              /**
-               * Amount of data downloaded in megabytes (MB)
-               */
-              download: number;
-              /**
-               * Required if roaming is suipported
-               */
-              roaming?: {
+            roaming?: {
                 /**
                  * Amount value of data roaming charges
                  */
@@ -8238,25 +7104,25 @@ export interface TelcoUsageListResponse {
                  */
                 download?: number | null;
                 [k: string]: unknown;
-              };
-              /**
-               * Number of data sessions
-               */
-              sessions?: number | null;
-              /**
-               * Amount of data uploaded in megabytes (MB)
-               */
-              upload: number;
-              [k: string]: unknown;
             };
             /**
-             * Summary of messaging. Required if messaging services is included in the product plan
+             * Number of data sessions
              */
-            messaging?: {
-              /**
-               * Summary of MMS usage
-               */
-              mms: {
+            sessions?: number | null;
+            /**
+             * Amount of data uploaded in megabytes (MB)
+             */
+            upload: number;
+            [k: string]: unknown;
+        };
+        /**
+         * Summary of messaging. Required if messaging services is included in the product plan
+         */
+        messaging?: {
+            /**
+             * Summary of MMS usage
+             */
+            mms: {
                 /**
                  * Cost amount of MMS messages
                  */
@@ -8274,11 +7140,11 @@ export interface TelcoUsageListResponse {
                  */
                 roaming?: number | null;
                 [k: string]: unknown;
-              };
-              /**
-               * Summary of SMS usage
-               */
-              sms: {
+            };
+            /**
+             * Summary of SMS usage
+             */
+            sms: {
                 /**
                  * Cost amount of SMS messages. Including premium SMS services
                  */
@@ -8296,17 +7162,17 @@ export interface TelcoUsageListResponse {
                  */
                 roaming?: number | null;
                 [k: string]: unknown;
-              };
-              [k: string]: unknown;
             };
+            [k: string]: unknown;
+        };
+        /**
+         * Summary of voice calls. Required if voice calls are included in product plan
+         */
+        voice?: {
             /**
-             * Summary of voice calls. Required if voice calls are included in product plan
+             * International voice calls. Requied if international calling is supported
              */
-            voice?: {
-              /**
-               * International voice calls. Requied if international calling is supported
-               */
-              international: {
+            international: {
                 /**
                  * Cost amount of international voice calls
                  */
@@ -8320,11 +7186,11 @@ export interface TelcoUsageListResponse {
                  */
                 number: number;
                 [k: string]: unknown;
-              };
-              /**
-               * National voice calls
-               */
-              national: {
+            };
+            /**
+             * National voice calls
+             */
+            national: {
                 /**
                  * Cost amount of national calls
                  */
@@ -8338,11 +7204,11 @@ export interface TelcoUsageListResponse {
                  */
                 number: number;
                 [k: string]: unknown;
-              };
-              /**
-               * Roaming voice calls, Required if roaming is supported
-               */
-              roaming: {
+            };
+            /**
+             * Roaming voice calls, Required if roaming is supported
+             */
+            roaming: {
                 /**
                  * Cost amount of roaming voice calls
                  */
@@ -8356,47 +7222,17 @@ export interface TelcoUsageListResponse {
                  */
                 number: number;
                 [k: string]: unknown;
-              };
-              [k: string]: unknown;
             };
             [k: string]: unknown;
-          };
-          [k: string]: unknown;
         };
         [k: string]: unknown;
-      }[];
-      [k: string]: unknown;
-    }[];
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
-export interface TelcoUsageListResponseData {
-  /**
-   * Array of usage on accounts
-   */
-  accounts: {
-    /**
-     * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    accountId: string;
-    /**
-     * List of services that are part of the account
-     */
-    services: {
-      service: {
+export interface TelcoServiceUsageListResponse {
+    data: {
         /**
          * Optional description of the service used for display purposes
          */
@@ -8421,161 +7257,1325 @@ export interface TelcoUsageListResponseData {
          * Object containing usage summary
          */
         usage?: {
-          /**
-           * Summary of data usage
-           */
-          data?: {
             /**
-             * Cost amount of data usage
+             * Summary of data usage
+             */
+            data?: {
+                /**
+                 * Cost amount of data usage
+                 */
+                amount: string;
+                /**
+                 * Amount of data downloaded in megabytes (MB)
+                 */
+                download: number;
+                /**
+                 * Required if roaming is suipported
+                 */
+                roaming?: {
+                    /**
+                     * Amount value of data roaming charges
+                     */
+                    amount?: string | null;
+                    /**
+                     * Amount of data used while roaming in megabytes (MB)
+                     */
+                    download?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Number of data sessions
+                 */
+                sessions?: number | null;
+                /**
+                 * Amount of data uploaded in megabytes (MB)
+                 */
+                upload: number;
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of messaging. Required if messaging services is included in the product plan
+             */
+            messaging?: {
+                /**
+                 * Summary of MMS usage
+                 */
+                mms: {
+                    /**
+                     * Cost amount of MMS messages
+                     */
+                    amount: string;
+                    /**
+                     * ber of international MMS messages sent
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national MMS messages sent
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of SMS usage
+                 */
+                sms: {
+                    /**
+                     * Cost amount of SMS messages. Including premium SMS services
+                     */
+                    amount: string;
+                    /**
+                     * Number of international SMS messages sent. Including premium SMS services
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national SMS messages sent. Including premium SMS services
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of voice calls. Required if voice calls are included in product plan
+             */
+            voice?: {
+                /**
+                 * International voice calls. Requied if international calling is supported
+                 */
+                international: {
+                    /**
+                     * Cost amount of international voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of international voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * National voice calls
+                 */
+                national: {
+                    /**
+                     * Cost amount of national calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of national voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Roaming voice calls, Required if roaming is supported
+                 */
+                roaming: {
+                    /**
+                     * Cost amount of roaming voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of roaming voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    }[];
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoServiceUsageResponse {
+    data: {
+        /**
+         * Optional description of the service used for display purposes
+         */
+        displayName?: string | null;
+        /**
+         * Date when the usage period ends
+         */
+        endDate?: string | null;
+        /**
+         * Required if the service includes a phone number
+         */
+        phoneNumber?: string | null;
+        /**
+         * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        serviceId: string;
+        /**
+         * Date when the usage period started
+         */
+        startDate: string;
+        /**
+         * Object containing usage summary
+         */
+        usage?: {
+            /**
+             * Summary of data usage
+             */
+            data?: {
+                /**
+                 * Cost amount of data usage
+                 */
+                amount: string;
+                /**
+                 * Amount of data downloaded in megabytes (MB)
+                 */
+                download: number;
+                /**
+                 * Required if roaming is suipported
+                 */
+                roaming?: {
+                    /**
+                     * Amount value of data roaming charges
+                     */
+                    amount?: string | null;
+                    /**
+                     * Amount of data used while roaming in megabytes (MB)
+                     */
+                    download?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Number of data sessions
+                 */
+                sessions?: number | null;
+                /**
+                 * Amount of data uploaded in megabytes (MB)
+                 */
+                upload: number;
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of messaging. Required if messaging services is included in the product plan
+             */
+            messaging?: {
+                /**
+                 * Summary of MMS usage
+                 */
+                mms: {
+                    /**
+                     * Cost amount of MMS messages
+                     */
+                    amount: string;
+                    /**
+                     * ber of international MMS messages sent
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national MMS messages sent
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Summary of SMS usage
+                 */
+                sms: {
+                    /**
+                     * Cost amount of SMS messages. Including premium SMS services
+                     */
+                    amount: string;
+                    /**
+                     * Number of international SMS messages sent. Including premium SMS services
+                     */
+                    international?: number | null;
+                    /**
+                     * Number of national SMS messages sent. Including premium SMS services
+                     */
+                    national: number;
+                    /**
+                     * Number of roaming SMS messages sent. Including premium SMS services
+                     */
+                    roaming?: number | null;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            /**
+             * Summary of voice calls. Required if voice calls are included in product plan
+             */
+            voice?: {
+                /**
+                 * International voice calls. Requied if international calling is supported
+                 */
+                international: {
+                    /**
+                     * Cost amount of international voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of international voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * National voice calls
+                 */
+                national: {
+                    /**
+                     * Cost amount of national calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of national voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                /**
+                 * Roaming voice calls, Required if roaming is supported
+                 */
+                roaming: {
+                    /**
+                     * Cost amount of roaming voice calls
+                     */
+                    amount: string;
+                    /**
+                     * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                     */
+                    duration: string;
+                    /**
+                     * Number of roaming voice calls
+                     */
+                    number: number;
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoTransactionListResponse {
+    data: {
+        /**
+         * Array of transactions sorted by date and time in descending order
+         */
+        transactions: {
+            account?: {
+                /**
+                 * Optional array of adjustments arising for this transaction
+                 */
+                adjustments?:
+                    | {
+                        /**
+                         * The amount of the adjustment
+                         */
+                        amount: string;
+                        /**
+                         * A free text description of the adjustment
+                         */
+                        description: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
+                 */
+                amount: string;
+                /**
+                 * Optional description of the transaction that can be used for display purposes
+                 */
+                description?: string | null;
+                /**
+                 * Date and time when the usage period ends
+                 */
+                endDate: string;
+                /**
+                 * The number of the invoice in which this transaction is included if it has been issued
+                 */
+                invoiceNumber?: string | null;
+                /**
+                 * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceIds?: string | null;
+                /**
+                 * Date and time when the usage period starts
+                 */
+                startDate: string;
+                [k: string]: unknown;
+            };
+            /**
+             * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+             */
+            accountId: string;
+            /**
+             * The date and time that the transaction occurred
+             */
+            executionDateTime: string;
+            /**
+             * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
+             */
+            gst?: string | null;
+            onceOff?: {
+                /**
+                 * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
+                 */
+                amount: string;
+                /**
+                 * A free text description of the item
+                 */
+                description: string;
+                /**
+                 * The number of the invoice in which this transaction is included if it has been issued
+                 */
+                invoiceNumber?: string | null;
+                /**
+                 * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceId?: string | null;
+                [k: string]: unknown;
+            };
+            otherCharges?: {
+                /**
+                 * Optional array of adjustments arising for this transaction
+                 */
+                adjustments?:
+                    | {
+                        /**
+                         * The amount of the adjustment
+                         */
+                        amount: string;
+                        /**
+                         * A free text description of the adjustment
+                         */
+                        description: string;
+                        [k: string]: unknown;
+                    }[]
+                    | null;
+                /**
+                 * The amount of the charge
+                 */
+                amount: string;
+                /**
+                 * A free text description of the item
+                 */
+                description: string;
+                /**
+                 * Optional end date for the application of the charge
+                 */
+                endDate?: string | null;
+                /**
+                 * The number of the invoice in which this transaction is included if it has been issued
+                 */
+                invoiceNumber?: string | null;
+                /**
+                 * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceId?: string | null;
+                /**
+                 * Optional start date for the application of the charge
+                 */
+                startDate?: string | null;
+                /**
+                 * Type of charge. Assumed to be OTHER if absent
+                 */
+                type?: ('SERVICE' | 'NETWORK' | 'EQUIPMENT' | 'METERING' | 'OTHER') | null;
+                [k: string]: unknown;
+            };
+            payment?: {
+                /**
+                 * The amount paid
+                 */
+                amount: string;
+                /**
+                 * The method of payment
+                 */
+                method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'VOUCHER' | 'OTHER';
+                [k: string]: unknown;
+            };
+            /**
+             * Indicator of the type of transaction object present in this record
+             */
+            transactionUType: 'account' | 'onceOff' | 'otherCharges' | 'payment';
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * URI to the first page of this set. Mandatory if this response is not the first page
+         */
+        first?: string | null;
+        /**
+         * URI to the last page of this set. Mandatory if this response is not the last page
+         */
+        last?: string | null;
+        /**
+         * URI to the next page of this set. Mandatory if this response is not the last page
+         */
+        next?: string | null;
+        /**
+         * URI to the previous page of this set. Mandatory if this response is not the first page
+         */
+        prev?: string | null;
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        /**
+         * The total number of pages in the full set. See [pagination](#pagination).
+         */
+        totalPages: number;
+        /**
+         * The total number of records in the full set. See [pagination](#pagination).
+         */
+        totalRecords: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoTransactionListResponseData {
+    /**
+     * Array of transactions sorted by date and time in descending order
+     */
+    transactions: {
+        account?: {
+            /**
+             * Optional array of adjustments arising for this transaction
+             */
+            adjustments?:
+                | {
+                    /**
+                     * The amount of the adjustment
+                     */
+                    amount: string;
+                    /**
+                     * A free text description of the adjustment
+                     */
+                    description: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The amount charged or credited for this transaction prior to any adjustments being applied.  A negative value indicates a credit
              */
             amount: string;
             /**
-             * Amount of data downloaded in megabytes (MB)
+             * Optional description of the transaction that can be used for display purposes
              */
-            download: number;
+            description?: string | null;
             /**
-             * Required if roaming is suipported
+             * Date and time when the usage period ends
              */
-            roaming?: {
-              /**
-               * Amount value of data roaming charges
-               */
-              amount?: string | null;
-              /**
-               * Amount of data used while roaming in megabytes (MB)
-               */
-              download?: number | null;
-              [k: string]: unknown;
-            };
+            endDate: string;
             /**
-             * Number of data sessions
+             * The number of the invoice in which this transaction is included if it has been issued
              */
-            sessions?: number | null;
+            invoiceNumber?: string | null;
             /**
-             * Amount of data uploaded in megabytes (MB)
+             * Array list of services identifiers to which this transaction applies if any. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
              */
-            upload: number;
+            serviceIds?: string | null;
+            /**
+             * Date and time when the usage period starts
+             */
+            startDate: string;
             [k: string]: unknown;
-          };
-          /**
-           * Summary of messaging. Required if messaging services is included in the product plan
-           */
-          messaging?: {
-            /**
-             * Summary of MMS usage
-             */
-            mms: {
-              /**
-               * Cost amount of MMS messages
-               */
-              amount: string;
-              /**
-               * ber of international MMS messages sent
-               */
-              international?: number | null;
-              /**
-               * Number of national MMS messages sent
-               */
-              national: number;
-              /**
-               * Number of roaming SMS messages sent. Including premium SMS services
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * Summary of SMS usage
-             */
-            sms: {
-              /**
-               * Cost amount of SMS messages. Including premium SMS services
-               */
-              amount: string;
-              /**
-               * Number of international SMS messages sent. Including premium SMS services
-               */
-              international?: number | null;
-              /**
-               * Number of national SMS messages sent. Including premium SMS services
-               */
-              national: number;
-              /**
-               * Number of roaming SMS messages sent. Including premium SMS services
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of voice calls. Required if voice calls are included in product plan
-           */
-          voice?: {
-            /**
-             * International voice calls. Requied if international calling is supported
-             */
-            international: {
-              /**
-               * Cost amount of international voice calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of international voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            /**
-             * National voice calls
-             */
-            national: {
-              /**
-               * Cost amount of national calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of national voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            /**
-             * Roaming voice calls, Required if roaming is supported
-             */
-            roaming: {
-              /**
-               * Cost amount of roaming voice calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of roaming voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
         };
+        /**
+         * The ID of the account for which the transaction occurred. accountId must comply in accordance with [CDR ID permanence](#id-permanence)
+         */
+        accountId: string;
+        /**
+         * The date and time that the transaction occurred
+         */
+        executionDateTime: string;
+        /**
+         * The GST incurred in the transaction.  Should not be included for credits or payments.  If absent zero is assumed
+         */
+        gst?: string | null;
+        onceOff?: {
+            /**
+             * The amount of the charge or credit.  A positive value indicates a charge and a negative value indicates a credit
+             */
+            amount: string;
+            /**
+             * A free text description of the item
+             */
+            description: string;
+            /**
+             * The number of the invoice in which this transaction is included if it has been issued
+             */
+            invoiceNumber?: string | null;
+            /**
+             * The ID of the service identifier to which this transaction applies if any. E.g a [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            serviceId?: string | null;
+            [k: string]: unknown;
+        };
+        otherCharges?: {
+            /**
+             * Optional array of adjustments arising for this transaction
+             */
+            adjustments?:
+                | {
+                    /**
+                     * The amount of the adjustment
+                     */
+                    amount: string;
+                    /**
+                     * A free text description of the adjustment
+                     */
+                    description: string;
+                    [k: string]: unknown;
+                }[]
+                | null;
+            /**
+             * The amount of the charge
+             */
+            amount: string;
+            /**
+             * A free text description of the item
+             */
+            description: string;
+            /**
+             * Optional end date for the application of the charge
+             */
+            endDate?: string | null;
+            /**
+             * The number of the invoice in which this transaction is included if it has been issued
+             */
+            invoiceNumber?: string | null;
+            /**
+             * The service identifier to which this transaction applies if any. E.g a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            serviceId?: string | null;
+            /**
+             * Optional start date for the application of the charge
+             */
+            startDate?: string | null;
+            /**
+             * Type of charge. Assumed to be OTHER if absent
+             */
+            type?: ('SERVICE' | 'NETWORK' | 'EQUIPMENT' | 'METERING' | 'OTHER') | null;
+            [k: string]: unknown;
+        };
+        payment?: {
+            /**
+             * The amount paid
+             */
+            amount: string;
+            /**
+             * The method of payment
+             */
+            method: 'DIRECT_DEBIT' | 'CARD' | 'TRANSFER' | 'BPAY' | 'CASH' | 'CHEQUE' | 'VOUCHER' | 'OTHER';
+            [k: string]: unknown;
+        };
+        /**
+         * Indicator of the type of transaction object present in this record
+         */
+        transactionUType: 'account' | 'onceOff' | 'otherCharges' | 'payment';
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
     }[];
     [k: string]: unknown;
-  }[];
-  [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Object containing usage summary
+ */
+export interface TelcoUsage {
+    /**
+     * Summary of data usage
+     */
+    data?: {
+        /**
+         * Cost amount of data usage
+         */
+        amount: string;
+        /**
+         * Amount of data downloaded in megabytes (MB)
+         */
+        download: number;
+        /**
+         * Required if roaming is suipported
+         */
+        roaming?: {
+            /**
+             * Amount value of data roaming charges
+             */
+            amount?: string | null;
+            /**
+             * Amount of data used while roaming in megabytes (MB)
+             */
+            download?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Number of data sessions
+         */
+        sessions?: number | null;
+        /**
+         * Amount of data uploaded in megabytes (MB)
+         */
+        upload: number;
+        [k: string]: unknown;
+    };
+    /**
+     * Summary of messaging. Required if messaging services is included in the product plan
+     */
+    messaging?: {
+        /**
+         * Summary of MMS usage
+         */
+        mms: {
+            /**
+             * Cost amount of MMS messages
+             */
+            amount: string;
+            /**
+             * ber of international MMS messages sent
+             */
+            international?: number | null;
+            /**
+             * Number of national MMS messages sent
+             */
+            national: number;
+            /**
+             * Number of roaming SMS messages sent. Including premium SMS services
+             */
+            roaming?: number | null;
+            [k: string]: unknown;
+        };
+        /**
+         * Summary of SMS usage
+         */
+        sms: {
+            /**
+             * Cost amount of SMS messages. Including premium SMS services
+             */
+            amount: string;
+            /**
+             * Number of international SMS messages sent. Including premium SMS services
+             */
+            international?: number | null;
+            /**
+             * Number of national SMS messages sent. Including premium SMS services
+             */
+            national: number;
+            /**
+             * Number of roaming SMS messages sent. Including premium SMS services
+             */
+            roaming?: number | null;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    /**
+     * Summary of voice calls. Required if voice calls are included in product plan
+     */
+    voice?: {
+        /**
+         * International voice calls. Requied if international calling is supported
+         */
+        international: {
+            /**
+             * Cost amount of international voice calls
+             */
+            amount: string;
+            /**
+             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+             */
+            duration: string;
+            /**
+             * Number of international voice calls
+             */
+            number: number;
+            [k: string]: unknown;
+        };
+        /**
+         * National voice calls
+         */
+        national: {
+            /**
+             * Cost amount of national calls
+             */
+            amount: string;
+            /**
+             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+             */
+            duration: string;
+            /**
+             * Number of national voice calls
+             */
+            number: number;
+            [k: string]: unknown;
+        };
+        /**
+         * Roaming voice calls, Required if roaming is supported
+         */
+        roaming: {
+            /**
+             * Cost amount of roaming voice calls
+             */
+            amount: string;
+            /**
+             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+             */
+            duration: string;
+            /**
+             * Number of roaming voice calls
+             */
+            number: number;
+            [k: string]: unknown;
+        };
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Roaming Data Usage
+ */
+export interface TelcoUsageDatRoaming {
+    /**
+     * Amount value of data roaming charges
+     */
+    amount?: string | null;
+    /**
+     * Amount of data used while roaming in megabytes (MB)
+     */
+    download?: number | null;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of data usage
+ */
+export interface TelcoUsageData {
+    /**
+     * Cost amount of data usage
+     */
+    amount: string;
+    /**
+     * Amount of data downloaded in megabytes (MB)
+     */
+    download: number;
+    /**
+     * Required if roaming is suipported
+     */
+    roaming?: {
+        /**
+         * Amount value of data roaming charges
+         */
+        amount?: string | null;
+        /**
+         * Amount of data used while roaming in megabytes (MB)
+         */
+        download?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Number of data sessions
+     */
+    sessions?: number | null;
+    /**
+     * Amount of data uploaded in megabytes (MB)
+     */
+    upload: number;
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoUsageListResponse {
+    data: {
+        /**
+         * Array of usage on accounts
+         */
+        accounts: {
+            /**
+             * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
+             */
+            accountId: string;
+            /**
+             * List of services that are part of the account
+             */
+            services: {
+                service: {
+                    /**
+                     * Optional description of the service used for display purposes
+                     */
+                    displayName?: string | null;
+                    /**
+                     * Date when the usage period ends
+                     */
+                    endDate?: string | null;
+                    /**
+                     * Required if the service includes a phone number
+                     */
+                    phoneNumber?: string | null;
+                    /**
+                     * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+                     */
+                    serviceId: string;
+                    /**
+                     * Date when the usage period started
+                     */
+                    startDate: string;
+                    /**
+                     * Object containing usage summary
+                     */
+                    usage?: {
+                        /**
+                         * Summary of data usage
+                         */
+                        data?: {
+                            /**
+                             * Cost amount of data usage
+                             */
+                            amount: string;
+                            /**
+                             * Amount of data downloaded in megabytes (MB)
+                             */
+                            download: number;
+                            /**
+                             * Required if roaming is suipported
+                             */
+                            roaming?: {
+                                /**
+                                 * Amount value of data roaming charges
+                                 */
+                                amount?: string | null;
+                                /**
+                                 * Amount of data used while roaming in megabytes (MB)
+                                 */
+                                download?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Number of data sessions
+                             */
+                            sessions?: number | null;
+                            /**
+                             * Amount of data uploaded in megabytes (MB)
+                             */
+                            upload: number;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of messaging. Required if messaging services is included in the product plan
+                         */
+                        messaging?: {
+                            /**
+                             * Summary of MMS usage
+                             */
+                            mms: {
+                                /**
+                                 * Cost amount of MMS messages
+                                 */
+                                amount: string;
+                                /**
+                                 * ber of international MMS messages sent
+                                 */
+                                international?: number | null;
+                                /**
+                                 * Number of national MMS messages sent
+                                 */
+                                national: number;
+                                /**
+                                 * Number of roaming SMS messages sent. Including premium SMS services
+                                 */
+                                roaming?: number | null;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Summary of SMS usage
+                             */
+                            sms: {
+                                /**
+                                 * Cost amount of SMS messages. Including premium SMS services
+                                 */
+                                amount: string;
+                                /**
+                                 * Number of international SMS messages sent. Including premium SMS services
+                                 */
+                                international?: number | null;
+                                /**
+                                 * Number of national SMS messages sent. Including premium SMS services
+                                 */
+                                national: number;
+                                /**
+                                 * Number of roaming SMS messages sent. Including premium SMS services
+                                 */
+                                roaming?: number | null;
+                                [k: string]: unknown;
+                            };
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of voice calls. Required if voice calls are included in product plan
+                         */
+                        voice?: {
+                            /**
+                             * International voice calls. Requied if international calling is supported
+                             */
+                            international: {
+                                /**
+                                 * Cost amount of international voice calls
+                                 */
+                                amount: string;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                                 */
+                                duration: string;
+                                /**
+                                 * Number of international voice calls
+                                 */
+                                number: number;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * National voice calls
+                             */
+                            national: {
+                                /**
+                                 * Cost amount of national calls
+                                 */
+                                amount: string;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                                 */
+                                duration: string;
+                                /**
+                                 * Number of national voice calls
+                                 */
+                                number: number;
+                                [k: string]: unknown;
+                            };
+                            /**
+                             * Roaming voice calls, Required if roaming is supported
+                             */
+                            roaming: {
+                                /**
+                                 * Cost amount of roaming voice calls
+                                 */
+                                amount: string;
+                                /**
+                                 * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                                 */
+                                duration: string;
+                                /**
+                                 * Number of roaming voice calls
+                                 */
+                                number: number;
+                                [k: string]: unknown;
+                            };
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            }[];
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+export interface TelcoUsageListResponseData {
+    /**
+     * Array of usage on accounts
+     */
+    accounts: {
+        /**
+         * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
+         */
+        accountId: string;
+        /**
+         * List of services that are part of the account
+         */
+        services: {
+            service: {
+                /**
+                 * Optional description of the service used for display purposes
+                 */
+                displayName?: string | null;
+                /**
+                 * Date when the usage period ends
+                 */
+                endDate?: string | null;
+                /**
+                 * Required if the service includes a phone number
+                 */
+                phoneNumber?: string | null;
+                /**
+                 * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceId: string;
+                /**
+                 * Date when the usage period started
+                 */
+                startDate: string;
+                /**
+                 * Object containing usage summary
+                 */
+                usage?: {
+                    /**
+                     * Summary of data usage
+                     */
+                    data?: {
+                        /**
+                         * Cost amount of data usage
+                         */
+                        amount: string;
+                        /**
+                         * Amount of data downloaded in megabytes (MB)
+                         */
+                        download: number;
+                        /**
+                         * Required if roaming is suipported
+                         */
+                        roaming?: {
+                            /**
+                             * Amount value of data roaming charges
+                             */
+                            amount?: string | null;
+                            /**
+                             * Amount of data used while roaming in megabytes (MB)
+                             */
+                            download?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Number of data sessions
+                         */
+                        sessions?: number | null;
+                        /**
+                         * Amount of data uploaded in megabytes (MB)
+                         */
+                        upload: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of messaging. Required if messaging services is included in the product plan
+                     */
+                    messaging?: {
+                        /**
+                         * Summary of MMS usage
+                         */
+                        mms: {
+                            /**
+                             * Cost amount of MMS messages
+                             */
+                            amount: string;
+                            /**
+                             * ber of international MMS messages sent
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national MMS messages sent
+                             */
+                            national: number;
+                            /**
+                             * Number of roaming SMS messages sent. Including premium SMS services
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of SMS usage
+                         */
+                        sms: {
+                            /**
+                             * Cost amount of SMS messages. Including premium SMS services
+                             */
+                            amount: string;
+                            /**
+                             * Number of international SMS messages sent. Including premium SMS services
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national SMS messages sent. Including premium SMS services
+                             */
+                            national: number;
+                            /**
+                             * Number of roaming SMS messages sent. Including premium SMS services
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of voice calls. Required if voice calls are included in product plan
+                     */
+                    voice?: {
+                        /**
+                         * International voice calls. Requied if international calling is supported
+                         */
+                        international: {
+                            /**
+                             * Cost amount of international voice calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of international voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * National voice calls
+                         */
+                        national: {
+                            /**
+                             * Cost amount of national calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of national voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Roaming voice calls, Required if roaming is supported
+                         */
+                        roaming: {
+                            /**
+                             * Cost amount of roaming voice calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of roaming voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
+            };
+            [k: string]: unknown;
+        }[];
+        [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -8583,10 +8583,58 @@ export interface TelcoUsageListResponseData {
  * Summary of messaging. Required if messaging services is included in the product plan
  */
 export interface TelcoUsageMessaging {
-  /**
-   * Summary of MMS usage
-   */
-  mms: {
+    /**
+     * Summary of MMS usage
+     */
+    mms: {
+        /**
+         * Cost amount of MMS messages
+         */
+        amount: string;
+        /**
+         * ber of international MMS messages sent
+         */
+        international?: number | null;
+        /**
+         * Number of national MMS messages sent
+         */
+        national: number;
+        /**
+         * Number of roaming SMS messages sent. Including premium SMS services
+         */
+        roaming?: number | null;
+        [k: string]: unknown;
+    };
+    /**
+     * Summary of SMS usage
+     */
+    sms: {
+        /**
+         * Cost amount of SMS messages. Including premium SMS services
+         */
+        amount: string;
+        /**
+         * Number of international SMS messages sent. Including premium SMS services
+         */
+        international?: number | null;
+        /**
+         * Number of national SMS messages sent. Including premium SMS services
+         */
+        national: number;
+        /**
+         * Number of roaming SMS messages sent. Including premium SMS services
+         */
+        roaming?: number | null;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of MMS usage
+ */
+export interface TelcoUsageMessagingMms {
     /**
      * Cost amount of MMS messages
      */
@@ -8604,11 +8652,13 @@ export interface TelcoUsageMessaging {
      */
     roaming?: number | null;
     [k: string]: unknown;
-  };
-  /**
-   * Summary of SMS usage
-   */
-  sms: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Summary of SMS usage
+ */
+export interface TelcoUsageMessagingSms {
     /**
      * Cost amount of SMS messages. Including premium SMS services
      */
@@ -8626,259 +8676,209 @@ export interface TelcoUsageMessaging {
      */
     roaming?: number | null;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of MMS usage
- */
-export interface TelcoUsageMessagingMms {
-  /**
-   * Cost amount of MMS messages
-   */
-  amount: string;
-  /**
-   * ber of international MMS messages sent
-   */
-  international?: number | null;
-  /**
-   * Number of national MMS messages sent
-   */
-  national: number;
-  /**
-   * Number of roaming SMS messages sent. Including premium SMS services
-   */
-  roaming?: number | null;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Summary of SMS usage
- */
-export interface TelcoUsageMessagingSms {
-  /**
-   * Cost amount of SMS messages. Including premium SMS services
-   */
-  amount: string;
-  /**
-   * Number of international SMS messages sent. Including premium SMS services
-   */
-  international?: number | null;
-  /**
-   * Number of national SMS messages sent. Including premium SMS services
-   */
-  national: number;
-  /**
-   * Number of roaming SMS messages sent. Including premium SMS services
-   */
-  roaming?: number | null;
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
 export interface TelcoUsageResponse {
-  data: {
-    /**
-     * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
-     */
-    accountId: string;
-    /**
-     * List of services that are part of the account
-     */
-    services: {
-      service: {
+    data: {
         /**
-         * Optional description of the service used for display purposes
+         * Tokenised ID of the account. In accordance with [CDR ID permanence](#id-permanence) requirements
          */
-        displayName?: string | null;
+        accountId: string;
         /**
-         * Date when the usage period ends
+         * List of services that are part of the account
          */
-        endDate?: string | null;
-        /**
-         * Required if the service includes a phone number
-         */
-        phoneNumber?: string | null;
-        /**
-         * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
-         */
-        serviceId: string;
-        /**
-         * Date when the usage period started
-         */
-        startDate: string;
-        /**
-         * Object containing usage summary
-         */
-        usage?: {
-          /**
-           * Summary of data usage
-           */
-          data?: {
-            /**
-             * Cost amount of data usage
-             */
-            amount: string;
-            /**
-             * Amount of data downloaded in megabytes (MB)
-             */
-            download: number;
-            /**
-             * Required if roaming is suipported
-             */
-            roaming?: {
-              /**
-               * Amount value of data roaming charges
-               */
-              amount?: string | null;
-              /**
-               * Amount of data used while roaming in megabytes (MB)
-               */
-              download?: number | null;
-              [k: string]: unknown;
+        services: {
+            service: {
+                /**
+                 * Optional description of the service used for display purposes
+                 */
+                displayName?: string | null;
+                /**
+                 * Date when the usage period ends
+                 */
+                endDate?: string | null;
+                /**
+                 * Required if the service includes a phone number
+                 */
+                phoneNumber?: string | null;
+                /**
+                 * Tokenised ID of the service identifier. E.g. a mobile [MSISDN](https://www.etsi.org/deliver/etsi_gts/03/0303/05.00.00_60/gsmts_0303v050000p.pdf), [FNN](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf) or internet service e.g [NBN AVC Service ID](https://www.nbnco.com.au/content/dam/nbnco2/documents/sfaa-wba2-dictionary_FTTN-launch.pdf). To be created in accordance with [CDR ID permanence](#id-permanence) requirements
+                 */
+                serviceId: string;
+                /**
+                 * Date when the usage period started
+                 */
+                startDate: string;
+                /**
+                 * Object containing usage summary
+                 */
+                usage?: {
+                    /**
+                     * Summary of data usage
+                     */
+                    data?: {
+                        /**
+                         * Cost amount of data usage
+                         */
+                        amount: string;
+                        /**
+                         * Amount of data downloaded in megabytes (MB)
+                         */
+                        download: number;
+                        /**
+                         * Required if roaming is suipported
+                         */
+                        roaming?: {
+                            /**
+                             * Amount value of data roaming charges
+                             */
+                            amount?: string | null;
+                            /**
+                             * Amount of data used while roaming in megabytes (MB)
+                             */
+                            download?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Number of data sessions
+                         */
+                        sessions?: number | null;
+                        /**
+                         * Amount of data uploaded in megabytes (MB)
+                         */
+                        upload: number;
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of messaging. Required if messaging services is included in the product plan
+                     */
+                    messaging?: {
+                        /**
+                         * Summary of MMS usage
+                         */
+                        mms: {
+                            /**
+                             * Cost amount of MMS messages
+                             */
+                            amount: string;
+                            /**
+                             * ber of international MMS messages sent
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national MMS messages sent
+                             */
+                            national: number;
+                            /**
+                             * Number of roaming SMS messages sent. Including premium SMS services
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Summary of SMS usage
+                         */
+                        sms: {
+                            /**
+                             * Cost amount of SMS messages. Including premium SMS services
+                             */
+                            amount: string;
+                            /**
+                             * Number of international SMS messages sent. Including premium SMS services
+                             */
+                            international?: number | null;
+                            /**
+                             * Number of national SMS messages sent. Including premium SMS services
+                             */
+                            national: number;
+                            /**
+                             * Number of roaming SMS messages sent. Including premium SMS services
+                             */
+                            roaming?: number | null;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    /**
+                     * Summary of voice calls. Required if voice calls are included in product plan
+                     */
+                    voice?: {
+                        /**
+                         * International voice calls. Requied if international calling is supported
+                         */
+                        international: {
+                            /**
+                             * Cost amount of international voice calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of international voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * National voice calls
+                         */
+                        national: {
+                            /**
+                             * Cost amount of national calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of national voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        /**
+                         * Roaming voice calls, Required if roaming is supported
+                         */
+                        roaming: {
+                            /**
+                             * Cost amount of roaming voice calls
+                             */
+                            amount: string;
+                            /**
+                             * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+                             */
+                            duration: string;
+                            /**
+                             * Number of roaming voice calls
+                             */
+                            number: number;
+                            [k: string]: unknown;
+                        };
+                        [k: string]: unknown;
+                    };
+                    [k: string]: unknown;
+                };
+                [k: string]: unknown;
             };
-            /**
-             * Number of data sessions
-             */
-            sessions?: number | null;
-            /**
-             * Amount of data uploaded in megabytes (MB)
-             */
-            upload: number;
             [k: string]: unknown;
-          };
-          /**
-           * Summary of messaging. Required if messaging services is included in the product plan
-           */
-          messaging?: {
-            /**
-             * Summary of MMS usage
-             */
-            mms: {
-              /**
-               * Cost amount of MMS messages
-               */
-              amount: string;
-              /**
-               * ber of international MMS messages sent
-               */
-              international?: number | null;
-              /**
-               * Number of national MMS messages sent
-               */
-              national: number;
-              /**
-               * Number of roaming SMS messages sent. Including premium SMS services
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            /**
-             * Summary of SMS usage
-             */
-            sms: {
-              /**
-               * Cost amount of SMS messages. Including premium SMS services
-               */
-              amount: string;
-              /**
-               * Number of international SMS messages sent. Including premium SMS services
-               */
-              international?: number | null;
-              /**
-               * Number of national SMS messages sent. Including premium SMS services
-               */
-              national: number;
-              /**
-               * Number of roaming SMS messages sent. Including premium SMS services
-               */
-              roaming?: number | null;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          /**
-           * Summary of voice calls. Required if voice calls are included in product plan
-           */
-          voice?: {
-            /**
-             * International voice calls. Requied if international calling is supported
-             */
-            international: {
-              /**
-               * Cost amount of international voice calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of international voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            /**
-             * National voice calls
-             */
-            national: {
-              /**
-               * Cost amount of national calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of national voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            /**
-             * Roaming voice calls, Required if roaming is supported
-             */
-            roaming: {
-              /**
-               * Cost amount of roaming voice calls
-               */
-              amount: string;
-              /**
-               * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-               */
-              duration: string;
-              /**
-               * Number of roaming voice calls
-               */
-              number: number;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
+        }[];
         [k: string]: unknown;
-      };
-      [k: string]: unknown;
-    }[];
+    };
+    links: {
+        /**
+         * Fully qualified link that generated the current response document
+         */
+        self: string;
+        [k: string]: unknown;
+    };
+    meta: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
-  };
-  links: {
-    /**
-     * Fully qualified link that generated the current response document
-     */
-    self: string;
-    [k: string]: unknown;
-  };
-  meta: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
 
@@ -8886,10 +8886,68 @@ export interface TelcoUsageResponse {
  * Summary of voice calls. Required if voice calls are included in product plan
  */
 export interface TelcoUsageVoice {
-  /**
-   * International voice calls. Requied if international calling is supported
-   */
-  international: {
+    /**
+     * International voice calls. Requied if international calling is supported
+     */
+    international: {
+        /**
+         * Cost amount of international voice calls
+         */
+        amount: string;
+        /**
+         * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
+         */
+        duration: string;
+        /**
+         * Number of international voice calls
+         */
+        number: number;
+        [k: string]: unknown;
+    };
+    /**
+     * National voice calls
+     */
+    national: {
+        /**
+         * Cost amount of national calls
+         */
+        amount: string;
+        /**
+         * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
+         */
+        duration: string;
+        /**
+         * Number of national voice calls
+         */
+        number: number;
+        [k: string]: unknown;
+    };
+    /**
+     * Roaming voice calls, Required if roaming is supported
+     */
+    roaming: {
+        /**
+         * Cost amount of roaming voice calls
+         */
+        amount: string;
+        /**
+         * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
+         */
+        duration: string;
+        /**
+         * Number of roaming voice calls
+         */
+        number: number;
+        [k: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * International voice calls. Requied if international calling is supported
+ */
+export interface TelcoUsageVoiceInternational {
     /**
      * Cost amount of international voice calls
      */
@@ -8903,11 +8961,13 @@ export interface TelcoUsageVoice {
      */
     number: number;
     [k: string]: unknown;
-  };
-  /**
-   * National voice calls
-   */
-  national: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * National voice calls
+ */
+export interface TelcoUsageVoiceNational {
     /**
      * Cost amount of national calls
      */
@@ -8921,11 +8981,13 @@ export interface TelcoUsageVoice {
      */
     number: number;
     [k: string]: unknown;
-  };
-  /**
-   * Roaming voice calls, Required if roaming is supported
-   */
-  roaming: {
+}
+/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
+
+/**
+ * Roaming voice calls, Required if roaming is supported
+ */
+export interface TelcoUsageVoiceRoaming {
     /**
      * Cost amount of roaming voice calls
      */
@@ -8939,66 +9001,4 @@ export interface TelcoUsageVoice {
      */
     number: number;
     [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * International voice calls. Requied if international calling is supported
- */
-export interface TelcoUsageVoiceInternational {
-  /**
-   * Cost amount of international voice calls
-   */
-  amount: string;
-  /**
-   * Total duration (hours, minutes, and seconds) of international voice calls. Not limited to 24hrs
-   */
-  duration: string;
-  /**
-   * Number of international voice calls
-   */
-  number: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * National voice calls
- */
-export interface TelcoUsageVoiceNational {
-  /**
-   * Cost amount of national calls
-   */
-  amount: string;
-  /**
-   * Total duration (hours, minutes, and seconds) of national voice calls. Not limited to 24hrs
-   */
-  duration: string;
-  /**
-   * Number of national voice calls
-   */
-  number: number;
-  [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the telco api. */
-
-/**
- * Roaming voice calls, Required if roaming is supported
- */
-export interface TelcoUsageVoiceRoaming {
-  /**
-   * Cost amount of roaming voice calls
-   */
-  amount: string;
-  /**
-   * Total duration (hours, minutes, and seconds) of roaming voice calls. Not limited to 24hrs
-   */
-  duration: string;
-  /**
-   * Number of roaming voice calls
-   */
-  number: number;
-  [k: string]: unknown;
 }


### PR DESCRIPTION
👋 Hi! This PR is meant to let you know that we're going to be applying formatting automatically to all DefinitelyTyped packages[^1]. This PR is split out of:

* https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65993: the discussion that includes backing context and our planned approach
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66235: onboards the repository to [dprint](https://dprint.dev)

This package is particularly huge (>1MB), so we're tagging you in an individual PR as a heads up. Please post here to let us know if you have any workflow needs that auto-formatting might disrupt[^2].

Cheers! 💖 

[^1]: Note that formatting will be applied as a commit to `master` after each PR. PRs won't be blocked on any CI check for proper formatting. See #65993 for more information.
[^2]: For example, if this package is fully auto-generated (rather than manually edited), subsequent PRs might have a lot of noise from formatting differences. We can exclude it from formatting in that case. 