### PR TITLE
fix(auth0): made AuthenticationClient members (e.g. oauth) always defined

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -135,8 +135,8 @@ management
             .catch(err => console.error('Cannot create SMS user', err))
             .then(smsUser => {
                 if (!smsUser) return;
-                const userId = emailUser.user_id;
-                const params = { user_id: smsUser.user_id, provider: 'sms' };
+                const userId = emailUser.user_id!;
+                const params = { user_id: smsUser.user_id!, provider: 'sms' };
                 management
                     .linkUsers(userId, params)
                     .catch(err => console.error('Cannot link E-mail and SMS users', err))

--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1130,9 +1130,9 @@ async () => {
 
 async function signupTest(): Promise<void> {
     const signupResult = await authentication.database.signUp({ email: 'email', password: 'password' });
-    signupResult._id; // $ExpectType string
-    signupResult.email; // $ExpectType string
-    signupResult.email_verified; // $ExpectType boolean
+    signupResult._id; // $ExpectType string | undefined
+    signupResult.email; // $ExpectType string | undefined
+    signupResult.email_verified; // $ExpectType boolean | undefined
 
     authentication.database.signUp({ email: 'email', password: 'password' }, (err, data) => {
         err; // $ExpectType Error
@@ -1284,14 +1284,21 @@ management.organizations.getByName({ name: '' }).then((organization: auth0.Organ
 /**
  * Create an Organization using a callback
  */
-management.organizations.create({
-    name: 'test_organization', display_name: 'Test Organization', enabled_connections: [{
-        connection_id: 'connection-id',
-        assign_membership_on_login: true,
-    }]
-}, (err, organization: auth0.Organization) => {
-    console.log({ organization });
-});
+management.organizations.create(
+    {
+        name: 'test_organization',
+        display_name: 'Test Organization',
+        enabled_connections: [
+            {
+                connection_id: 'connection-id',
+                assign_membership_on_login: true,
+            },
+        ],
+    },
+    (err, organization: auth0.Organization) => {
+        console.log({ organization });
+    },
+);
 
 /**
  * Create an Organization returning a Promise

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1157,11 +1157,11 @@ export interface GrantResponse {
 
 export class AuthenticationClient {
     // Members
-    database?: DatabaseAuthenticator | undefined;
-    oauth?: OAuthAuthenticator | undefined;
-    passwordless?: PasswordlessAuthenticator | undefined;
-    tokens?: TokensManager | undefined;
-    users?: UsersManager | undefined;
+    database: DatabaseAuthenticator;
+    oauth: OAuthAuthenticator;
+    passwordless: PasswordlessAuthenticator;
+    tokens: TokensManager;
+    users: UsersManager ;
 
     constructor(options: AuthenticationClientOptions);
     getClientInfo(): ClientInfo;

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1161,7 +1161,7 @@ export class AuthenticationClient {
     oauth: OAuthAuthenticator;
     passwordless: PasswordlessAuthenticator;
     tokens: TokensManager;
-    users: UsersManager ;
+    users: UsersManager;
 
     constructor(options: AuthenticationClientOptions);
     getClientInfo(): ClientInfo;

--- a/types/auth0/tsconfig.json
+++ b/types/auth0/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-auth0/blob/bd7cfc31a45ca68a549445a44b102998193efe88/src/auth/index.js#L82-L115
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


These 5 members are set in the constructor
