### PR TITLE
Add types for WICG JS Self Profiling API

### DIFF
--- a/types/wicg-js-self-profiling/index.d.ts
+++ b/types/wicg-js-self-profiling/index.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for non-npm package JS Self-Profiling API API 2022.03
+// Project: https://github.com/WICG/js-self-profiling, https://wicg.github.io/js-self-profiling/
+// Definitions by: Tiger Oakes <https://github.com/NotWoods>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type ProfilerResource = string;
+
+interface ProfilerEventMap {
+    "samplebufferfull": Event;
+}
+
+declare global {
+    interface ProfilerTrace {
+        resources: ProfilerResource[]
+        frames: ProfilerFrame[]
+        stacks: ProfilerStack[]
+        samples: ProfilerSample[]
+    }
+
+    interface ProfilerSample {
+        timestamp: number;
+        stackId?: number;
+    }
+
+    interface ProfilerStack {
+        parentId?: number;
+        frameId: number;
+    }
+
+    interface ProfilerFrame {
+        name: string;
+        resourceId?: number;
+        line?: string;
+        column?: string;
+    }
+
+    interface ProfilerInitOptions {
+        /**
+         * The application's desired sample interval. Must be greater than or equal to 0.
+         */
+        sampleInterval: number;
+        /**
+         * The desired sample buffer size limit, in samples.
+         */
+        maxBufferSize: number;
+    }
+
+    class Profiler extends EventTarget {
+        readonly sampleInterval: number;
+        readonly stopped: boolean;
+
+        constructor(options: ProfilerInitOptions);
+
+        stop(): Promise<ProfilerTrace>;
+
+        onsamplebufferfull: ((this: Profiler, ev: Event) => any) | null;
+        addEventListener<K extends keyof ProfilerEventMap>(type: K, listener: (this: Profiler, ev: ProfilerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    }
+}
+
+export { };

--- a/types/wicg-js-self-profiling/index.d.ts
+++ b/types/wicg-js-self-profiling/index.d.ts
@@ -6,15 +6,15 @@
 type ProfilerResource = string;
 
 interface ProfilerEventMap {
-    "samplebufferfull": Event;
+    samplebufferfull: Event;
 }
 
 declare global {
     interface ProfilerTrace {
-        resources: ProfilerResource[]
-        frames: ProfilerFrame[]
-        stacks: ProfilerStack[]
-        samples: ProfilerSample[]
+        resources: ProfilerResource[];
+        frames: ProfilerFrame[];
+        stacks: ProfilerStack[];
+        samples: ProfilerSample[];
     }
 
     interface ProfilerSample {
@@ -54,9 +54,17 @@ declare global {
         stop(): Promise<ProfilerTrace>;
 
         onsamplebufferfull: ((this: Profiler, ev: Event) => any) | null;
-        addEventListener<K extends keyof ProfilerEventMap>(type: K, listener: (this: Profiler, ev: ProfilerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof ProfilerEventMap>(
+            type: K,
+            listener: (this: Profiler, ev: ProfilerEventMap[K]) => any,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+        addEventListener(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
     }
 }
 
-export { };
+export {};

--- a/types/wicg-js-self-profiling/tsconfig.json
+++ b/types/wicg-js-self-profiling/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wicg-js-self-profiling-tests.ts"
+    ]
+}

--- a/types/wicg-js-self-profiling/tslint.json
+++ b/types/wicg-js-self-profiling/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/wicg-js-self-profiling/wicg-js-self-profiling-tests.ts
+++ b/types/wicg-js-self-profiling/wicg-js-self-profiling-tests.ts
@@ -1,0 +1,20 @@
+const profiler = new Profiler({
+  sampleInterval: 10,      // Target sampling every 10ms
+  maxBufferSize: 10 * 100, // Cap at ~10s worth of samples
+});
+
+async function collectAndSendTrace() {
+  if (profiler.stopped) return;
+
+  const trace: ProfilerTrace = await profiler.stop();
+  const traceJson = JSON.stringify({
+    timing: performance.timing,
+    trace,
+  });
+
+  // Send the trace JSON to a server via Fetch/XHR
+  fetch('/server', { method: 'POST', body: traceJson });
+}
+
+profiler.addEventListener('samplebufferfull', collectAndSendTrace);
+window.addEventListener('load', collectAndSendTrace);


### PR DESCRIPTION
Types for the [JS Self Profiling API](https://wicg.github.io/js-self-profiling/). I don't love having "js" in the package name but it's in the feature policy and seemed like it would be best to match that.

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
