### PR TITLE
[ari-client] Fix `event` param incorrectly optional on removeAllListeners

### DIFF
--- a/types/ari-client/index.d.ts
+++ b/types/ari-client/index.d.ts
@@ -1801,10 +1801,10 @@ export interface Resource {
     removeListener(event: AnyEventType, handler: (...args: any[]) => void): void;
 
     /**
-     *  Removes all listeners, or those of the specified event type.
+     *  Removes all listeners of the specified event type.
      *  @param [event] - The event type.
      */
-    removeAllListeners(event?: AnyEventType): void;
+    removeAllListeners(event: AnyEventType): void;
 }
 export interface Applications {
     /**


### PR DESCRIPTION
The `event` param is currently optional in the type definitions for the `removeAllListeners` function in `ari-client`, but this is inaccurate. I noticed during development that it didn't have any effect without specifying a specific `event`, and verified this in the the [ari-client source code](https://github.com/asterisk/node-ari-client/blob/c2e516a75023ded19c8e2bf328d14ff36d005a86/lib/resources.js#L201): the function clearly wouldn't do anything if `event` is undefined due to the condition `if (listeners[event]) { ... }`.

I don't consider this to be a breaking change since omitting the `event` param would never have worked in the first place, but please let me know if this doesn't follow DT's conventions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/asterisk/node-ari-client/blob/c2e516a75023ded19c8e2bf328d14ff36d005a86/lib/resources.js#L201
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
