### PR TITLE
fix(maxmsp): Global(indexed access), Dict(contructor), Maxobj(patchcords)

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -580,6 +580,14 @@ declare class Global {
      * TODO: Can have any property assigned to it
      */
     sendnamed(receive_name: string, property_name: string): void;
+
+    /*
+     * Global is used to set user defined properties that can't be known beforehand, casting
+     * a Globals instance as any to work with it defeats the whole purpose of using TS.
+     * This indexed access type will make sure you put the right checks in place before
+     * things go sideways, one can always cast to any if this becomes too annoying.
+     */
+    [index: string | number | symbol]: unknown;
 }
 
 /**

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -50,11 +50,41 @@ if (!folder.end) {
 folder.close();
 
 // maxmsp-tests.ts
+// working with Global
+//
+// 1. cast Global to any, lie to typescript that all is fine
+//    by using any or typescript ignore comments (see below)
+const globalOne = new Global('myGlobal');
+(<any> globalOne).prop = 'hello';
+messnamed("myobj", (<any> globalOne).prop);
+// @ts-expect-error
+messnamed("myobj", globalOne.prop);
+//
+// 2. Use a type guard
+const globalTwo = new Global("myGlobal");
+globalTwo.prop = "hello";
+// @ts-expect-error
+messnamed("myobj", globalTwo.prop);
+if (typeof globalTwo.prop !== "string") {
+    throw new Error("prop is not a string");
+}
+globalTwo.sendnamed("catcher", globalTwo.prop);
+messnamed("myobj", globalTwo.prop);
+//
+// 3. create a subclass with the properties you will work with
+class MyGlobal extends Global {
+    prop: string | undefined;
+}
+const myglobal = new MyGlobal("myGlobal");
+if (myglobal.prop === undefined) {
+    myglobal.prop = "hello";
+} else {
+    post(`global prop: ${myglobal.prop}`);
+}
 
-const glbl = new Global('myGlobal');
-(<any> glbl).prop = 'hello';
+messnamed("myobj", myglobal.prop);
 // ou must have an [r] object in your patch named catcher
-glbl.sendnamed('catcher', 'prop');
+myglobal.sendnamed("catcher", myglobal.prop);
 
 const liveApiCallback = (args: any) => {
     post(args);


### PR DESCRIPTION
The [Global Object](https://docs.cycling74.com/max8/vignettes/jsglobalobject) is used to set your own properties
but as it's currently defined typescript will immediately complain because they are not defined in the class.

The current solution is to cast the global to any, which defeats the whole purpose of using types (see test example).

This PR allows an indexer and forces the user to do type narrowing and make sure at runtime that he has the type he expects.
