### PR TITLE
fix(maxmsp): MaxobjListener missing

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -43,6 +43,12 @@ declare function outlet(outlet_number: number, ...arguments: any[]): void;
 declare function setinletassist(inlet_number: number, object: any): void;
 declare function setoutletassist(outlet_number: number, object: any): void;
 
+type Range = [number, number];
+type Color = [number, number, number, number];
+type Rect = [number, number, number, number];
+type Position = [number, number];
+type Size = [number, number];
+
 type MaxMessage =
     | 'buildcollective'
     | 'checkpreempt'
@@ -1220,6 +1226,38 @@ declare class Maxobj {
      * others.
      */
     understands(message: string): boolean;
+
+    /**
+     * Returns an Array value containing the names of available attributes for the object.
+     */
+    getattrnames(): string[];
+
+    /**
+     * Returns the value of the attribute specified by attribute_name. Lists are returned as JS Array objects.
+     */
+    getattr(attribute_name: string): unknown;
+
+    /**
+     * Sets the value of the attribute specified by attribute_name.
+     *
+     * enabletransparentbgwithtitlebar was introduced in 8.1.4 https://cycling74.com/forums/max-8-1-4-released
+     */
+    setattr(attribute_name: string, anything: unknown): void;
+
+    /**
+     * Returns an Array value containing the names of available attributes for the object's box.
+     */
+    getboxattrnames(): string[];
+
+    /**
+     * Returns the value of the object's box attribute specified by box_attribute_name. Lists are returned as JS Array objects.
+     */
+    getboxattr(box_attribute_name: string): unknown;
+
+    /**
+     * Sets the value of the object's box attribute specified by box_attribute_name.
+     */
+    setboxattr(box_attribute_name: string, anything: unknown): void;
 }
 
 /**

--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -1128,6 +1128,13 @@ declare class Max {
     useslowbutcompletesearching(enable: 0 | 1): void;
 }
 
+declare class MaxobjConnection {
+    srcobject: object;
+    dstobject: object;
+    srcoutlet: number;
+    dstinlet: number;
+}
+
 /**
  * A Maxobj is a Javascript representation of a Max object in a patcher. It is returned by various methods of a Javascript Patcher object, such as newobject().One important thing to keep in mind about
  * a Maxobj is that it could eventually refer to an object that no longer exists if the underlying Max object is freed. The valid property can be used to test for this condition.
@@ -1239,8 +1246,6 @@ declare class Maxobj {
 
     /**
      * Sets the value of the attribute specified by attribute_name.
-     *
-     * enabletransparentbgwithtitlebar was introduced in 8.1.4 https://cycling74.com/forums/max-8-1-4-released
      */
     setattr(attribute_name: string, anything: unknown): void;
 
@@ -1258,6 +1263,71 @@ declare class Maxobj {
      * Sets the value of the object's box attribute specified by box_attribute_name.
      */
     setboxattr(box_attribute_name: string, anything: unknown): void;
+}
+
+/**
+ * The MaxobjListener object listens for changes to a Maxobj object's value,
+ * or changes to a specified attribute of a Maxobj object.
+ * When a change occurs, a user-specified function will be called.
+ * The object also provides methods for getting and setting the value of the observed value or attribute.
+ */
+declare class MaxobjListener  {
+    constructor(object: Maxobj, attribute_name: string, callback: (data: MaxobjListenerData<any>) => void);
+
+    /**
+     * The Maxobj to observe.
+     */
+    maxobject: Maxobj;
+
+    /**
+     * An attribute to observe for changes, if desired.
+     */
+    attrname: string;
+
+    /**
+     * Never execute the callback function in response to calling setvalue from this MaxobjListener.
+     */
+    silent: number;
+
+    /**
+     * Report the value of the Maxobj or its specified attribute. List values are reported in a JS Array object.
+     */
+    getvalue(): void;
+
+    /**
+     * Set the value of the Maxobj or its specified attribute.
+     */
+    setvalue(): void;
+
+    /**
+     * Set the value of the Maxobj or its specified attribute, without executing the callback function (also see the silent property).
+     */
+    setvalue_silent(): void;
+}
+
+/**
+ * The MaxobjListenerData object is the argument to your MaxobjListener's function
+ */
+declare class MaxobjListenerData<Tvalue>  {
+    /**
+     * The MaxobjListener which called the function.
+     */
+    listener: MaxobjListener;
+
+    /**
+     * The Maxobj being observed.
+     */
+    maxobject: Maxobj;
+
+    /**
+     * If the MaxobjListener is observing an attribute, the attribute's name, otherwise undefined.
+     */
+    attrname: string;
+
+    /**
+     * The current value of the observed object or attribute. List values are represented by a JS Array object.
+     */
+    value: Tvalue;
 }
 
 /**

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -189,6 +189,14 @@ const mySubpatcher = myMaxobj.subpatcher(0);
 post(mySubpatcher);
 const understandsResult = myMaxobj.understands('testMessage');
 post(understandsResult);
+let [r1, r2, r3, r4] = [0, 0, 0, 0];
+const attrnames = myMaxobj.getattrnames();
+[r1, r2, r3, r4] = myMaxobj.getattr("openrect") as Rect;
+myMaxobj.setattr("openrect", [0, 0, 0, 0]);
+
+const boxattrnames = myMaxobj.getboxattrnames();
+[r1, r2, r3, r4] = myMaxobj.getboxattr("presentation_rect") as Rect;
+myMaxobj.setboxattr("presentation_rect", [0, 0, 0, 0]);
 
 // ------------- Patcher usage examples -------------
 

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -198,6 +198,21 @@ const boxattrnames = myMaxobj.getboxattrnames();
 [r1, r2, r3, r4] = myMaxobj.getboxattr("presentation_rect") as Rect;
 myMaxobj.setboxattr("presentation_rect", [0, 0, 0, 0]);
 
+// MaxobjListener
+function onWorkspaceDisabled(rectData: MaxobjListenerData<number>) {
+    const workspacedisabled = rectData.value;
+    if (workspacedisabled === 0) {
+        post("workspace disabled");
+    } else {
+        post("workspace enabled");
+    }
+}
+
+const maxobjListener = new MaxobjListener(myMaxobj, "workspacedisabled", onWorkspaceDisabled);
+post(maxobjListener.maxobject);
+post(maxobjListener.attrname);
+post(maxobjListener.silent);
+
 // ------------- Patcher usage examples -------------
 
 // Create a new Patcher


### PR DESCRIPTION
Depends on #66452

The maxobjlistener is missing, here [the docs](https://docs.cycling74.com/max8/vignettes/jsmaxobjlistener)

# Testing it in max
```
<pre><code>
----------begin_max5_patcher----------
653.3ocuVsriZCCEccPZ9Gr7ZJJuHD0+gtq6ppPNIlIllXGY6v.ZT+2601IP
JPXfLztAiu9Ze74be379Ky7vYh8TEF8UzOPdduCV7r1LV75M3gqI6yqHJqi3
MUBdaMdd2Z6HRNolZWx7mh0fCD8w0AeEs5Jp1t6vdyNa5CMTG5X7bDNiveEi
9YuOMDIbfZpbMkSxprd52uHqvBoHa6WB7GhFi2CVvoCRmWx3utVRy0N7BVEs
veNJHJwLrz27aX3B+SnuQHqIVuSrV98KyLivv76VqxE00T9IwPS2aOQ72KoH
6sJWHKTnFongJ0GPhMnuQ1CjBYHA5fnEkWRy+EhsYn+DIEkK3bfNzBjVXbTh
fsAFPDdA5sRVdYmAm6DMRCfRgEAPzkB0wifI3pEGuiULvlnkaunQWOLdsnP5
iGDRCsxtezhkvPZpYVbpIHLYEWUwJnxajcdlC+MuBFO87wSKSdbAYUhQIBRc
xhMAM1+SoGb5avc4xDvFIiOVQ50HyxGmLtRqv.6PT3oJroSl15raFbGmS+SZ
7DOg9NAqFouyjUkrVsVvugpblC2aJ+DEknoloD3aaIGF2+6yKsenlrUcpQ5Z
WGxKKO1pP0G1vpnK1p9L8JFnKgWWWh9XcYkUQRhu7MJEYGDecjXMQqkLHV6d
P26jz.ukAL4n.bAwFI15VrS8GDEbvaem37OcvxAyBmEaTvyS48xSmXfFviBp
Ry3DyKQCbZoyowSBta3LegvGim4RE9TvK5dg64Pu3+urK4dgK3B35xcHMM6n
RU2NbHAEvaERy7z4t4LtatqDAKo6X8aoyDQBkLZH4uU5xs2mz0SFWKfm44sL
aoJXwvUCz1dDlZAnMfiU1dIuLCb3OD96VVJ
-----------end_max5_patcher-----------
</code></pre>
```
and the javascript.

```js
// myfile.js
autowatch = true;
inlets = 3;

function bang() {
	var obj = this.box;
	var pc = obj.patchcords;
	if (pc) {
		post("pc: " + JSON.stringify(pc) + "\n");
		for (p in pc) {
			post(p + "\n");
			var arr = pc[p];
			for (a in arr) {
				post("constructorname " + a + arr[a].constructor.name);
				if (arr[a].constructor.name === "MaxobjConnection") {
					var connex = arr[a];
					//Returned object is two arrays of MaxobjConnection objects named 'inputs' and 'outputs'. 'srcobject', 'dstobject', 'srcoutlet' and 'dstinlet' and can be used to walk thr graph from JS to get the information you want.
					//Here we simply parse by maxclass of the objects.
					post(
						connex.srcobject.maxclass +
							" (outlet " +
							connex.srcoutlet +
							") => " +
							connex.dstobject.maxclass +
							" (inlet " +
							connex.dstinlet +
							")\n"
					);
					//Here we parse by varname instead of maxclass.
					//post(connex.srcobject.varname + ' (outlet ' + connex.srcoutlet + ') => ' + connex.dstobject.varname + ' (inlet ' + connex.dstinlet + ')\n');
				}
			}
		}
	} else {
		post("!pc\n");
	}
}
```

```
