### PR TITLE
[diff-match-patch] Fix types to use `export =`

### DIFF
--- a/types/diff-match-patch/diff-match-patch-tests.ts
+++ b/types/diff-match-patch/diff-match-patch-tests.ts
@@ -1,4 +1,4 @@
-import * as DiffMatchPatch from 'diff-match-patch';
+import DiffMatchPatch = require('diff-match-patch');
 
 function testDiffMainEach() {
     const oldValue = "hello world, how are you?";

--- a/types/diff-match-patch/index.d.ts
+++ b/types/diff-match-patch/index.d.ts
@@ -29,7 +29,7 @@ declare class diff_match_patch {
 
     diff_bisect_(text1: string, text2: string, deadline: number): diff_match_patch.Diff[];
 
-    diff_linesToChars_(text1: string, text2: string): { chars1: string; chars2: string; lineArray: string[]; };
+    diff_linesToChars_(text1: string, text2: string): { chars1: string; chars2: string; lineArray: string[] };
 
     diff_charsToLines_(diffs: diff_match_patch.Diff[], lineArray: string[]): void;
 

--- a/types/diff-match-patch/index.d.ts
+++ b/types/diff-match-patch/index.d.ts
@@ -3,17 +3,7 @@
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type Diff = [number, string];
-
-export class patch_obj {
-    diffs: Diff[];
-    start1: number | null;
-    start2: number | null;
-    length1: number;
-    length2: number;
-}
-
-export class diff_match_patch {
+declare class diff_match_patch {
     Diff_Timeout: number;
     Diff_EditCost: number;
     Match_Threshold: number;
@@ -22,42 +12,89 @@ export class diff_match_patch {
     Patch_Margin: number;
     Match_MaxBits: number;
 
-    diff_main(text1: string, text2: string, opt_checklines?: boolean, opt_deadline?: number): Diff[];
-    diff_bisect_(text1: string, text2: string, deadline: number): Diff[];
+    diff_main(text1: string, text2: string, opt_checklines?: boolean, opt_deadline?: number): diff_match_patch.Diff[];
+
+    diff_bisect_(text1: string, text2: string, deadline: number): diff_match_patch.Diff[];
+
     diff_linesToChars_(text1: string, text2: string): { chars1: string; chars2: string; lineArray: string[]; };
-    diff_charsToLines_(diffs: Diff[], lineArray: string[]): void;
+
+    diff_charsToLines_(diffs: diff_match_patch.Diff[], lineArray: string[]): void;
+
     diff_commonPrefix(text1: string, text2: string): number;
+
     diff_commonSuffix(text1: string, text2: string): number;
+
     diff_commonOverlap_(text1: string, text2: string): number;
+
     diff_halfMatch_(text1: string, text2: string): string[];
-    diff_cleanupSemantic(diffs: Diff[]): void;
-    diff_cleanupSemanticLossless(diffs: Diff[]): void;
-    diff_cleanupEfficiency(diffs: Diff[]): void;
-    diff_cleanupMerge(diffs: Diff[]): void;
-    diff_xIndex(diffs: Diff[], loc: number): number;
-    diff_prettyHtml(diffs: Diff[]): string;
-    diff_text1(diffs: Diff[]): string;
-    diff_text2(diffs: Diff[]): string;
-    diff_levenshtein(diffs: Diff[]): number;
-    diff_toDelta(diffs: Diff[]): string;
-    diff_fromDelta(text1: string, delta: string): Diff[];
+
+    diff_cleanupSemantic(diffs: diff_match_patch.Diff[]): void;
+
+    diff_cleanupSemanticLossless(diffs: diff_match_patch.Diff[]): void;
+
+    diff_cleanupEfficiency(diffs: diff_match_patch.Diff[]): void;
+
+    diff_cleanupMerge(diffs: diff_match_patch.Diff[]): void;
+
+    diff_xIndex(diffs: diff_match_patch.Diff[], loc: number): number;
+
+    diff_prettyHtml(diffs: diff_match_patch.Diff[]): string;
+
+    diff_text1(diffs: diff_match_patch.Diff[]): string;
+
+    diff_text2(diffs: diff_match_patch.Diff[]): string;
+
+    diff_levenshtein(diffs: diff_match_patch.Diff[]): number;
+
+    diff_toDelta(diffs: diff_match_patch.Diff[]): string;
+
+    diff_fromDelta(text1: string, delta: string): diff_match_patch.Diff[];
 
     match_main(text: string, pattern: string, loc: number): number;
-    match_bitap_(text: string, pattern: string, loc: number): number;
-    match_alphabet_(pattern: string): {[char: string]: number};
 
-    patch_addContext_(patch: patch_obj, text: string): void;
-    patch_make(a: string, opt_b: string | Diff[]): patch_obj[];
-    patch_make(a: Diff[]): patch_obj[];
-    patch_make(a: string, opt_b: string, opt_c: Diff[]): patch_obj[];
-    patch_deepCopy(patches: patch_obj[]): patch_obj[];
-    patch_apply(patches: patch_obj[], text: string): [string, boolean[]];
-    patch_addPadding(patches: patch_obj[]): string;
-    patch_splitMax(patches: patch_obj[]): void;
-    patch_fromText(text: string): patch_obj[];
-    patch_toText(patches: patch_obj[]): string;
+    match_bitap_(text: string, pattern: string, loc: number): number;
+
+    match_alphabet_(pattern: string): { [char: string]: number };
+
+    patch_addContext_(patch: typeof diff_match_patch.patch_obj, text: string): void;
+
+    patch_make(a: string, opt_b: string | diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
+    patch_make(a: diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
+    patch_make(a: string, opt_b: string, opt_c: diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
+
+    patch_deepCopy(patches: typeof diff_match_patch.patch_obj[]): typeof diff_match_patch.patch_obj[];
+
+    patch_apply(patches: typeof diff_match_patch.patch_obj[], text: string): [string, boolean[]];
+
+    patch_addPadding(patches: typeof diff_match_patch.patch_obj[]): string;
+
+    patch_splitMax(patches: typeof diff_match_patch.patch_obj[]): void;
+
+    patch_fromText(text: string): typeof diff_match_patch.patch_obj[];
+
+    patch_toText(patches: typeof diff_match_patch.patch_obj[]): string;
+
+    static patch_obj: {
+        new (): diff_match_patch.patch_obj;
+    }
+
+    static diff_match_patch: typeof diff_match_patch;
+    static DIFF_DELETE: -1;
+    static DIFF_INSERT: 1;
+    static DIFF_EQUAL: 0;
 }
 
-export const DIFF_DELETE: number;
-export const DIFF_INSERT: number;
-export const DIFF_EQUAL: number;
+declare namespace diff_match_patch
+{
+    type Diff = [number, string];
+
+    interface patch_obj {
+        diffs: diff_match_patch.Diff[];
+        start1: number | null;
+        start2: number | null;
+        length1: number;
+        length2: number;
+    }
+}
+
+export = diff_match_patch;

--- a/types/diff-match-patch/index.d.ts
+++ b/types/diff-match-patch/index.d.ts
@@ -4,12 +4,11 @@
 //                 Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace diff_match_patch
-{
+declare namespace diff_match_patch {
     type Diff = [number, string];
 
     interface patch_obj {
-        diffs: diff_match_patch.Diff[];
+        diffs: Diff[];
         start1: number | null;
         start2: number | null;
         length1: number;
@@ -72,25 +71,25 @@ declare class diff_match_patch {
 
     patch_addContext_(patch: typeof diff_match_patch.patch_obj, text: string): void;
 
-    patch_make(a: string, opt_b: string | diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
-    patch_make(a: diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
-    patch_make(a: string, opt_b: string, opt_c: diff_match_patch.Diff[]): typeof diff_match_patch.patch_obj[];
+    patch_make(a: string, opt_b: string | diff_match_patch.Diff[]): Array<typeof diff_match_patch.patch_obj>;
+    patch_make(a: diff_match_patch.Diff[]): Array<typeof diff_match_patch.patch_obj>;
+    patch_make(a: string, opt_b: string, opt_c: diff_match_patch.Diff[]): Array<typeof diff_match_patch.patch_obj>;
 
-    patch_deepCopy(patches: typeof diff_match_patch.patch_obj[]): typeof diff_match_patch.patch_obj[];
+    patch_deepCopy(patches: Array<typeof diff_match_patch.patch_obj>): Array<typeof diff_match_patch.patch_obj>;
 
-    patch_apply(patches: typeof diff_match_patch.patch_obj[], text: string): [string, boolean[]];
+    patch_apply(patches: Array<typeof diff_match_patch.patch_obj>, text: string): [string, boolean[]];
 
-    patch_addPadding(patches: typeof diff_match_patch.patch_obj[]): string;
+    patch_addPadding(patches: Array<typeof diff_match_patch.patch_obj>): string;
 
-    patch_splitMax(patches: typeof diff_match_patch.patch_obj[]): void;
+    patch_splitMax(patches: Array<typeof diff_match_patch.patch_obj>): void;
 
-    patch_fromText(text: string): typeof diff_match_patch.patch_obj[];
+    patch_fromText(text: string): Array<typeof diff_match_patch.patch_obj>;
 
-    patch_toText(patches: typeof diff_match_patch.patch_obj[]): string;
+    patch_toText(patches: Array<typeof diff_match_patch.patch_obj>): string;
 
     static patch_obj: {
         new (): diff_match_patch.patch_obj;
-    }
+    };
 
     static diff_match_patch: typeof diff_match_patch;
     static DIFF_DELETE: -1;

--- a/types/diff-match-patch/index.d.ts
+++ b/types/diff-match-patch/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for diff-match-patch 1.0
 // Project: https://www.npmjs.com/package/diff-match-patch
 // Definitions by: Asana <https://asana.com>
+//                 Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace diff_match_patch

--- a/types/diff-match-patch/index.d.ts
+++ b/types/diff-match-patch/index.d.ts
@@ -3,6 +3,19 @@
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare namespace diff_match_patch
+{
+    type Diff = [number, string];
+
+    interface patch_obj {
+        diffs: diff_match_patch.Diff[];
+        start1: number | null;
+        start2: number | null;
+        length1: number;
+        length2: number;
+    }
+}
+
 declare class diff_match_patch {
     Diff_Timeout: number;
     Diff_EditCost: number;
@@ -82,19 +95,6 @@ declare class diff_match_patch {
     static DIFF_DELETE: -1;
     static DIFF_INSERT: 1;
     static DIFF_EQUAL: 0;
-}
-
-declare namespace diff_match_patch
-{
-    type Diff = [number, string];
-
-    interface patch_obj {
-        diffs: diff_match_patch.Diff[];
-        start1: number | null;
-        start2: number | null;
-        length1: number;
-        length2: number;
-    }
 }
 
 export = diff_match_patch;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JackuB/diff-match-patch/blob/master/index.js#L2214-L2218
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As can be seen by the provided link, this package is CJS and so should use `export =` instead of ESM exports.