### PR TITLE
Upate react-lazy-load-image-component types for 1.6

### DIFF
--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-lazy-load-image-component 1.5
+// Type definitions for react-lazy-load-image-component 1.6
 // Project: https://github.com/Aljullu/react-lazy-load-image-component#readme
 // Definitions by: Dan Vanderkam <https://github.com/danvk>
 //                 Diego Chavez <https://github.com/diegochavez>
@@ -25,8 +25,10 @@ export interface ScrollPosition {
 }
 
 export interface CommonProps {
-    /** Function called after the image has been completely loaded. */
+    /** @deprecated Use onLoad instead. This prop is only for backward compatibility. */
     afterLoad?: (() => any) | undefined;
+    /** Function called when the image has been loaded. This is the same function as the onLoad of an <img> which contains an event object. */
+    onLoad?: (() => any) | undefined;
     /** Function called right before the placeholder is replaced with the image element. */
     beforeLoad?: (() => any) | undefined;
     /* Method from lodash to use to delay the scroll/resize events. */

--- a/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
+++ b/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
@@ -31,7 +31,8 @@ const ImageWithCallbacks = () => (
     delayTime={500}
     threshold={200}
     beforeLoad={() => {}}
-    afterLoad={() => {}}
+    afterLoad={() => {}}  // deprecated
+    onLoad={() => {}}
     placeholder={<span/>}
     wrapperProps={{
         style: {


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66447

I couldn't tell from the docs or code whether `onLoad` takes any parameters so I left the signature the same as `afterLoad`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Aljullu/react-lazy-load-image-component/releases/tag/1.6.0, https://github.com/Aljullu/react-lazy-load-image-component/pull/120
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
