### PR TITLE
[tedious]: add missing `Variant` data type.

### DIFF
--- a/types/tedious/index.d.ts
+++ b/types/tedious/index.d.ts
@@ -115,7 +115,7 @@ export interface TediousTypes {
     Numeric: TediousType;
     Real: TediousType;
     SmallDateTime: TediousType;
-    SmallInt        : TediousType;
+    SmallInt: TediousType;
     SmallMoney: TediousType;
     TVP: TediousType;
     Text: TediousType;
@@ -125,6 +125,7 @@ export interface TediousTypes {
     UniqueIdentifier: TediousType;
     VarBinary: TediousType;
     VarChar: TediousType;
+    Variant: TediousType;
     Xml: TediousType;
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/tedious/blob/master/src/data-type.ts#L439-L471 (`Variant` has been there for 5 years according to git blame).
https://tediousjs.github.io/tedious/api-datatypes.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.