### PR TITLE
feat: Update web-push to 3.6

### DIFF
--- a/types/web-push/index.d.ts
+++ b/types/web-push/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for web-push 3.3
+// Type definitions for web-push 3.6
 // Project: https://github.com/web-push-libs/web-push
 // Definitions by: Paul Lessing <https://github.com/paullessing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,7 +21,11 @@ import https = require('https');
  * @see WebPushError
  * @see https://github.com/web-push-libs/web-push#sendnotificationpushsubscription-payload-options
  */
-export function sendNotification(subscription: PushSubscription, payload?: string | Buffer | null, options?: RequestOptions): Promise<SendResult>;
+export function sendNotification(
+    subscription: PushSubscription,
+    payload?: string | Buffer | null,
+    options?: RequestOptions,
+): Promise<SendResult>;
 
 /**
  * Generate VAPID keys.
@@ -58,13 +62,18 @@ export function setGCMAPIKey(apiKey: string | null): void;
  * @see ContentEncoding
  * @see https://github.com/web-push-libs/web-push#encryptuserpublickey-userauth-payload-contentencoding
  */
-export function encrypt(userPublicKey: string, userAuth: string, payload: string | Buffer, contentEncoding: ContentEncoding): EncryptionResult;
+export function encrypt(
+    userPublicKey: string,
+    userAuth: string,
+    payload: string | Buffer,
+    contentEncoding: ContentEncoding,
+): EncryptionResult;
 
 /**
  * This method takes the required VAPID parameters and returns the required
  * header to be added to a Web Push Protocol Request.
  * @param audience         This must be the origin of the push service.
- * @param subject          This should be a URL or a 'mailto:' email address.
+ * @param subject          This should be a 'https:' URL or a 'mailto:' email address.
  * @param publicKey        The VAPID public key.
  * @param privateKey       The VAPID private key.
  * @param contentEncoding  The contentEncoding type.
@@ -72,18 +81,33 @@ export function encrypt(userPublicKey: string, userAuth: string, payload: string
  * @returns                 Returns an Object with the Authorization and 'Crypto-Key' values to be used as headers.
  */
 export function getVapidHeaders(
-    audience: string, subject: string, publicKey: string, privateKey: string, contentEncoding: 'aes128gcm', expiration?: number
+    audience: string,
+    subject: string,
+    publicKey: string,
+    privateKey: string,
+    contentEncoding: 'aes128gcm',
+    expiration?: number,
 ): {
     Authorization: string;
 };
 export function getVapidHeaders(
-    audience: string, subject: string, publicKey: string, privateKey: string, contentEncoding: 'aesgcm', expiration?: number
+    audience: string,
+    subject: string,
+    publicKey: string,
+    privateKey: string,
+    contentEncoding: 'aesgcm',
+    expiration?: number,
 ): {
     Authorization: string;
     'Crypto-Key': string;
 };
 export function getVapidHeaders(
-    audience: string, subject: string, publicKey: string, privateKey: string, contentEncoding: ContentEncoding, expiration?: number
+    audience: string,
+    subject: string,
+    publicKey: string,
+    privateKey: string,
+    contentEncoding: ContentEncoding,
+    expiration?: number,
 ): {
     Authorization: string;
     'Crypto-Key'?: string | undefined;
@@ -107,9 +131,21 @@ export function getVapidHeaders(
  * @see RequestDetails
  * @see https://github.com/web-push-libs/web-push#generaterequestdetailspushsubscription-payload-options
  */
-export function generateRequestDetails(subscription: PushSubscription, payload?: null, options?: RequestOptions): RequestDetails & { body: null };
-export function generateRequestDetails(subscription: PushSubscription, payload?: string | Buffer, options?: RequestOptions): RequestDetails & { body: Buffer };
-export function generateRequestDetails(subscription: PushSubscription, payload?: string | Buffer, options?: RequestOptions): RequestDetails;
+export function generateRequestDetails(
+    subscription: PushSubscription,
+    payload?: null,
+    options?: RequestOptions,
+): RequestDetails & { body: null };
+export function generateRequestDetails(
+    subscription: PushSubscription,
+    payload?: string | Buffer,
+    options?: RequestOptions,
+): RequestDetails & { body: Buffer };
+export function generateRequestDetails(
+    subscription: PushSubscription,
+    payload?: string | Buffer,
+    options?: RequestOptions,
+): RequestDetails;
 
 /**
  * Valid content encodings used by encrypt(), getVapidHeaders(), generateRequestDetails() and sendNotification().
@@ -122,6 +158,21 @@ export type ContentEncoding = 'aesgcm' | 'aes128gcm';
 export const supportedContentEncodings: {
     readonly AES_GCM: 'aesgcm' & ContentEncoding;
     readonly AES_128_GCM: 'aws128gcm' & ContentEncoding;
+};
+
+/**
+ * Valid urgency used by RequestOptions.
+ */
+export type Urgency = 'very-low' | 'low' | 'normal' | 'high';
+
+/**
+ * Map of valid urgency values.
+ */
+export const supportedUrgency: {
+    readonly VERY_LOW: 'very-low' & Urgency;
+    readonly LOW: 'low' & Urgency;
+    readonly NORMAL: 'normal' & Urgency;
+    readonly HIGH: 'high' & Urgency;
 };
 
 /**
@@ -145,10 +196,10 @@ export interface VapidKeys {
  * When making requests where you want to define VAPID details, call this method before sendNotification()
  * or pass in the details and options to sendNotification.
  *
- * @param  subject     This must be either a URL or a 'mailto:' address.
+ * @param  subject     This must be either a 'https:' URL or a 'mailto:' address.
  *                     For example: 'https://my-site.com/contact' or 'mailto: contact@my-site.com'
- * @param  publicKey   The public VAPID key.
- * @param  privateKey  The private VAPID key.
+ * @param  publicKey   The public VAPID key, a URL safe, base64 encoded string.
+ * @param  privateKey  The private VAPID key, a URL safe, base64 encoded string.
  */
 export function setVapidDetails(subject: string, publicKey: string, privateKey: string): void;
 
@@ -170,27 +221,78 @@ export interface Headers {
 }
 
 /**
+ * Options which can be passed to the https-proxy-agent constructor.
+ * These are the usual http.Agent constructor options, and some additional properties:
+ * headers - Object containing additional headers to send to the proxy server in the CONNECT request.
+ * @see https://www.npmjs.com/package/https-proxy-agent#user-content-api
+ */
+export type HttpsProxyAgentOptions = https.AgentOptions & { headers: Headers };
+
+/**
  * Options for configuring the outgoing request in generateRequestDetails() or sendNotification().
  */
 export interface RequestOptions {
-    /** Is the HTTPS Agent instance which will be used in the https.request method. If the proxy options defined, agent will be ignored! */
-    agent?: https.Agent | undefined;
-    headers?: Headers | undefined;
-    gcmAPIKey?: string | undefined; // can be a GCM API key to be used for this request and this request only. This overrides any API key set via setGCMAPIKey().
-    vapidDetails?: { // should be an object with subject, publicKey and privateKey values defined. These values should follow the VAPID Spec. (https://tools.ietf.org/html/draft-thomson-webpush-vapid)
-        subject: string;
-        publicKey: string;
-        privateKey: string;
-    } | undefined;
-    TTL?: number | undefined; // a value in seconds that describes how long a push message is retained by the push service (by default, four weeks).
-    contentEncoding?: ContentEncoding | undefined; // the type of push encoding to use (e.g. 'aesgcm', by default, or 'aes128gcm').
-    proxy?: string | undefined; // proxy hostname/ip and a port to tunnel your requests through (eg. http://< hostname >:< port >).
     /**
-     * Is the timeout to receive the full response. So if you have a socket timeout of 1 second, and a response comprised of 3 TCP packets,
-     * where each response packet takes 0.9 seconds to arrive, for a total response time of 2.7 seconds, then there will be no timeout.
+     * Can be a GCM API key to be used for this request and this request only. This overrides any API key set via setGCMAPIKey().
+     */
+    gcmAPIKey?: string | undefined;
+    /**
+     * Should be an object with subject, publicKey and privateKey values defined. These values should follow the VAPID Spec.
+     * @see https://datatracker.ietf.org/doc/html/draft-thomson-webpush-vapid
+     */
+    vapidDetails?:
+        | {
+              subject: string;
+              publicKey: string;
+              privateKey: string;
+          }
+        | undefined;
+    /**
+     * A value in milliseconds that specifies the request's socket timeout.
+     * On timeout, the request will be destroyed and the promise will be rejected with a meaningful error.
+     * It's a common misconception that a socket timeout is the timeout to receive the full response.
+     * So if you have a socket timeout of 1 second, and a response comprised of 3 TCP packets,
+     * where each response packet takes 0.9 seconds to arrive, for a total response time of 2.7 seconds,
+     * then there will be no timeout.
      * Once a socket 'timeout' triggers the request will be aborted by the library (by default undefined).
      */
     timeout?: number | undefined;
+    /**
+     * A value in seconds that describes how long a push message is retained by the push service (by default, four weeks).
+     */
+    TTL?: number | undefined;
+    /**
+     * An object with all the extra headers you want to add to the request.
+     */
+    headers?: Headers | undefined;
+    /**
+     * The type of push encoding to use (e.g. 'aesgcm', by default, or 'aes128gcm').
+     * @see supportedContentEncodings
+     */
+    contentEncoding?: ContentEncoding | undefined;
+    /**
+     * To indicate to the push service whether to send the notification immediately
+     * or prioritize the recipient’s device power considerations for delivery.
+     * Provide one of the following values: very-low, low, normal, or high.
+     * To attempt to deliver the notification immediately, specify high.
+     * @see supportedUrgency
+     */
+    urgency?: Urgency | undefined;
+    /**
+     * Optionally provide an identifier that the push service uses to coalesce notifications.
+     * Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.
+     */
+    topic?: string | undefined;
+    /**
+     * The HttpsProxyAgent's constructor argument that may either be a string URI of the proxy server
+     * (eg. http://< hostname >:< port >) or an "options" object with more specific properties.
+     * @see https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-optionsb
+     */
+    proxy?: string | HttpsProxyAgentOptions | undefined;
+    /**
+     * The HTTPS Agent instance which will be used in the https.request method. If the proxy options are defined, agent will be ignored!
+     */
+    agent?: https.Agent | undefined;
 }
 
 /**
@@ -224,11 +326,5 @@ export class WebPushError extends Error {
     readonly body: string;
     readonly endpoint: string;
 
-    constructor(
-        message: string,
-        statusCode: number,
-        headers: Headers,
-        body: string,
-        endpoint: string
-    );
+    constructor(message: string, statusCode: number, headers: Headers, body: string, endpoint: string);
 }

--- a/types/web-push/web-push-tests.ts
+++ b/types/web-push/web-push-tests.ts
@@ -16,10 +16,12 @@ import {
     RequestDetails,
     generateRequestDetails,
     SendResult,
-    sendNotification
+    sendNotification,
+    HttpsProxyAgentOptions,
 } from 'web-push';
 
 declare const anything: any;
+declare const stringValue: string;
 
 // ==============
 //  WebPushError
@@ -77,23 +79,53 @@ encryptionResult.cipherText;
 // ===================
 
 // $ExpectType { Authorization: string; 'Crypto-Key': string; }
-getVapidHeaders('audience', 'subject', 'publicKey', 'privateKey', supportedContentEncodings.AES_GCM, 150);
+getVapidHeaders('audience', 'https://subject.com', 'publicKey', 'privateKey', supportedContentEncodings.AES_GCM, 150);
 // $ExpectType { Authorization: string; }
-getVapidHeaders('audience', 'subject', 'publicKey', 'privateKey', supportedContentEncodings.AES_128_GCM, 150);
+getVapidHeaders(
+    'audience',
+    'https://subject.com',
+    'publicKey',
+    'privateKey',
+    supportedContentEncodings.AES_128_GCM,
+    150,
+);
+
+// $ExpectType { Authorization: string; 'Crypto-Key': string; }
+getVapidHeaders(
+    'audience',
+    'mailto:subject@subject.com',
+    'publicKey',
+    'privateKey',
+    supportedContentEncodings.AES_GCM,
+    150,
+);
+// $ExpectType { Authorization: string; }
+getVapidHeaders(
+    'audience',
+    'mailto:subject@subject.com',
+    'publicKey',
+    'privateKey',
+    supportedContentEncodings.AES_128_GCM,
+    150,
+);
 
 // expiration is optional
 // $ExpectType { Authorization: string; 'Crypto-Key': string; }
-getVapidHeaders('audience', 'subject', 'publicKey', 'privateKey', supportedContentEncodings.AES_GCM);
+getVapidHeaders('audience', 'https://subject.com', 'publicKey', 'privateKey', supportedContentEncodings.AES_GCM);
 // $ExpectType { Authorization: string; }
-getVapidHeaders('audience', 'subject', 'publicKey', 'privateKey', supportedContentEncodings.AES_128_GCM);
+getVapidHeaders('audience', 'https://subject.com', 'publicKey', 'privateKey', supportedContentEncodings.AES_128_GCM);
+
+// Allow "string" subjects since we can't verify what they start with
+// $ExpectType { Authorization: string; 'Crypto-Key': string; }
+getVapidHeaders('audience', stringValue, 'publicKey', 'privateKey', supportedContentEncodings.AES_GCM);
 
 // Buffers are not supported here
 // @ts-expect-error
 getVapidHeaders('audience', buffer, 'publicKey', 'privateKey', supportedContentEncodings.AES_128_GCM);
 // @ts-expect-error
-getVapidHeaders('audience', 'subject', buffer, 'privateKey', supportedContentEncodings.AES_128_GCM);
+getVapidHeaders('audience', 'https://subject.com', buffer, 'privateKey', supportedContentEncodings.AES_128_GCM);
 // @ts-expect-error
-getVapidHeaders('audience', 'subject', 'publicKey', buffer, supportedContentEncodings.AES_128_GCM);
+getVapidHeaders('audience', 'https://subject.com', 'publicKey', buffer, supportedContentEncodings.AES_128_GCM);
 
 // =====================
 //  generateVAPIDKeys()
@@ -140,7 +172,7 @@ const pushSubscription: PushSubscription = {
     keys: {
         p256dh: 'p256dhString',
         auth: 'authString',
-    }
+    },
 };
 
 // ================
@@ -153,32 +185,32 @@ requestOptions = {};
 
 requestOptions = {
     headers: {
-        someHeader: 'value'
-    }
+        someHeader: 'value',
+    },
 };
 
 requestOptions = {
-    gcmAPIKey: 'key'
+    gcmAPIKey: 'key',
 };
 
 requestOptions = {
     vapidDetails: {
         privateKey: 'private',
         publicKey: 'public',
-        subject: 'subject'
-    }
+        subject: 'subject',
+    },
 };
 
 requestOptions = {
-    TTL: 100
+    TTL: 100,
 };
 
 requestOptions = {
-    contentEncoding: supportedContentEncodings.AES_128_GCM
+    contentEncoding: supportedContentEncodings.AES_128_GCM,
 };
 
 requestOptions = {
-    proxy: 'http://proxy'
+    proxy: 'http://proxy',
 };
 
 declare const agent: https.Agent;
@@ -193,18 +225,24 @@ requestOptions = {
 requestOptions = {
     agent,
     headers: {
-        someHeader: 'value'
+        someHeader: 'value',
     },
     gcmAPIKey: 'key',
     vapidDetails: {
         privateKey: 'private',
         publicKey: 'public',
-        subject: 'subject'
+        subject: 'subject',
     },
     TTL: 100,
     contentEncoding: supportedContentEncodings.AES_GCM,
     proxy: 'http://proxy',
     timeout: 2000,
+};
+
+declare const proxyOptions: HttpsProxyAgentOptions;
+
+requestOptions = {
+    proxy: proxyOptions,
 };
 
 // ==========================
@@ -303,7 +341,7 @@ sendNotification({ endpoint: 'endpoint', keys: { p256dh: 'p256dh', auth: 'auth' 
 
 const sendResult = sendNotification(pushSubscription, 'payload');
 
-sendResult.then((result) => {
+sendResult.then(result => {
     // ExpectType number
     result.statusCode;
     // $ExpectType string
@@ -311,5 +349,4 @@ sendResult.then((result) => {
     // $ExpectType Headers
     result.headers;
 });
-sendResult.catch((error: WebPushError) => {
-});
+sendResult.catch((error: WebPushError) => {});


### PR DESCRIPTION
This updates web-push to 3.6.4, which introduces two new properties `urgency` and `topic`.

This also:
* ensures the code matches `prettier` specs;
* rearranges the properties for `RequestOptions` to match the [documentation on npm](https://www.npmjs.com/package/web-push#user-content-input); 
* adds a missing type for the `proxy` property (which accepts the HttpsProxyAgent constructor arguments). Unfortunately the types published in that package are broken (they do not compile in TS 5.3) so I had to replicate them locally.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
   - Issue #66487
   - [Diff between 3.3 and 3.6](https://github.com/web-push-libs/web-push/compare/v3.3.0...v3.6.4)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
