### PR TITLE
[spotify-web-playback-sdk] Add missing property for PlayerInit Interface

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -137,6 +137,7 @@ declare namespace Spotify {
         name: string;
         getOAuthToken(cb: (token: string) => void): void;
         volume?: number | undefined;
+        enableMediaSession?: boolean | undefined;
     }
 
     type ErrorListener = (err: Error) => void;

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -9,7 +9,8 @@ const player = new window.Spotify.Player({
         // Run code to get a fresh access token
         callback("access token here");
     },
-    volume: 0.5
+    volume: 0.5,
+    enableMediaSession: true
 });
 // https://developer.spotify.com/documentation/web-playback-sdk/reference/#playing-a-spotify-uri
 const {id: device_id} = player._options;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

(changing an existing definition):
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-playback-sdk/reference#spotifyplayer
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
