### PR TITLE
[phoenix] Fix Channel.[onClose,onError] return types

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -28,8 +28,8 @@ export class Channel {
   join(timeout?: number): Push;
   leave(timeout?: number): Push;
 
-  onClose(callback: (payload: any, ref: any, joinRef: any) => void | Promise<void>): void;
-  onError(callback: (reason?: any) => void | Promise<void>): void;
+  onClose(callback: (payload: any, ref: any, joinRef: any) => void | Promise<void>): number;
+  onError(callback: (reason?: any) => void | Promise<void>): number;
   onMessage(event: string, payload: any, ref: any): any;
 
   on(event: string, callback: (response?: any) => void | Promise<void>): number;

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -51,13 +51,16 @@ function test_hooks() {
   const socket = new Socket('/ws', { params: { userToken: '123' } });
   socket.connect();
 
-  socket.onError(() => console.log('there was an error with the connection!'));
-  socket.onClose(() => console.log('the connection dropped'));
+  const socketOnErrorRef = socket.onError(() => console.log('there was an error with the connection!'));
+  const socketOnCloseRef = socket.onClose(() => console.log('the connection dropped'));
+  socket.off([socketOnErrorRef, socketOnCloseRef]);
 
   const channel = socket.channel('room:123', { token: '123' });
 
-  channel.onError(() => console.log('there was an error!'));
-  channel.onClose(() => console.log('the channel has gone away gracefully'));
+  const channelOnErrorRef = channel.onError(() => console.log('there was an error!'));
+  const channelOnCloseRef = channel.onClose(() => console.log('the channel has gone away gracefully'));
+  channel.off('phx_error', channelOnErrorRef);
+  channel.off('phx_close', channelOnCloseRef);
 }
 
 function test_presence() {


### PR DESCRIPTION
These methods return refs like Channel.on(). Keeping the refs allows to disconnect handlers.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/phoenixframework/phoenix/blob/main/assets/js/phoenix/channel.js#L90-L127
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.