### PR TITLE
Fix zdog: remove readonly from Polygon properties

### DIFF
--- a/types/zdog/index.d.ts
+++ b/types/zdog/index.d.ts
@@ -694,10 +694,10 @@ export interface PolygonOptions extends ShapeOptions {
  */
 export class Polygon extends Shape {
     /** @see {@link PolygonOptions#radius} */
-    readonly radius?: number | undefined;
+    radius?: number | undefined;
 
     /** @see {@link PolygonOptions#sides} */
-    readonly sides?: number | undefined;
+    sides?: number | undefined;
 
     constructor(options?: PolygonOptions);
 


### PR DESCRIPTION
Fixes an error with the Zdog package type definitions.

This PR removes the `readonly` keyword from the properties of the Polygon class. All other Shape classes have editable properties, only ShapeOptions interfaces have read-only properties.

# Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

## If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/metafizzy/zdog/blob/master/js/polygon.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
