### PR TITLE
fix: wrong postcss-prefix-selector return type

### DIFF
--- a/types/postcss-prefix-selector/index.d.ts
+++ b/types/postcss-prefix-selector/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for postcss-prefix-selector 1.15
+// Type definitions for postcss-prefix-selector 1.16
 // Project: https://github.com/RadValentin/postcss-prefix-selector
 // Definitions by: robertmaier <https://github.com/robertmaier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/types/postcss-prefix-selector
+import { Root } from 'postcss';
 
 interface Options {
     prefix?: string | undefined;
@@ -11,6 +12,6 @@ interface Options {
     transform?: ((prefix: Readonly<string>, selector: Readonly<string>, prefixedSelector: Readonly<string>, file: Readonly<string>) => string) | undefined;
 }
 
-declare function postcssPrefixSelector(options: Readonly<Options>): (root: any) => string | undefined;
+declare function postcssPrefixSelector(options: Readonly<Options>): (root: Root) => void;
 
 export = postcssPrefixSelector;

--- a/types/postcss-prefix-selector/package.json
+++ b/types/postcss-prefix-selector/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.4.27"
+    }
+}

--- a/types/postcss-prefix-selector/postcss-prefix-selector-tests.ts
+++ b/types/postcss-prefix-selector/postcss-prefix-selector-tests.ts
@@ -1,4 +1,4 @@
 import postcssPrefixSelector = require('postcss-prefix-selector');
 
-// $ExpectType (root: any) => string | undefined
+// $ExpectType (root: Root_) => void
 postcssPrefixSelector({});

--- a/types/postcss-prefix-selector/tsconfig.json
+++ b/types/postcss-prefix-selector/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es2018"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/RadValentin/postcss-prefix-selector/blob/master/index.js -- the returned function doesn't return anything as opposed to the current types that indicate that a `string | undefined` is returned
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.