### PR TITLE
Add empty args method overload for node async_hooks

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -452,6 +452,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its

--- a/types/node/ts4.8/async_hooks.d.ts
+++ b/types/node/ts4.8/async_hooks.d.ts
@@ -452,6 +452,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its

--- a/types/node/v14/async_hooks.d.ts
+++ b/types/node/v14/async_hooks.d.ts
@@ -199,6 +199,7 @@ declare module 'async_hooks' {
          * stacktrace will not be impacted by this call and the context will be exited.
          */
         // TODO: Apply generic vararg once available
+        run<R>(store: T, callback: () => R): R;
         run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
 
         /**

--- a/types/node/v14/ts4.8/async_hooks.d.ts
+++ b/types/node/v14/ts4.8/async_hooks.d.ts
@@ -199,6 +199,7 @@ declare module 'async_hooks' {
          * stacktrace will not be impacted by this call and the context will be exited.
          */
         // TODO: Apply generic vararg once available
+        run<R>(store: T, callback: () => R): R;
         run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
 
         /**

--- a/types/node/v16/async_hooks.d.ts
+++ b/types/node/v16/async_hooks.d.ts
@@ -419,6 +419,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its

--- a/types/node/v16/ts4.8/async_hooks.d.ts
+++ b/types/node/v16/ts4.8/async_hooks.d.ts
@@ -419,6 +419,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its

--- a/types/node/v18/async_hooks.d.ts
+++ b/types/node/v18/async_hooks.d.ts
@@ -440,6 +440,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its

--- a/types/node/v18/ts4.8/async_hooks.d.ts
+++ b/types/node/v18/ts4.8/async_hooks.d.ts
@@ -440,6 +440,7 @@ declare module 'async_hooks' {
          * ```
          * @since v13.10.0, v12.17.0
          */
+        run<R>(store: T, callback: () => R): R;
         run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
         /**
          * Runs a function synchronously outside of a context and returns its


### PR DESCRIPTION
When I was implementing an Express middleware using `async_hooks`, I found that the `NextFunction` type and the `AsyncLocalStorage.run()` method were not compatible.

This problem occurs when using one of the three method options, which allows optional arguments. I expected the third argument to be optional when invoking the `AsyncLocalStorage.run()` method.

e.g.

```ts
app.use((_req, _res, next) => {
    const logger = log4js.getLogger();
    contextLogger.run(logger, next); // >
});                                  // Expected 3 arguments, but got 2.ts(2554)
                                     // async_hooks.d.ts(456, 80): Arguments for 
                                     // the rest parameter 'args' were not provided.
```

```ts
export interface NextFunction {
    (err?: any): void;
    /**
     * "Break-out" of a router by calling {next('router')};
     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
     */
    (deferToNext: 'router'): void;
    /**
     * "Break-out" of a route by calling {next('route')};
     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.application}
     */
    (deferToNext: 'route'): void;
}
```

Including the overloaded method signature `run<R>(store: T, callback: () => R): R;` effectively addresses this issue without requiring any modifications to the implementation.

**Please fill in this template.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

**Select one of these and delete the others:**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-serve-static-core/index.d.ts#L38>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.