### PR TITLE
[ari-client] Use string type instead of JS Date type for ISO 8601 formatted date/time responses

### DIFF
--- a/types/ari-client/index.d.ts
+++ b/types/ari-client/index.d.ts
@@ -355,9 +355,9 @@ export interface Event extends Message {
     application: string;
 
     /**
-     * Time at which this event was created.
+     * ISO 8601 date/time at which this event was created.
      */
-    timestamp: Date;
+    timestamp: string;
 }
 export interface ContactInfo {
     /**
@@ -2383,14 +2383,14 @@ export interface ConfigInfo {
 }
 export interface StatusInfo {
     /**
-     * Time when Asterisk was started.
+     * ISO 8601 date/time when Asterisk was started.
      */
-    startup_time: Date;
+    startup_time: string;
 
     /**
-     * Time when Asterisk was last reloaded.
+     * ISO 8601 date/time when Asterisk was last reloaded.
      */
-    last_reload_time: Date;
+    last_reload_time: string;
 }
 export interface AsteriskInfo {
     /**
@@ -2885,9 +2885,9 @@ export interface Bridge extends Resource {
     video_source_id?: string | undefined;
 
     /**
-     * Timestamp when bridge was created.
+     * ISO 8601 date/time when the bridge was created.
      */
-    creationtime: Date;
+    creationtime: string;
 
     /**
      * List all active bridges in Asterisk.
@@ -4286,9 +4286,9 @@ export interface Channel extends Resource {
     dialplan: DialplanCEP;
 
     /**
-     * Timestamp when channel was created.
+     * ISO 8601 date/time when the channel was created.
      */
-    creationtime: Date;
+    creationtime: string;
 
     /**
      * The default spoken language.


### PR DESCRIPTION
The `Date` type is currently used for fields where a date/time is returned by ARI, but it should be `string` because it is an ISO 8601 formatted date/time (i.e. a string representation).

This can be verified at runtime - each of these tests log `typeof` value followed by the value:

```
info.status.startup_time string 2023-08-22T03:17:56.060+0000
info.status.last_reload_time string 2023-08-22T03:17:56.060+0000
event.timestamp string 2023-08-22T08:53:09.136+0000
bridge.creationtime string 2023-08-22T08:53:05.606+0000
channel.creationtime string 2023-08-22T08:53:02.833+0000
```

It also logically makes sense that a raw API response (which is not processed by `node-ari-client` in any way that I can see) would have to be a JSON-serialisable object (i.e. a `string` rather than a `Date`). Of course, the user could then pass it to the JS `Date` constructor.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: sample output provided
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
