### PR TITLE
[node]: Fix test runner HookFn method signature

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -648,7 +648,7 @@ declare module 'node:test' {
      * The hook function. If the hook uses callbacks, the callback function is passed as the
      * second argument.
      */
-    type HookFn = (done: (result?: any) => void) => any;
+    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
     /**
      * Configuration options for hooks.
      * @since v18.8.0

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -256,7 +256,6 @@ declare module 'node:test' {
     type TestFn = (t: TestContext, done: (result?: any) => void) => void | Promise<void>;
     /**
      * The type of a function under Suite.
-     * If the test uses callbacks, the callback function is passed as an argument
      */
     type SuiteFn = (s: SuiteContext) => void | Promise<void>;
     interface TestShard {

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -289,7 +289,7 @@ it.only('only shorthand', {
     timeout: Infinity,
 });
 
-// Test callback mode
+// Test with suite context
 describe(s => {
     // $ExpectType SuiteContext
     s;

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -320,31 +320,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before(cb => {
+before((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-beforeEach(cb => {
+beforeEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-after(cb => {
+after((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-afterEach(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
-});
-beforeEach(cb => {
+afterEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -648,7 +648,7 @@ declare module 'node:test' {
      * The hook function. If the hook uses callbacks, the callback function is passed as the
      * second argument.
      */
-    type HookFn = (done: (result?: any) => void) => any;
+    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
     /**
      * Configuration options for hooks.
      * @since v18.8.0

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -256,7 +256,6 @@ declare module 'node:test' {
     type TestFn = (t: TestContext, done: (result?: any) => void) => void | Promise<void>;
     /**
      * The type of a function under Suite.
-     * If the test uses callbacks, the callback function is passed as an argument
      */
     type SuiteFn = (s: SuiteContext) => void | Promise<void>;
     interface TestShard {

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -289,7 +289,7 @@ it.only('only shorthand', {
     timeout: Infinity,
 });
 
-// Test callback mode
+// Test with suite context
 describe(s => {
     // $ExpectType SuiteContext
     s;

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -320,31 +320,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before(cb => {
+before((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-beforeEach(cb => {
+beforeEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-after(cb => {
+after((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-afterEach(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
-});
-beforeEach(cb => {
+afterEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -167,9 +167,8 @@ declare module 'node:test' {
 
     /**
      * The type of a function under Suite.
-     * If the test uses callbacks, the callback function is passed as an argument
      */
-    type SuiteFn = (done: (result?: any) => void) => void;
+    type SuiteFn = (s: SuiteContext) => void | Promise<void>;
 
     interface RunOptions {
         /**
@@ -386,6 +385,24 @@ declare module 'node:test' {
         readonly mock: MockTracker;
     }
 
+    /**
+     * An instance of `SuiteContext` is passed to each suite function in order to
+     * interact with the test runner. However, the `SuiteContext` constructor is not
+     * exposed as part of the API.
+     * @since v18.7.0, v16.17.0
+     */
+    class SuiteContext {
+        /**
+         * The name of the suite.
+         * @since v18.8.0, v16.18.0
+         */
+        readonly name: string;
+        /**
+         * Can be used to abort test subtasks when the test has been aborted.
+         * @since v18.7.0, v16.17.0
+         */
+        readonly signal: AbortSignal;
+    }
     interface TestOptions {
         /**
          * If a number is provided, then that many tests would run in parallel.

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -490,7 +490,7 @@ declare module 'node:test' {
      * The hook function. If the hook uses callbacks, the callback function is passed as the
      * second argument.
      */
-    type HookFn = (done: (result?: any) => void) => any;
+    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
 
     /**
      * Configuration options for hooks.

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -217,31 +217,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before(cb => {
+before((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-beforeEach(cb => {
+beforeEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-after(cb => {
+after((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-afterEach(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
-});
-beforeEach(cb => {
+afterEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -186,12 +186,12 @@ it.only('only shorthand', {
     timeout: Infinity,
 });
 
-// Test callback mode
-describe(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
+// Test with suite context
+describe(s => {
+    // $ExpectType SuiteContext
+    s;
+    // $ExpectType string
+    s.name;
 });
 
 // Test callback mode

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -166,9 +166,8 @@ declare module 'node:test' {
 
     /**
      * The type of a function under Suite.
-     * If the test uses callbacks, the callback function is passed as an argument
      */
-    type SuiteFn = (done: (result?: any) => void) => void;
+    type SuiteFn = (s: SuiteContext) => void | Promise<void>;
 
     interface RunOptions {
         /**
@@ -372,6 +371,24 @@ declare module 'node:test' {
         readonly mock: MockTracker;
     }
 
+    /**
+     * An instance of `SuiteContext` is passed to each suite function in order to
+     * interact with the test runner. However, the `SuiteContext` constructor is not
+     * exposed as part of the API.
+     * @since v18.7.0, v16.17.0
+     */
+    class SuiteContext {
+        /**
+         * The name of the suite.
+         * @since v18.8.0, v16.18.0
+         */
+        readonly name: string;
+        /**
+         * Can be used to abort test subtasks when the test has been aborted.
+         * @since v18.7.0, v16.17.0
+         */
+        readonly signal: AbortSignal;
+    }
     interface TestOptions {
         /**
          * If a number is provided, then that many tests would run in parallel.

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -476,7 +476,7 @@ declare module 'node:test' {
      * The hook function. If the hook uses callbacks, the callback function is passed as the
      * second argument.
      */
-    type HookFn = (done: (result?: any) => void) => any;
+    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
 
     /**
      * Configuration options for hooks.

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -216,31 +216,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before(cb => {
+before((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-beforeEach(cb => {
+beforeEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-after(cb => {
+after((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: 'anything' });
 });
-afterEach(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
-});
-beforeEach(cb => {
+afterEach((s, cb) => {
+    // $ExpectType SuiteContext
+    s;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -185,12 +185,12 @@ it.only('only shorthand', {
     timeout: Infinity,
 });
 
-// Test callback mode
-describe(cb => {
-    // $ExpectType (result?: any) => void
-    cb;
-    // $ExpectType void
-    cb({ x: 'anything' });
+// Test with suite context
+describe(s => {
+    // $ExpectType SuiteContext
+    s;
+    // $ExpectType string
+    s.name;
 });
 
 // Test callback mode


### PR DESCRIPTION
This fixes an incorrect method signature on the `HookFn` type used by hooks such as `before` and `after`. Per the Node documentation, and based on my experience and observations using the Test Runner, the callback function is the second argument to the hook function. See https://nodejs.org/api/test.html#beforefn-options.

The first argument is not documented but it appears to be a `SuiteContext` object like the first argument passed to `describe`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

NOTE: I could not run `npm test node` - it gives me this error:

```
dtslint@0.0.168
testing from 4.4 to 4.8 in /Users/dmcnally/github/DefinitelyTyped/types/node/ts4.8
Error: Cannot find module '/Users/dmcnally/.dts/typescript-installs/4.4/node_modules/typescript'
```


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/test.html#beforefn-options
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
