### PR TITLE
[mssql] parseConnectionString always returns `pool` and `options` props

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mssql 8.1
+// Type definitions for mssql 9.1
 // Project: https://www.npmjs.com/package/mssql
 // Definitions by: Jørgen Elgaard Larsen <https://github.com/elhaard>
 //                 Peter Keuter <https://github.com/pkeuter>
@@ -219,7 +219,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public readonly pending: number;
     public readonly borrowed: number;
     public readonly pool: Pool<Connection>;
-    public static parseConnectionString(connectionString: string): config;
+    public static parseConnectionString(connectionString: string): config & { options: IOptions, pool: Partial<PoolOpts<Connection>> };
     public constructor(config: config, callback?: (err?: any) => void);
     public constructor(connectionString: string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -172,6 +172,8 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
 
 function test_connection_string_parser() {
     var parsedConfig: sql.config = sql.ConnectionPool.parseConnectionString(connectionString);
+    parsedConfig.pool // $ExpectType PoolOpts<Connection>
+    parsedConfig.options // $ExpectType IOptions
 }
 
 function test_table() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql/blob/v9.1.3/lib/base/connection-pool.js#L291
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
