### PR TITLE
[bcrypt-js] allow `err` argument in callbacks to be `null`

### DIFF
--- a/types/bcryptjs/bcryptjs-tests.ts
+++ b/types/bcryptjs/bcryptjs-tests.ts
@@ -9,10 +9,10 @@ let error: Error;
 str = bcryptjs.genSaltSync();
 str = bcryptjs.genSaltSync(10);
 
-bcryptjs.genSalt((err: Error, salt: string) => {
+bcryptjs.genSalt((err: Error | null, salt: string) => {
     str = salt;
 });
-bcryptjs.genSalt(10, (err: Error, salt: string) => {
+bcryptjs.genSalt(10, (err: Error | null, salt: string) => {
     str = salt;
 });
 bcryptjs.genSalt()
@@ -26,10 +26,10 @@ str = bcryptjs.hashSync("string");
 str = bcryptjs.hashSync("string", 10);
 str = bcryptjs.hashSync("string", "salt");
 
-bcryptjs.hash("string", 10, (err: Error, hash: string) => {
+bcryptjs.hash("string", 10, (err: Error | null, hash: string) => {
     str = hash;
 });
-bcryptjs.hash("string", 10, (err: Error, hash: string) => {
+bcryptjs.hash("string", 10, (err: Error | null, hash: string) => {
     str = hash;
 }, (percent: number) => {
     num = percent;
@@ -38,10 +38,10 @@ bcryptjs.hash("string", 10)
         .then(salt => str = salt)
         .catch(err => error = err);
 
-bcryptjs.hash("string", "salt", (err: Error, hash: string) => {
+bcryptjs.hash("string", "salt", (err: Error | null, hash: string) => {
     str = hash;
 });
-bcryptjs.hash("string", "salt", (err: Error, hash: string) => {
+bcryptjs.hash("string", "salt", (err: Error | null, hash: string) => {
     str = hash;
 }, (percent: number) => {
     num = percent;
@@ -49,10 +49,10 @@ bcryptjs.hash("string", "salt", (err: Error, hash: string) => {
 
 bool = bcryptjs.compareSync("string1", "string2");
 
-bcryptjs.compare("string1", "string2", (err: Error, success: boolean) => {
+bcryptjs.compare("string1", "string2", (err: Error | null, success: boolean) => {
     bool = success;
 });
-bcryptjs.compare("string1", "string2", (err: Error, success: boolean) => {
+bcryptjs.compare("string1", "string2", (err: Error | null, success: boolean) => {
     bool = success;
 }, (percent: number) => {
     num = percent;

--- a/types/bcryptjs/index.d.ts
+++ b/types/bcryptjs/index.d.ts
@@ -33,14 +33,14 @@ export declare function genSalt(rounds?: number): Promise<string>;
  * Asynchronously generates a salt.
  * @param callback Callback receiving the error, if any, and the resulting salt
  */
-export declare function genSalt(callback: (err: Error, salt: string) => void): void;
+export declare function genSalt(callback: (err: Error | null, salt: string) => void): void;
 
 /**
  * Asynchronously generates a salt.
  * @param  rounds   Number of rounds to use, defaults to 10 if omitted
  * @param  callback Callback receiving the error, if any, and the resulting salt
  */
-export declare function genSalt(rounds: number, callback: (err: Error, salt: string) => void): void;
+export declare function genSalt(rounds: number, callback: (err: Error | null, salt: string) => void): void;
 
 /**
  * Synchronously generates a hash for the given string.
@@ -65,7 +65,7 @@ export declare function hash(s: string, salt: number | string): Promise<string>;
  * @param callback         Callback receiving the error, if any, and the resulting hash
  * @param progressCallback Callback successively called with the percentage of rounds completed (0.0 - 1.0), maximally once per MAX_EXECUTION_TIME = 100 ms.
  */
-export declare function hash(s: string, salt: number | string, callback?: (err: Error, hash: string) => void, progressCallback?: (percent: number) => void): void;
+export declare function hash(s: string, salt: number | string, callback?: (err: Error | null, hash: string) => void, progressCallback?: (percent: number) => void): void;
 
 /**
  * Synchronously tests a string against a hash.
@@ -90,7 +90,7 @@ export declare function compare(s: string, hash: string): Promise<boolean>;
  * @param  callback         Callback receiving the error, if any, otherwise the result
  * @param  progressCallback Callback successively called with the percentage of rounds completed (0.0 - 1.0), maximally once per MAX_EXECUTION_TIME = 100 ms.
  */
-export declare function compare(s: string, hash: string, callback?: (err: Error, success: boolean) => void, progressCallback?: (percent: number) => void): void;
+export declare function compare(s: string, hash: string, callback?: (err: Error | null, success: boolean) => void, progressCallback?: (percent: number) => void): void;
 
 /**
  * Gets the number of rounds used to encrypt the specified hash.


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Here are the calls:
- https://github.com/dcodeIO/bcrypt.js/blob/7e2e93af99df2952253f9cf32db29aefa8f272f7/src/bcrypt.js#L111
- https://github.com/dcodeIO/bcrypt.js/blob/7e2e93af99df2952253f9cf32db29aefa8f272f7/src/bcrypt.js#L244
- https://github.com/dcodeIO/bcrypt.js/blob/7e2e93af99df2952253f9cf32db29aefa8f272f7/src/bcrypt/impl.js#L666

