### PR TITLE
[websocket] fix resourceURL type

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -222,7 +222,7 @@ export class request extends events.EventEmitter {
     /** `Sec-WebSocket-Key` */
     key: string;
     /** Parsed resource, including the query string parameters */
-    resourceURL: url.Url;
+    resourceURL: url.UrlWithParsedQuery;
 
     /**
      * Client's IP. If an `X-Forwarded-For` header is present, the value will be taken
@@ -662,7 +662,7 @@ export interface IRouterRequest extends events.EventEmitter {
     /** A string containing the path that was requested by the client */
     resource: string;
     /** Parsed resource, including the query string parameters */
-    resourceURL: url.Url;
+    resourceURL: url.UrlWithParsedQuery;
 
     /** A reference to the original Node HTTP request object */
     httpRequest: http.IncomingMessage;

--- a/types/websocket/websocket-tests.ts
+++ b/types/websocket/websocket-tests.ts
@@ -170,6 +170,7 @@ function serverAcceptNullParameterTest() {
     });
 
     wsServer.on("request", (request) => {
+        console.log("token parameter:", request.resourceURL.query.token);
         request.accept(null, request.origin);
     });
 }


### PR DESCRIPTION
use the more correct type `url.UrlWithParsedQuery` rather than `url.Url`, since in this case we know the library parses the query parameters

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - blame: https://github.com/theturtle32/WebSocket-Node/blame/cce6d468986dd356a52af5630fd8ed5726ba5b7a/lib/WebSocketRequest.js#L115
  - docs: https://github.com/theturtle32/WebSocket-Node/blob/cce6d468986dd356a52af5630fd8ed5726ba5b7a/docs/WebSocketRequest.md#resourceurl