### PR TITLE
[@types/ember__owner] Add types for getOwner and setOwner

### DIFF
--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -1,4 +1,6 @@
-import Owner, { Factory, FactoryManager, FullName, RegisterOptions, KnownForTypeResult, Resolver } from '@ember/owner';
+import ApplicationInstance from '@ember/application/instance';
+import EngineInstance from '@ember/engine/instance';
+import Owner, { Factory, FactoryManager, FullName, RegisterOptions, KnownForTypeResult, Resolver, getOwner, setOwner } from '@ember/owner';
 
 // Just a class we can construct in the Factory and FactoryManager tests
 declare class ConstructThis {
@@ -152,3 +154,28 @@ const pojoFactory: Factory<typeof Creatable> = {
 };
 
 pojoFactory.create(); // $ExpectType { hasProps: boolean; }
+
+// ----- getOwner ----- //
+
+// @ts-expect-error
+getOwner();
+
+// $ExpectType Owner | undefined
+getOwner({});
+
+// ----- setOwner ----- //
+
+// @ts-expect-error
+setOwner();
+
+// @ts-expect-error
+setOwner({});
+
+declare let baseOwner: Owner;
+setOwner({}, baseOwner); // $ExpectType void
+
+declare let engine: EngineInstance;
+setOwner({}, engine); // $ExpectType void
+
+declare let application: ApplicationInstance;
+setOwner({}, application); // $ExpectType void

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -187,5 +187,9 @@ export interface Resolver {
     normalize?: (fullName: FullName) => string;
 }
 
+export function getOwner(object: object): Owner | undefined;
+
+export function setOwner(object: object, owner: Owner): void;
+
 // Don't export things unless we *intend* to.
 export {};


### PR DESCRIPTION
This adds types for `getOwner` and `setOwner` from `@ember/object`.

These imports were added to `@ember/owner` in 4.10 https://blog.emberjs.com/ember-released-4-10#toc_features

Refs

- `getOwner` https://api.emberjs.com/ember/5.1/functions/@ember%2Fowner/getOwner
- `setOwner` https://api.emberjs.com/ember/5.1/functions/@ember%2Fowner/setOwner

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
