### PR TITLE
Add support for include_totals to getClients method

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -466,6 +466,18 @@ management
         // Handle the error
     });
 
+// Get all clients with pagination and totals using a callback
+management.getClients({ page: 0, per_page: 5, include_totals: true }, (err, pagedClients) => {
+    // $ExpectType ClientsPaged
+    pagedClients;
+});
+
+// Get all clients with pagination and totals returning a Promise
+management.getClients({ page: 0, per_page: 5, include_totals: true }).then(pagedClients => {
+    // $ExpectType ClientsPaged
+    pagedClients;
+});
+
 // Connections
 // Get all Connections with promise
 management
@@ -1284,14 +1296,21 @@ management.organizations.getByName({ name: '' }).then((organization: auth0.Organ
 /**
  * Create an Organization using a callback
  */
-management.organizations.create({
-    name: 'test_organization', display_name: 'Test Organization', enabled_connections: [{
-        connection_id: 'connection-id',
-        assign_membership_on_login: true,
-    }]
-}, (err, organization: auth0.Organization) => {
-    console.log({ organization });
-});
+management.organizations.create(
+    {
+        name: 'test_organization',
+        display_name: 'Test Organization',
+        enabled_connections: [
+            {
+                connection_id: 'connection-id',
+                assign_membership_on_login: true,
+            },
+        ],
+    },
+    (err, organization: auth0.Organization) => {
+        console.log({ organization });
+    },
+);
 
 /**
  * Create an Organization returning a Promise

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -317,6 +317,10 @@ export interface Client {
     initiate_login_uri?: string | undefined;
 }
 
+export interface ClientsPaged extends Omit<Page, 'length'> {
+    clients: Client[];
+}
+
 export interface ResourceServer {
     /**
      * The identifier of the resource server.
@@ -1569,11 +1573,11 @@ export interface UsersLogsQuery {
 interface LogStreamBase {
     id: string;
     name: string;
-    status: "active" | "paused" | "suspended";
+    status: 'active' | 'paused' | 'suspended';
 }
 
 interface DatadogLogStream extends LogStreamBase {
-    type: "datadog";
+    type: 'datadog';
     sink: {
         datadogRegion: string;
         datadogApiKey: string;
@@ -1581,7 +1585,7 @@ interface DatadogLogStream extends LogStreamBase {
 }
 
 interface EventBridgeLogStream extends LogStreamBase {
-    type: "eventbridge";
+    type: 'eventbridge';
     sink: {
         awsAccountId: string;
         awsRegion: string;
@@ -1590,7 +1594,7 @@ interface EventBridgeLogStream extends LogStreamBase {
 }
 
 interface EventGridLogStream extends LogStreamBase {
-    type: "eventgrid";
+    type: 'eventgrid';
     sink: {
         azureSubscriptionId: string;
         azureResourceGroup: string;
@@ -1600,9 +1604,9 @@ interface EventGridLogStream extends LogStreamBase {
 }
 
 interface HttpLogStream extends LogStreamBase {
-    type: "http";
+    type: 'http';
     sink: {
-        httpContentFormat: "JSONLINES" | "JSONARRAY";
+        httpContentFormat: 'JSONLINES' | 'JSONARRAY';
         httpContentType: string;
         httpEndpoint: string;
         httpAuthorization: string;
@@ -1610,7 +1614,7 @@ interface HttpLogStream extends LogStreamBase {
 }
 
 interface SplunkLogStream extends LogStreamBase {
-    type: "splunk";
+    type: 'splunk';
     sink: {
         splunkDomain: string;
         splunkToken: string;
@@ -1620,7 +1624,7 @@ interface SplunkLogStream extends LogStreamBase {
 }
 
 interface SumoLogStream extends LogStreamBase {
-    type: "sumo";
+    type: 'sumo';
     sink: {
         sumoSourceAddress: string;
     };
@@ -1868,9 +1872,18 @@ export class ManagementClient<A = AppMetadata, U = UserMetadata> {
     updateConnection(params: ObjectWithId, data: UpdateConnection): Promise<Connection>;
 
     // Clients
-    getClients(params?: GetClientsOptions): Promise<Client[]>;
+    getClients(): Promise<Client[]>;
     getClients(cb: (err: Error, clients: Client[]) => void): void;
-    getClients(params: GetClientsOptions, cb: (err: Error, clients: Client[]) => void): void;
+    getClients(params: GetClientsOptions & { include_totals?: false }): Promise<Client[]>;
+    getClients(params: GetClientsOptions & { include_totals: true }): Promise<ClientsPaged>;
+    getClients(
+        params: GetClientsOptions & { include_totals?: false },
+        cb: (err: Error, clients: Client[]) => void,
+    ): void;
+    getClients(
+        params: GetClientsOptions & { include_totals: true },
+        cb: (err: Error, pagedClients: ClientsPaged) => void,
+    ): void;
 
     getClient(params: ClientParams): Promise<Client>;
     getClient(params: ClientParams, cb: (err: Error, client: Client) => void): void;


### PR DESCRIPTION
This PR adds the `include_totals` parameter for the `getClients` method.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [getClients documentation](https://auth0.com/docs/api/management/v2/clients/get-clients)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

*Like in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56432, this endpoint does not return a length property, so we cannot fully reuse the Page type, hence the omitting of the length property in ClientsPaged.*