### PR TITLE
Fix aws-lambda sns trigger urls

### DIFF
--- a/types/aws-lambda/test/sns-tests.ts
+++ b/types/aws-lambda/test/sns-tests.ts
@@ -11,12 +11,12 @@ const handler: SNSHandler = async (event, context, callback) => {
     str = message.SignatureVersion;
     str = message.Timestamp;
     str = message.Signature;
-    str = message.SigningCertURL;
+    str = message.SigningCertUrl;
     str = message.MessageId;
     str = message.Message;
     const attributes: SNSMessageAttributes = message.MessageAttributes;
     str = message.Type;
-    str = message.UnsubscribeURL;
+    str = message.UnsubscribeUrl;
     str = message.TopicArn;
     strOrUndefined = message.Subject;
     strOrUndefined = message.Token;

--- a/types/aws-lambda/trigger/sns.d.ts
+++ b/types/aws-lambda/trigger/sns.d.ts
@@ -16,12 +16,12 @@ export interface SNSMessage {
     SignatureVersion: string;
     Timestamp: string;
     Signature: string;
-    SigningCertURL: string;
+    SigningCertUrl: string;
     MessageId: string;
     Message: string;
     MessageAttributes: SNSMessageAttributes;
     Type: string;
-    UnsubscribeURL: string;
+    UnsubscribeUrl: string;
     TopicArn: string;
     Subject?: string;
     Token?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This changes the spelling back to how it was before #65607. In #65607 the change was justified with the documentation for the "HTTP/HTTPS subscription confirmation JSON format" at https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html. But this documentation only concerns the JSON Format when using SNS via a HTTP/HTTPS subscription and not AWS Lambda.

For some reason the spelling/casing differs depending on the SNS subscription protocol used. The `aws-lambda` types are intended to be used with AWS lambda and here the URL Fields are spelled `SigningCertUrl` and `UnsubscribeUrl`. This is also reflected in the documentation at https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html and in the following support libraries published by aws.

* https://github.com/aws/aws-lambda-java-libs/blob/main/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java#L224
* https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.SNSEvents/SNSEvent.cs#L77
* https://github.com/aws/aws-lambda-go/blob/main/events/sns.go#L30

I also checked it in a sample project my self and even the sample sns event provided in the aws web ui shows this spelling.

![Screenshot 2023-08-18 at 18 41 43](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/143302/db54dd31-ccaa-4b40-be83-001579ab94d1)
