### PR TITLE
[node] Expose `performance` global in v16

### DIFF
--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -580,6 +580,21 @@ declare module 'perf_hooks' {
      * @since v15.9.0
      */
     function createHistogram(options?: CreateHistogramOptions): RecordableHistogram;
+
+    import { performance as _performance } from 'perf_hooks';
+    global {
+        /**
+         * `performance` is a global reference for `require('perf_hooks').performance`
+         * https://nodejs.org/api/globals.html#performance
+         * @since v16.0.0
+         */
+        var performance: typeof globalThis extends {
+            onmessage: any;
+            performance: infer T;
+        }
+            ? T
+            : typeof _performance;
+    }
 }
 declare module 'node:perf_hooks' {
     export * from 'perf_hooks';

--- a/types/node/v16/test/perf_hooks.ts
+++ b/types/node/v16/test/perf_hooks.ts
@@ -1,5 +1,5 @@
 import {
-    performance,
+    performance as NodePerf,
     monitorEventLoopDelay,
     PerformanceObserverCallback,
     PerformanceObserver,
@@ -13,7 +13,8 @@ import {
     NodeGCPerformanceDetail,
 } from 'node:perf_hooks';
 
-performance.mark('start');
+// Test module import once, the rest use global
+NodePerf.mark('start');
 (() => {})();
 performance.mark('end');
 
@@ -85,9 +86,10 @@ const mean: number = monitor.mean;
 const stddev: number = monitor.stddev;
 const exceeds: number = monitor.exceeds;
 
-const eventLoopUtilization1: EventLoopUtilization = performance.eventLoopUtilization();
-const eventLoopUtilization2: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization1);
-const eventLoopUtilization3: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization2, eventLoopUtilization1);
+// eventLoopUtilization isn't available in DOM environment, so use the import rather than the global
+const eventLoopUtilization1: EventLoopUtilization = NodePerf.eventLoopUtilization();
+const eventLoopUtilization2: EventLoopUtilization = NodePerf.eventLoopUtilization(eventLoopUtilization1);
+const eventLoopUtilization3: EventLoopUtilization = NodePerf.eventLoopUtilization(eventLoopUtilization2, eventLoopUtilization1);
 
 let histogram: RecordableHistogram = createHistogram({
     figures: 123,
@@ -106,9 +108,9 @@ performance.clearMarks("test");
 performance.clearMeasures();
 performance.clearMeasures("test");
 
-performance.getEntries(); // $ExpectType PerformanceEntry[]
+performance.getEntries()[0]; // $ExpectType PerformanceEntry
 
-performance.getEntriesByName("test"); // $ExpectType PerformanceEntry[]
-performance.getEntriesByName("test", "mark"); // $ExpectType PerformanceEntry[]
+performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
+performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
-performance.getEntriesByType("mark"); // $ExpectType PerformanceEntry[]
+performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry

--- a/types/node/v16/ts4.8/perf_hooks.d.ts
+++ b/types/node/v16/ts4.8/perf_hooks.d.ts
@@ -580,6 +580,21 @@ declare module 'perf_hooks' {
      * @since v15.9.0
      */
     function createHistogram(options?: CreateHistogramOptions): RecordableHistogram;
+
+    import { performance as _performance } from 'perf_hooks';
+    global {
+        /**
+         * `performance` is a global reference for `require('perf_hooks').performance`
+         * https://nodejs.org/api/globals.html#performance
+         * @since v16.0.0
+         */
+        var performance: typeof globalThis extends {
+            onmessage: any;
+            performance: infer T;
+        }
+            ? T
+            : typeof _performance;
+    }
 }
 declare module 'node:perf_hooks' {
     export * from 'perf_hooks';

--- a/types/node/v16/ts4.8/test/perf_hooks.ts
+++ b/types/node/v16/ts4.8/test/perf_hooks.ts
@@ -1,5 +1,5 @@
 import {
-    performance,
+    performance as NodePerf,
     monitorEventLoopDelay,
     PerformanceObserverCallback,
     PerformanceObserver,
@@ -13,7 +13,8 @@ import {
     NodeGCPerformanceDetail,
 } from 'node:perf_hooks';
 
-performance.mark('start');
+// Test module import once, the rest use global
+NodePerf.mark('start');
 (() => {})();
 performance.mark('end');
 
@@ -85,9 +86,10 @@ const mean: number = monitor.mean;
 const stddev: number = monitor.stddev;
 const exceeds: number = monitor.exceeds;
 
-const eventLoopUtilization1: EventLoopUtilization = performance.eventLoopUtilization();
-const eventLoopUtilization2: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization1);
-const eventLoopUtilization3: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization2, eventLoopUtilization1);
+// eventLoopUtilization isn't available in DOM environment, so use the import rather than the global
+const eventLoopUtilization1: EventLoopUtilization = NodePerf.eventLoopUtilization();
+const eventLoopUtilization2: EventLoopUtilization = NodePerf.eventLoopUtilization(eventLoopUtilization1);
+const eventLoopUtilization3: EventLoopUtilization = NodePerf.eventLoopUtilization(eventLoopUtilization2, eventLoopUtilization1);
 
 let histogram: RecordableHistogram = createHistogram({
     figures: 123,
@@ -106,9 +108,9 @@ performance.clearMarks("test");
 performance.clearMeasures();
 performance.clearMeasures("test");
 
-performance.getEntries(); // $ExpectType PerformanceEntry[]
+performance.getEntries()[0]; // $ExpectType PerformanceEntry
 
-performance.getEntriesByName("test"); // $ExpectType PerformanceEntry[]
-performance.getEntriesByName("test", "mark"); // $ExpectType PerformanceEntry[]
+performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
+performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
-performance.getEntriesByType("mark"); // $ExpectType PerformanceEntry[]
+performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v16.x/api/globals.html#performance
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

This PR backports the `performance` global from the Node v18 and v20 types to v16, which is when it was first introduced. I've copied the code and tests from v18.