### PR TITLE
[@types/chrome] Add cloudIdentifier to chrome.fileSystemProvider

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3650,6 +3650,13 @@ declare namespace chrome.fileSystemProvider {
         lastTag?: string | undefined;
     }
 
+    export interface CloudIdentifier {
+        /** Identifier for the cloud storage provider (e.g. 'drive.google.com'). */
+        providerName: string;
+        /** The provider's identifier for the given file/directory. */
+        id: string;
+    }
+
     export interface EntryMetadata {
         /** True if it is a directory. Must be provided if requested in `options`. */
         isDirectory?: boolean;
@@ -3663,6 +3670,8 @@ declare namespace chrome.fileSystemProvider {
         mimeType?: string | undefined;
         /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event. */
         thumbnail?: string | undefined;
+        /** Optional. Cloud storage representation of this entry. Must be provided if requested in `options` and the file is backed by cloud storage. For local files not backed by cloud storage, it should be undefined when requested. */
+        cloudIdentifier?: CloudIdentifier | undefined;
     }
 
     export interface FileSystemInfo {
@@ -3786,34 +3795,36 @@ declare namespace chrome.fileSystemProvider {
     }
 
     export interface MetadataRequestedEventOptions extends EntryPathRequestedEventOptions {
-        /** Set to true if the thumbnail is requested. */
-        thumbnail: boolean;
-        /** Set to true if is_directory value is requested. */
+        /** Set to true if `is_directory` value is requested. */
         isDirectory: boolean;
-        /** Set to true if name value is requested. */
+        /** Set to true if `name` value is requested. */
         name: boolean;
-        /** Set to true if size value is requested. */
+        /** Set to true if `size` value is requested. */
         size: boolean;
-        /** Set to true if modificationTime value is requested. */
+        /** Set to true if `modificationTime` value is requested. */
         modificationTime: boolean;
-        /** Set to true if mimeType value is requested. */
+        /** Set to true if `mimeType` value is requested. */
         mimeType: boolean;
+        /** Set to true if `thumbnail` is requested. */
+        thumbnail: boolean;
+        /** Set to true if `cloudIdentigfier` is requested. */
+        cloudIdentifier: boolean;
     }
 
     export interface DirectoryPathRequestedEventOptions extends RequestedEventOptions {
         /** The path of the directory which is to be operated on. */
         directoryPath: string;
-        /** Set to true if is_directory value is requested. */
+        /** Set to true if `is_directory` value is requested. */
         isDirectory: boolean;
-        /** Set to true if name value is requested. */
+        /** Set to true if `name` value is requested. */
         name: boolean;
-        /** Set to true if size value is requested. */
+        /** Set to true if `size` value is requested. */
         size: boolean;
-        /** Set to true if modificationTime value is requested. */
+        /** Set to true if `modificationTime` value is requested. */
         modificationTime: boolean;
-        /** Set to true if mimeType value is requested. */
+        /** Set to true if `mimeType` value is requested. */
         mimeType: boolean;
-        /** Set to true if the thumbnail is requested. */
+        /** Set to true if `thumbnail` is requested. */
         thumbnail: boolean;
     }
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3807,7 +3807,7 @@ declare namespace chrome.fileSystemProvider {
         mimeType: boolean;
         /** Set to true if `thumbnail` is requested. */
         thumbnail: boolean;
-        /** Set to true if `cloudIdentigfier` is requested. */
+        /** Set to true if `cloudIdentifier` is requested. */
         cloudIdentifier: boolean;
     }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1993,8 +1993,17 @@ function testFileSystemProvider() {
             if (options.size) {
                 entryMetadata.size = 42;
             }
+            if (options.modificationTime) {
+                entryMetadata.modificationTime = new Date();
+            }
             if (options.mimeType) {
                 entryMetadata.mimeType = 'text/plain';
+            }
+            if(options.thumbnail) {
+                entryMetadata.thumbnail = "DaTa:ImAgE/pNg;base64";
+            }
+            if(options.cloudIdentifier) {
+                entryMetadata.cloudIdentifier = {providerName: 'provider-name', id: 'id'};
             }
         },
     );


### PR DESCRIPTION
* Adds cloudIdentifier to EntryMetadata
* Adds cloudIdentifier to MetadataRequestedEventOptions
* Add CloudIdentifier type
* Fixes comment formatting
* Adds missing tests for EntryMetadata and MetadataRequestedEventOptions

Incorporating the changes made by https://crrev.com/c/4513899.

Please fill in this template.

- [✅] Use a meaningful title for the pull request. Include the name of the package modified.
- [✅] Test the change in your own code. (Compile and run.)
- [✅] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [✅] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✅] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✅] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [✅] Provide a URL to documentation or source code which provides context for the suggested changes: [https://crrev.com/c/4513899](https://crrev.com/c/4513899)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
