### PR TITLE
[node-forge] more details about encryption in PKCS#7 EnvelopedData

### DIFF
--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -729,7 +729,6 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
 {
     // create an EnvelopedData with encrypted content (3DES with RSA)
     let p7 = forge.pkcs7.createEnvelopedData();
-    let cert = forge.pki.certificateFromPem(certPem);
     let symmetricCipher = forge.pki.oids['des-EDE3-CBC'];
     p7.addRecipient(cert);
     p7.content = forge.util.createBuffer('content');
@@ -743,6 +742,20 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     if (p7.content !== encP7.content) {
         throw new Error('decrypted result does not match');
     }
+}
+
+{
+    // alternatively, EnvelopedData can be encrypted with a predefined symmetric key
+    let p7 = forge.pkcs7.createEnvelopedData();
+    p7.addRecipient(cert);
+    p7.content = forge.util.createBuffer('cleartext');
+    // let's define a key suitable for AES-128 (key length: 16 bytes)
+    let symmetricCipher = forge.pki.oids['aes128-CBC'];
+    let predefinedKey = forge.util.hexToBytes('b5d36c67837faa95d02455ec162588ed');
+    p7.encrypt(forge.util.createBuffer(predefinedKey), symmetricCipher);
+
+    let recipient = p7.findRecipient(cert);
+    p7.decrypt(recipient, privateKeyRsa);
 }
 
 {


### PR DESCRIPTION
**Encryption:** a key and (more importantly) the symmetric cipher can be specified when calling "encrypt()".

**Decryption:** the correct recipient should be retrieved based on the certificate, then content can be decrypted with the private key.

_Documentation copied from 'node-forge'._

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - encryption: `envelopedData.encrypt` accepting key and cipher defined [here](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/pkcs7.js#L727)
  - decryption: envelopedData contains recipients ([here](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/pkcs7.js#L591)), and they are created with said properties [here](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/pkcs7.js#L834)
  - `envelopedData.findRecipient` is defined [here](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/pkcs7.js#L637), and `envelopedData.decrypt` is [here](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/pkcs7.js#L675)