### PR TITLE
update(node): `fs.openAsBlob`

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3900,6 +3900,31 @@ declare module 'fs' {
      * @return The number of bytes read.
      */
     export function readvSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
+
+    export interface OpenAsBlobOptions {
+        /**
+         * An optional mime type for the blob.
+         *
+         * @default 'undefined'
+         */
+        type?: string | undefined;
+    }
+
+    /**
+     * Returns a Blob whose data is backed by the given file.
+     *
+     * The file must not be modified after the `Blob` is created.
+     * Any modifications will cause reading the `Blob` data to fail with a `DOMException` error.
+     * Synchronous stat operations on the file when the `Blob` is created, and before each read in order to detect whether the file data has been modified on disk.
+     *
+     * @param path
+     * @param [options]
+     *
+     * @experimental
+     * @since v19.8.0
+     */
+    export function openAsBlob(path: PathLike, options?: OpenAsBlobOptions): Promise<Blob>;
+
     export interface OpenDirOptions {
         /**
          * @default 'utf8'

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -432,6 +432,23 @@ async function testPromisify() {
 }
 
 {
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt');
+    });
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt', {});
+    });
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt', {
+            type: 'text/ecmascript',
+        });
+    });
+}
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });

--- a/types/node/ts4.8/fs.d.ts
+++ b/types/node/ts4.8/fs.d.ts
@@ -3900,6 +3900,31 @@ declare module 'fs' {
      * @return The number of bytes read.
      */
     export function readvSync(fd: number, buffers: ReadonlyArray<NodeJS.ArrayBufferView>, position?: number): number;
+
+    export interface OpenAsBlobOptions {
+        /**
+         * An optional mime type for the blob.
+         *
+         * @default 'undefined'
+         */
+        type?: string | undefined;
+    }
+
+    /**
+     * Returns a Blob whose data is backed by the given file.
+     *
+     * The file must not be modified after the `Blob` is created.
+     * Any modifications will cause reading the `Blob` data to fail with a `DOMException` error.
+     * Synchronous stat operations on the file when the `Blob` is created, and before each read in order to detect whether the file data has been modified on disk.
+     *
+     * @param path
+     * @param [options]
+     *
+     * @experimental
+     * @since v19.8.0
+     */
+    export function openAsBlob(path: PathLike, options?: OpenAsBlobOptions): Promise<Blob>;
+
     export interface OpenDirOptions {
         /**
          * @default 'utf8'

--- a/types/node/ts4.8/test/fs.ts
+++ b/types/node/ts4.8/test/fs.ts
@@ -432,6 +432,23 @@ async function testPromisify() {
 }
 
 {
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt');
+    });
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt', {});
+    });
+    (async () => {
+        // $ExpectType Blob
+        const blob = await fs.openAsBlob('the.file.txt', {
+            type: 'text/ecmascript',
+        });
+    });
+}
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });


### PR DESCRIPTION
Added in v19, as per #66366 discussion:
https://nodejs.dev/en/api/v19/fs/#fsopenasblobpath-options

/cc @Artoria2e5

Thanks!

Closes #66366

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).