### PR TITLE
[Tedious] Add multiSubnetFailover connection option

### DIFF
--- a/types/tedious/index.d.ts
+++ b/types/tedious/index.d.ts
@@ -341,6 +341,12 @@ export interface ConnectionOptions {
     maxRetriesOnTransientErrors?: number | undefined;
 
     /**
+     * Sets the MultiSubnetFailover = True parameter, which can help minimize the client recovery latency when failovers occur.
+     * (default: `false`).
+     */
+    multiSubnetFailover?: boolean | undefined;
+
+    /**
      * Size of data to be returned by SELECT statement for varchar(max), nvarchar(max), varbinary(max), text, ntext, and image type. (default: 2147483647)
      */
     textsize?: number | undefined;

--- a/types/tedious/tedious-tests.ts
+++ b/types/tedious/tedious-tests.ts
@@ -8,7 +8,8 @@ var config: tedious.ConnectionConfig = {
         cryptoCredentialsDetails: {
             minVersion: "TLSv1"
         },
-        useColumnNames: true
+        useColumnNames: true,
+        multiSubnetFailover: false
     },
     authentication: {
         type: "default",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/tedious/blob/4f3e2109128a5291675aba5f73a0b56aa8016d2f/src/connection.ts#L740-L745 Tedious has supported `multiSubnetFailover` for over 7 years. https://tediousjs.github.io/tedious/api-connection.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
