### PR TITLE
[jasmine] Add support for passing DiffBuilder as the third argument to v3

### DIFF
--- a/types/jasmine/v3/index.d.ts
+++ b/types/jasmine/v3/index.d.ts
@@ -494,6 +494,7 @@ declare namespace jasmine {
 
     interface MatchersUtil {
         equals(a: any, b: any, customTesters?: ReadonlyArray<CustomEqualityTester>, diffBuilder?: DiffBuilder): boolean;
+        equals(a: any, b: any, diffBuilder?: DiffBuilder): boolean;
         contains<T>(
             haystack: ArrayLike<T> | string,
             needle: any,

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -1302,6 +1302,11 @@ describe("DiffBuilder", () => {
         jasmine.matchersUtil.equals(1, 1, undefined, differ);
     });
 
+    it("can be passed to matchersUtil.equals as the third argument", () => {
+        const differ = jasmine.DiffBuilder();
+        jasmine.matchersUtil.equals(1, 1, differ);
+    });
+
     it("records the actual and expected objects", () => {
         const diffBuilder = jasmine.DiffBuilder();
         diffBuilder.setRoots({ x: "actual" }, { x: "expected" });


### PR DESCRIPTION
This was added in v3.99 to ease the transition to v4.0

https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#tips-for-resolving-specific-deprecation-warnings

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#tips-for-resolving-specific-deprecation-warnings
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.