### PR TITLE
🏷️ Alpinejs 3.13

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -514,16 +514,22 @@ import Alpine, {
     Alpine.store('darkMode', darkModeDataContext);
 
     // $ExpectType void
-    Alpine.store<typeof darkModeDataContext>('darkMode').toggle();
+    Alpine.store('darkMode').toggle();
 
     // $ExpectType void
-    Alpine.store('darkMode', false);
+    Alpine.store('darkModeState', false);
 
     // $ExpectType void
     Alpine.store('tabs', {
         current: 'first',
 
         items: ['first', 'second', 'third'],
+    });
+    // @ts-expect-error
+    Alpine.store('tabs', 'hello');
+
+    Alpine.store('untypedKey', {
+        foo: 'bar',
     });
 }
 
@@ -693,4 +699,18 @@ import Alpine, {
             },
         }),
     );
+}
+
+declare module 'alpinejs' {
+    interface Stores {
+        darkMode: {
+            on: boolean;
+            toggle(): void;
+        };
+        darkModeState: boolean;
+        tabs: {
+            current: string;
+            items: string[];
+        };
+    }
 }

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -12,7 +12,6 @@ import Alpine, {
     DirectiveUtilities,
     DirectiveCallback,
     ElementWithXAttributes,
-    ReactiveEffect,
 } from 'alpinejs';
 
 {

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -6,10 +6,17 @@
  * are not intended as functional tests.
  */
 
-import Alpine, { AlpineComponent, DirectiveParameters, DirectiveUtilities } from 'alpinejs';
+import Alpine, {
+    AlpineComponent,
+    DirectiveData,
+    DirectiveUtilities,
+    DirectiveCallback,
+    ElementWithXAttributes,
+} from 'alpinejs';
 import { reactive, effect, stop, toRaw } from '@vue/reactivity';
 
-{ // Alpine.reactive
+{
+    // Alpine.reactive
     // example usage from docs:
     // https://alpinejs.dev/advanced/reactivity#alpine-reactive
     const data = { count: 1 };
@@ -22,13 +29,15 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     reactiveData.count;
 }
 
-{ // Alpine.release
+{
+    // Alpine.release
     const effectRunner = Alpine.effect(() => {});
     // $ExpectType void
     Alpine.release(effectRunner);
 }
 
-{ // Alpine.effect
+{
+    // Alpine.effect
     // example usage from docs:
     // https://alpinejs.dev/advanced/reactivity#alpine-effect
     const data = Alpine.reactive({ count: 1 });
@@ -39,59 +48,66 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     });
 }
 
-{ // Alpine.raw
+{
+    // Alpine.raw
     const data = Alpine.reactive({ count: 1 });
     // $ExpectType { count: number; }
     Alpine.raw(data);
 }
 
-{ // Alpine.version
+{
+    // Alpine.version
     // $ExpectType string
     Alpine.version;
 }
 
-{ // Alpine.flushAndStopDeferringMutations
+{
+    // Alpine.flushAndStopDeferringMutations
     // $ExpectType void
     Alpine.flushAndStopDeferringMutations();
 }
 
-{ // Alpine.disableEffectScheduling
+{
+    // Alpine.disableEffectScheduling
     // $ExpectType void
     Alpine.disableEffectScheduling(() => {
         // do something
     });
 }
 
-{ // Alpine.setReactivityEngine
+{
+    // Alpine.setReactivityEngine
     // $ExpectType void
     Alpine.setReactivityEngine({ reactive, effect, release: stop, raw: toRaw });
 }
 
-{ // Alpine.closestDataStack
+{
+    // Alpine.closestDataStack
     const someNode = document.body;
-    // $ExpectType object[]
+    // $ExpectType Record<string | symbol, unknown>[]
     Alpine.closestDataStack(someNode);
 }
 
-{ // Alpine.skipDuringClone
+{
+    // Alpine.skipDuringClone
     // inspired by
     // https://github.com/alpinejs/alpine/blob/688200e1a4a2631c48894484f0fea9c4d409701d/packages/trap/src/index.js
 
-    // $ExpectType (el: Node, params: DirectiveParameters, utils: DirectiveUtilities) => void
+    // $ExpectType (el: ElementWithXAttributes<HTMLElement>, { expression, modifiers }: DirectiveData, { evaluate }: DirectiveUtilities) => void
     const directiveHandler = Alpine.skipDuringClone(
-        (el, { expression, modifiers}, { effect, evaluateLater}) => {
+        ((el, { expression, modifiers }, { effect, evaluateLater }) => {
             // do something
-            // $ExpectType Node
+            // $ExpectType ElementWithXAttributes<HTMLElement>
             el;
             // $ExpectType string
             expression;
             // $ExpectType string[]
             modifiers;
-            // $ExpectType (cb: () => void) => void
+            // $ExpectType <T = any>(fn: () => T, options?: ReactiveEffectOptions | undefined) => ReactiveEffectRunner<any>
             effect;
-            // $ExpectType (expression: string) => (result: unknown) => void
+            // $ExpectType <T>(expression: string) => (callback?: ((value: T) => void) | undefined, extras?: {} | undefined) => void
             evaluateLater;
-        },
+        }) as DirectiveCallback,
         (el, { expression, modifiers }, { evaluate }) => {
             // do something
         },
@@ -99,7 +115,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.directive('trap', directiveHandler);
 }
 
-{ // Alpine.addRootSelector
+{
+    // Alpine.addRootSelector
     // inspired by
     // https://github.com/alpinejs/alpine/blob/98805c323d42f74189540716c693b5dc66f0c05c/packages/alpinejs/src/directives/x-data.js
 
@@ -107,7 +124,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.addRootSelector(() => `[${Alpine.prefixed('data')}]`);
 }
 
-{ // Alpine.addInitSelector
+{
+    // Alpine.addInitSelector
     // inspired by
     // https://github.com/alpinejs/alpine/blob/09951d6b5893fe99158299794fea184876e16f74/packages/portal/src/index.js
 
@@ -115,13 +133,14 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.addInitSelector(() => `[${Alpine.prefixed('portal-target')}]`);
 }
 
-{ // Alpine.addScopeToNode
+{
+    // Alpine.addScopeToNode
     // inspired by
     // https://github.com/alpinejs/alpine/blob/e75587e61dfa7913aa03886c84aea084b595383f/packages/alpinejs/src/directives/x-if.js
     // https://github.com/alpinejs/alpine/blob/98805c323d42f74189540716c693b5dc66f0c05c/packages/alpinejs/src/directives/x-data.js
 
-    const target = document.querySelector('target')!;
-    const clone = document.querySelector('clone')!;
+    const target = document.querySelector<ElementWithXAttributes>('target')!;
+    const clone = document.querySelector<ElementWithXAttributes>('clone')!;
 
     // $ExpectType () => void
     Alpine.addScopeToNode(clone, {}, target);
@@ -133,29 +152,40 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     undo;
 }
 
-{ // Alpine.deferMutations
-
+{
+    // Alpine.deferMutations
     // $ExpectType void
     Alpine.deferMutations();
 }
 
-{ // Alpine.mapAttributes
+{
+    // Alpine.mapAttributes
     // inspired by
     // https://github.com/alpinejs/alpine/blob/8d4f1266b25a550d9bd777b8aeb632a6857e89d1/packages/alpinejs/src/directives/x-bind.js
 
-    const startingWith = (s: string, r: string) => ({ name, value }: { name: string, value: unknown }) => ({ name: name.replace(s, r), value });
+    const startingWith = (s: string, r: string) => <T>(attribute: {
+        name: string;
+        value: T;
+    }): {
+        name: string;
+        value: T;
+    } => ({
+        name: attribute.name.replace(s, r),
+        value: attribute.value,
+    });
     const into = (i: string) => i;
 
     // $ExpectType void
     Alpine.mapAttributes(startingWith(':', into(Alpine.prefixed('bind:'))));
 }
 
-{ // Alpine.evaluateLater
+{
+    // Alpine.evaluateLater
     // example usage from docs:
     // https://alpinejs.dev/advanced/extending#introducing-reactivity
 
     const el = document.body;
-    const expression = "2 < 5";
+    const expression = '2 < 5';
     // $resultType (resultCallback: (result: unknown) => void) => void
     const getThingToLog = Alpine.evaluateLater(el, expression);
 
@@ -164,68 +194,79 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     });
 }
 
-{ // Alpine.setEvaluator
+{
+    // Alpine.setEvaluator
     // inspired by
     // https://github.com/alpinejs/alpine/blob/b46c41fa240cd8af2dcaa29fb60fb1db0389c95a/packages/alpinejs/src/index.js
 
-    const justExpressionEvaluator = (el: Node, expression: string) => (resultCallback: (result: unknown) => void) => resultCallback(expression);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    const justExpressionEvaluator = <T>(el: ElementWithXAttributes, expression?: string | (() => T)) => (
+        resultCallback: (result: T) => void,
+    ) => resultCallback(typeof expression === 'function' ? expression() : Alpine.evaluate<T>(el, expression ?? ''));
 
     Alpine.setEvaluator(justExpressionEvaluator);
 }
 
-{ // Alpine.mergeProxies
+{
+    // Alpine.mergeProxies
     const el = document.body;
 
-    // $ExpectType any
+    // $ExpectType Record<string, unknown>
     const data = Alpine.mergeProxies(Alpine.closestDataStack(el));
 
     const one = { one: 1 };
     const two = { two: '2' };
     const three = { three: [3] };
     const four = { four: true };
-    // $ExpectType { one: number; } & { two: string; } & { three: number[]; } & { four: boolean; }
+    // $ExpectType Record<string, unknown>
     const mergedFour = Alpine.mergeProxies([one, two, three, four]);
-
-    // $ExpectType string
-    const mergedTwo = Alpine.mergeProxies(['hello', 'world']);
-
-    // $ExpectType never
-    const mergedTwoNever = Alpine.mergeProxies(['hello', 123]);
 }
 
-{ // Alpine.closestRoot
+{
+    // Alpine.closestRoot
     const el = document.body;
 
-    // $ExpectType Node | undefined
+    // $ExpectType ElementWithXAttributes<HTMLElement> | undefined
     Alpine.closestRoot(el);
-    // $ExpectType Node | undefined
+    // $ExpectType ElementWithXAttributes<HTMLElement> | undefined
     Alpine.closestRoot(el, true);
 }
 
-{ // Alpine.interceptor
+{
+    // Alpine.interceptor
     // inspired by
     // https://github.com/alpinejs/alpine/blob/1ff2f77077acc4e9221b78572097e4045b67db5e/packages/persist/src/index.js
 
     let alias: string;
     let storage: Storage;
 
-    // $ExpectType (initialValue: string) => string
-    const persist = Alpine.interceptor<string>((initialValue, getter, setter, path, key) => {
-        const lookup = alias || `_x_${path}`;
-        setter(initialValue);
-        Alpine.effect(() => {
-            const value = getter();
-            storage.setItem(lookup, JSON.stringify(value));
-            setter(value);
-        });
-        return initialValue;
-    }, (func: any) => {
-        func.as = (key: string) => { alias = key; return func; };
-        func.using = (target: Storage) => { storage = target; return func; };
-    });
+    // $ExpectType (initialValue: any) => { initialValue: unknown; _x_interceptor: true; initialize: (data: Record<string, unknown>, path: string, key: string) => void; }
+    const persist = Alpine.interceptor<string>(
+        (initialValue, getter, setter, path, key) => {
+            const lookup = alias || `_x_${path}`;
+            setter(initialValue);
+            Alpine.effect(() => {
+                const value = getter();
+                storage.setItem(lookup, JSON.stringify(value));
+                setter(value);
+            });
+            return initialValue;
+        },
+        (func: any) => {
+            func.as = (key: string) => {
+                alias = key;
+                return func;
+            };
+            func.using = (target: Storage) => {
+                storage = target;
+                return func;
+            };
+        },
+    );
 }
 
-{ // Alpine.transition
+{
+    // Alpine.transition
     // inspired by
     // https://github.com/alpinejs/alpine/blob/286ac9914ac0f4c0bea1da16ea3782b15d407824/packages/collapse/src/index.js
 
@@ -234,14 +275,21 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     let transitioning = false;
 
     // $ExpectType void
-    Alpine.transition(el, setFunction, {
-        during: { overflow: 'hidden' },
-        start: { height: '100px' },
-        end: { height: '200px' },
-    }, () => transitioning = true, () => transitioning = false);
+    Alpine.transition(
+        el,
+        setFunction,
+        {
+            during: { overflow: 'hidden' },
+            start: { height: '100px' },
+            end: { height: '200px' },
+        },
+        () => (transitioning = true),
+        () => (transitioning = false),
+    );
 }
 
-{ // Alpine.setStyles
+{
+    // Alpine.setStyles
 
     const el = document.body;
 
@@ -251,12 +299,13 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.setStyles(el, { visibility: 'hidden' });
 }
 
-{ // Alpine.mutateDom
+{
+    // Alpine.mutateDom
     // inspired by
     // https://github.com/alpinejs/alpine/blob/09951d6b5893fe99158299794fea184876e16f74/packages/portal/src/index.js
 
-    const target = document.querySelector('target')!;
-    const clone = document.querySelector('clone')!;
+    const target = document.querySelector<ElementWithXAttributes>('target')!;
+    const clone = document.querySelector<ElementWithXAttributes>('clone')!;
 
     // $ExpectType void
     Alpine.mutateDom(() => {
@@ -265,12 +314,30 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     });
 }
 
-{ // Alpine.directive
+{
+    // Alpine.directive
     // example usage from docs:
     // https://alpinejs.dev/advanced/extending#method-signature
 
-    // $ExpectType void
+    // $ExpectType { before(directive: string): void; }
     Alpine.directive('[name]', (el, { value, modifiers, expression }, { Alpine, effect, cleanup }) => {
+        // $ExpectType ElementWithXAttributes<HTMLElement>
+        el;
+        // $ExpectType string
+        value;
+        // $ExpectType string[]
+        modifiers;
+        // $ExpectType string
+        expression;
+        // $ExpectType Alpine
+        Alpine;
+        // $ExpectType <T = any>(fn: () => T, options?: ReactiveEffectOptions | undefined) => ReactiveEffectRunner<any>
+        effect;
+        // $ExpectType (callback: () => void) => void
+        cleanup;
+    });
+
+    (el: Node, { value, modifiers, expression }: DirectiveData, { Alpine, effect, cleanup }: DirectiveUtilities) => {
         // $ExpectType Node
         el;
         // $ExpectType string
@@ -281,33 +348,19 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         expression;
         // $ExpectType Alpine
         Alpine;
-        // $ExpectType (cb: () => void) => void
+        // $ExpectType <T = any>(fn: () => T, options?: ReactiveEffectOptions | undefined) => ReactiveEffectRunner<any>
         effect;
-        // $ExpectType (cb: () => void) => void
+        // $ExpectType (callback: () => void) => void
         cleanup;
-    });
-
-    (el: Node, { value, modifiers, expression }: DirectiveParameters, { Alpine, effect, cleanup }: DirectiveUtilities) => {
-      // $ExpectType Node
-      el;
-      // $ExpectType string
-      value;
-      // $ExpectType string[]
-      modifiers;
-      // $ExpectType string
-      expression;
-      // $ExpectType Alpine
-      Alpine;
-      // $ExpectType (cb: () => void) => void
-      effect;
-      // $ExpectType (cb: () => void) => void
-      cleanup;
-  };
+    };
 }
 
-{ // Alpine.throttle
+{
+    // Alpine.throttle
     const limit = 200;
-    const handler1 = () => { /* do something */ };
+    const handler1 = () => {
+        /* do something */
+    };
 
     // $ExpectType () => void
     Alpine.throttle(handler1, limit);
@@ -318,9 +371,12 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.throttle(handler2);
 }
 
-{ // Alpine.debounce
+{
+    // Alpine.debounce
     const wait = 200;
-    const handler1 = () => { /* do something */ };
+    const handler1 = () => {
+        /* do something */
+    };
 
     // $ExpectType () => void
     Alpine.debounce(handler1, wait);
@@ -331,18 +387,20 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.debounce(handler2);
 }
 
-{ // Alpine.evaluate
+{
+    // Alpine.evaluate
     // inspired by
     // https://github.com/alpinejs/alpine/blob/98805c323d42f74189540716c693b5dc66f0c05c/packages/alpinejs/src/directives/x-data.js
     const el = document.body;
-    const expression = "2 < 5";
+    const expression = '2 < 5';
     const dataProviderContext = {};
 
     // $ExpectType unknown
     const data = Alpine.evaluate(el, expression, { scope: dataProviderContext });
 }
 
-{ // Alpine.initTree
+{
+    // Alpine.initTree
     // inspired by
     // https://github.com/alpinejs/alpine/blob/09951d6b5893fe99158299794fea184876e16f74/packages/portal/src/index.js
     // https://github.com/alpinejs/alpine/blob/09951d6b5893fe99158299794fea184876e16f74/packages/alpinejs/src/clone.js
@@ -351,23 +409,30 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     // $ExpectType void
     Alpine.initTree(clone);
 
-    const shallowWalker = (el: Node, callback: (el: Node, skip: () => void) => void) => {
+    const shallowWalker = (
+        el: ElementWithXAttributes,
+        callback: (el: ElementWithXAttributes, skip: () => void) => void,
+    ) => {
         // do walking
     };
     // $ExpectType void
     Alpine.initTree(clone, shallowWalker);
 }
 
-{ // Alpine.nextTick
+{
+    // Alpine.nextTick
     // example usage from docs:
     // https://alpinejs.dev/magics/nextTick
 
     const $el = document.body;
-    // $ExpectType void
-    Alpine.nextTick(() => { console.log($el.innerText); });
+    // $ExpectType Promise<unknown>
+    Alpine.nextTick(() => {
+        console.log($el.innerText);
+    });
 }
 
-{ // Alpine.prefixed
+{
+    // Alpine.prefixed
     // inspired by
     // https://github.com/alpinejs/alpine/blob/34b86216a51b3d67018d51b96daf970d4e9b5150/packages/alpinejs/src/directives/x-cloak.js
 
@@ -379,7 +444,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     el.removeAttribute(Alpine.prefixed('cloak'));
 }
 
-{ // Alpine.prefix
+{
+    // Alpine.prefix
     // inspired by
     // https://github.com/alpinejs/alpine/blob/7922e7fb8d54de64ebfc4814c2115293a5518ebd/tests/cypress/integration/custom-prefix.spec.js
 
@@ -387,7 +453,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.prefix('data-x-');
 }
 
-{ // Alpine.plugin
+{
+    // Alpine.plugin
     // example usage from docs:
     // https://alpinejs.dev/advanced/extending#bundle-module
 
@@ -400,13 +467,14 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.plugin(MyAlpinePlugin);
 }
 
-{ // Alpine.magic
+{
+    // Alpine.magic
     // example usage from docs:
     // https://alpinejs.dev/advanced/extending#custom-magics
 
     // $ExpectType void
     Alpine.magic('now', () => {
-        return (new Date()).toLocaleTimeString();
+        return new Date().toLocaleTimeString();
     });
     // $ExpectType void
     Alpine.magic('clipboard', () => {
@@ -418,7 +486,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     });
 }
 
-{ // Alpine.store
+{
+    // Alpine.store
     // example usage from docs:
     // https://alpinejs.dev/essentials/state#global-state
     // https://alpinejs.dev/globals/alpine-store
@@ -427,15 +496,15 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         on: false,
 
         toggle() {
-            this.on = ! this.on;
-        }
+            this.on = !this.on;
+        },
     };
 
     // $ExpectType void
     Alpine.store('darkMode', darkModeDataContext);
 
     // $ExpectType void
-    (Alpine.store('darkMode') as typeof darkModeDataContext).toggle();
+    Alpine.store<typeof darkModeDataContext>('darkMode').toggle();
 
     // $ExpectType void
     Alpine.store('darkMode', false);
@@ -448,7 +517,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     });
 }
 
-{ // Alpine.start
+{
+    // Alpine.start
     // example usage from docs:
     // https://alpinejs.dev/upgrade-guide#need-to-call-alpine-start
     // https://alpinejs.dev/essentials/installation#as-a-module
@@ -457,7 +527,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.start();
 }
 
-{ // Alpine.clone
+{
+    // Alpine.clone
     // inspired by
     // https://github.com/alpinejs/alpine/blob/b46c41fa240cd8af2dcaa29fb60fb1db0389c95a/tests/cypress/integration/clone.spec.js
 
@@ -468,7 +539,8 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
     Alpine.clone(original, copy);
 }
 
-{ // Alpine.data
+{
+    // Alpine.data
     // example usage from docs:
     // https://alpinejs.dev/essentials/state#re-usable-data
     // https://alpinejs.dev/essentials/lifecycle#element-initialization
@@ -483,13 +555,13 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         open: false,
 
         toggle() {
-            this.open = ! this.open;
-        }
+            this.open = !this.open;
+        },
     }));
 
     // $ExpectType void
     Alpine.data('dropdown', (initialOpenState = false) => ({
-        open: initialOpenState
+        open: initialOpenState,
     }));
 
     // $ExpectType void
@@ -497,7 +569,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         init() {
             // This code will be executed before Alpine
             // initializes the rest of the component.
-        }
+        },
     }));
 
     // $ExpectType void
@@ -506,7 +578,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
 
         init() {
             this.$watch('open', () => {});
-        }
+        },
     }));
 
     // $ExpectType void
@@ -515,7 +587,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
 
         trigger: {
             ['@click']() {
-                this.open = ! this.open;
+                this.open = !this.open;
             },
         },
 
@@ -531,10 +603,10 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
         user: { id: 1, name: 'John Doe' },
 
         init() {
-            // $ExpectType Record<string, any> & XDataContext & AlpineMagics<Record<string, any>>
+            // $ExpectType { user: { id: number; name: string; }; init(): void; } & XDataContext & AlpineMagics<{ user: { id: number; name: string; }; init(): void; }>
             this;
 
-            // $ExpectType Record<string, any>
+            // $ExpectType { user: { id: number; name: string; }; init(): void; }
             this.$data;
 
             // $ExpectType HTMLElement
@@ -543,7 +615,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
             // $ExpectType HTMLElement
             this.$refs.fooElement;
 
-            // $ExpectType XData
+            // $ExpectType (name: string) => string | number | boolean | XDataContext
             this.$store;
 
             // $ExpectType void
@@ -570,7 +642,7 @@ import { reactive, effect, stop, toRaw } from '@vue/reactivity';
             this.$watch(
                 'user',
                 (
-                    // $ExpectType any
+                    // $ExpectType { id: number; name: string; }
                     newValue,
                 ) => {},
             );

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -1,53 +1,147 @@
-// Type definitions for alpinejs 3.7
+// Type definitions for alpinejs 3.13
 // Project: https://github.com/alpinejs/alpine
 // Definitions by: Thomas Wirth <https://github.com/wtho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.6
 
-import { ReactiveEffect, UnwrapNestedRefs, ReactiveEffectOptions, reactive as VueReactive } from '@vue/reactivity';
+export type ElementWithXAttributes<T extends Element = HTMLElement> = withXAttributes<T>;
 
-interface Evaluator {
-    (el: Node, expression: string /*, extras?: unknown */): (resultCallback: (result: unknown) => void) => void;
+export type withXAttributes<T extends Element> = T & Partial<XAttributes>;
+
+export interface XAttributes {
+    _x_virtualDirectives: Bindings;
+    _x_ids: Record<string, number>;
+    _x_effects: Set<() => void>;
+    _x_runEffects: () => void;
+    _x_dataStack: Array<Record<string, unknown>>;
+    _x_ignore: true;
+    _x_ignoreSelf: true;
+    _x_isShown: boolean;
+    _x_bindings: Record<string, unknown>;
+    _x_undoAddedClasses: () => void;
+    _x_undoAddedStyles: () => void;
+    _x_cleanups: MutationCallback[];
+    _x_attributeCleanups: Record<string, Array<() => void>>;
+    _x_ignoreMutationObserver: boolean;
+    _x_teleportBack: ElementWithXAttributes;
+    _x_refs_proxy: Record<string, unknown>;
+    _x_refs: unknown;
+    _x_keyExpression: string;
+    _x_prevKeys: string[];
+    _x_forScope: Record<string, unknown>;
+    _x_lookup: Record<string, ElementWithXAttributes>;
+    _x_currentIfEl: ElementWithXAttributes;
+    _x_undoIf: () => void;
+    _x_removeModelListeners: Record<string, () => void>;
+    _x_model: {
+        get: () => unknown;
+        set: (value: unknown) => void;
+    };
+    _x_forceModelUpdate: (value: unknown) => void;
+    _x_forwardEvents: string[];
+    _x_doHide: () => void;
+    _x_doShow: () => void;
+    _x_toggleAndCascadeWithTransitions: (
+        el: ElementWithXAttributes,
+        val: boolean,
+        show: () => void,
+        hide: () => void,
+    ) => void;
+    _x_teleport: ElementWithXAttributes;
+    _x_transition: Transitions;
+    _x_hidePromise: Promise<() => void>;
+    _x_transitioning: {
+        beforeCancel: (fn: () => void) => void;
+        beforeCancels: Array<() => void>;
+        cancel: () => void;
+        finish: () => void;
+    };
+    _x_hideChildren: ElementWithXAttributes[];
+    _x_inlineBindings: Record<string, Binding>;
 }
 
-interface ReactiveEffectRunner<T = any> {
-    (): T;
-    effect: ReactiveEffect;
+export type Transitions = {
+    enter: TransitionStages;
+    leave: TransitionStages;
+} & TransitionFromObject;
+export type TransitionStages = Partial<{
+    start: string | TransitionFromHelpers;
+    during: string | TransitionFromHelpers;
+    end: string | TransitionFromHelpers;
+}>;
+type TransitionFromHelpers = Partial<CSSStyleDeclaration>;
+interface TransitionFromObject {
+    in: (before: () => void, after?: () => void) => void;
+    out: (before: () => void, after?: () => void) => void;
 }
 
-interface ReactivityEngine {
-    reactive: Alpine['reactive'];
-    release: Alpine['release'];
-    effect: Alpine['effect'];
-    raw: Alpine['raw'];
+interface Binding {
+    expression: string;
+    extract: boolean;
 }
 
-type Walker = (el: Node, callback: (el: Node, skip: () => void) => void) => void;
-export type AttributeTransformer<T = unknown> = (args: { name: string; value: T }) => { name: string; value: T };
+export interface Bindings {
+    [key: string]: string | (() => unknown);
+}
+
+export type AttrMutationCallback = (
+    el: ElementWithXAttributes,
+    attrs: Array<{
+        name: string;
+        value: string;
+    }>,
+) => void;
+
+export interface DirectiveData {
+    type: string;
+    value: string;
+    modifiers: string[];
+    expression: string;
+    original: string;
+}
+
+type InterceptorCallback = <T>(initial: T, get: () => T, set: (val: T) => void, path: string, key: string) => void;
+
+interface InterceptorObject {
+    initialValue: unknown;
+    _x_interceptor: true;
+    initialize: (data: Record<string, unknown>, path: string, key: string) => void;
+}
+
+export interface DirectiveUtilities {
+    Alpine: Alpine;
+    effect: typeof import('@vue/reactivity').effect;
+    cleanup: (callback: () => void) => void;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    evaluateLater: <T>(expression: string) => (callback?: (value: T) => void, extras?: {}) => void;
+    evaluate: <T>(expression: string | (() => T), extras?: Record<string, unknown>, _?: boolean) => T;
+}
+export type MagicUtilities = DirectiveUtilities & {
+    interceptor: (
+        callback: InterceptorCallback,
+        mutateObj: (obj: InterceptorObject) => void,
+    ) => (initialValue: unknown) => InterceptorObject;
+};
+
+export interface DirectiveCallback {
+    (el: ElementWithXAttributes, directive: DirectiveData, utilities: DirectiveUtilities): void;
+    inline?: (el: ElementWithXAttributes, directive: DirectiveData, utilities: DirectiveUtilities) => void;
+}
+
+export type WalkerCallback = (el: ElementWithXAttributes, skip: () => void) => void;
+
+export type AlpineComponent<T> = T & XDataContext & ThisType<T & XDataContext & AlpineMagics<T>>;
 
 interface XDataContext {
     /**
      * Will be executed before Alpine initializes teh rest of the component.
      */
     init?(): void;
-    [stateKey: string]: any;
+    /**
+     * Will be executed when the component is destroyed.
+     */
+    destroy?(): void;
 }
-type XData = XDataContext | string | number | boolean;
-
-export interface DirectiveUtilities {
-    Alpine: Alpine;
-    effect: (cb: () => void) => void;
-    cleanup: (cb: () => void) => void;
-    evaluate: (expression: string) => unknown;
-    evaluateLater: (expression: string) => (result: unknown) => void;
-}
-export interface DirectiveParameters {
-    value: string;
-    modifiers: string[];
-    expression: string;
-    original: string;
-    type: string;
-}
-
 export interface AlpineMagics<T> {
     /**
      * Access to current Alpine data.
@@ -64,7 +158,7 @@ export interface AlpineMagics<T> {
     /**
      * Access registered global Alpine stores.
      */
-    $store: XData;
+    $store: (name: string) => XDataContext | string | number | boolean;
     /**
      * Dispatch browser events.
      *
@@ -91,186 +185,183 @@ export interface AlpineMagics<T> {
      * @param property the component property
      * @param callback a callback that will fire when a given property is changed
      */
-    $watch: <K extends keyof T | string, V extends (K extends keyof T ? T[K] : any)>(
+    $watch: <K extends keyof T | string, V extends K extends keyof T ? T[K] : any>(
         property: K,
         callback: (newValue: V, oldValue: V) => void,
     ) => void;
 }
 
-export type AlpineComponent<T = Record<string, any>> = T & XDataContext & ThisType<T & XDataContext & AlpineMagics<T>>;
-
 export interface Alpine {
-    // following TSDoc under MIT was taken from
-    // https://github.com/vuejs/vue-next/blob/92f11d6740929f5b591740e30ae5fba50940ec82/packages/reactivity/src/reactive.ts#L65-L87
-    /**
-     * Creates a reactive copy of the original object.
-     * The reactive conversion is "deep"—it affects all nested properties. In the
-     * ES2015 Proxy based implementation, the returned proxy is **not** equal to the
-     * original object. It is recommended to work exclusively with the reactive
-     * proxy and avoid relying on the original object.
-     *
-     * A reactive object also automatically unwraps refs contained in it, so you
-     * don't need to use `.value` when accessing and mutating their value:
-     *
-     * ```js
-     * const count = ref(0)
-     * const obj = reactive({
-     *   count
-     * })
-     *
-     * obj.count++
-     * obj.count // -> 1
-     * count.value // -> 1
-     * ```
-     */
-    reactive<T extends object>(target: T): UnwrapNestedRefs<T>;
-    /**
-     * Releases/stops a reactive effect, if it is currently active.
-     *
-     * @param runner the reactive effect runner to be stopped
-     */
-    release(runner: ReactiveEffectRunner): void;
-    /**
-     * As soon as effect is called, it will run the provided callback
-     * functionbut actively look for any interactions with reactive
-     * data. If it detects an interaction (a get or set from the
-     * aforementioned reactive proxy) it will keep track of it and
-     * make sure to re-run the callback if any of reactive data
-     * changes in the future.
-     *
-     * @param callback the function to be run while looking for reactive interactions
-     */
-    effect(callback: (() => unknown) | ReactiveEffectRunner, options?: ReactiveEffectOptions): ReactiveEffectRunner;
-    /**
-     * Returns the raw, original object of a reactive proxy. This is an escape
-     * hatch that can be used to temporarily read without incurring proxy
-     * access/tracking overhead or write without triggering changes. It is not
-     * recommended to hold a persistent reference to the original object.
-     * Use with caution.
-     *
-     * @param observed the reactive, proxied object
-     */
-    raw<T>(observed: T): T;
-    /**
-     * Version of Alpine.js
-     */
+    readonly reactive: typeof import('@vue/reactivity').reactive;
+    readonly release: typeof import('@vue/reactivity').stop;
+    readonly effect: typeof import('@vue/reactivity').effect;
+    readonly raw: typeof import('@vue/reactivity').toRaw;
     version: string;
-    flushAndStopDeferringMutations(): void;
-    disableEffectScheduling(callback: () => void): void;
-    setReactivityEngine(engine: ReactivityEngine): void;
-    closestDataStack(node: Node): object[];
-    skipDuringClone<R = unknown>(
-        callback: (el: Node, params: DirectiveParameters, utils: DirectiveUtilities) => R,
-        fallback?: (el: Node, params: DirectiveParameters, utils: DirectiveUtilities) => R,
-    ): (el: Node, params: DirectiveParameters, utils: DirectiveUtilities) => R;
-    addRootSelector(selectorCallback: () => string): void;
-    addInitSelector(selectorCallback: () => string): void;
-    addScopeToNode(node: Node, data: object, referenceNode?: Node): () => void;
-    deferMutations(): void;
-    mapAttributes(callback: AttributeTransformer): void;
-    evaluateLater: Evaluator;
-    setEvaluator(newEvaluator: Evaluator): void;
-    mergeProxies(objects: []): {};
-    mergeProxies<T>(objects: [T]): T;
-    mergeProxies<T, U>(objects: [T, U]): T & U;
-    mergeProxies<T, U, V>(objects: [T, U, V]): T & U & V;
-    mergeProxies<T, U, V, W>(objects: [T, U, V, W]): T & U & V & W;
-    mergeProxies(objects: any[]): any;
-    closestRoot(el: Node, includeInitSelectors?: boolean): Node | undefined;
-    /**
-     * **INTERNAL: not public API and is subject to change without major release**
-     * @internal
-     */
-    interceptor<V = unknown>(
-        callback: (initialValue: V, getter: () => V, setter: (value: V) => void, path: string, key: string) => V,
-        mutateObj?: (obj: { initialValue: V, _x_intceptor: true, intialize: (data: V, path: string, key: string) => V}) => void
-    ): (initialValue: V) => V;
-    /**
-     * **INTERNAL**
-     * @internal
-     */
-    transition(
-        el: Node,
-        setFunction: (el: Node, styles: Record<string, string> | string) => () => void,
-        duringStartAndEnd: { during: Record<string, string> | string, start: Record<string, string> | string, end: Record<string, string> | string },
-        before: () => void,
-        after: () => void
-    ): void;
-    /**
-     * INTERNAL
-     * @internal
-     */
-    setStyles(el: Node, value: Record<string, string> | string): () => void;
-    mutateDom<R = unknown>(callback: () => R): R;
-    /**
-     * Allows you to register your own custom directives.
-     *
-     * @param name the name of the directive, "foo" would be consumed as "x-foo"
-     * @param handler a callback function to apply the directive on the node element
-     */
-    directive(
+    flushAndStopDeferringMutations: () => void;
+    dontAutoEvaluateFunctions: (callback: () => void) => void;
+    disableEffectScheduling: (callback: () => void) => void;
+    startObservingMutations: () => void;
+    stopObservingMutations: () => void;
+    setReactivityEngine: (engine: {
+        reactive: typeof import('@vue/reactivity').reactive;
+        effect: typeof import('@vue/reactivity').effect;
+        release: typeof import('@vue/reactivity').stop;
+        raw: typeof import('@vue/reactivity').toRaw;
+    }) => void;
+    onAttributeRemoved: (el: ElementWithXAttributes, name: string, callback: () => void) => void;
+    onAttributesAdded: (callback: AttrMutationCallback) => void;
+    closestDataStack: (node: ElementWithXAttributes) => Array<Record<string | symbol, unknown>>;
+    skipDuringClone: <T extends (...args: Parameters<T>) => ReturnType<T>>(callback: T, fallback?: T) => T;
+    onlyDuringClone: (callback: DirectiveCallback) => DirectiveCallback;
+    addRootSelector: (selectorCallback: () => string) => void;
+    addInitSelector: (selectorCallback: () => string) => void;
+    addScopeToNode: (
+        node: ElementWithXAttributes,
+        data: Record<string, unknown>,
+        referenceNode?: ElementWithXAttributes,
+    ) => () => void;
+    deferMutations: () => void;
+    mapAttributes: (
+        callback: (attribute: {
+            name: string;
+            value: string | (() => unknown);
+        }) => {
+            name: string;
+            value: string | (() => unknown);
+        },
+    ) => void;
+    evaluateLater: <T_1>(
+        el: ElementWithXAttributes,
+        expression?: string | (() => T_1),
+    ) => (
+        callback?: (value: T_1) => void,
+        extras?: {
+            scope?: object;
+            params?: unknown[];
+        },
+    ) => void;
+    interceptInit: (callback: WalkerCallback) => void;
+    setEvaluator: (
+        newEvaluator: <T_2>(
+            el: ElementWithXAttributes,
+            expression?: string | (() => T_2),
+        ) => (
+            callback: (value: T_2) => void,
+            extras?: {
+                scope?: object;
+                params?: unknown[];
+            },
+        ) => void,
+    ) => void;
+    mergeProxies: (objects: Array<Record<string, unknown>>) => Record<string, unknown>;
+    extractProp: <T_3 extends string | boolean>(
+        el: ElementWithXAttributes,
         name: string,
-        handler: (el: Node, directive: DirectiveParameters, utilities: DirectiveUtilities) => void,
-    ): void;
-    throttle<A extends any[]>(func: (...args: A) => void, limit?: number): (...args: A) => void;
-    debounce<A extends any[], R = unknown>(func: (...args: A) => R, wait?: number): (...args: A) => R;
-    evaluate(el: Node, expression: string, extras?: object): unknown;
-    initTree(el: Node, walker?: Walker): void;
-    nextTick(callback: () => void): void;
-    prefixed(subject?: string): string;
-    prefix(newPrefix: string): void;
-    /**
-     * Convenience method to prevent consumers of a plugin from having
-     * to register multiple different directives and magics themselves,
-     * by providing the Alpine global object as argument in the callback.
-     *
-     * @param callback plugin installation function
-     */
-    plugin(callback: (alpine: Alpine) => void): void;
-    /**
-     * Registers a global magics helper, which can be referenced in
-     * expressions using $[name]. Return a function instead of a value
-     * in the callback to provide a function magic helper
-     * through $[name](...).
-     *
-     * @param name identifier of the magic function, without prefixed '$'
-     * @param callback function to evaluate the magic helper
-     */
-    magic(
+        fallback: T_3 | (() => T_3),
+        extract?: boolean,
+    ) => unknown;
+    findClosest: (
+        el: ElementWithXAttributes,
+        callback: (el: ElementWithXAttributes) => boolean,
+    ) => ElementWithXAttributes;
+    closestRoot: (el: ElementWithXAttributes, includeInitSelectors?: boolean) => ElementWithXAttributes | undefined;
+    destroyTree: (root: ElementWithXAttributes) => void;
+    interceptor: <T_4>(
+        callback: (initial: T_4, get: () => T_4, set: (val: T_4) => void, path: string, key: string) => void,
+        mutateObj?: (obj: {
+            initialValue: unknown;
+            _x_interceptor: true;
+            initialize: (data: Record<string, unknown>, path: string, key: string) => void;
+        }) => void,
+    ) => (
+        initialValue: any,
+    ) => {
+        initialValue: unknown;
+        _x_interceptor: true;
+        initialize: (data: Record<string, unknown>, path: string, key: string) => void;
+    };
+    transition: (
+        el: ElementWithXAttributes,
+        setFunction:
+            | ((
+                  el: ElementWithXAttributes,
+                  value:
+                      | string
+                      | boolean
+                      | Record<string, boolean>
+                      | (() => string | boolean | Record<string, boolean>),
+              ) => () => void)
+            | ((el: ElementWithXAttributes, value: string | Partial<CSSStyleDeclaration>) => () => void),
+        {
+            during,
+            start,
+            end,
+        }: Partial<{
+            start: string | Partial<CSSStyleDeclaration>;
+            during: string | Partial<CSSStyleDeclaration>;
+            end: string | Partial<CSSStyleDeclaration>;
+        }>,
+        before?: () => void,
+        after?: () => void,
+    ) => void;
+    setStyles: (el: ElementWithXAttributes, value: string | Partial<CSSStyleDeclaration>) => () => void;
+    mutateDom: <T_5>(callback: () => T_5) => T_5;
+    directive: (
         name: string,
-        callback: (el: Node, extras: { Alpine: Alpine; interceptor: Alpine['interceptor'] }) => any,
-    ): void;
-    /**
-     * Retrieves state in the global store.
-     *
-     * @param name state key
-     */
-    store(name: string): XData;
-    /**
-     * Sets state in the global store.
-     *
-     * @param name state key
-     * @param value the initial state value
-     */
-    store(name: string, value: XData): void;
-    /**
-     * Initializes Alpine.js, which is required if Alpine is imported
-     * into a bundle instead of included from a script tag.
-     *
-     * Extensions must have been registered IN BETWEEN when the Alpine
-     * global object is imported and when Alpine is initialized with
-     * the Alpine.start() call.
-     */
-    start(): void;
-    clone(oldEl: Node, newEl: Node): void;
-    /**
-     * Provides a way to reuse x-data contexts within your application.
-     *
-     * @param name the id of the x-data context
-     * @param callback the initializer of the x-data context
-     */
-    data(name: string, callback: (...initialStateArgs: unknown[]) => AlpineComponent): void;
+        callback: DirectiveCallback,
+    ) => {
+        before(directive: string): void;
+    };
+    entangle: <T_6>(
+        {
+            get: outerGet,
+            set: outerSet,
+        }: {
+            get: () => T_6;
+            set: (value: T_6) => void;
+        },
+        {
+            get: innerGet,
+            set: innerSet,
+        }: {
+            get: () => T_6;
+            set: (value: T_6) => void;
+        },
+    ) => () => void;
+    throttle: <T_7 extends (...args: Parameters<T_7>) => void>(
+        func: T_7,
+        limit?: number,
+    ) => (...args: Parameters<T_7>) => void;
+    debounce: <T_8 extends (...args: Parameters<T_8>) => void>(func: T_8, wait?: number) => T_8;
+    evaluate: <T_9>(el: ElementWithXAttributes, expression: string | (() => T_9), extras?: {}) => T_9;
+    initTree: (
+        el: ElementWithXAttributes,
+        walker?: (el: ElementWithXAttributes, callback: WalkerCallback) => any,
+        intercept?: WalkerCallback,
+    ) => void;
+    nextTick: (callback?: () => void) => Promise<unknown>;
+    prefixed: (subject?: string) => string;
+    prefix: (newPrefix: string) => void;
+    plugin: (callbacks: ((Alpine: any) => void) | Array<(Alpine: any) => void>) => void;
+    magic: (name: string, callback: (el: ElementWithXAttributes, options: MagicUtilities) => unknown) => void;
+    store: {
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T_10 extends string | number | boolean | unknown[] | Record<string, unknown>>(name: string): T_10;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T_11 extends string | number | boolean | unknown[] | Record<string, unknown>>(name: string, value: T_11): void;
+    };
+    start: () => void;
+    clone: (oldEl: ElementWithXAttributes, newEl: ElementWithXAttributes) => void;
+    bound: (el: ElementWithXAttributes, name: string, fallback?: unknown) => unknown;
+    $data: (node: ElementWithXAttributes) => {};
+    walk: (el: ElementWithXAttributes, callback: WalkerCallback) => any;
+    data: <T_12 extends Record<string | symbol, unknown>>(
+        name: string,
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        callback: (...args: unknown[]) => AlpineComponent<T_12>,
+    ) => void;
+    bind: (name: string | ElementWithXAttributes, bindings: Bindings | ((...args: unknown[]) => Bindings)) => void;
 }
 
-declare const AlpineInstance: Alpine;
-export default AlpineInstance;
+declare const Alpine: Alpine;
+export default Alpine;

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -130,7 +130,7 @@ export interface DirectiveCallback {
 
 export type WalkerCallback = (el: ElementWithXAttributes, skip: () => void) => void;
 
-export type AlpineComponent<T> = T & XDataContext & ThisType<T & XDataContext & AlpineMagics<T>>;
+export type AlpineComponent<T> = T & XDataContext & ThisType<T & XDataContext & Magics<T>>;
 
 interface XDataContext {
     /**
@@ -142,43 +142,51 @@ interface XDataContext {
      */
     destroy?(): void;
 }
-export interface AlpineMagics<T> {
+
+export interface Stores {}
+
+export interface Magics<T> {
     /**
      * Access to current Alpine data.
      */
     $data: T;
     /**
+     * Dispatches a CustomEvent on the current DOM node.
+     * Event automatically bubbles up.
+     *
+     * @param event the event name
+     * @param detail an event-dependent value associated with the event, the value is then available to the handler using the CustomEvent.detail property
+     */
+    $dispatch: (event: string, detail?: any) => void;
+    /**
      * Retrieve the current DOM node.
      */
     $el: HTMLElement;
-    /**
-     * Retrieve DOM elements marked with x-ref inside the component.
-     */
-    $refs: Record<string, HTMLElement>;
-    /**
-     * Access registered global Alpine stores.
-     */
-    $store: (name: string) => XDataContext | string | number | boolean;
-    /**
-     * Dispatch browser events.
-     *
-     * @param event the event name
-     * @param data an event-dependent value associated with the event, the value is then available to the handler using the CustomEvent.detail property
-     */
-    $dispatch: (event: string, data?: any) => void;
     /**
      * Generate an element's ID and ensure that it won't conflict with other IDs of the same name on the same page.
      *
      * @param name the name of the id
      * @param key suffix on the end of the generated ID, usually helpful for the purpose of identifying id in a loop
      */
-    $id: (name: string, key?: number | string) => string;
+    $id: (name: string, key?: number | string | null) => string;
     /**
      * Execute a given expression AFTER Alpine has made its reactive DOM updates.
      *
      * @param callback a callback that will be fired after Alpine finishes updating the DOM
      */
     $nextTick: (callback?: () => void) => Promise<void>;
+    /**
+     * Retrieve DOM elements marked with x-ref inside the component.
+     */
+    $refs: Record<string, HTMLElement>;
+    /**
+     * Accesses the root element of the current component context.
+     */
+    $root: ElementWithXAttributes;
+    /**
+     * Access registered global Alpine stores.
+     */
+    $store: Stores
     /**
      * Fire the given callback when the value in the property is changed.
      *

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -202,6 +202,8 @@ export interface Magics<T> {
     ) => void;
 }
 
+export type PluginCallback = (Alpine: Alpine) => void;
+
 export interface ReactiveEffect<T = any> {
     (): T;
     id: number;
@@ -355,7 +357,7 @@ export interface Alpine {
     nextTick: (callback?: () => void) => Promise<unknown>;
     prefixed: (subject?: string) => string;
     prefix: (newPrefix: string) => void;
-    plugin: (callbacks: ((Alpine: any) => void) | Array<(Alpine: any) => void>) => void;
+    plugin: (callbacks: PluginCallback | PluginCallback[]) => void;
     magic: (name: string, callback: (el: ElementWithXAttributes, options: MagicUtilities) => unknown) => void;
     store: {
         <T extends keyof Stores>(name: T): Stores[T];

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for alpinejs 3.13
 // Project: https://github.com/alpinejs/alpine
 // Definitions by: Thomas Wirth <https://github.com/wtho>
+//                 Eric Kwoka <https://github.com/ekwoka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.6
 

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -143,7 +143,9 @@ interface XDataContext {
     destroy?(): void;
 }
 
-export interface Stores {}
+export interface Stores {
+    [key: string | symbol]: unknown;
+}
 
 export interface Magics<T> {
     /**
@@ -355,10 +357,8 @@ export interface Alpine {
     plugin: (callbacks: ((Alpine: any) => void) | Array<(Alpine: any) => void>) => void;
     magic: (name: string, callback: (el: ElementWithXAttributes, options: MagicUtilities) => unknown) => void;
     store: {
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T_10 extends string | number | boolean | unknown[] | Record<string, unknown>>(name: string): T_10;
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T_11 extends string | number | boolean | unknown[] | Record<string, unknown>>(name: string, value: T_11): void;
+        <T extends keyof Stores>(name: T): Stores[T];
+        <T extends keyof Stores>(name: T, value: Stores[T]): void;
     };
     start: () => void;
     clone: (oldEl: ElementWithXAttributes, newEl: ElementWithXAttributes) => void;
@@ -368,7 +368,7 @@ export interface Alpine {
     data: <T_12 extends Record<string | symbol, unknown>>(
         name: string,
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        callback: (...args: unknown[]) => AlpineComponent<T_12>,
+        callback: (...args: unknown[]) => AlpineComponent<T_12>, // Needed generic to properly autotype objects
     ) => void;
     bind: (name: string | ElementWithXAttributes, bindings: Bindings | ((...args: unknown[]) => Bindings)) => void;
 }

--- a/types/alpinejs/package.json
+++ b/types/alpinejs/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@vue/reactivity": "^3.2.26"
+        "@vue/reactivity": "~3.1.1"
     }
 }

--- a/types/alpinejs/package.json
+++ b/types/alpinejs/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "@vue/reactivity": "~3.1.1"
-    }
+    "private": true
 }

--- a/types/alpinejs/tslint.json
+++ b/types/alpinejs/tslint.json
@@ -1,1 +1,5 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{ "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false
+    }
+}

--- a/types/alpinejs/tslint.json
+++ b/types/alpinejs/tslint.json
@@ -1,5 +1,1 @@
-{ "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "no-empty-interface": false
-    }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/alpinejs__focus/alpinejs__focus-tests.ts
+++ b/types/alpinejs__focus/alpinejs__focus-tests.ts
@@ -1,4 +1,18 @@
-import focusPlugin from "@alpinejs/focus";
-import Alpine from "alpinejs";
+import focusPlugin from '@alpinejs/focus';
+import Alpine, { AlpineComponent } from 'alpinejs';
 
 Alpine.plugin(focusPlugin);
+
+{
+    const testObject: AlpineComponent<{
+        canFocus(): void;
+    }> = {
+        canFocus() {
+            // $ExpectType $focus
+            this.$focus;
+
+            // $ExpectType boolean
+            this.$focus.focusable(new HTMLButtonElement());
+        },
+    };
+}

--- a/types/alpinejs__focus/index.d.ts
+++ b/types/alpinejs__focus/index.d.ts
@@ -1,8 +1,44 @@
-// Type definitions for @alpinejs/focus 3.10
+// Type definitions for @alpinejs/focus 3.13
 // Project: https://github.com/alpinejs/alpine
 // Definitions by: Brian Surowiec <https://github.com/xt0rted>
+//                 Eric Kwoka <https://github.com/ekwoka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.6
 
-import { Alpine } from 'alpinejs';
+import type { PluginCallback } from 'alpinejs';
 
-export default function(alpine: Alpine): void;
+declare const focusPlugin: PluginCallback;
+
+export default focusPlugin;
+
+interface $focus {
+    within(el: Element): $focus;
+    withoutScrolling(): $focus;
+    noscroll(): $focus;
+    withWrapAround(): $focus;
+    wrap(): $focus;
+    focusable(el: Element): boolean;
+    previouslyFocused(): Element | undefined;
+    lastFocused(): Element | undefined;
+    focused(): Element | undefined;
+    focusables(): Element[];
+    all(): Element[];
+    isFirst(el: Element): boolean;
+    isLast(el: Element): boolean;
+    getFirst(): Element | undefined;
+    getLast(): Element | undefined;
+    getNext(): Element | undefined;
+    getPrevious(): Element | undefined;
+    first(): Element | undefined;
+    last(): Element | undefined;
+    next(): Element | undefined;
+    previous(): Element | undefined;
+    prev(): Element | undefined;
+    focus(el: Element): void;
+}
+
+declare module 'alpinejs' {
+    interface Magics<T> {
+        $focus: $focus;
+    }
+}


### PR DESCRIPTION
These definitions were quite out of date (was from 3.7, now on 3.13), and needed a good refresh and update to work better with plugin maintainers and more involved Alpine users.

[Link to Releases](https://github.com/alpinejs/alpine/releases)

This is a significantly rewritten types (mostly generated from a TS rewrite of the package) to be more accurate, erring on the side of providing too much information.

This also allows for Stores and Magics to be more easily extended by plugins and users

Note: I abstracted the types that were formerly provided from Vue Reactivity. this is because of issues handling the fact that Alpine does not use the latest versions of Vue Reactivity, and it can become more difficult ensure the types are properly conveyed. Generally, users don't need to be aware of the full identity of those types, only that the type returned from one thing can go into another thing (and other things shouldn't).

Also Updates Alpinejs focus plugin to work with the new types providing improved safety for users. Would have done separately but there was a test-failure conflict.

Will make separate PRs after this merges to type other core plugins

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
