### PR TITLE
[node] Expose `TextDecoder` and `TextEncoder` globals in v16

### DIFF
--- a/types/node/v16/test/util.ts
+++ b/types/node/v16/test/util.ts
@@ -150,6 +150,10 @@ const td = new util.TextDecoder();
 new util.TextDecoder("utf-8");
 new util.TextDecoder("utf-8", { fatal: true });
 new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+// Test global alias
+const td2 = new TextDecoder();
+
 const ignoreBom: boolean = td.ignoreBOM;
 const fatal: boolean = td.fatal;
 const encoding: string = td.encoding;
@@ -173,6 +177,9 @@ const decode: string = td.decode(new Int8Array(1));
 const te = new util.TextEncoder();
 const teEncoding: string = te.encoding;
 const teEncodeRes: Uint8Array = te.encode("TextEncoder");
+
+// Test global alias
+const te2 = new TextEncoder();
 
 const encIntoRes: util.EncodeIntoResult = te.encodeInto('asdf', new Uint8Array(16));
 

--- a/types/node/v16/ts4.8/test/util.ts
+++ b/types/node/v16/ts4.8/test/util.ts
@@ -150,6 +150,10 @@ const td = new util.TextDecoder();
 new util.TextDecoder("utf-8");
 new util.TextDecoder("utf-8", { fatal: true });
 new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+// Test global alias
+const td2 = new TextDecoder();
+
 const ignoreBom: boolean = td.ignoreBOM;
 const fatal: boolean = td.fatal;
 const encoding: string = td.encoding;
@@ -173,6 +177,9 @@ const decode: string = td.decode(new Int8Array(1));
 const te = new util.TextEncoder();
 const teEncoding: string = te.encoding;
 const teEncodeRes: Uint8Array = te.encode("TextEncoder");
+
+// Test global alias
+const te2 = new TextEncoder();
 
 const encIntoRes: util.EncodeIntoResult = te.encodeInto('asdf', new Uint8Array(16));
 

--- a/types/node/v16/ts4.8/util.d.ts
+++ b/types/node/v16/ts4.8/util.d.ts
@@ -1094,6 +1094,33 @@ declare module 'util' {
          */
         encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
     }
+
+    import { TextDecoder as _TextDecoder, TextEncoder as _TextEncoder } from 'util';
+    global {
+        /**
+         * `TextDecoder` class is a global reference for `require('util').TextDecoder`
+         * https://nodejs.org/api/globals.html#textdecoder
+         * @since v11.0.0
+         */
+         var TextDecoder: typeof globalThis extends {
+            onmessage: any;
+            TextDecoder: infer TextDecoder;
+        }
+            ? TextDecoder
+            : typeof _TextDecoder;
+
+        /**
+         * `TextEncoder` class is a global reference for `require('util').TextEncoder`
+         * https://nodejs.org/api/globals.html#textencoder
+         * @since v11.0.0
+         */
+         var TextEncoder: typeof globalThis extends {
+            onmessage: any;
+            TextEncoder: infer TextEncoder;
+        }
+            ? TextEncoder
+            : typeof _TextEncoder;
+    }
 }
 declare module 'util/types' {
     export * from 'util/types';

--- a/types/node/v16/util.d.ts
+++ b/types/node/v16/util.d.ts
@@ -1094,6 +1094,33 @@ declare module 'util' {
          */
         encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
     }
+
+    import { TextDecoder as _TextDecoder, TextEncoder as _TextEncoder } from 'util';
+    global {
+        /**
+         * `TextDecoder` class is a global reference for `require('util').TextDecoder`
+         * https://nodejs.org/api/globals.html#textdecoder
+         * @since v11.0.0
+         */
+         var TextDecoder: typeof globalThis extends {
+            onmessage: any;
+            TextDecoder: infer TextDecoder;
+        }
+            ? TextDecoder
+            : typeof _TextDecoder;
+
+        /**
+         * `TextEncoder` class is a global reference for `require('util').TextEncoder`
+         * https://nodejs.org/api/globals.html#textencoder
+         * @since v11.0.0
+         */
+         var TextEncoder: typeof globalThis extends {
+            onmessage: any;
+            TextEncoder: infer TextEncoder;
+        }
+            ? TextEncoder
+            : typeof _TextEncoder;
+    }
 }
 declare module 'util/types' {
     export * from 'util/types';


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v16.x/api/globals.html#textdecoder
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

This PR backports the `TextDecoder` and `TextEncoder` globals from the Node v18 and v20 types to v16. I've copied the code and tests from v18.