### PR TITLE
Formatted types/q* packages with dprint

### DIFF
--- a/types/q-io/index.d.ts
+++ b/types/q-io/index.d.ts
@@ -6,24 +6,23 @@
 
 /// <reference types="node" />
 
-//TODO add support for q-io/http-apps
-//TODO add verified support for q-io/fs-mock
-//TODO fix Readers/Writers properly
-//TODO find solution for overloaded return types (QioFS.open/QioFS.read)
+// TODO add support for q-io/http-apps
+// TODO add verified support for q-io/fs-mock
+// TODO fix Readers/Writers properly
+// TODO find solution for overloaded return types (QioFS.open/QioFS.read)
 //     for some ideas see https://typescript.codeplex.com/discussions/461587#post1105930
 
 declare namespace QioFS {
-
-    //TODO how to define the multiple return types? use any for now?
+    // TODO how to define the multiple return types? use any for now?
     export function open(path: string, options?: any): Q.Promise<any>;
-    //export function open(path:string, options?:any):Q.Promise<Qio.Reader>;
-    //export function open(path:string, options?:any):Q.Promise<Qio.Writer>;
-    //export function open(path:string, options?:any):Q.Promise<Buffer>;
+    // export function open(path:string, options?:any):Q.Promise<Qio.Reader>;
+    // export function open(path:string, options?:any):Q.Promise<Qio.Writer>;
+    // export function open(path:string, options?:any):Q.Promise<Buffer>;
 
-    //TODO how to define the multiple return types? use any for now?
+    // TODO how to define the multiple return types? use any for now?
     export function read(path: string, options?: any): Q.Promise<any>;
-    //export function read(path:string, options?:any):Q.Promise<string>;
-    //export function read(path:string, options?:any):Q.Promise<Buffer>;
+    // export function read(path:string, options?:any):Q.Promise<string>;
+    // export function read(path:string, options?:any):Q.Promise<Buffer>;
 
     export function write(path: string, content: Buffer, options?: any): Q.Promise<void>;
     export function write(path: string, content: string, options?: any): Q.Promise<void>;
@@ -99,16 +98,16 @@ declare namespace QioFS {
     export function base(path: string, extension: string): string;
     export function extension(path: string): string;
 
-    //this should return a q-io/fs-mock MockFS
+    // this should return a q-io/fs-mock MockFS
     export function reroot(path: string): typeof QioFS;
 
     export function toObject(path: string): { [path: string]: Buffer };
 
-    //listed but not implemented by Q-io
-    //export function glob(pattern):Q.Promise<string[]>;
-    //export function match(pattern, path:string):Q.Promise<string[]>;
+    // listed but not implemented by Q-io
+    // export function glob(pattern):Q.Promise<string[]>;
+    // export function match(pattern, path:string):Q.Promise<string[]>;
 
-    //TODO link this to node.js FS module (no lazy clones)
+    // TODO link this to node.js FS module (no lazy clones)
     interface Stats {
         node: NodeStats;
         size: number;
@@ -171,7 +170,7 @@ declare namespace QioHTTP {
     interface Response {
         status: number;
         headers: Headers;
-        body: Qio.Reader
+        body: Qio.Reader;
         onclose: () => void;
         node: any;
     }
@@ -180,7 +179,6 @@ declare namespace QioHTTP {
         // [name:string]:any[];
     }
     interface Body extends Qio.Stream {
-
     }
     interface Application {
         (req: Request): Q.Promise<any>;
@@ -223,11 +221,10 @@ declare namespace Qio {
     }
 
     interface BufferReader extends QioBufferReader {
-
     }
 }
 interface QioBufferReader {
-    new (): Qio.Reader;
+    new(): Qio.Reader;
     read(stream: Qio.Reader, charset: string): string;
     read(stream: Qio.Reader): Buffer;
     join(buffers: Buffer[]): Buffer;
@@ -237,7 +234,7 @@ interface QioBufferWriter {
     Writer: Qio.Writer;
 }
 interface QioBufferStream {
-    (buffer: Buffer, encoding: string): Qio.Stream
+    (buffer: Buffer, encoding: string): Qio.Stream;
 }
 
 declare module "q-io/http" {

--- a/types/q-io/q-io-tests.ts
+++ b/types/q-io/q-io-tests.ts
@@ -1,47 +1,47 @@
-var fs:typeof QioFS = require('q-io/fs');
-var http:typeof QioHTTP = require('q-io/http');
+var fs: typeof QioFS = require("q-io/fs");
+var http: typeof QioHTTP = require("q-io/http");
 
-var bool:boolean;
-var num:number;
-var x:any;
-var path:string;
-var buffer:Buffer;
-var str:string;
-var strArr:string[];
-var source:string;
-var target:string;
-var type:string;
+var bool: boolean;
+var num: number;
+var x: any;
+var path: string;
+var buffer: Buffer;
+var str: string;
+var strArr: string[];
+var source: string;
+var target: string;
+var type: string;
 
-var options:any;
-var strArrQ:Q.Promise<string[]>;
-var voidQ:Q.Promise<void>;
-var anyQ:Q.Promise<any>;
-var strQ:Q.Promise<string>;
-var boolQ:Q.Promise<boolean>;
-var dateQ:Q.Promise<Date>;
-var bufferQ:Q.Promise<Buffer>;
+var options: any;
+var strArrQ: Q.Promise<string[]>;
+var voidQ: Q.Promise<void>;
+var anyQ: Q.Promise<any>;
+var strQ: Q.Promise<string>;
+var boolQ: Q.Promise<boolean>;
+var dateQ: Q.Promise<Date>;
+var bufferQ: Q.Promise<Buffer>;
 
-var statsQ:Q.Promise<QioFS.Stats>;
-var readQ:Q.Promise<Qio.Reader>;
-var writeQ:Q.Promise<Qio.Writer>;
+var statsQ: Q.Promise<QioFS.Stats>;
+var readQ: Q.Promise<Qio.Reader>;
+var writeQ: Q.Promise<Qio.Writer>;
 
-var headers:QioHTTP.Headers;
-var reader:Qio.Reader;
-var writer:Qio.Writer;
-var stream:Qio.Stream;
+var headers: QioHTTP.Headers;
+var reader: Qio.Reader;
+var writer: Qio.Writer;
+var stream: Qio.Stream;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 fs.open(path, options).then((x) => {
 });
-//fs.open(path, options):Q.Promise<Qio.Reader>;
-//fs.open(path, options):Q.Promise<Qio.Writer>;
-//fs.open(path, options):Q.Promise<Buffer>;
+// fs.open(path, options):Q.Promise<Qio.Reader>;
+// fs.open(path, options):Q.Promise<Qio.Writer>;
+// fs.open(path, options):Q.Promise<Buffer>;
 
-//TODO how to define the multiple return types? use any for now?
+// TODO how to define the multiple return types? use any for now?
 anyQ = fs.read(path, options);
-//strQ = fs.read(path, options);
-//fs.read(path, options):Q.Promise<Buffer>;
+// strQ = fs.read(path, options);
+// fs.read(path, options):Q.Promise<Buffer>;
 
 voidQ = fs.write(path, buffer, options);
 voidQ = fs.write(path, str, options);
@@ -78,7 +78,7 @@ voidQ = fs.chown(path, num, num);
 voidQ = fs.chmod(path, str);
 voidQ = fs.chmod(path, num);
 
-statsQ = fs.stat(path)
+statsQ = fs.stat(path);
 statsQ = fs.statLink(path);
 statsQ = fs.statFd(num);
 
@@ -119,14 +119,14 @@ str = fs.directory(path);
 str = fs.base(path, str);
 str = fs.extension(path);
 
-//this should return a q-io/fs-mock MockFS
-//fs = fs.reroot(str);
+// this should return a q-io/fs-mock MockFS
+// fs = fs.reroot(str);
 x = fs.toObject(str);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-var request:QioHTTP.Request;
-var headers:QioHTTP.Headers;
+var request: QioHTTP.Request;
+var headers: QioHTTP.Headers;
 
 str = request.url;
 str = request.path;
@@ -146,10 +146,10 @@ x = request.agent;
 x = request.body;
 x = request.node;
 
-str = headers['foo'];
+str = headers["foo"];
 
-var response:QioHTTP.Response;
-var responseQ:Q.Promise<QioHTTP.Response>;
+var response: QioHTTP.Response;
+var responseQ: Q.Promise<QioHTTP.Response>;
 
 responseQ = http.request(request);
 responseQ = http.request(str);
@@ -165,7 +165,6 @@ num = response.status;
 headers = response.headers;
 reader = response.body;
 response.onclose = () => {
-
 };
 x = response.node;
 
@@ -175,7 +174,7 @@ strQ = reader.read(str);
 bufferQ = reader.read();
 reader.close();
 x = reader.node;
-voidQ = reader.forEach((chunk:any) => {
+voidQ = reader.forEach((chunk: any) => {
     return anyQ;
 });
 
@@ -192,6 +191,6 @@ stream.write(buffer);
 stream.flush();
 stream.close();
 x = stream.node;
-voidQ = reader.forEach((chunk:any) => {
+voidQ = reader.forEach((chunk: any) => {
     return anyQ;
 });

--- a/types/q-retry/index.d.ts
+++ b/types/q-retry/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import * as Q from 'q';
+import * as Q from "q";
 
 export = Q;
 
-declare module 'q' {
+declare module "q" {
     export interface IRetryOptions {
         limit?: number | undefined;
         interval?: number | undefined;
@@ -16,22 +16,50 @@ declare module 'q' {
         intervalMultiplier?: number | undefined;
     }
 
-    export function retry<U>(process: () => IPromise<U>, onFail: (reason: any, retries: number) => void, limit: number): Promise<U>;
-    export function retry<U>(process: () => IPromise<U>, onFail: (reason: any, retries: number) => void, options?: IRetryOptions): Promise<U>;
+    export function retry<U>(
+        process: () => IPromise<U>,
+        onFail: (reason: any, retries: number) => void,
+        limit: number,
+    ): Promise<U>;
+    export function retry<U>(
+        process: () => IPromise<U>,
+        onFail: (reason: any, retries: number) => void,
+        options?: IRetryOptions,
+    ): Promise<U>;
     export function retry<U>(process: () => IPromise<U>, limit: number): Promise<U>;
     export function retry<U>(process: () => IPromise<U>, options?: IRetryOptions): Promise<U>;
-    export function retry<U>(process: () => U, onFail: (reason: any, retries: number) => void, limit: number): Promise<U>;
-    export function retry<U>(process: () => U, onFail: (reason: any, retries: number) => void, options?: IRetryOptions): Promise<U>;
+    export function retry<U>(
+        process: () => U,
+        onFail: (reason: any, retries: number) => void,
+        limit: number,
+    ): Promise<U>;
+    export function retry<U>(
+        process: () => U,
+        onFail: (reason: any, retries: number) => void,
+        options?: IRetryOptions,
+    ): Promise<U>;
     export function retry<U>(process: () => U, limit: number): Promise<U>;
     export function retry<U>(process: () => U, options?: IRetryOptions): Promise<U>;
 
     interface Promise<T> {
-        retry<U>(process: (value: T) => IPromise<U>, onFail: (reason: any, retries: number) => void, limit: number): Promise<U>;
-        retry<U>(process: (value: T) => IPromise<U>, onFail: (reason: any, retries: number) => void, options?: IRetryOptions): Promise<U>;
+        retry<U>(
+            process: (value: T) => IPromise<U>,
+            onFail: (reason: any, retries: number) => void,
+            limit: number,
+        ): Promise<U>;
+        retry<U>(
+            process: (value: T) => IPromise<U>,
+            onFail: (reason: any, retries: number) => void,
+            options?: IRetryOptions,
+        ): Promise<U>;
         retry<U>(process: (value: T) => IPromise<U>, limit: number): Promise<U>;
         retry<U>(process: (value: T) => IPromise<U>, options?: IRetryOptions): Promise<U>;
         retry<U>(process: (value: T) => U, onFail: (reason: any, retries: number) => void, limit: number): Promise<U>;
-        retry<U>(process: (value: T) => U, onFail: (reason: any, retries: number) => void, options?: IRetryOptions): Promise<U>;
+        retry<U>(
+            process: (value: T) => U,
+            onFail: (reason: any, retries: number) => void,
+            options?: IRetryOptions,
+        ): Promise<U>;
         retry<U>(process: (value: T) => U, limit: number): Promise<U>;
         retry<U>(process: (value: T) => U, options?: IRetryOptions): Promise<U>;
     }

--- a/types/q-retry/q-retry-tests.ts
+++ b/types/q-retry/q-retry-tests.ts
@@ -1,10 +1,8 @@
-
-
-﻿import Q = require('q-retry');
+import Q = require("q-retry");
 
 Q
     .retry(() => {
-        return '';
+        return "";
     })
     .then(str => {
         str.charAt;
@@ -14,27 +12,23 @@ Q
         num.toFixed;
     })
     .retry(() => {
-
     }, 5)
     .retry(() => {
-
     }, (reason, retries) => {
         retries.toFixed;
     })
     .retry(() => {
-
     }, (reason, retries) => {
         retries.toFixed;
     }, 10)
     .retry(() => {
-        return '';
+        return "";
     }, (reason, retries) => {
-
     }, {
         limit: 10,
         interval: 1000,
         maxInterval: 20000,
-        intervalMultiplier: 1.5
+        intervalMultiplier: 1.5,
     })
     .then(str => {
         str.charAt;

--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -60,8 +60,16 @@ declare namespace Q {
         /**
          * The then method from the Promises/A+ specification, with an additional progress handler.
          */
-        then<U>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<U>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
-        then<U = T, V = never>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<V>) | null, onProgress?: ((progress: any) => any) | null): Promise<U | V>;
+        then<U>(
+            onFulfill?: ((value: T) => IWhenable<U>) | null,
+            onReject?: ((error: any) => IWhenable<U>) | null,
+            onProgress?: ((progress: any) => any) | null,
+        ): Promise<U>;
+        then<U = T, V = never>(
+            onFulfill?: ((value: T) => IWhenable<U>) | null,
+            onReject?: ((error: any) => IWhenable<V>) | null,
+            onProgress?: ((progress: any) => any) | null,
+        ): Promise<U | V>;
         /**
          * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so
          * without modifying the final value. This is useful for collecting resources regardless of whether a job succeeded,
@@ -116,7 +124,11 @@ declare namespace Q {
          * with you, call done to terminate it. Terminating with catch is not sufficient because the catch handler may
          * itself throw an error.
          */
-        done(onFulfilled?: ((value: T) => any) | null, onRejected?: ((reason: any) => any) | null, onProgress?: ((progress: any) => any) | null): void;
+        done(
+            onFulfilled?: ((value: T) => any) | null,
+            onRejected?: ((reason: any) => any) | null,
+            onProgress?: ((progress: any) => any) | null,
+        ): void;
 
         /**
          * If callback is a function, assumes it's a Node.js-style callback, and calls it as either callback(rejectionReason)
@@ -289,7 +301,7 @@ declare namespace Q {
         value: IWhenable<T>,
         onFulfilled: (val: T) => IWhenable<U>,
         onRejected?: ((reason: any) => IWhenable<U>) | null,
-        onProgress?: ((progress: any) => any) | null
+        onProgress?: ((progress: any) => any) | null,
     ): Promise<U>;
 
     /**
@@ -391,7 +403,11 @@ declare namespace Q {
      *     //...
      * });
      */
-    export function nbind<T>(nodeFunction: (...args: any[]) => any, thisArg: any, ...args: any[]): (...args: any[]) => Promise<T>;
+    export function nbind<T>(
+        nodeFunction: (...args: any[]) => any,
+        thisArg: any,
+        ...args: any[]
+    ): (...args: any[]) => Promise<T>;
 
     /**
      * Calls a Node.js-style function with the given array of arguments, returning a promise that is fulfilled if the
@@ -456,15 +472,21 @@ declare namespace Q {
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D, E, F>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>): Promise<[A, B, C, D, E, F]>;
+    export function all<A, B, C, D, E, F>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>,
+    ): Promise<[A, B, C, D, E, F]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D, E>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>): Promise<[A, B, C, D, E]>;
+    export function all<A, B, C, D, E>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>,
+    ): Promise<[A, B, C, D, E]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>]>): Promise<[A, B, C, D]>;
+    export function all<A, B, C, D>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>]>,
+    ): Promise<[A, B, C, D]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
@@ -502,7 +524,11 @@ declare namespace Q {
      * rejected, instead calls onRejected with the first rejected promise's rejection reason. This is especially useful
      * in conjunction with all.
      */
-    export function spread<T, U>(promises: Array<IWhenable<T>>, onFulfilled: (...args: T[]) => IWhenable<U>, onRejected?: (reason: any) => IWhenable<U>): Promise<U>;
+    export function spread<T, U>(
+        promises: Array<IWhenable<T>>,
+        onFulfilled: (...args: T[]) => IWhenable<U>,
+        onRejected?: (reason: any) => IWhenable<U>,
+    ): Promise<U>;
 
     /**
      * Returns a promise that will have the same result as promise, except that if promise is not fulfilled or rejected
@@ -543,7 +569,13 @@ declare namespace Q {
      * note: In the latest github, this method is called Q.Promise, but if you are using the npm package version 0.9.7
      * or below, the method is called Q.promise (lowercase vs uppercase p).
      */
-    export function Promise<T>(resolver: (resolve: (val?: IWhenable<T>) => void, reject: (reason?: any) => void, notify: (progress: any) => void) => void): Promise<T>;
+    export function Promise<T>(
+        resolver: (
+            resolve: (val?: IWhenable<T>) => void,
+            reject: (reason?: any) => void,
+            notify: (progress: any) => void,
+        ) => void,
+    ): Promise<T>;
 
     /**
      * Creates a new version of func that accepts any combination of promise and non-promise values, converting them to their

--- a/types/q/q-tests.ts
+++ b/types/q/q-tests.ts
@@ -44,14 +44,14 @@ Q.when(x, (x) => {
 
 Q.all([
     eventually(10),
-    eventually(20)
+    eventually(20),
 ]).spread((x: number, y: number) => {
     console.log(x, y);
 });
 
 Q.all([
     eventually(10),
-    eventually(20)
+    eventually(20),
 ]).then((results) => {
     const [x, y] = results;
     console.log(x, y);
@@ -99,18 +99,18 @@ declare function returnsNumPromise(text: string): Q.Promise<number>;
 declare function returnsNumPromise(text: string): JQueryPromise<number>;
 
 Q(arrayPromise)
-    .then((arr) => arr.join(','))
+    .then((arr) => arr.join(","))
     .then(returnsNumPromise) // requires specification
     .then((num) => num.toFixed());
 
 declare let jPromise: JQueryPromise<string>;
 
 // if jQuery promises definition supported generics, this could be more interesting example
-Q<string>(jPromise).then((str) => str.split(','));
+Q<string>(jPromise).then((str) => str.split(","));
 jPromise.then(returnsNumPromise);
 
 // watch the typing flow through from jQueryPromise to Q.Promise
-Q(jPromise).then((str) => str.split(','));
+Q(jPromise).then((str) => str.split(","));
 
 declare let promiseArray: Array<Q.IPromise<number>>;
 const qPromiseArray = promiseArray.map((p) => {
@@ -118,14 +118,14 @@ const qPromiseArray = promiseArray.map((p) => {
 });
 const myNums: any[] = [2, 3, Q(4), 5, Q(6), Q(7)];
 
-Q.all(promiseArray).then((nums) => nums.map((num) => num.toPrecision(2)).join(','));
+Q.all(promiseArray).then((nums) => nums.map((num) => num.toPrecision(2)).join(","));
 
 Q.all<number>(myNums).then((nums) => nums.map(Math.round));
 
 Q.fbind((dateString?: string) => new Date(<string> dateString), "11/11/1991")().then((d) => d.toLocaleDateString());
 
 Q.when(8, (num) => num + "!");
-Q.when(Q(8), (num) => num + "!").then((str) => str.split(','));
+Q.when(Q(8), (num) => num + "!").then((str) => str.split(","));
 const voidPromise: Q.Promise<void> = Q.when();
 
 declare function saveToDisk(): Q.Promise<any>;
@@ -163,11 +163,11 @@ interface Kitty {
 
 class Repo {
     private readonly items: Kitty[] = [
-        {name: "Max", cute: false},
-        {name: "Annie", cute: true}
+        { name: "Max", cute: false },
+        { name: "Annie", cute: true },
     ];
 
-    find(options: {[K in keyof Kitty]: Kitty[K] }): Q.Promise<Kitty[]> {
+    find(options: { [K in keyof Kitty]: Kitty[K] }): Q.Promise<Kitty[]> {
         let result = this.items;
 
         for (const key in options) {

--- a/types/q/v0/index.d.ts
+++ b/types/q/v0/index.d.ts
@@ -52,7 +52,11 @@ declare namespace Q {
         /**
          * The then method from the Promises/A+ specification, with an additional progress handler.
          */
-        then<U>(onFulfill?: (value: T) => IWhenable<U>, onReject?: (error: any) => IWhenable<U>, onProgress?: Function): Promise<U>;
+        then<U>(
+            onFulfill?: (value: T) => IWhenable<U>,
+            onReject?: (error: any) => IWhenable<U>,
+            onProgress?: Function,
+        ): Promise<U>;
 
         /**
          * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are rejected, instead calls onRejected with the first rejected promise's rejection reason.
@@ -82,7 +86,11 @@ declare namespace Q {
          *
          * The Golden Rule of done vs. then usage is: either return your promise to someone else, or if the chain ends with you, call done to terminate it.
          */
-        done(onFulfilled?: (value: T) => any, onRejected?: (reason: any) => any, onProgress?: (progress: any) => any): void;
+        done(
+            onFulfilled?: (value: T) => any,
+            onRejected?: (reason: any) => any,
+            onProgress?: (progress: any) => any,
+        ): void;
 
         /**
          * If callback is a function, assumes it's a Node.js-style callback, and calls it as either callback(rejectionReason) when/if promise becomes rejected, or as callback(null, fulfillmentValue) when/if promise becomes fulfilled. If callback is not a function, simply returns promise.
@@ -167,11 +175,15 @@ declare namespace Q {
          */
         inspect(): PromiseState<T>;
 
-        all<A, B, C, D, E, F>(this: Promise<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>): Promise<[A, B, C, D, E, F]>;
+        all<A, B, C, D, E, F>(
+            this: Promise<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>,
+        ): Promise<[A, B, C, D, E, F]>;
         /**
          * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
          */
-        all<A, B, C, D, E>(this: Promise<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>): Promise<[A, B, C, D, E]>;
+        all<A, B, C, D, E>(
+            this: Promise<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>,
+        ): Promise<[A, B, C, D, E]>;
         /**
          * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
          */
@@ -203,7 +215,12 @@ declare namespace Q {
     export function when<T>(value: IWhenable<T>): Promise<T>;
 
     // If a non-promise value is provided, it will not reject or progress
-    export function when<T, U>(value: IWhenable<T>, onFulfilled: (val: T) => IWhenable<U>, onRejected?: (reason: any) => IWhenable<U>, onProgress?: (progress: any) => any): Promise<U>;
+    export function when<T, U>(
+        value: IWhenable<T>,
+        onFulfilled: (val: T) => IWhenable<U>,
+        onRejected?: (reason: any) => IWhenable<U>,
+        onProgress?: (progress: any) => any,
+    ): Promise<U>;
 
     /**
      * Currently "impossible" (and I use the term loosely) to implement due to TypeScript limitations as it is now.
@@ -233,15 +250,21 @@ declare namespace Q {
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D, E, F>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>): Promise<[A, B, C, D, E, F]>;
+    export function all<A, B, C, D, E, F>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>, IWhenable<F>]>,
+    ): Promise<[A, B, C, D, E, F]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D, E>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>): Promise<[A, B, C, D, E]>;
+    export function all<A, B, C, D, E>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>, IWhenable<E>]>,
+    ): Promise<[A, B, C, D, E]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
-    export function all<A, B, C, D>(promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>]>): Promise<[A, B, C, D]>;
+    export function all<A, B, C, D>(
+        promises: IWhenable<[IWhenable<A>, IWhenable<B>, IWhenable<C>, IWhenable<D>]>,
+    ): Promise<[A, B, C, D]>;
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
@@ -259,8 +282,8 @@ declare namespace Q {
     export function all<T>(promises: IWhenable<IWhenable<T>[]>): Promise<T[]>;
 
     /**
-    * Returns a promise for the first of an array of promises to become settled.
-    */
+     * Returns a promise for the first of an array of promises to become settled.
+     */
     export function race<T>(promises: IWhenable<T>[]): Promise<T>;
 
     /**
@@ -274,7 +297,11 @@ declare namespace Q {
      * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are rejected, instead calls onRejected with the first rejected promise's rejection reason.
      * This is especially useful in conjunction with all.
      */
-    export function spread<T, U>(promises: IWhenable<T>[], onFulfilled: (...args: T[]) => IWhenable<U>, onRejected?: (reason: any) => IWhenable<U>): Promise<U>;
+    export function spread<T, U>(
+        promises: IWhenable<T>[],
+        onFulfilled: (...args: T[]) => IWhenable<U>,
+        onRejected?: (reason: any) => IWhenable<U>,
+    ): Promise<U>;
 
     /**
      * Returns a promise that will have the same result as promise, except that if promise is not fulfilled or rejected before ms milliseconds, the returned promise will be rejected with an Error with the given message. If message is not supplied, the message will be "Timed out after " + ms + " ms".
@@ -292,7 +319,7 @@ declare namespace Q {
     /**
      * Returns a promise that will be fulfilled with undefined after at least ms milliseconds have passed.
      */
-    export function delay(ms: number): Promise <void>;
+    export function delay(ms: number): Promise<void>;
     /**
      * Returns whether a given promise is in the fulfilled state. When the static version is used on non-promises, the result is always true.
      */
@@ -321,7 +348,13 @@ declare namespace Q {
      */
     export function reject<T>(reason?: any): Promise<T>;
 
-    export function Promise<T>(resolver: (resolve: (val: IWhenable<T>) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): Promise<T>;
+    export function Promise<T>(
+        resolver: (
+            resolve: (val: IWhenable<T>) => void,
+            reject: (reason: any) => void,
+            notify: (progress: any) => void,
+        ) => void,
+    ): Promise<T>;
 
     /**
      * Creates a new version of func that accepts any combination of promise and non-promise values, converting them to their fulfillment values before calling the original func. The returned version also always returns a promise: if func does a return or throw, then Q.promised(func) will return fulfilled or rejected promise, respectively.

--- a/types/q/v0/q-tests.ts
+++ b/types/q/v0/q-tests.ts
@@ -1,19 +1,18 @@
 /// <reference types="jquery" />
 
-
-import Q = require('q');
+import Q = require("q");
 
 Q(8).then(x => console.log(x.toExponential()));
 Q().then(() => console.log("nothing"));
 
-var delay = function (delay: number) {
+var delay = function(delay: number) {
     var d = Q.defer<void>();
     setTimeout(d.resolve, delay);
     return d.promise;
 };
 
-Q.when(delay(1000), function (val: void) {
-    console.log('Hello, World!');
+Q.when(delay(1000), function(val: void) {
+    console.log("Hello, World!");
     return;
 });
 
@@ -33,49 +32,48 @@ eventualAdd(Q(1), Q(2)).then(x => x.toExponential());
 
 function eventually<T>(eventually: T) {
     return Q.delay(eventually, 1000);
-};
+}
 
 var x = Q.all([1, 2, 3].map(eventually));
-Q.when(x, function (x) {
+Q.when(x, function(x) {
     console.log(x);
 });
 
 Q.all([
     eventually(10),
-    eventually(20)
-]).spread(function (x: number, y: number) {
+    eventually(20),
+]).spread(function(x: number, y: number) {
     console.log(x, y);
 });
 
 Q.all([
     eventually(10),
-    eventually(20)
-]).then(function (results) {
+    eventually(20),
+]).then(function(results) {
     let [x, y] = results;
     console.log(x, y);
 });
 
-
-Q.fcall(function () { })
-    .then(function () { })
-    .then(function () { })
-    .then(function () { })
-    .then(function (value4) {
+Q.fcall(function() {})
+    .then(function() {})
+    .then(function() {})
+    .then(function() {})
+    .then(function(value4) {
         // Do something with value4
-    }, function (error) {
+    }, function(error) {
         // Handle any error from step1 through step4
     }).done();
 
 Q.allResolved([])
-.then(function (promises: Q.Promise<any>[]) {
-    promises.forEach(function (promise) {
-        if (promise.isFulfilled()) {
-            var value = promise.valueOf();
-        } else {
-            var exception = promise.valueOf().exception;
-        }
-    })
-});
+    .then(function(promises: Q.Promise<any>[]) {
+        promises.forEach(function(promise) {
+            if (promise.isFulfilled()) {
+                var value = promise.valueOf();
+            } else {
+                var exception = promise.valueOf().exception;
+            }
+        });
+    });
 
 Q(42)
     .tap(() => "hello")
@@ -92,43 +90,42 @@ declare function returnsNumPromise(text: string): Q.Promise<number>;
 declare function returnsNumPromise(text: string): JQueryPromise<number>;
 
 Q<number[]>(arrayPromise) // type specification required
-    .then(arr => arr.join(','))
+    .then(arr => arr.join(","))
     .then<number>(returnsNumPromise) // requires specification
     .then(num => num.toFixed());
 
 declare var jPromise: JQueryPromise<string>;
 
 // if jQuery promises definition supported generics, this could be more interesting example
-Q<string>(jPromise).then(str => str.split(','));
+Q<string>(jPromise).then(str => str.split(","));
 jPromise.then(returnsNumPromise);
 
 // watch the typing flow through from jQueryPromise to Q.Promise
-Q(jPromise).then(str => str.split(','));
+Q(jPromise).then(str => str.split(","));
 
 declare var promiseArray: Q.IPromise<number>[];
 var qPromiseArray = promiseArray.map(p => Q<number>(p));
 var myNums: any[] = [2, 3, Q(4), 5, Q(6), Q(7)];
 
-Q.all(promiseArray).then(nums => nums.map(num => num.toPrecision(2)).join(','));
+Q.all(promiseArray).then(nums => nums.map(num => num.toPrecision(2)).join(","));
 
 Q.all<number>(myNums).then(nums => nums.map(Math.round));
 
 Q.fbind((dateString?: string) => new Date(dateString), "11/11/1991")().then(d => d.toLocaleDateString());
 
 Q.when(8, num => num + "!");
-Q.when(Q(8), num => num + "!").then(str => str.split(','));
+Q.when(Q(8), num => num + "!").then(str => str.split(","));
 var voidPromise: Q.Promise<void> = Q.when();
 
 declare function saveToDisk(): Q.Promise<any>;
 declare function saveToCloud(): Q.Promise<any>;
-Q.allSettled([saveToDisk(), saveToCloud()]).spread(function (disk: any, cloud: any) {
+Q.allSettled([saveToDisk(), saveToCloud()]).spread(function(disk: any, cloud: any) {
     console.log("saved to disk:", disk.state === "fulfilled");
     console.log("saved to cloud:", cloud.state === "fulfilled");
 
     if (disk.state === "fulfilled") {
         console.log("value was " + disk.value);
-    }
-    else if (disk.state === "rejected") {
+    } else if (disk.state === "rejected") {
         console.log("rejected because " + disk.reason);
     }
 }).done();
@@ -139,14 +136,13 @@ var nodeStyle = (input: string, cb: Function) => {
 
 Q.nfapply(nodeStyle, ["foo"]).done((result: string) => {});
 Q.nfcall(nodeStyle, "foo").done((result: string) => {});
-Q.denodeify(nodeStyle)('foo').done((result: string) => {});
-Q.nfbind(nodeStyle)('foo').done((result: string) => {});
-
+Q.denodeify(nodeStyle)("foo").done((result: string) => {});
+Q.nfbind(nodeStyle)("foo").done((result: string) => {});
 
 class Repo {
     private readonly items: any[] = [
-        { name: 'Max', cute: false },
-        { name: 'Annie', cute: true }
+        { name: "Max", cute: false },
+        { name: "Annie", cute: true },
     ];
 
     find(options: any): Q.Promise<any[]> {
@@ -163,12 +159,10 @@ class Repo {
 var kitty = new Repo();
 Q.nbind(kitty.find, kitty)({ cute: true }).done((kitties: any[]) => {});
 
-
 /*
  * Test: Can "rethrow" rejected promises
  */
 namespace TestCanRethrowRejectedPromises {
-
     interface Foo {
         a: number;
     }
@@ -181,7 +175,7 @@ namespace TestCanRethrowRejectedPromises {
 
     function bar(): Q.Promise<Foo> {
         return nestedBar()
-            .then((foo:Foo) => {
+            .then((foo: Foo) => {
                 console.log("Lorem ipsum");
             })
             .fail((error) => {
@@ -191,33 +185,30 @@ namespace TestCanRethrowRejectedPromises {
                  * Cannot do this, because:
                  *     error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<Foo>'
                  */
-                //throw error;
+                // throw error;
 
                 return Q.reject<Foo>(error);
-            })
-        ;
+            });
     }
 
     bar()
         .finally(() => {
-            console.log("Cleanup")
+            console.log("Cleanup");
         })
-        .done()
-    ;
-
+        .done();
 }
 
 // test Q.Promise.all
 var y1 = Q().then(() => {
     var s = Q("hello");
     var n = Q(1);
-    return <[typeof s, typeof n]>[s, n];
+    return <[typeof s, typeof n]> [s, n];
 });
 
 var y2 = Q().then(() => {
     var s = "hello";
     var n = Q(1);
-    return <[typeof s, typeof n]>[s, n];
+    return <[typeof s, typeof n]> [s, n];
 });
 
 var p1: Q.Promise<[string, number]> = y1.all();

--- a/types/qbittorrent-api-v2/index.d.ts
+++ b/types/qbittorrent-api-v2/index.d.ts
@@ -155,7 +155,7 @@ export interface QBittorrentApiEndpoint {
 
     deleteSearch(id: number): Promise<void>;
 
-    searchCategories(pluginName?: string | 'all' | 'enabled'): Promise<string[]>;
+    searchCategories(pluginName?: string | "all" | "enabled"): Promise<string[]>;
 
     searchPlugins(): Promise<SearchPlugin[]>;
 
@@ -289,7 +289,7 @@ export interface Log {
 
 export type LogTypesInt = 1 | 2 | 4 | 8;
 
-export type LogTypesString = 'normal' | 'info' | 'warning' | 'critical';
+export type LogTypesString = "normal" | "info" | "warning" | "critical";
 
 export interface PeerLog {
     id: number;
@@ -454,7 +454,7 @@ export interface SearchResults {
     total: number;
 }
 
-export interface SearchPlugin  {
+export interface SearchPlugin {
     enabled: boolean;
     fullName: string;
     name: string;
@@ -463,7 +463,7 @@ export interface SearchPlugin  {
     version: string;
 }
 
-export type filterString = 'all' | 'downloading' | 'completed' | 'paused' | 'active' | 'inactive' | 'resumed';
+export type filterString = "all" | "downloading" | "completed" | "paused" | "active" | "inactive" | "resumed";
 
 export type Categories = object;
 

--- a/types/qbittorrent-api-v2/qbittorrent-api-v2-tests.ts
+++ b/types/qbittorrent-api-v2/qbittorrent-api-v2-tests.ts
@@ -1,74 +1,74 @@
 // test from : https://github.com/flowbe/node-qbittorrent-api-v2/blob/master/test/qbt-tests.js
 
-import assert = require('assert');
-import api = require('qbittorrent-api-v2');
+import assert = require("assert");
+import api = require("qbittorrent-api-v2");
 
 api.connect("loaclhost", "admin", "admin")
-	.then(qbt => {
-		// Application methods
-		qbt.appVersion()
-			.then(version => assert(version.startsWith('v')))
-			.catch(err => assert.ifError(err));
-		qbt.apiVersion()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-		qbt.buildInfo()
-			.then(info => assert(info.qt))
-			.catch(err => assert.ifError(err));
-		qbt.defaultSavePath()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-		qbt.preferences()
-			.then(preferences => assert(preferences.locale))
-			.catch(err => assert.ifError(err));
-		// Transfer info methods
-		qbt.transferInfo()
-			.then(info => assert(info.connection_status))
-			.catch(err => assert.ifError(err));
-		qbt.speedLimitsMode()
-			.then(enabled => assert(!isNaN(enabled)))
-			.catch(err => assert.ifError(err));
-		qbt.globalDownloadLimit()
-			.then(limit => assert(!isNaN(limit)))
-			.catch(err => assert.ifError(err));
-		qbt.globalUploadLimit()
-			.then(limit => assert(!isNaN(limit)))
-			.catch(err => assert.ifError(err));
-		// Torrent management methods
-		qbt.torrents()
-			.then(torrents => {
-				const torrent = torrents[0];
-				qbt.properties(torrent.hash)
-					.then(properties => assert(properties.creation_date))
-					.catch(err => assert.ifError(err));
-				qbt.trackers(torrent.hash)
-					.then(trackers => assert(trackers.length > 0))
-					.catch(err => assert.ifError(err));
-				qbt.webseeds(torrent.hash)
-					.then(assert)
-					.catch(err => assert.ifError(err));
-				qbt.files(torrent.hash)
-					.then(contents => assert(contents.length > 0))
-					.catch(err => assert.ifError(err));
-				qbt.pieceStates(torrent.hash)
-					.then(states => assert(states.length > 0))
-					.catch(err => assert.ifError(err));
-				qbt.pieceHashes(torrent.hash)
-					.then(hashes => assert(hashes.length > 0))
-					.catch(err => assert.ifError(err));
-			})
-			.catch(err => assert.ifError(err));
-		qbt.categories()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-		qbt.tags()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-		// Search
-		qbt.searchCategories()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-		qbt.searchPlugins()
-			.then(assert)
-			.catch(err => assert.ifError(err));
-	});
+    .then(qbt => {
+        // Application methods
+        qbt.appVersion()
+            .then(version => assert(version.startsWith("v")))
+            .catch(err => assert.ifError(err));
+        qbt.apiVersion()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+        qbt.buildInfo()
+            .then(info => assert(info.qt))
+            .catch(err => assert.ifError(err));
+        qbt.defaultSavePath()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+        qbt.preferences()
+            .then(preferences => assert(preferences.locale))
+            .catch(err => assert.ifError(err));
+        // Transfer info methods
+        qbt.transferInfo()
+            .then(info => assert(info.connection_status))
+            .catch(err => assert.ifError(err));
+        qbt.speedLimitsMode()
+            .then(enabled => assert(!isNaN(enabled)))
+            .catch(err => assert.ifError(err));
+        qbt.globalDownloadLimit()
+            .then(limit => assert(!isNaN(limit)))
+            .catch(err => assert.ifError(err));
+        qbt.globalUploadLimit()
+            .then(limit => assert(!isNaN(limit)))
+            .catch(err => assert.ifError(err));
+        // Torrent management methods
+        qbt.torrents()
+            .then(torrents => {
+                const torrent = torrents[0];
+                qbt.properties(torrent.hash)
+                    .then(properties => assert(properties.creation_date))
+                    .catch(err => assert.ifError(err));
+                qbt.trackers(torrent.hash)
+                    .then(trackers => assert(trackers.length > 0))
+                    .catch(err => assert.ifError(err));
+                qbt.webseeds(torrent.hash)
+                    .then(assert)
+                    .catch(err => assert.ifError(err));
+                qbt.files(torrent.hash)
+                    .then(contents => assert(contents.length > 0))
+                    .catch(err => assert.ifError(err));
+                qbt.pieceStates(torrent.hash)
+                    .then(states => assert(states.length > 0))
+                    .catch(err => assert.ifError(err));
+                qbt.pieceHashes(torrent.hash)
+                    .then(hashes => assert(hashes.length > 0))
+                    .catch(err => assert.ifError(err));
+            })
+            .catch(err => assert.ifError(err));
+        qbt.categories()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+        qbt.tags()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+        // Search
+        qbt.searchCategories()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+        qbt.searchPlugins()
+            .then(assert)
+            .catch(err => assert.ifError(err));
+    });

--- a/types/qlik-engineapi/index.d.ts
+++ b/types/qlik-engineapi/index.d.ts
@@ -5,11 +5,26 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace EngineAPI {
-    type CommandType = "JsonRequest" | "GetCustomCaption" | "IsConnected" | "DisableQlikViewSelectButton" | "HaveStarField";
+    type CommandType =
+        | "JsonRequest"
+        | "GetCustomCaption"
+        | "IsConnected"
+        | "DisableQlikViewSelectButton"
+        | "HaveStarField";
     type LogonType = "LOG_ON_SERVICE_USER" | "LOG_ON_CURRENT_USER";
     type NxGrpType = "N" | "H" | "C" | string;
     type FieldAttributesType = "U" | "A" | "I" | "R" | "F" | "M" | "D" | "T" | "TS" | "IV";
-    type FileDataFormatType = "CSV" | "FIX" | "DIF" | "EXCEL_BIFF" | "EXCEL_OOXML" | "HTML" | "XML" | "QVX" | "JSON" | "KML";
+    type FileDataFormatType =
+        | "CSV"
+        | "FIX"
+        | "DIF"
+        | "EXCEL_BIFF"
+        | "EXCEL_OOXML"
+        | "HTML"
+        | "XML"
+        | "QVX"
+        | "JSON"
+        | "KML";
     type TableRecordKeyType = "NOT_KEY" | "ANY_KEY" | "PRIMARY_KEY" | "PERFECT_KEY";
 
     /**
@@ -38,7 +53,13 @@ declare namespace EngineAPI {
     type NxCellType = "V" | "E" | "N" | "T" | "P" | "R" | "U";
     type NxSelectionCellType = "D" | "T" | "L";
     type SortIndicatorType = "N" | "A" | "D";
-    type OtherModeType = "OTHER_OFF" | "OTHER_COUNTED" | "OTHER_ABS_LIMITED" | "OTHER_ABS_ACC_TARGET" | "OTHER_REL_LIMITED" | "OTHER_REL_ACC_TARGET";
+    type OtherModeType =
+        | "OTHER_OFF"
+        | "OTHER_COUNTED"
+        | "OTHER_ABS_LIMITED"
+        | "OTHER_ABS_ACC_TARGET"
+        | "OTHER_REL_LIMITED"
+        | "OTHER_REL_ACC_TARGET";
     type OtherLimitModeType = "OTHER_GE_LIMIT" | "OTHER_LE_LIMIT" | "OTHER_GT_LIMIT" | "OTHER_LT_LIMIT";
     type OtherSortModeType = "OTHER_SORT_DEFAULT" | "OTHER_SORT_DESCENDING" | "OTHER_SORT_ASCENDING";
     type TotalModeType = "TOTAL_OFF" | "TOTAL_EXPR";
@@ -101,8 +122,34 @@ declare namespace EngineAPI {
      * - GEO for FUNC_GROUP_GEO
      * - EXT for FUNC_GROUP_EXTERNAL
      */
-    type FunctionGroupType = "ALL" | "U" | "NONE" | "AGGR" | "NUM" | "RNG" | "EXP" | "TRIG" | "FIN" | "MATH" | "COUNT" | "STR" | "MAPP" |
-        "RCRD" | "CND" | "LOG" | "NULL" | "SYS" | "FILE" | "TBL" | "DATE" | "NUMI" | "FRMT" | "CLR" | "RNK" | "GEO" | "EXT";
+    type FunctionGroupType =
+        | "ALL"
+        | "U"
+        | "NONE"
+        | "AGGR"
+        | "NUM"
+        | "RNG"
+        | "EXP"
+        | "TRIG"
+        | "FIN"
+        | "MATH"
+        | "COUNT"
+        | "STR"
+        | "MAPP"
+        | "RCRD"
+        | "CND"
+        | "LOG"
+        | "NULL"
+        | "SYS"
+        | "FILE"
+        | "TBL"
+        | "DATE"
+        | "NUMI"
+        | "FRMT"
+        | "CLR"
+        | "RNK"
+        | "GEO"
+        | "EXT";
 
     type DimensionType = "D" | "N" | "T";
 
@@ -122,7 +169,11 @@ declare namespace EngineAPI {
      * - NX_FREQUENCY_PERCENT. The percentage is between 0 and 100.
      * - NX_FREQUENCY_RELATIVE. Same as percent except that the relative value is between 0 and 1.
      */
-    type FrequencyModeType = "NX_FREQUENCY_NONE" | "NX_FREQUENCY_VALUE" | "NX_FREQUENCY_PERCENT" | "NX_FREQUENCY_RELATIVE";
+    type FrequencyModeType =
+        | "NX_FREQUENCY_NONE"
+        | "NX_FREQUENCY_VALUE"
+        | "NX_FREQUENCY_PERCENT"
+        | "NX_FREQUENCY_RELATIVE";
 
     type TypeSortDirection = "1" | "-1" | "0";
 
@@ -497,7 +548,6 @@ declare namespace EngineAPI {
          *    - T for TIME; Numeric fields values are shown as times.
          *    - TS TIMESTAMP; Numeric fields values are shown as time stamps.
          *    - IV for INTERVAL; Numeric fields values are shown as intervals.
-         *
          */
         qType: FieldAttributesType;
 
@@ -949,7 +999,6 @@ declare namespace EngineAPI {
     interface IDataField {
         /**
          * Name of the field.
-         *
          */
         qName: string;
 
@@ -2802,7 +2851,9 @@ declare namespace EngineAPI {
          *                   qExpires - download expires in [s]
          * @returns - return a Promise with the qDownloadInfo
          */
-        exportReducedData(qOptions?: { qBookmarkId?: string | undefined, qExpires?: number | undefined}): Promise<{ qDownloadInfo: any }>;
+        exportReducedData(
+            qOptions?: { qBookmarkId?: string | undefined; qExpires?: number | undefined },
+        ): Promise<{ qDownloadInfo: any }>;
 
         /**
          * Retrieves any fields that belong to the same archipelago as the specified field and
@@ -2934,7 +2985,12 @@ declare namespace EngineAPI {
          * @param qTable - Name of the table. >> This parameter is mandatory.
          * @returns - return a Promise Array of DataField.
          */
-        getDatabaseTableFields(qConnectionId: string, qTable: string, qDatabase?: string, qOwner?: string): Promise<IDataField[]>;
+        getDatabaseTableFields(
+            qConnectionId: string,
+            qTable: string,
+            qDatabase?: string,
+            qOwner?: string,
+        ): Promise<IDataField[]>;
 
         /**
          * Retrieves the values of the specified table of a database for a ODBC, OLEDB or CUSTOM connection.
@@ -2946,7 +3002,12 @@ declare namespace EngineAPI {
          * @param qTable - Name of the table. >> This parameter is mandatory.
          * @returns - return a Promise Array of DataRecord.
          */
-        getDatabaseTablePreview(qConnectionId: string, qTable: string, qDatabase?: string, qOwner?: string): Promise<IDataRecord[]>;
+        getDatabaseTablePreview(
+            qConnectionId: string,
+            qTable: string,
+            qDatabase?: string,
+            qOwner?: string,
+        ): Promise<IDataRecord[]>;
 
         /**
          * Lists the tables inside a database for a ODBC, OLEDB or CUSTOM connection.
@@ -2994,7 +3055,7 @@ declare namespace EngineAPI {
          * @param qReadableName: name of a Field that is declared with DECLARE FIELD DEFINITION
          * @returns qname wich contains the expression
          */
-        getFieldOnTheFlyByName(qReadableName: string): Promise<{qName: string}>;
+        getFieldOnTheFlyByName(qReadableName: string): Promise<{ qName: string }>;
 
         /**
          * Retrieves the description of a field.
@@ -3012,7 +3073,12 @@ declare namespace EngineAPI {
          * @param qTable - Name of the table. This parameter must be set for XLS, XLSX, HTML and XML files.
          * @returns - return a Promise Array of DataField or String.
          */
-        getFileTableFields(qConnectionId: string, qDataFormat: IFileDataFormat, qTable: string, qRelativePath?: string): Promise<{qFields: IDataField[], qFormatSpec: string}>;
+        getFileTableFields(
+            qConnectionId: string,
+            qDataFormat: IFileDataFormat,
+            qTable: string,
+            qRelativePath?: string,
+        ): Promise<{ qFields: IDataField[]; qFormatSpec: string }>;
 
         /**
          * Lists the values in a table for a folder connection.
@@ -3022,7 +3088,12 @@ declare namespace EngineAPI {
          * @param qTable - Name of the table. This parameter must be set for XLS, XLSX, HTML and XML files.
          * @returns - return a Promise <Array of DataField> or <String>.
          */
-        getFileTablePreview(qConnectionId: string, qRelativePath: string, qDataFormat: IFileDataFormat, qTable: string): Promise<{qPreview: IDataRecord[], qFormatSpec: string}>;
+        getFileTablePreview(
+            qConnectionId: string,
+            qRelativePath: string,
+            qDataFormat: IFileDataFormat,
+            qTable: string,
+        ): Promise<{ qPreview: IDataRecord[]; qFormatSpec: string }>;
 
         /**
          * Lists the tables and fields of a JSON or XML file for a folder connection.
@@ -3031,7 +3102,11 @@ declare namespace EngineAPI {
          * @param qDataFormat - Type of the file.
          * @returns - return a Promise Array of DataTableEx.
          */
-        getFileTablesEx(qConnectionId: string, qRelativePath: string, qDataFormat: IFileDataFormat): Promise<IDataTableEx[]>;
+        getFileTablesEx(
+            qConnectionId: string,
+            qRelativePath: string,
+            qDataFormat: IFileDataFormat,
+        ): Promise<IDataTableEx[]>;
 
         /**
          * Lists the tables for a folder connection.
@@ -3040,7 +3115,11 @@ declare namespace EngineAPI {
          * @param qDataFormat - Type of the file.
          * @returns - return a Promise Array of DataTable.
          */
-        getFileTables(qConnectionId: string, qRelativePath: string, qDataFormat: IFileDataFormat): Promise<IDataTable[]>;
+        getFileTables(
+            qConnectionId: string,
+            qRelativePath: string,
+            qDataFormat: IFileDataFormat,
+        ): Promise<IDataTable[]>;
 
         /**
          * There are two ways to specify the directory to retrieve the files from:
@@ -3198,7 +3277,13 @@ declare namespace EngineAPI {
          * @param qIncludeSysVars - If set to true, the system variables are included.
          * @returns - return a Promise <Array of TableRecord> or <Array of SourceKeyRecord>
          */
-        getTablesAndKeys(qWindowSize: ISize, qNullSize: ISize, qCellHeight: number, qSyntheticMode: boolean, qIncludeSysVars: boolean): Promise<{qtr: ITableRecord[], qk: ISourceKeyRecord[]}>;
+        getTablesAndKeys(
+            qWindowSize: ISize,
+            qNullSize: ISize,
+            qCellHeight: number,
+            qSyntheticMode: boolean,
+            qIncludeSysVars: boolean,
+        ): Promise<{ qtr: ITableRecord[]; qk: ISourceKeyRecord[] }>;
 
         /**
          * Fetches updated variables after a statement execution.
@@ -3418,7 +3503,11 @@ declare namespace EngineAPI {
          * >> This parameter is mandatory.
          * @returns - A Promise List of SearchResults
          */
-        searchResults(qOptions: ISearchCombinationOptions, qTerms: string[], qPage: ISearchPage): Promise<ISearchResult>;
+        searchResults(
+            qOptions: ISearchCombinationOptions,
+            qTerms: string[],
+            qPage: ISearchPage,
+        ): Promise<ISearchResult>;
 
         /**
          * For every search group item, there are one or several search matches. The position of the match in each search result is given.
@@ -3438,7 +3527,12 @@ declare namespace EngineAPI {
          * @param qSoftLock - This parameter is deprecated and should not be set.
          * @returns - A promise of a Qlik engine reply.
          */
-        selectAssociations(qOptions: ISearchCombinationOptions, qTerms: string[], qMatchIx: number, qSoftLock: boolean): Promise<void>;
+        selectAssociations(
+            qOptions: ISearchCombinationOptions,
+            qTerms: string[],
+            qMatchIx: number,
+            qSoftLock: boolean,
+        ): Promise<void>;
 
         /**
          * Sends a generic command to a custom connector.
@@ -3455,7 +3549,13 @@ declare namespace EngineAPI {
          * @param qAppendConnection - Name of the connection. This parameter is optional.
          * @returns - A promise of a Qlik engine reply.
          */
-        sendGenericCommandToCustomConnector(qProvider: string, qCommand: CommandType, qMethod: string, qParameters: string[], qAppendConnection: string[]): Promise<string>;
+        sendGenericCommandToCustomConnector(
+            qProvider: string,
+            qCommand: CommandType,
+            qMethod: string,
+            qParameters: string[],
+            qAppendConnection: string[],
+        ): Promise<string>;
 
         /**
          * Sets properties to an app.
@@ -3956,7 +4056,11 @@ declare namespace EngineAPI {
          * @param qDataPage - Start and End of DataPage
          * @returns - A promise of Array of FieldValues.
          */
-        getFieldValues(qField: string, qGetExcludedValues: boolean, qDataPage: {"qStartIndex": number, "qEndIndex": number}): Promise<{qFieldValues: IFieldValue[]}>;
+        getFieldValues(
+            qField: string,
+            qGetExcludedValues: boolean,
+            qDataPage: { "qStartIndex": number; "qEndIndex": number },
+        ): Promise<{ qFieldValues: IFieldValue[] }>;
 
         /**
          * Returns:
@@ -5370,7 +5474,12 @@ declare namespace EngineAPI {
          *
          * @returns - A Promise of String qUrl: <url of the exported file> and qWarnings: [1000] only if exported data is truncated
          */
-        exportData(qFileType: FileType, qPath: string, qFileName?: string, qExportState?: ExportStateType): Promise<string>;
+        exportData(
+            qFileType: FileType,
+            qPath: string,
+            qFileName?: string,
+            qExportState?: ExportStateType,
+        ): Promise<string>;
 
         /**
          * Returns the identifier and the type for each child in an app object.
@@ -5448,8 +5557,15 @@ declare namespace EngineAPI {
          *           0: Adaptive grid
          * @returns - A Promise Array of NxDataPage
          */
-        getHyperCubeBinnedData(qPath: string, qPages: INxPage[], qViewport: INxViewPort, qDataRanges: INxDataAreaPage,
-                               qMaxNbrCells: number, qQueryLevel: number, qBinningMethod: number): Promise<INxDataPage[]>;
+        getHyperCubeBinnedData(
+            qPath: string,
+            qPages: INxPage[],
+            qViewport: INxViewPort,
+            qDataRanges: INxDataAreaPage,
+            qMaxNbrCells: number,
+            qQueryLevel: number,
+            qBinningMethod: number,
+        ): Promise<INxDataPage[]>;
 
         /**
          * Retrieves and packs compressed hypercube and axis data. It is possible to retrieve specific pages of data.
@@ -5463,7 +5579,10 @@ declare namespace EngineAPI {
          * Options.MaxNbrTicks - maximum number of ticks.
          * @returns - A Promise <Boolean> or <Array of NxDataPage> or <Array of NxAxisData>
          */
-        getHyperCubeContinuousData(qPath: string, qOptions: IContinuousDataOptions[]): Promise<{qDataPages: INxDataPage[], qAxisData: INxAxisData[]}>;
+        getHyperCubeContinuousData(
+            qPath: string,
+            qOptions: IContinuousDataOptions[],
+        ): Promise<{ qDataPages: INxDataPage[]; qAxisData: INxAxisData[] }>;
 
         /**
          * Retrieves the values of a chart, a table, or a scatter plot. It is possible to retrieve specific pages of data.
@@ -5535,7 +5654,12 @@ declare namespace EngineAPI {
          *       - ST to reduce the data of a stacked pivot table.
          * @returns - A data set Array of NxDataPage.
          */
-        getHyperCubeReducedData(qPath: string, qPages: INxPage[], qZoomFactor: number, qReductionMode: ReductionModeType): Promise<INxDataPage[]>;
+        getHyperCubeReducedData(
+            qPath: string,
+            qPages: INxPage[],
+            qZoomFactor: number,
+            qReductionMode: ReductionModeType,
+        ): Promise<INxDataPage[]>;
 
         /**
          * Retrieves the values of a stacked pivot table. It is possible to retrieve specific pages of data.
@@ -5591,7 +5715,10 @@ declare namespace EngineAPI {
          * - Options.MaxNbrTicks - maximum number of ticks.
          * @returns - A data set Array of (NxDataPage) or (NxAxisData)
          */
-        getListObjectContinuousData(qPath: string, qOptions: IContinuousDataOptions): Promise<{qDataPages: INxDataPage, qAxisData: INxAxisData[]}>;
+        getListObjectContinuousData(
+            qPath: string,
+            qOptions: IContinuousDataOptions,
+        ): Promise<{ qDataPages: INxDataPage; qAxisData: INxAxisData[] }>;
 
         /**
          * Retrieves the values of a list object.
@@ -5663,7 +5790,13 @@ declare namespace EngineAPI {
          * >> The default value is false.
          * @returns - true or false
          */
-        multiRangeSelectHyperCubeValues(qPath: string, qRanges: INxMultiRangeSelectInfo, qDeselectOnlyOneSelected: boolean, qColumnsToSelect?: number[], qOrMode?: boolean): Promise<boolean>;
+        multiRangeSelectHyperCubeValues(
+            qPath: string,
+            qRanges: INxMultiRangeSelectInfo,
+            qDeselectOnlyOneSelected: boolean,
+            qColumnsToSelect?: number[],
+            qOrMode?: boolean,
+        ): Promise<boolean>;
 
         /**
          * Make range selections in measures.
@@ -5688,7 +5821,13 @@ declare namespace EngineAPI {
          * This parameter is optional. The default value is false.
          * @returns - true or false
          */
-        rangeSelectHyperCubeValues(qPath: string, qRanges: INxRangeSelectInfo[], qDeselectOnlyOneSelected: boolean, qColumnsToSelect?: number[], qOrMode?: boolean): Promise<boolean>;
+        rangeSelectHyperCubeValues(
+            qPath: string,
+            qRanges: INxRangeSelectInfo[],
+            qDeselectOnlyOneSelected: boolean,
+            qColumnsToSelect?: number[],
+            qOrMode?: boolean,
+        ): Promise<boolean>;
 
         /**
          * Resets all selections made in selection mode.
@@ -5737,7 +5876,13 @@ declare namespace EngineAPI {
          * The default value is false.
          * @returns - true or false.
          */
-        selectHyperCubeCells(qPath: string, qRowIndices: number[], qColIndices: number[], qSoftLock: boolean, qDeselectOnlyOneSelected: boolean): Promise<boolean>;
+        selectHyperCubeCells(
+            qPath: string,
+            qRowIndices: number[],
+            qColIndices: number[],
+            qSoftLock: boolean,
+            qDeselectOnlyOneSelected: boolean,
+        ): Promise<boolean>;
 
         /**
          * SelectHyperCubeContinuousRange method
@@ -5751,7 +5896,11 @@ declare namespace EngineAPI {
          * >> This parameter is mandatory.
          * @returns - true or false.
          */
-        selectHyperCubeContinuousRange(qPath: string, qRanges: INxContinuousRangeSelectInfo[], qSoftLock: boolean): Promise<boolean>;
+        selectHyperCubeContinuousRange(
+            qPath: string,
+            qRanges: INxContinuousRangeSelectInfo[],
+            qSoftLock: boolean,
+        ): Promise<boolean>;
 
         /**
          * Selects some values in one dimension.
@@ -5860,7 +6009,12 @@ declare namespace EngineAPI {
          * >> This parameter is optional.
          * @returns - true or false.
          */
-        selectListObjectValues(qPath: string, qValues: number[], qToggleMode: boolean, qSoftLock?: boolean): Promise<boolean>;
+        selectListObjectValues(
+            qPath: string,
+            qValues: number[],
+            qToggleMode: boolean,
+            qSoftLock?: boolean,
+        ): Promise<boolean>;
 
         /**
          * Note: This method only applies to hypercubes that are not represented as straight tables.
@@ -5886,7 +6040,12 @@ declare namespace EngineAPI {
          * The default value is false.
          * @returns - true or false.
          */
-        selectPivotCells(qPath: string, qSelections: INxSelectionCell[], qDeselectOnlyOneSelected: boolean, qSoftLock?: boolean): Promise<boolean>;
+        selectPivotCells(
+            qPath: string,
+            qSelections: INxSelectionCell[],
+            qDeselectOnlyOneSelected: boolean,
+            qSoftLock?: boolean,
+        ): Promise<boolean>;
 
         /**
          * Sets the order of the children in a generic object.
@@ -6962,7 +7121,11 @@ declare namespace EngineAPI {
          * This parameter is relevant only if the variable ErrorMode is set to 1 and the script is run in
          * debug mode (qDebug is set to true when calling the DoReload method).
          */
-        configureReload(qCancelOnScriptError: boolean, qUseErrorData: boolean, qInteractOnError: boolean): Promise<void>;
+        configureReload(
+            qCancelOnScriptError: boolean,
+            qUseErrorData: boolean,
+            qInteractOnError: boolean,
+        ): Promise<void>;
 
         /**
          * Copies an app that is in the Qlik Sense repository.
@@ -7015,7 +7178,13 @@ declare namespace EngineAPI {
          * >> The default value is Main.
          * @returns - A Promise of App
          */
-        createDocEx(qDocName: string, qUserName?: string, qPassword?: string, qSerial?: string, qLocalizedScriptMainSection?: string): Promise<IApp>;
+        createDocEx(
+            qDocName: string,
+            qUserName?: string,
+            qPassword?: string,
+            qSerial?: string,
+            qLocalizedScriptMainSection?: string,
+        ): Promise<IApp>;
 
         /**
          * Creates an empty session app.
@@ -7173,7 +7342,7 @@ declare namespace EngineAPI {
          *                   E: returns the chart functions.
          * @returns qBnfDefs and qBnfHash
          */
-        getBaseBNFString(qBnfType: BnfType): Promise<{qBnfDefs: IBNFDef, qBnfHash: string}>;
+        getBaseBNFString(qBnfType: BnfType): Promise<{ qBnfDefs: IBNFDef; qBnfHash: string }>;
 
         /**
          * Get a Config Object
@@ -7273,7 +7442,7 @@ declare namespace EngineAPI {
          * Gets the MyDocumenstFolder Path in the system.
          * @returns A Promise of the MyDocumenstFolder Path
          */
-        getMyDocumentsFolder(): Promise<{ qFolder: string; }>;
+        getMyDocumentsFolder(): Promise<{ qFolder: string }>;
 
         /**
          * Returns the list of the ODBC connectors that are installed in the system.
@@ -7403,7 +7572,13 @@ declare namespace EngineAPI {
          * >> The default value is false.
          * @returns A Promise of App
          */
-        openDoc(qDocName: string, qUserName?: string, qPassword?: string, qSerial?: string, qNoData?: boolean): Promise<IApp>;
+        openDoc(
+            qDocName: string,
+            qUserName?: string,
+            qPassword?: string,
+            qSerial?: string,
+            qNoData?: boolean,
+        ): Promise<IApp>;
 
         /**
          * Returns the name of the operating system.
@@ -8491,9 +8666,11 @@ declare namespace EngineAPI {
     // }
 }
 
-//#region Prototype Interfaces for Class definitions
+// #region Prototype Interfaces for Class definitions
 declare namespace EngineAPI {
-    interface IGenericObjectPrototype<P extends IGenericObjectProperties, L extends IGenericBaseLayout> extends IGenericObject {
+    interface IGenericObjectPrototype<P extends IGenericObjectProperties, L extends IGenericBaseLayout>
+        extends IGenericObject
+    {
         getLayout(): Promise<L>;
         getProperties(): Promise<P>;
         setProperties(properties: P): Promise<void>;
@@ -8504,9 +8681,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: P): Promise<O>;
     }
 }
-//#endregion
+// #endregion
 
-//#region ListObject
+// #region ListObject
 declare namespace EngineAPI {
     /**
      * Renders the properties of a list object. Is the layout for ListObjectDef.
@@ -8677,9 +8854,9 @@ declare namespace EngineAPI {
         clearSelections(qPath: "/qListObjectDef", qColIndices?: number[]): Promise<void>;
     }
 }
-//#endregion
+// #endregion
 
-//#region HyperCubeObject
+// #region HyperCubeObject
 declare namespace EngineAPI {
     interface IHyperCubeDimensionDef extends INxDimension {
         qDef: IHyperCubeDimensionqDef;
@@ -8991,9 +9168,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericHyperCubeProperties): Promise<IHyperCubeObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region SelectionListObject
+// #region SelectionListObject
 declare namespace EngineAPI {
     type FieldSelectionModeType = "NORMAL" | "AND" | "NOT";
 
@@ -9133,7 +9310,9 @@ declare namespace EngineAPI {
     /**
      * SelectionListObject width extend GenericObject
      */
-    interface ISelectionListObject extends IGenericObjectPrototype<IGenericSelectionListProperties, IGenericSelectionListLayout> {
+    interface ISelectionListObject
+        extends IGenericObjectPrototype<IGenericSelectionListProperties, IGenericSelectionListLayout>
+    {
     }
 
     interface IApp {
@@ -9141,9 +9320,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericSelectionListProperties): Promise<ISelectionListObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region BookmarkListObject
+// #region BookmarkListObject
 declare namespace EngineAPI {
     /**
      * Lists the bookmarks. Is the layout for BookmarkListDef.
@@ -9195,7 +9374,9 @@ declare namespace EngineAPI {
     /**
      * BookmarkListObject width extend GenericObject
      */
-    interface IBookmarkListObject extends IGenericObjectPrototype<IGenericBookmarkListProperties, IGenericBookmarkListLayout> {
+    interface IBookmarkListObject
+        extends IGenericObjectPrototype<IGenericBookmarkListProperties, IGenericBookmarkListLayout>
+    {
     }
 
     interface IApp {
@@ -9203,9 +9384,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericBookmarkListProperties): Promise<IBookmarkListObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region MeassureListObject
+// #region MeassureListObject
 declare namespace EngineAPI {
     /**
      * GenericDimensionsListProperties width extend GenericBaseLayout
@@ -9257,7 +9438,9 @@ declare namespace EngineAPI {
     /**
      * IMeassureListObject
      */
-    interface IMeassureListObject extends IGenericObjectPrototype<IGenericMeasureListProperties, IGenericMeasureListLayout> {
+    interface IMeassureListObject
+        extends IGenericObjectPrototype<IGenericMeasureListProperties, IGenericMeasureListLayout>
+    {
     }
 
     interface IApp {
@@ -9265,9 +9448,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericMeasureListProperties): Promise<IMeassureListObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region DimensionsListObject
+// #region DimensionsListObject
 declare namespace EngineAPI {
     /**
      * DimensionItemLayout...
@@ -9325,7 +9508,9 @@ declare namespace EngineAPI {
         qData: any;
     }
 
-    interface IDimensionListObject extends IGenericObjectPrototype<IGenericDimensionsListProperties, IGenericDimensionListLayout> {
+    interface IDimensionListObject
+        extends IGenericObjectPrototype<IGenericDimensionsListProperties, IGenericDimensionListLayout>
+    {
     }
 
     interface IApp {
@@ -9333,9 +9518,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericDimensionsListProperties): Promise<IDimensionListObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region VariableListObject
+// #region VariableListObject
 declare namespace EngineAPI {
     /**
      * NxVariableListItem...
@@ -9448,7 +9633,9 @@ declare namespace EngineAPI {
     /**
      * VariableListObject width extend GenericObject
      */
-    interface IVariableListObject extends IGenericObjectPrototype<IGenericVariableListProperties, IGenericVariableListLayout> {
+    interface IVariableListObject
+        extends IGenericObjectPrototype<IGenericVariableListProperties, IGenericVariableListLayout>
+    {
     }
 
     interface IApp {
@@ -9456,9 +9643,9 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericVariableListProperties): Promise<IVariableListObject>;
     }
 }
-//#endregion
+// #endregion
 
-//#region FieldListObject
+// #region FieldListObject
 declare namespace EngineAPI {
     /**
      * FieldListObject...
@@ -9705,7 +9892,7 @@ declare namespace EngineAPI {
         createSessionObject(qProp: IGenericFieldListProperties): Promise<IFieldListObject>;
     }
 }
-//#endregion
+// #endregion
 
 declare namespace enigmaJS {
     interface IGeneratedAPI {

--- a/types/qlik-visualizationextensions/index.d.ts
+++ b/types/qlik-visualizationextensions/index.d.ts
@@ -2233,8 +2233,19 @@ declare namespace VariableAPI {
 }
 
 declare namespace VisualizationAPI {
-    type VisualizationType = "barchart" | "combochart" | "gauge" | "kpi" | "linechart" | "piechart" | "pivot-table" |
-        "scatterplot" | "table" | "treemap" | "extension" | "listbox";
+    type VisualizationType =
+        | "barchart"
+        | "combochart"
+        | "gauge"
+        | "kpi"
+        | "linechart"
+        | "piechart"
+        | "pivot-table"
+        | "scatterplot"
+        | "table"
+        | "treemap"
+        | "extension"
+        | "listbox";
 
     interface IVisualization {
         /**
@@ -2361,13 +2372,13 @@ declare namespace ExtensionAPI {
         // [""]:
     }
 
-    //#region IDefinition
+    // #region IDefinition
     type ExpressionType = "always" | "optional" | "";
 
     type func<T> = () => T;
     type valueOrfunc<T> = T | func<T>;
 
-    //#region Controls
+    // #region Controls
     interface ICustomControlOption {
         value: string;
         label: string;
@@ -2484,7 +2495,7 @@ declare namespace ExtensionAPI {
         defaultValue: string;
         show: valueOrfunc<boolean>;
     }
-    //#endregion
+    // #endregion
 
     interface IDefinition {
         type: "items";
@@ -2535,7 +2546,7 @@ declare namespace ExtensionAPI {
         max?: number | undefined;
     }
 
-    //#endregion
+    // #endregion
 }
 
 declare module "qlik" {

--- a/types/qr-image/index.d.ts
+++ b/types/qr-image/index.d.ts
@@ -8,10 +8,10 @@
 /**
  * error correction level. One of L, M, Q, H. Default M.
  */
-export type ec_level = 'L' | 'M' | 'Q' | 'H';
+export type ec_level = "L" | "M" | "Q" | "H";
 
 /** @default 'png' */
-export type image_type = 'png' | 'svg' | 'pdf' | 'eps';
+export type image_type = "png" | "svg" | "pdf" | "eps";
 
 export interface Bitmap {
     /**

--- a/types/qr-image/qr-image-tests.ts
+++ b/types/qr-image/qr-image-tests.ts
@@ -1,18 +1,18 @@
-import * as qr from 'qr-image';
-import * as fs from 'fs';
+import * as fs from "fs";
+import * as qr from "qr-image";
 
-const qr_svg = qr.image('I love QR!', { type: 'svg' });
-qr_svg.pipe(fs.createWriteStream('i_love_qr.svg'));
+const qr_svg = qr.image("I love QR!", { type: "svg" });
+qr_svg.pipe(fs.createWriteStream("i_love_qr.svg"));
 
-const svg_string = qr.imageSync('I love QR!', { type: 'svg' });
+const svg_string = qr.imageSync("I love QR!", { type: "svg" });
 
 // customize
 function coord2offset(x: number, y: number, size: number) {
     return (size + 1) * y + x + 1;
 }
 
-qr.image('Customize PNG', {
-    type: 'png',
+qr.image("Customize PNG", {
+    type: "png",
     customize: bitmap => {
         const size = bitmap.size;
         const data = bitmap.data;
@@ -25,7 +25,7 @@ qr.image('Customize PNG', {
             }
         }
     },
-}).pipe(fs.createWriteStream('custom.png'));
+}).pipe(fs.createWriteStream("custom.png"));
 
 // $ExpectType SvgObject
-const res = qr.svgObject('test data');
+const res = qr.svgObject("test data");

--- a/types/qrcode-svg/index.d.ts
+++ b/types/qrcode-svg/index.d.ts
@@ -33,7 +33,7 @@ declare class QRCode {
      * @param  opt Set the container. Defaults to `{ container: "svg" }`.
      * @return The svg string.
      */
-    svg(opt?: { container: 'svg' | 'g' | 'none' }): string;
+    svg(opt?: { container: "svg" | "g" | "none" }): string;
     /**
      * Writes this QRCode to a file. Requires `fs`.
      * @param  file The filename to write to
@@ -57,7 +57,7 @@ declare namespace QRCode {
         /** Color of background, color name or hex string. Default is `#fffff`. */
         background?: string | undefined;
         /** Error correction level. Default is `"M"`. */
-        ecl?: 'L' | 'M' | 'H' | 'Q' | undefined;
+        ecl?: "L" | "M" | "H" | "Q" | undefined;
         /** Join modules (squares) into one shape, into the SVG path element, **recommended** for web and responsive use. Default is `false`. */
         join?: boolean | undefined;
         /** To create a squares as pattern, then populate the canvas. Default is `false`. */
@@ -78,7 +78,7 @@ declare namespace QRCode {
          * Useful when you need to put multiple QR Codes in a single SVG document \
          * `none`: No wrapper.
          */
-        container?: 'svg' | 'svg-viewbox' | 'g' | 'none' | undefined;
+        container?: "svg" | "svg-viewbox" | "g" | "none" | undefined;
     }
 
     interface Model {

--- a/types/qrcode-svg/qrcode-svg-tests.ts
+++ b/types/qrcode-svg/qrcode-svg-tests.ts
@@ -1,4 +1,4 @@
-import QRCode = require('qrcode-svg');
+import QRCode = require("qrcode-svg");
 
 const qrCode = new QRCode(`sample-data`);
 
@@ -10,24 +10,24 @@ const assert = (result: boolean, messagePrefix: string, successMessage: string, 
     }
 };
 
-assert(qrCode.options.padding === 4, 'Default value for padding', 'matches expected.', 'does not match expected.');
-assert(qrCode.options.width === 256, 'Default value for width', 'matches expected.', 'does not match expected.');
-assert(qrCode.options.height === 256, 'Default value for height', 'matches expected.', 'does not match expected.');
+assert(qrCode.options.padding === 4, "Default value for padding", "matches expected.", "does not match expected.");
+assert(qrCode.options.width === 256, "Default value for width", "matches expected.", "does not match expected.");
+assert(qrCode.options.height === 256, "Default value for height", "matches expected.", "does not match expected.");
 assert(
-    qrCode.options.background === '#ffffff',
-    'Default value for background',
-    'matches expected.',
-    'does not match expected.',
+    qrCode.options.background === "#ffffff",
+    "Default value for background",
+    "matches expected.",
+    "does not match expected.",
 );
-assert(qrCode.options.color === '#000000', 'Default value for color', 'matches expected.', 'does not match expected.');
-assert(qrCode.options.ecl === 'M', 'Default value for ecl', 'matches expected.', 'does not match expected');
+assert(qrCode.options.color === "#000000", "Default value for color", "matches expected.", "does not match expected.");
+assert(qrCode.options.ecl === "M", "Default value for ecl", "matches expected.", "does not match expected");
 
 assert(
-    (Array.isArray(qrCode.qrcode.modules) && qrCode.qrcode.modules.length === 0) ||
-        Array.isArray(qrCode.qrcode.modules[0]),
-    'Modules in qrcode is',
-    'a two-dimensional array',
-    'not a two-dimensional array',
+    (Array.isArray(qrCode.qrcode.modules) && qrCode.qrcode.modules.length === 0)
+        || Array.isArray(qrCode.qrcode.modules[0]),
+    "Modules in qrcode is",
+    "a two-dimensional array",
+    "not a two-dimensional array",
 );
 
-assert(typeof qrCode.svg() === 'string', 'QRCode object', 'generated an svg string', 'did not generate an svg string');
+assert(typeof qrCode.svg() === "string", "QRCode object", "generated an svg string", "did not generate an svg string");

--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -24,16 +24,16 @@ declare namespace qrcode {
         includeMargin?: boolean | undefined;
         bgColor?: string | undefined;
         fgColor?: string | undefined;
-        level?: "L"|"M"|"Q"|"H" | undefined;
+        level?: "L" | "M" | "Q" | "H" | undefined;
         imageSettings?: ImageSettings | undefined;
     }
 
     type CanvasQRCodeProps = BaseQRCodeProps & {
-        renderAs?: "canvas" | undefined
+        renderAs?: "canvas" | undefined;
     } & React.CanvasHTMLAttributes<HTMLCanvasElement>;
 
     type SvgQRCodeProps = BaseQRCodeProps & {
-        renderAs: "svg"
+        renderAs: "svg";
     } & React.SVGProps<SVGSVGElement>;
 
     type QRCode = React.ComponentClass<CanvasQRCodeProps | SvgQRCodeProps>;

--- a/types/qrcode.react/qrcode.react-tests.tsx
+++ b/types/qrcode.react/qrcode.react-tests.tsx
@@ -2,28 +2,37 @@ import QRCode = require("qrcode.react");
 import * as React from "react";
 
 const qrcodes = [
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" size={64}/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" bgColor="#555555"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" fgColor="#aaaaaa"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="L"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="H"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" includeMargin={true}/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" size={256} bgColor="pink" fgColor="red" level="Q"/>,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" size={64} />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" bgColor="#555555" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" fgColor="#aaaaaa" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="L" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="H" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" includeMargin={true} />,
+    <QRCode
+        value="https://github.com/DefinitelyTyped/DefinitelyTyped"
+        size={256}
+        bgColor="pink"
+        fgColor="red"
+        level="Q"
+    />,
     // Test imageSettings property:
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" imageSettings={{src: "./some-file.png"}}/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" imageSettings={{
-        src: "./some-file.png",
-        x: 1,
-        y: 1,
-        height: 1,
-        width: 1,
-        excavate: true
-    }}/>,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" imageSettings={{ src: "./some-file.png" }} />,
+    <QRCode
+        value="https://github.com/DefinitelyTyped/DefinitelyTyped"
+        imageSettings={{
+            src: "./some-file.png",
+            x: 1,
+            y: 1,
+            height: 1,
+            width: 1,
+            excavate: true,
+        }}
+    />,
     // Test some passed-through props for svg and canvas elements:
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg" amplitude={1}/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas"/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas" height={1} width={1}/>,
-    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" height={1} width={1}/>,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg" amplitude={1} />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas" />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas" height={1} width={1} />,
+    <QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" height={1} width={1} />,
 ];

--- a/types/qrcode/build/qrcode.d.ts
+++ b/types/qrcode/build/qrcode.d.ts
@@ -1,4 +1,4 @@
-import * as QRCodeLib from '../index';
+import * as QRCodeLib from "../index";
 
 declare global {
     namespace QRCode {

--- a/types/qrcode/build/qrcode.tosjis.d.ts
+++ b/types/qrcode/build/qrcode.tosjis.d.ts
@@ -1,4 +1,4 @@
-import toSJISFunc = require('../helper/to-sjis');
+import toSJISFunc = require("../helper/to-sjis");
 
 declare global {
     namespace QRCode {

--- a/types/qrcode/helper/to-sjis.d.ts
+++ b/types/qrcode/helper/to-sjis.d.ts
@@ -1,4 +1,4 @@
-import { QRCodeToSJISFunc } from '..';
+import { QRCodeToSJISFunc } from "..";
 
 declare const toSJISFunc: QRCodeToSJISFunc;
 

--- a/types/qrcode/index.d.ts
+++ b/types/qrcode/index.d.ts
@@ -8,9 +8,9 @@
 
 /// <reference types="node" />
 
-import * as stream from 'stream';
+import * as stream from "stream";
 
-export type QRCodeErrorCorrectionLevel = 'low' | 'medium' | 'quartile' | 'high' | 'L' | 'M' | 'Q' | 'H';
+export type QRCodeErrorCorrectionLevel = "low" | "medium" | "quartile" | "high" | "L" | "M" | "Q" | "H";
 export type QRCodeMaskPattern = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type QRCodeToSJISFunc = (codePoint: string) => number;
 
@@ -37,22 +37,22 @@ export interface QRCodeOptions {
     toSJISFunc?: QRCodeToSJISFunc | undefined;
 }
 
-export type QRCodeDataURLType = 'image/png' | 'image/jpeg' | 'image/webp';
+export type QRCodeDataURLType = "image/png" | "image/jpeg" | "image/webp";
 export type QRCodeToDataURLOptions = QRCodeToDataURLOptionsJpegWebp | QRCodeToDataURLOptionsOther;
 export interface QRCodeToDataURLOptionsJpegWebp extends QRCodeRenderersOptions {
     /**
      * Data URI format.
      * @default 'image/png'
      */
-    type: 'image/jpeg' | 'image/webp';
+    type: "image/jpeg" | "image/webp";
     rendererOpts?:
         | {
-              /**
-               * A number between `0` and `1` indicating image quality.
-               * @default 0.92
-               */
-              quality?: number | undefined;
-          }
+            /**
+             * A number between `0` and `1` indicating image quality.
+             * @default 0.92
+             */
+            quality?: number | undefined;
+        }
         | undefined;
 }
 export interface QRCodeToDataURLOptionsOther extends QRCodeRenderersOptions {
@@ -60,17 +60,17 @@ export interface QRCodeToDataURLOptionsOther extends QRCodeRenderersOptions {
      * Data URI format.
      * @default 'image/png'
      */
-    type?: Exclude<QRCodeDataURLType, 'image/jpeg' | 'image/webp'> | undefined;
+    type?: Exclude<QRCodeDataURLType, "image/jpeg" | "image/webp"> | undefined;
 }
 
-export type QRCodeStringType = 'utf8' | 'svg' | 'terminal';
+export type QRCodeStringType = "utf8" | "svg" | "terminal";
 export type QRCodeToStringOptions = QRCodeToStringOptionsTerminal | QRCodeToStringOptionsOther;
 export interface QRCodeToStringOptionsTerminal extends QRCodeRenderersOptions {
     /**
      * Output format.
      * @default 'utf8'
      */
-    type: 'terminal';
+    type: "terminal";
     /**
      * Outputs smaller QR code.
      * @default false
@@ -82,30 +82,30 @@ export interface QRCodeToStringOptionsOther extends QRCodeRenderersOptions {
      * Output format.
      * @default 'utf8'
      */
-    type?: Exclude<QRCodeStringType, 'terminal'> | undefined;
+    type?: Exclude<QRCodeStringType, "terminal"> | undefined;
 }
 
-export type QRCodeFileType = 'png' | 'svg' | 'utf8';
+export type QRCodeFileType = "png" | "svg" | "utf8";
 export type QRCodeToFileOptions = QRCodeToFileOptionsPng | QRCodeToFileOptionsOther;
 export interface QRCodeToFileOptionsPng extends QRCodeRenderersOptions {
     /**
      * Output format.
      * @default 'png'
      */
-    type?: 'png' | undefined;
+    type?: "png" | undefined;
     rendererOpts?:
         | {
-              /**
-               * Compression level for deflate.
-               * @default 9
-               */
-              deflateLevel?: number | undefined;
-              /**
-               * Compression strategy for deflate.
-               * @default 3
-               */
-              deflateStrategy?: number | undefined;
-          }
+            /**
+             * Compression level for deflate.
+             * @default 9
+             */
+            deflateLevel?: number | undefined;
+            /**
+             * Compression strategy for deflate.
+             * @default 3
+             */
+            deflateStrategy?: number | undefined;
+        }
         | undefined;
 }
 export interface QRCodeToFileOptionsOther extends QRCodeRenderersOptions {
@@ -113,10 +113,10 @@ export interface QRCodeToFileOptionsOther extends QRCodeRenderersOptions {
      * Output format.
      * @default 'png'
      */
-    type: Exclude<QRCodeFileType, 'png'> | undefined;
+    type: Exclude<QRCodeFileType, "png"> | undefined;
 }
 
-export type QRCodeFileStreamType = 'png';
+export type QRCodeFileStreamType = "png";
 export interface QRCodeToFileStreamOptions extends QRCodeRenderersOptions {
     /**
      * Output format. Only png supported for file stream.
@@ -124,21 +124,21 @@ export interface QRCodeToFileStreamOptions extends QRCodeRenderersOptions {
     type?: QRCodeFileStreamType | undefined;
     rendererOpts?:
         | {
-              /**
-               * Compression level for deflate.
-               * @default 9
-               */
-              deflateLevel?: number | undefined;
-              /**
-               * Compression strategy for deflate.
-               * @default 3
-               */
-              deflateStrategy?: number | undefined;
-          }
+            /**
+             * Compression level for deflate.
+             * @default 9
+             */
+            deflateLevel?: number | undefined;
+            /**
+             * Compression strategy for deflate.
+             * @default 3
+             */
+            deflateStrategy?: number | undefined;
+        }
         | undefined;
 }
 
-export type QRCodeBufferType = 'png';
+export type QRCodeBufferType = "png";
 export interface QRCodeToBufferOptions extends QRCodeRenderersOptions {
     /**
      * Output format. Only png supported for Buffer.
@@ -146,17 +146,17 @@ export interface QRCodeToBufferOptions extends QRCodeRenderersOptions {
     type?: QRCodeBufferType | undefined;
     rendererOpts?:
         | {
-              /**
-               * Compression level for deflate.
-               * @default 9
-               */
-              deflateLevel?: number | undefined;
-              /**
-               * Compression strategy for deflate.
-               * @default 3
-               */
-              deflateStrategy?: number | undefined;
-          }
+            /**
+             * Compression level for deflate.
+             * @default 9
+             */
+            deflateLevel?: number | undefined;
+            /**
+             * Compression strategy for deflate.
+             * @default 3
+             */
+            deflateStrategy?: number | undefined;
+        }
         | undefined;
 }
 
@@ -179,49 +179,49 @@ export interface QRCodeRenderersOptions extends QRCodeOptions {
     width?: number | undefined;
     color?:
         | {
-              /**
-               * Color of dark module. Value must be in hex format (RGBA).
-               * Note: dark color should always be darker than `color.light`.
-               * @default '#000000ff'
-               */
-              dark?: string | undefined;
-              /**
-               * Color of light module. Value must be in hex format (RGBA).
-               * @default '#ffffffff'
-               */
-              light?: string | undefined;
-          }
+            /**
+             * Color of dark module. Value must be in hex format (RGBA).
+             * Note: dark color should always be darker than `color.light`.
+             * @default '#000000ff'
+             */
+            dark?: string | undefined;
+            /**
+             * Color of light module. Value must be in hex format (RGBA).
+             * @default '#ffffffff'
+             */
+            light?: string | undefined;
+        }
         | undefined;
 }
 
-export type QRCodeSegmentMode = 'alphanumeric' | 'numeric' | 'byte' | 'kanji';
+export type QRCodeSegmentMode = "alphanumeric" | "numeric" | "byte" | "kanji";
 export type QRCodeSegment =
     | QRCodeNumericSegment
     | QRCodeAlphanumericSegment
     | QRCodeByteSegment
     | QRCodeKanjiSegment
     | {
-          mode?: never;
-          data: string | Buffer | Uint8ClampedArray | Uint8Array;
-      };
+        mode?: never;
+        data: string | Buffer | Uint8ClampedArray | Uint8Array;
+    };
 
 export interface QRCodeNumericSegment {
-    mode: 'numeric';
+    mode: "numeric";
     data: string | number;
 }
 
 export interface QRCodeAlphanumericSegment {
-    mode: 'alphanumeric';
+    mode: "alphanumeric";
     data: string;
 }
 
 export interface QRCodeByteSegment {
-    mode: 'byte';
+    mode: "byte";
     data: Buffer | Uint8ClampedArray | Uint8Array;
 }
 
 export interface QRCodeKanjiSegment {
-    mode: 'kanji';
+    mode: "kanji";
     data: string;
 }
 
@@ -281,7 +281,7 @@ export interface ErrorCorrectionLevel {
     bit: 0 | 1 | 2 | 3;
 }
 
-export type ModeId = 'Numeric' | 'Alphanumeric' | 'Byte' | 'Kanji';
+export type ModeId = "Numeric" | "Alphanumeric" | "Byte" | "Kanji";
 export interface Mode<TModeId extends ModeId = ModeId> {
     id: TModeId;
     bit: number;
@@ -296,22 +296,22 @@ export interface DataSegment {
 }
 
 export interface NumericData extends DataSegment {
-    mode: Mode<'Numeric'>;
+    mode: Mode<"Numeric">;
     data: string;
 }
 
 export interface AlphanumericData extends DataSegment {
-    mode: Mode<'Alphanumeric'>;
+    mode: Mode<"Alphanumeric">;
     data: string;
 }
 
 export interface ByteData extends DataSegment {
-    mode: Mode<'Byte'>;
+    mode: Mode<"Byte">;
     data: Uint8Array;
 }
 
 export interface KanjiData extends DataSegment {
-    mode: Mode<'Kanji'>;
+    mode: Mode<"Kanji">;
     data: string;
 }
 

--- a/types/qrcode/test/qrcode-browser-tests.ts
+++ b/types/qrcode/test/qrcode-browser-tests.ts
@@ -1,5 +1,5 @@
-import 'qrcode/build/qrcode';
-import 'qrcode/build/qrcode.tosjis';
+import "qrcode/build/qrcode";
+import "qrcode/build/qrcode.tosjis";
 
 globalThis.QRCode.create;
 globalThis.QRCode.toCanvas;
@@ -7,4 +7,4 @@ globalThis.QRCode.toDataURL;
 globalThis.QRCode.toString;
 globalThis.QRCode.toSJIS;
 
-globalThis.QRCode.create('foo', { toSJISFunc: globalThis.QRCode.toSJIS });
+globalThis.QRCode.create("foo", { toSJISFunc: globalThis.QRCode.toSJIS });

--- a/types/qrcode/test/qrcode-tests.ts
+++ b/types/qrcode/test/qrcode-tests.ts
@@ -1,6 +1,6 @@
-import * as QC from 'qrcode';
-import toSJIS = require('qrcode/helper/to-sjis');
-import { Writable } from 'stream';
+import * as QC from "qrcode";
+import toSJIS = require("qrcode/helper/to-sjis");
+import { Writable } from "stream";
 
 // test type exports
 type ErrorCorrectionLevel = QC.QRCodeErrorCorrectionLevel;
@@ -41,55 +41,55 @@ type AlphanumericData = QC.AlphanumericData;
 type ByteData = QC.ByteData;
 type KanjiData = QC.KanjiData;
 
-const qrcode = QC.create('foo'); // $ExpectType QRCode
-QC.create([{ data: 'foo' }]); // $ExpectType QRCode
-QC.create([{ data: Buffer.from('foo') }]); // $ExpectType QRCode
+const qrcode = QC.create("foo"); // $ExpectType QRCode
+QC.create([{ data: "foo" }]); // $ExpectType QRCode
+QC.create([{ data: Buffer.from("foo") }]); // $ExpectType QRCode
 QC.create([{ data: new Uint8Array([30]) }]); // $ExpectType QRCode
 QC.create([{ data: new Uint8ClampedArray([30]) }]); // $ExpectType QRCode
-QC.create([{ mode: 'numeric', data: '123' }]); // $ExpectType QRCode
-QC.create([{ mode: 'numeric', data: 123 }]); // $ExpectType QRCode
+QC.create([{ mode: "numeric", data: "123" }]); // $ExpectType QRCode
+QC.create([{ mode: "numeric", data: 123 }]); // $ExpectType QRCode
 // @ts-expect-error
-QC.create([{ mode: 'numeric', data: new Uint8Array([30]) }]);
-QC.create([{ mode: 'alphanumeric', data: 'foo' }]); // $ExpectType QRCode
+QC.create([{ mode: "numeric", data: new Uint8Array([30]) }]);
+QC.create([{ mode: "alphanumeric", data: "foo" }]); // $ExpectType QRCode
 // @ts-expect-error
-QC.create([{ mode: 'alphanumeric', data: new Uint8Array([30]) }]);
-QC.create([{ mode: 'byte', data: Buffer.from('foo') }]); // $ExpectType QRCode
-QC.create([{ mode: 'byte', data: new Uint8Array([30]) }]); // $ExpectType QRCode
-QC.create([{ mode: 'byte', data: new Uint8ClampedArray([30]) }]); // $ExpectType QRCode
+QC.create([{ mode: "alphanumeric", data: new Uint8Array([30]) }]);
+QC.create([{ mode: "byte", data: Buffer.from("foo") }]); // $ExpectType QRCode
+QC.create([{ mode: "byte", data: new Uint8Array([30]) }]); // $ExpectType QRCode
+QC.create([{ mode: "byte", data: new Uint8ClampedArray([30]) }]); // $ExpectType QRCode
 // @ts-expect-error
-QC.create([{ mode: 'byte', data: 'foo' }]);
-QC.create([{ mode: 'kanji', data: 'foo' }]); // $ExpectType QRCode
+QC.create([{ mode: "byte", data: "foo" }]);
+QC.create([{ mode: "kanji", data: "foo" }]); // $ExpectType QRCode
 // @ts-expect-error
-QC.create([{ mode: 'kanji', data: new Uint8Array([30]) }]);
-QC.create('foo', { version: 1 }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'H' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'L' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'M' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'Q' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'high' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'low' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'medium' }); // $ExpectType QRCode
-QC.create('foo', { errorCorrectionLevel: 'quartile' }); // $ExpectType QRCode
+QC.create([{ mode: "kanji", data: new Uint8Array([30]) }]);
+QC.create("foo", { version: 1 }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "H" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "L" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "M" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "Q" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "high" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "low" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "medium" }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "quartile" }); // $ExpectType QRCode
 // @ts-expect-error
-QC.create('foo', { errorCorrectionLevel: 'foo' });
-QC.create('foo', { maskPattern: 0 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 1 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 2 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 3 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 4 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 5 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 6 }); // $ExpectType QRCode
-QC.create('foo', { maskPattern: 7 }); // $ExpectType QRCode
+QC.create("foo", { errorCorrectionLevel: "foo" });
+QC.create("foo", { maskPattern: 0 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 1 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 2 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 3 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 4 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 5 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 6 }); // $ExpectType QRCode
+QC.create("foo", { maskPattern: 7 }); // $ExpectType QRCode
 // @ts-expect-error
-QC.create('foo', { maskPattern: 8 });
+QC.create("foo", { maskPattern: 8 });
 // $ExpectType QRCode
-QC.create('foo', {
+QC.create("foo", {
     toSJISFunc: codePoint => {
         codePoint; // $ExpectType string
         return 1;
     },
 });
-QC.create('foo', { toSJISFunc: toSJIS }); // $ExpectType QRCode
+QC.create("foo", { toSJISFunc: toSJIS }); // $ExpectType QRCode
 
 qrcode.errorCorrectionLevel; // $ExpectType ErrorCorrectionLevel
 const bit: 0 | 1 | 2 | 3 = qrcode.errorCorrectionLevel.bit;
@@ -127,34 +127,34 @@ dataSegment.getBitsLength(); // $ExpectType number
  */
 
 // $ExpectType void
-QC.toCanvas('sample text', error => {
+QC.toCanvas("sample text", error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toCanvas([{ data: Buffer.from('foo') }], (error, canvas) => {
+QC.toCanvas([{ data: Buffer.from("foo") }], (error, canvas) => {
     error; // $ExpectType Error | null | undefined
     canvas; // $ExpectType HTMLCanvasElement
 });
 // $ExpectType void
-QC.toCanvas('sample text', { maskPattern: 0 }, (error, canvas) => {
+QC.toCanvas("sample text", { maskPattern: 0 }, (error, canvas) => {
     error; // $ExpectType Error | null | undefined
     canvas; // $ExpectType HTMLCanvasElement
 });
 // $ExpectType void
-QC.toCanvas([{ data: Buffer.from('foo') }], { maskPattern: 0 }, error => {
+QC.toCanvas([{ data: Buffer.from("foo") }], { maskPattern: 0 }, error => {
     error; // $ExpectType Error | null | undefined
 });
 
-QC.toCanvas('sample text'); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas([{ data: Buffer.from('foo') }]); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas('sample text', { maskPattern: 0 }); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas([{ data: Buffer.from('foo') }], { maskPattern: 0 }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text"); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas([{ data: Buffer.from("foo") }]); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { maskPattern: 0 }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas([{ data: Buffer.from("foo") }], { maskPattern: 0 }); // $ExpectType Promise<HTMLCanvasElement>
 
-QC.toCanvas('sample text', { margin: 0 }); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas('sample text', { scale: 0 }); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas('sample text', { width: 0 }); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas('sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<HTMLCanvasElement>
-QC.toCanvas('sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { margin: 0 }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { scale: 0 }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { width: 0 }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<HTMLCanvasElement>
+QC.toCanvas("sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<HTMLCanvasElement>
 
 /*
  * toCanvas() with HTML canvas param
@@ -163,234 +163,234 @@ QC.toCanvas('sample text', { color: { light: '#000000ff' } }); // $ExpectType Pr
 declare const canvas: HTMLCanvasElement;
 
 // $ExpectType void
-QC.toCanvas(canvas, 'sample text', error => {
+QC.toCanvas(canvas, "sample text", error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toCanvas(canvas, [{ data: Buffer.from('foo') }], error => {
+QC.toCanvas(canvas, [{ data: Buffer.from("foo") }], error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toCanvas(canvas, 'sample text', (error, foo) => ({}));
+QC.toCanvas(canvas, "sample text", (error, foo) => ({}));
 // $ExpectType void
-QC.toCanvas(canvas, 'sample text', { maskPattern: 0 }, error => {
+QC.toCanvas(canvas, "sample text", { maskPattern: 0 }, error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toCanvas(canvas, [{ data: Buffer.from('foo') }], { maskPattern: 0 }, error => {
+QC.toCanvas(canvas, [{ data: Buffer.from("foo") }], { maskPattern: 0 }, error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toCanvas(canvas, 'sample text', { maskPattern: 0 }, (error, foo) => ({}));
+QC.toCanvas(canvas, "sample text", { maskPattern: 0 }, (error, foo) => ({}));
 
-QC.toCanvas(canvas, 'sample text'); // $ExpectType Promise<void>
-QC.toCanvas(canvas, [{ data: Buffer.from('foo') }]); // $ExpectType Promise<void>
-QC.toCanvas(canvas, 'sample text', { maskPattern: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(canvas, [{ data: Buffer.from('foo') }], { maskPattern: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text"); // $ExpectType Promise<void>
+QC.toCanvas(canvas, [{ data: Buffer.from("foo") }]); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { maskPattern: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, [{ data: Buffer.from("foo") }], { maskPattern: 0 }); // $ExpectType Promise<void>
 
-QC.toCanvas(canvas, 'sample text', { margin: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(canvas, 'sample text', { scale: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(canvas, 'sample text', { width: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(canvas, 'sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toCanvas(canvas, 'sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { margin: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { scale: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { width: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toCanvas(canvas, "sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<void>
 
 /*
  * toCanvas() with any canvas param
  */
 
 declare const nodeCanvas: {
-    some: 'prop';
-    foo: 'bar';
+    some: "prop";
+    foo: "bar";
 };
 
 // $ExpectType void
-QC.toCanvas(nodeCanvas, 'sample text', error => {
+QC.toCanvas(nodeCanvas, "sample text", error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toCanvas(nodeCanvas, [{ data: Buffer.from('foo') }], error => {
+QC.toCanvas(nodeCanvas, [{ data: Buffer.from("foo") }], error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toCanvas(nodeCanvas, 'sample text', (error, foo) => ({}));
+QC.toCanvas(nodeCanvas, "sample text", (error, foo) => ({}));
 // $ExpectType void
-QC.toCanvas(nodeCanvas, 'sample text', { maskPattern: 0 }, error => {
+QC.toCanvas(nodeCanvas, "sample text", { maskPattern: 0 }, error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toCanvas(nodeCanvas, [{ data: Buffer.from('foo') }], { maskPattern: 0 }, error => {
+QC.toCanvas(nodeCanvas, [{ data: Buffer.from("foo") }], { maskPattern: 0 }, error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toCanvas(nodeCanvas, 'sample text', { maskPattern: 0 }, (error, foo) => ({}));
+QC.toCanvas(nodeCanvas, "sample text", { maskPattern: 0 }, (error, foo) => ({}));
 
-QC.toCanvas(nodeCanvas, 'sample text'); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, [{ data: Buffer.from('foo') }]); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, 'sample text', { maskPattern: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, [{ data: Buffer.from('foo') }], { maskPattern: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text"); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, [{ data: Buffer.from("foo") }]); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { maskPattern: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, [{ data: Buffer.from("foo") }], { maskPattern: 0 }); // $ExpectType Promise<void>
 
-QC.toCanvas(nodeCanvas, 'sample text', { margin: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, 'sample text', { scale: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, 'sample text', { width: 0 }); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, 'sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toCanvas(nodeCanvas, 'sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { margin: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { scale: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { width: 0 }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toCanvas(nodeCanvas, "sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<void>
 
 /*
  * toDataURL() without canvas param
  */
 
 // $ExpectType void
-QC.toDataURL('some text', (error, url) => {
+QC.toDataURL("some text", (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL([{ data: Buffer.from([253, 254, 255]), mode: 'byte' }], (error, url) => {
+QC.toDataURL([{ data: Buffer.from([253, 254, 255]), mode: "byte" }], (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL('some text', { version: 2 }, (error, url) => {
+QC.toDataURL("some text", { version: 2 }, (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }, (error, url) => {
+QC.toDataURL([{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }, (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 
-QC.toDataURL('some text'); // $ExpectType Promise<string>
-QC.toDataURL([{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<string>
-QC.toDataURL('some text', { version: 2 }); // $ExpectType Promise<string>
-QC.toDataURL([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<string>
+QC.toDataURL("some text"); // $ExpectType Promise<string>
+QC.toDataURL([{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<string>
+QC.toDataURL("some text", { version: 2 }); // $ExpectType Promise<string>
+QC.toDataURL([{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<string>
 
-QC.toDataURL('sample text', { margin: 0 }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { scale: 0 }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { width: 0 }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { type: 'image/jpeg' }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { type: 'image/webp' }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { type: 'image/png' }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { margin: 0 }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { scale: 0 }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { width: 0 }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { type: "image/jpeg" }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { type: "image/webp" }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { type: "image/png" }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toDataURL('sample text', { type: 'foo' });
-QC.toDataURL('sample text', { type: 'image/jpeg', rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
-QC.toDataURL('sample text', { type: 'image/webp', rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { type: "foo" });
+QC.toDataURL("sample text", { type: "image/jpeg", rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
+QC.toDataURL("sample text", { type: "image/webp", rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toDataURL('sample text', { type: 'image/png', rendererOpts: { quality: 1 } });
+QC.toDataURL("sample text", { type: "image/png", rendererOpts: { quality: 1 } });
 
 /*
  * toDataURL() with canvas param
  */
 
 // $ExpectType void
-QC.toDataURL(canvas, 'some text', (error, url) => {
+QC.toDataURL(canvas, "some text", (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL(canvas, [{ data: Buffer.from([253, 254, 255]), mode: 'byte' }], (error, url) => {
+QC.toDataURL(canvas, [{ data: Buffer.from([253, 254, 255]), mode: "byte" }], (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL(canvas, 'some text', { version: 2 }, (error, url) => {
+QC.toDataURL(canvas, "some text", { version: 2 }, (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 // $ExpectType void
-QC.toDataURL(canvas, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }, (error, url) => {
+QC.toDataURL(canvas, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }, (error, url) => {
     error; // $ExpectType Error | null | undefined
     url; // $ExpectType string
 });
 
-QC.toDataURL(canvas, 'some text'); // $ExpectType Promise<string>
-QC.toDataURL(canvas, [{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'some text', { version: 2 }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "some text"); // $ExpectType Promise<string>
+QC.toDataURL(canvas, [{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "some text", { version: 2 }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<string>
 
-QC.toDataURL(canvas, 'sample text', { margin: 0 }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { scale: 0 }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { width: 0 }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { type: 'image/jpeg' }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { type: 'image/webp' }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { type: 'image/png' }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { margin: 0 }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { scale: 0 }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { width: 0 }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { type: "image/jpeg" }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { type: "image/webp" }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { type: "image/png" }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toDataURL(canvas, 'sample text', { type: 'foo' });
-QC.toDataURL(canvas, 'sample text', { type: 'image/jpeg', rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
-QC.toDataURL(canvas, 'sample text', { type: 'image/webp', rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { type: "foo" });
+QC.toDataURL(canvas, "sample text", { type: "image/jpeg", rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
+QC.toDataURL(canvas, "sample text", { type: "image/webp", rendererOpts: { quality: 1 } }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toDataURL(canvas, 'sample text', { type: 'image/png', rendererOpts: { quality: 1 } });
+QC.toDataURL(canvas, "sample text", { type: "image/png", rendererOpts: { quality: 1 } });
 
 /*
  * toString()
  */
 
 // $ExpectType void
-QC.toString('some text', (error, string) => {
+QC.toString("some text", (error, string) => {
     error; // $ExpectType Error | null | undefined
     string; // $ExpectType string
 });
 // $ExpectType void
-QC.toString([{ data: Buffer.from([253, 254, 255]), mode: 'byte' }], (error, string) => {
+QC.toString([{ data: Buffer.from([253, 254, 255]), mode: "byte" }], (error, string) => {
     error; // $ExpectType Error | null | undefined
     string; // $ExpectType string
 });
 // $ExpectType void
-QC.toString('some text', { version: 2 }, (error, string) => {
+QC.toString("some text", { version: 2 }, (error, string) => {
     error; // $ExpectType Error | null | undefined
     string; // $ExpectType string
 });
 // $ExpectType void
-QC.toString([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }, (error, string) => {
+QC.toString([{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }, (error, string) => {
     error; // $ExpectType Error | null | undefined
     string; // $ExpectType string
 });
 
-QC.toString('some text'); // $ExpectType Promise<string>
-QC.toString([{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<string>
-QC.toString('some text', { version: 2 }); // $ExpectType Promise<string>
-QC.toString([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<string>
+QC.toString("some text"); // $ExpectType Promise<string>
+QC.toString([{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<string>
+QC.toString("some text", { version: 2 }); // $ExpectType Promise<string>
+QC.toString([{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<string>
 
-QC.toString('sample text', { margin: 0 }); // $ExpectType Promise<string>
-QC.toString('sample text', { scale: 0 }); // $ExpectType Promise<string>
-QC.toString('sample text', { width: 0 }); // $ExpectType Promise<string>
-QC.toString('sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toString('sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<string>
-QC.toString('sample text', { type: 'utf8' }); // $ExpectType Promise<string>
-QC.toString('sample text', { type: 'svg' }); // $ExpectType Promise<string>
-QC.toString('sample text', { type: 'terminal' }); // $ExpectType Promise<string>
+QC.toString("sample text", { margin: 0 }); // $ExpectType Promise<string>
+QC.toString("sample text", { scale: 0 }); // $ExpectType Promise<string>
+QC.toString("sample text", { width: 0 }); // $ExpectType Promise<string>
+QC.toString("sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toString("sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<string>
+QC.toString("sample text", { type: "utf8" }); // $ExpectType Promise<string>
+QC.toString("sample text", { type: "svg" }); // $ExpectType Promise<string>
+QC.toString("sample text", { type: "terminal" }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toString('sample text', { type: 'foo' });
-QC.toString('sample text', { type: 'terminal', small: true }); // $ExpectType Promise<string>
+QC.toString("sample text", { type: "foo" });
+QC.toString("sample text", { type: "terminal", small: true }); // $ExpectType Promise<string>
 // @ts-expect-error
-QC.toString('sample text', { type: 'utf8', small: true });
+QC.toString("sample text", { type: "utf8", small: true });
 
 /*
  * toFile()
  */
 
 // $ExpectType void
-QC.toFile('path/to/filename.png', 'Some text', error => {
+QC.toFile("path/to/filename.png", "Some text", error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
-QC.toFile('path/to/filename.png', [{ data: Buffer.from([253, 254, 255]) }], error => {
+QC.toFile("path/to/filename.png", [{ data: Buffer.from([253, 254, 255]) }], error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toFile('path/to/filename.png', 'some text', (error, foo) => {});
+QC.toFile("path/to/filename.png", "some text", (error, foo) => {});
 // $ExpectType void
 QC.toFile(
-    'path/to/filename.png',
-    'some text',
+    "path/to/filename.png",
+    "some text",
     {
         color: {
-            dark: '#00F', // Blue dots
-            light: '#0000', // Transparent background
+            dark: "#00F", // Blue dots
+            light: "#0000", // Transparent background
         },
     },
     error => {
@@ -399,37 +399,37 @@ QC.toFile(
 );
 // $ExpectType void
 QC.toFile(
-    'path/to/filename.png',
-    [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }],
-    { errorCorrectionLevel: 'H', maskPattern: 3 },
+    "path/to/filename.png",
+    [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }],
+    { errorCorrectionLevel: "H", maskPattern: 3 },
     error => {
         error; // $ExpectType Error | null | undefined
     },
 );
 // @ts-expect-error
-QC.toFile('path/to/filename.png', 'some text', { margin: 0 }, (error, foo) => {});
+QC.toFile("path/to/filename.png", "some text", { margin: 0 }, (error, foo) => {});
 
-QC.toFile('file/path', 'some text'); // $ExpectType Promise<void>
-QC.toFile('file/path', [{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<void>
-QC.toFile('file/path', 'some text', { version: 2 }); // $ExpectType Promise<void>
-QC.toFile('file/path', [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<void>
+QC.toFile("file/path", "some text"); // $ExpectType Promise<void>
+QC.toFile("file/path", [{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<void>
+QC.toFile("file/path", "some text", { version: 2 }); // $ExpectType Promise<void>
+QC.toFile("file/path", [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<void>
 
-QC.toFile('file/path', 'sample text', { margin: 0 }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { scale: 0 }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { width: 0 }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { type: 'png' }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { type: 'svg' }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { type: 'utf8' }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { margin: 0 }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { scale: 0 }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { width: 0 }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "png" }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "svg" }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "utf8" }); // $ExpectType Promise<void>
 // @ts-expect-error
-QC.toFile('file/path', 'sample text', { type: 'foo' });
-QC.toFile('file/path', 'sample text', { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { type: 'png', rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
-QC.toFile('file/path', 'sample text', { type: 'png', rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "foo" });
+QC.toFile("file/path", "sample text", { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "png", rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
+QC.toFile("file/path", "sample text", { type: "png", rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
 // @ts-expect-error
-QC.toFile('file/path', 'sample text', { type: 'utf8', rendererOpts: { deflateStrategy: 1 } });
+QC.toFile("file/path", "sample text", { type: "utf8", rendererOpts: { deflateStrategy: 1 } });
 
 /*
  * toFileStream()
@@ -438,7 +438,7 @@ QC.toFile('file/path', 'sample text', { type: 'utf8', rendererOpts: { deflateStr
 declare const fileStream: Writable;
 
 // $ExpectType void
-QC.toFileStream(fileStream, 'Some text', error => {
+QC.toFileStream(fileStream, "Some text", error => {
     error; // $ExpectType Error | null | undefined
 });
 // $ExpectType void
@@ -446,15 +446,15 @@ QC.toFileStream(fileStream, [{ data: Buffer.from([253, 254, 255]) }], error => {
     error; // $ExpectType Error | null | undefined
 });
 // @ts-expect-error
-QC.toFileStream(fileStream, 'some text', (error, foo) => {});
+QC.toFileStream(fileStream, "some text", (error, foo) => {});
 // $ExpectType void
 QC.toFileStream(
     fileStream,
-    'some text',
+    "some text",
     {
         color: {
-            dark: '#00F', // Blue dots
-            light: '#0000', // Transparent background
+            dark: "#00F", // Blue dots
+            light: "#0000", // Transparent background
         },
     },
     error => {
@@ -464,36 +464,36 @@ QC.toFileStream(
 // $ExpectType void
 QC.toFileStream(
     fileStream,
-    [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }],
-    { errorCorrectionLevel: 'H', maskPattern: 3 },
+    [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }],
+    { errorCorrectionLevel: "H", maskPattern: 3 },
     error => {
         error; // $ExpectType Error | null | undefined
     },
 );
 // @ts-expect-error
-QC.toFileStream(fileStream, 'some text', { margin: 0 }, (error, foo) => {});
+QC.toFileStream(fileStream, "some text", { margin: 0 }, (error, foo) => {});
 
-QC.toFileStream(fileStream, 'some text'); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, [{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'some text', { version: 2 }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "some text"); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, [{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "some text", { version: 2 }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, [{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<void>
 
-QC.toFileStream(fileStream, 'sample text', { margin: 0 }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { scale: 0 }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { width: 0 }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { type: 'png' }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { margin: 0 }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { scale: 0 }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { width: 0 }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { type: "png" }); // $ExpectType Promise<void>
 // @ts-expect-error
-QC.toFileStream(fileStream, 'sample text', { type: 'foo' });
-QC.toFileStream(fileStream, 'sample text', { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
-QC.toFileStream(fileStream, 'sample text', { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { type: "foo" });
+QC.toFileStream(fileStream, "sample text", { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<void>
+QC.toFileStream(fileStream, "sample text", { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<void>
 
 /*
  * toBuffer()
  */
 
-QC.toBuffer('http://www.google.com', (error, buffer) => {
+QC.toBuffer("http://www.google.com", (error, buffer) => {
     error; // $ExpectType Error | null | undefined
     buffer; // $ExpectType Buffer
 });
@@ -501,7 +501,7 @@ QC.toBuffer([{ data: Buffer.from([253, 254, 255]) }], (error, buffer) => {
     error; // $ExpectType Error | null | undefined
     buffer; // $ExpectType Buffer
 });
-QC.toBuffer('some text', { errorCorrectionLevel: 'H', maskPattern: 3 }, (error, buffer) => {
+QC.toBuffer("some text", { errorCorrectionLevel: "H", maskPattern: 3 }, (error, buffer) => {
     error; // $ExpectType Error | null | undefined
     buffer; // $ExpectType Buffer
 });
@@ -509,8 +509,8 @@ QC.toBuffer(
     [{ data: Buffer.from([253, 254, 255]) }],
     {
         color: {
-            dark: '#00F', // Blue dots
-            light: '#0000', // Transparent background
+            dark: "#00F", // Blue dots
+            light: "#0000", // Transparent background
         },
     },
     (error, buffer) => {
@@ -519,18 +519,18 @@ QC.toBuffer(
     },
 );
 
-QC.toBuffer('some text'); // $ExpectType Promise<Buffer>
-QC.toBuffer([{ data: Buffer.from([253, 254, 255]), mode: 'byte' }]); // $ExpectType Promise<Buffer>
-QC.toBuffer('some text', { version: 2 }); // $ExpectType Promise<Buffer>
-QC.toBuffer([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }], { version: 2 }); // $ExpectType Promise<Buffer>
+QC.toBuffer("some text"); // $ExpectType Promise<Buffer>
+QC.toBuffer([{ data: Buffer.from([253, 254, 255]), mode: "byte" }]); // $ExpectType Promise<Buffer>
+QC.toBuffer("some text", { version: 2 }); // $ExpectType Promise<Buffer>
+QC.toBuffer([{ data: new Uint8ClampedArray([253, 254, 255]), mode: "byte" }], { version: 2 }); // $ExpectType Promise<Buffer>
 
-QC.toBuffer('sample text', { margin: 0 }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { scale: 0 }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { width: 0 }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { color: { dark: '#000000ff' } }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { color: { light: '#000000ff' } }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { type: 'png' }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { margin: 0 }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { scale: 0 }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { width: 0 }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { color: { dark: "#000000ff" } }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { color: { light: "#000000ff" } }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { type: "png" }); // $ExpectType Promise<Buffer>
 // @ts-expect-error
-QC.toBuffer('sample text', { type: 'foo' });
-QC.toBuffer('sample text', { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<Buffer>
-QC.toBuffer('sample text', { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { type: "foo" });
+QC.toBuffer("sample text", { rendererOpts: { deflateLevel: 1 } }); // $ExpectType Promise<Buffer>
+QC.toBuffer("sample text", { rendererOpts: { deflateStrategy: 1 } }); // $ExpectType Promise<Buffer>

--- a/types/qrcodejs/index.d.ts
+++ b/types/qrcodejs/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import QRCode = require('./qrcodejs');
+import QRCode = require("./qrcodejs");
 
 export = QRCode;
 

--- a/types/qrcodejs/qrcodejs-tests.ts
+++ b/types/qrcodejs/qrcodejs-tests.ts
@@ -1,14 +1,14 @@
 // test as global script only
 
-const qrcode = new QRCode('test', {
-    text: 'http://jindo.dev.naver.com/collie',
+const qrcode = new QRCode("test", {
+    text: "http://jindo.dev.naver.com/collie",
     width: 128,
     height: 128,
-    colorDark: '#000000',
-    colorLight: '#ffffff',
+    colorDark: "#000000",
+    colorLight: "#ffffff",
     correctLevel: QRCode.CorrectLevel.H,
     useSVG: true,
 });
 
 qrcode.clear(); // $ExpectType void
-qrcode.makeCode('https://github.com/llyys/qrcodejs'); // $ExpectType void
+qrcode.makeCode("https://github.com/llyys/qrcodejs"); // $ExpectType void

--- a/types/qs-middleware/index.d.ts
+++ b/types/qs-middleware/index.d.ts
@@ -8,7 +8,7 @@ import express = require("express");
 import qs = require("qs");
 
 declare function qsMiddleware(
-    options?: qs.IParseOptions
+    options?: qs.IParseOptions,
 ): express.RequestHandler;
 
 export = qsMiddleware;

--- a/types/qs-middleware/qs-middleware-tests.ts
+++ b/types/qs-middleware/qs-middleware-tests.ts
@@ -17,7 +17,7 @@ app.use(
         allowPrototypes: true,
         parameterLimit: 123,
         strictNullHandling: true,
-        ignoreQueryPrefix: true
-    })
+        ignoreQueryPrefix: true,
+    }),
 );
 app.use(query({ delimiter: /regexp/ }));

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -22,17 +22,19 @@ declare namespace QueryString {
         strictNullHandling?: boolean | undefined;
         skipNulls?: boolean | undefined;
         encode?: boolean | undefined;
-        encoder?: ((str: any, defaultEncoder: defaultEncoder, charset: string, type: 'key' | 'value') => string) | undefined;
+        encoder?:
+            | ((str: any, defaultEncoder: defaultEncoder, charset: string, type: "key" | "value") => string)
+            | undefined;
         filter?: Array<string | number> | ((prefix: string, value: any) => any) | undefined;
-        arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma' | undefined;
+        arrayFormat?: "indices" | "brackets" | "repeat" | "comma" | undefined;
         indices?: boolean | undefined;
         sort?: ((a: any, b: any) => number) | undefined;
         serializeDate?: ((d: Date) => string) | undefined;
-        format?: 'RFC1738' | 'RFC3986' | undefined;
+        format?: "RFC1738" | "RFC3986" | undefined;
         encodeValuesOnly?: boolean | undefined;
         addQueryPrefix?: boolean | undefined;
         allowDots?: boolean | undefined;
-        charset?: 'utf-8' | 'iso-8859-1' | undefined;
+        charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
     }
 
@@ -40,7 +42,9 @@ declare namespace QueryString {
         comma?: boolean | undefined;
         delimiter?: string | RegExp | undefined;
         depth?: number | false | undefined;
-        decoder?: ((str: string, defaultDecoder: defaultDecoder, charset: string, type: 'key' | 'value') => any) | undefined;
+        decoder?:
+            | ((str: string, defaultDecoder: defaultDecoder, charset: string, type: "key" | "value") => any)
+            | undefined;
         arrayLimit?: number | undefined;
         parseArrays?: boolean | undefined;
         allowDots?: boolean | undefined;
@@ -49,12 +53,14 @@ declare namespace QueryString {
         parameterLimit?: number | undefined;
         strictNullHandling?: boolean | undefined;
         ignoreQueryPrefix?: boolean | undefined;
-        charset?: 'utf-8' | 'iso-8859-1' | undefined;
+        charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
         interpretNumericEntities?: boolean | undefined;
     }
 
-    interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
+    interface ParsedQs {
+        [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[];
+    }
 
     function stringify(obj: any, options?: IStringifyOptions): string;
     function parse(str: string, options?: IParseOptions & { decoder?: never | undefined }): ParsedQs;

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -1,28 +1,30 @@
-import qs = require('qs');
+import qs = require("qs");
 import * as assert from "power-assert";
 
-qs.stringify({ a: 'b' });
-qs.stringify({ a: 'b', c: 'd' }, { delimiter: '&' });
+qs.stringify({ a: "b" });
+qs.stringify({ a: "b", c: "d" }, { delimiter: "&" });
 
-qs.parse('a=b');
-qs.parse('a=b&c=d', { delimiter: '&' });
+qs.parse("a=b");
+qs.parse("a=b&c=d", { delimiter: "&" });
 
-() => {
-    let obj = qs.parse('a=z&b[c]=z&d=z&d=z&e[][f]=z');
+(() => {
+    let obj = qs.parse("a=z&b[c]=z&d=z&d=z&e[][f]=z");
     obj; // $ExpectType ParsedQs
     obj.a; // $ExpectType string | ParsedQs | string[] | ParsedQs[] | undefined || string | string[] | ParsedQs | ParsedQs[] | undefined
-    assert.deepEqual(obj, { a: 'c' });
+    assert.deepEqual(obj, { a: "c" });
 
     var str = qs.stringify(obj);
-    assert.equal(str, 'a=c');
-};
+    assert.equal(str, "a=c");
+});
 
 {
-    let obj = qs.parse('a=c', {
+    let obj = qs.parse("a=c", {
         decoder: (str, defaultDecoder, charset, type) => {
             switch (type) {
-                case 'key': return str;
-                case 'value': return parseFloat(str);
+                case "key":
+                    return str;
+                case "value":
+                    return parseFloat(str);
             }
         },
     });
@@ -34,43 +36,45 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     const options: qs.IParseOptions = {
         decoder: (str, defaultDecoder, charset, type) => {
             switch (type) {
-                case 'key': return str;
-                case 'value': return parseFloat(str);
+                case "key":
+                    return str;
+                case "value":
+                    return parseFloat(str);
             }
         },
     };
-    let obj = qs.parse('a=c', options);
+    let obj = qs.parse("a=c", options);
     obj; // $ExpectType { [key: string]: unknown; }
     obj.a; // $ExpectType unknown
 }
 
-() => {
-    var plainObject = qs.parse('a[hasOwnProperty]=b', { plainObjects: true });
-    assert.deepEqual(plainObject, { a: { hasOwnProperty: 'b' } });
-}
+(() => {
+    var plainObject = qs.parse("a[hasOwnProperty]=b", { plainObjects: true });
+    assert.deepEqual(plainObject, { a: { hasOwnProperty: "b" } });
+});
 
-() => {
-    var protoObject = qs.parse('a[hasOwnProperty]=b', { allowPrototypes: true });
-    assert.deepEqual(protoObject, { a: { hasOwnProperty: 'b' } });
-}
+(() => {
+    var protoObject = qs.parse("a[hasOwnProperty]=b", { allowPrototypes: true });
+    assert.deepEqual(protoObject, { a: { hasOwnProperty: "b" } });
+});
 
-() => {
-    assert.deepEqual(qs.parse('a%5Bb%5D=c'), {
-        a: { b: 'c' }
+(() => {
+    assert.deepEqual(qs.parse("a%5Bb%5D=c"), {
+        a: { b: "c" },
     });
-}
+});
 
-() => {
-    assert.deepEqual(qs.parse('foo[bar][baz]=foobarbaz'), {
+(() => {
+    assert.deepEqual(qs.parse("foo[bar][baz]=foobarbaz"), {
         foo: {
             bar: {
-                baz: 'foobarbaz'
-            }
-        }
+                baz: "foobarbaz",
+            },
+        },
     });
-}
+});
 
-() => {
+(() => {
     var expected = {
         a: {
             b: {
@@ -78,119 +82,119 @@ qs.parse('a=b&c=d', { delimiter: '&' });
                     d: {
                         e: {
                             f: {
-                                '[g][h][i]': 'j'
-                            }
-                        }
-                    }
-                }
-            }
-        }
+                                "[g][h][i]": "j",
+                            },
+                        },
+                    },
+                },
+            },
+        },
     };
-    var string = 'a[b][c][d][e][f][g][h][i]=j';
+    var string = "a[b][c][d][e][f][g][h][i]=j";
     assert.deepEqual(qs.parse(string), expected);
-}
+});
 
-() => {
-    var deep = qs.parse('a[b][c][d][e][f][g][h][i]=j', { depth: 1 });
-    assert.deepEqual(deep, { a: { b: { '[c][d][e][f][g][h][i]': 'j' } } });
-}
+(() => {
+    var deep = qs.parse("a[b][c][d][e][f][g][h][i]=j", { depth: 1 });
+    assert.deepEqual(deep, { a: { b: { "[c][d][e][f][g][h][i]": "j" } } });
+});
 
-() => {
-    var limited = qs.parse('a=b&c=d', { parameterLimit: 1 });
-    assert.deepEqual(limited, { a: 'b' });
-}
+(() => {
+    var limited = qs.parse("a=b&c=d", { parameterLimit: 1 });
+    assert.deepEqual(limited, { a: "b" });
+});
 
-() => {
-    var delimited = qs.parse('a=b;c=d', { delimiter: ';' });
-    assert.deepEqual(delimited, { a: 'b', c: 'd' });
-}
+(() => {
+    var delimited = qs.parse("a=b;c=d", { delimiter: ";" });
+    assert.deepEqual(delimited, { a: "b", c: "d" });
+});
 
-() => {
-    var regexed = qs.parse('a=b;c=d,e=f', { delimiter: /[;,]/ });
-    assert.deepEqual(regexed, { a: 'b', c: 'd', e: 'f' });
-}
+(() => {
+    var regexed = qs.parse("a=b;c=d,e=f", { delimiter: /[;,]/ });
+    assert.deepEqual(regexed, { a: "b", c: "d", e: "f" });
+});
 
-() => {
-    var withDots = qs.parse('a.b=c', { allowDots: true });
-    assert.deepEqual(withDots, { a: { b: 'c' } });
-}
+(() => {
+    var withDots = qs.parse("a.b=c", { allowDots: true });
+    assert.deepEqual(withDots, { a: { b: "c" } });
+});
 
-() => {
-    var withArray = qs.parse('a[]=b&a[]=c');
-    assert.deepEqual(withArray, { a: ['b', 'c'] });
-}
+(() => {
+    var withArray = qs.parse("a[]=b&a[]=c");
+    assert.deepEqual(withArray, { a: ["b", "c"] });
+});
 
-() => {
-    var withIndexes = qs.parse('a[1]=c&a[0]=b');
-    assert.deepEqual(withIndexes, { a: ['b', 'c'] });
-}
+(() => {
+    var withIndexes = qs.parse("a[1]=c&a[0]=b");
+    assert.deepEqual(withIndexes, { a: ["b", "c"] });
+});
 
-() => {
-    var noSparse = qs.parse('a[1]=b&a[15]=c');
-    assert.deepEqual(noSparse, { a: ['b', 'c'] });
-}
+(() => {
+    var noSparse = qs.parse("a[1]=b&a[15]=c");
+    assert.deepEqual(noSparse, { a: ["b", "c"] });
+});
 
-() => {
-    var withEmptyString = qs.parse('a[]=&a[]=b');
-    assert.deepEqual(withEmptyString, { a: ['', 'b'] });
+(() => {
+    var withEmptyString = qs.parse("a[]=&a[]=b");
+    assert.deepEqual(withEmptyString, { a: ["", "b"] });
 
-    var withIndexedEmptyString = qs.parse('a[0]=b&a[1]=&a[2]=c');
-    assert.deepEqual(withIndexedEmptyString, { a: ['b', '', 'c'] });
-}
+    var withIndexedEmptyString = qs.parse("a[0]=b&a[1]=&a[2]=c");
+    assert.deepEqual(withIndexedEmptyString, { a: ["b", "", "c"] });
+});
 
-() => {
-    var withMaxIndex = qs.parse('a[100]=b');
-    assert.deepEqual(withMaxIndex, { a: { '100': 'b' } });
-}
+(() => {
+    var withMaxIndex = qs.parse("a[100]=b");
+    assert.deepEqual(withMaxIndex, { a: { "100": "b" } });
+});
 
-() => {
-    var withArrayLimit = qs.parse('a[1]=b', { arrayLimit: 0 });
-    assert.deepEqual(withArrayLimit, { a: { '1': 'b' } });
-}
+(() => {
+    var withArrayLimit = qs.parse("a[1]=b", { arrayLimit: 0 });
+    assert.deepEqual(withArrayLimit, { a: { "1": "b" } });
+});
 
-() => {
-    var noParsingArrays = qs.parse('a[]=b', { parseArrays: false });
-    assert.deepEqual(noParsingArrays, { a: { '0': 'b' } });
-}
+(() => {
+    var noParsingArrays = qs.parse("a[]=b", { parseArrays: false });
+    assert.deepEqual(noParsingArrays, { a: { "0": "b" } });
+});
 
-() => {
-    var mixedNotation = qs.parse('a[0]=b&a[b]=c');
-    assert.deepEqual(mixedNotation, { a: { '0': 'b', b: 'c' } });
-}
+(() => {
+    var mixedNotation = qs.parse("a[0]=b&a[b]=c");
+    assert.deepEqual(mixedNotation, { a: { "0": "b", b: "c" } });
+});
 
-() => {
-    var arraysOfObjects = qs.parse('a[][b]=c');
-    assert.deepEqual(arraysOfObjects, { a: [{ b: 'c' }] });
-}
+(() => {
+    var arraysOfObjects = qs.parse("a[][b]=c");
+    assert.deepEqual(arraysOfObjects, { a: [{ b: "c" }] });
+});
 
-() => {
-    assert.equal(qs.stringify({ a: 'b' }), 'a=b');
-    assert.equal(qs.stringify({ a: { b: 'c' } }), 'a%5Bb%5D=c');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "b" }), "a=b");
+    assert.equal(qs.stringify({ a: { b: "c" } }), "a%5Bb%5D=c");
+});
 
-() => {
-    var unencoded = qs.stringify({ a: { b: 'c' } }, { encode: false });
-    assert.equal(unencoded, 'a[b]=c');
-}
+(() => {
+    var unencoded = qs.stringify({ a: { b: "c" } }, { encode: false });
+    assert.equal(unencoded, "a[b]=c");
+});
 
-() => {
-    var toBeCalled = new Set(['key', 'value']);
+(() => {
+    var toBeCalled = new Set(["key", "value"]);
     var encoded = qs.stringify({ a: 12 }, {
-        encoder: function (str, defaultEncoder, charset, type) {
+        encoder: function(str, defaultEncoder, charset, type) {
             assert.ok(toBeCalled.has(type));
             toBeCalled.delete(type);
-            if (typeof str === 'number') return 'Number('+str+')';
+            if (typeof str === "number") return "Number(" + str + ")";
             return defaultEncoder(str, defaultEncoder, charset);
-        }
+        },
     });
     assert.equal(toBeCalled.size, 0);
-    assert.equal(encoded, 'a=Number(12)');
-}
+    assert.equal(encoded, "a=Number(12)");
+});
 
-() => {
-    var decoded = qs.parse('a=Number(12)&b=foo', {
-        decoder: function (str, defaultDecoder, charset, type) {
-            if (type !== 'key') {
+(() => {
+    var decoded = qs.parse("a=Number(12)&b=foo", {
+        decoder: function(str, defaultDecoder, charset, type) {
+            if (type !== "key") {
                 var numberMatch = str.match(/^Number\((\d+)\)$/);
                 if (numberMatch) {
                     return +numberMatch[1];
@@ -198,151 +202,157 @@ qs.parse('a=b&c=d', { delimiter: '&' });
             }
 
             return defaultDecoder(str, defaultDecoder, charset);
-        }
+        },
     });
-    assert.deepEqual(decoded, { a: 12, b: 'foo' });
-}
+    assert.deepEqual(decoded, { a: 12, b: "foo" });
+});
 
-() => {
-    qs.stringify({ a: ['b', 'c', 'd'] });
+(() => {
+    qs.stringify({ a: ["b", "c", "d"] });
     // 'a[0]=b&a[1]=c&a[2]=d'
-}
+});
 
-() => {
-    qs.stringify({ a: ['b', 'c', 'd'] }, { indices: false });
+(() => {
+    qs.stringify({ a: ["b", "c", "d"] }, { indices: false });
     // 'a=b&a=c&a=d'
-}
+});
 
-() => {
-    qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'indices' })
+(() => {
+    qs.stringify({ a: ["b", "c"] }, { arrayFormat: "indices" });
     // 'a[0]=b&a[1]=c'
-    qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'brackets' })
+    qs.stringify({ a: ["b", "c"] }, { arrayFormat: "brackets" });
     // 'a[]=b&a[]=c'
-    qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'repeat' })
+    qs.stringify({ a: ["b", "c"] }, { arrayFormat: "repeat" });
     // 'a=b&a=c'
-}
+});
 
-() => {
-    assert.equal(qs.stringify({ a: '' }), 'a=');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "" }), "a=");
+});
 
-() => {
-    assert.equal(qs.stringify({ a: null, b: undefined }), 'a=');
-}
+(() => {
+    assert.equal(qs.stringify({ a: null, b: undefined }), "a=");
+});
 
-() => {
-    assert.equal(qs.stringify({ a: 'b', c: 'd' }, { delimiter: ';' }), 'a=b;c=d');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "b", c: "d" }, { delimiter: ";" }), "a=b;c=d");
+});
 
-() => {
-    qs.stringify({ a: 'b', c: 'd', e: { f: new Date(123), g: [2] } }, { filter: function (prefix, value) {
-        if (prefix == 'b') {
-            // Return an `undefined` value to omit a property.
-            return;
-        }
-        if (prefix == 'e[f]') {
-            return value.getTime();
-        }
-        if (prefix == 'e[g][0]') {
-            return value * 2;
-        }
-        return value;
-    } });
+(() => {
+    qs.stringify({ a: "b", c: "d", e: { f: new Date(123), g: [2] } }, {
+        filter: function(prefix, value) {
+            if (prefix == "b") {
+                // Return an `undefined` value to omit a property.
+                return;
+            }
+            if (prefix == "e[f]") {
+                return value.getTime();
+            }
+            if (prefix == "e[g][0]") {
+                return value * 2;
+            }
+            return value;
+        },
+    });
     // 'a=b&c=d&e[f]=123&e[g][0]=4'
-    qs.stringify({ a: 'b', c: 'd', e: 'f' }, { filter: ['a', 'e'] });
+    qs.stringify({ a: "b", c: "d", e: "f" }, { filter: ["a", "e"] });
     // 'a=b&e=f'
-    qs.stringify({ a: ['b', 'c', 'd'], e: 'f' }, { filter: ['a', 0, 2] });
-}
+    qs.stringify({ a: ["b", "c", "d"], e: "f" }, { filter: ["a", 0, 2] });
+});
 
-() => {
-    var withNull = qs.stringify({ a: null, b: '' });
-    assert.equal(withNull, 'a=&b=');
-}
+(() => {
+    var withNull = qs.stringify({ a: null, b: "" });
+    assert.equal(withNull, "a=&b=");
+});
 
-() => {
-    var equalsInsensitive = qs.parse('a&b=');
-    assert.deepEqual(equalsInsensitive, { a: '', b: '' });
-}
+(() => {
+    var equalsInsensitive = qs.parse("a&b=");
+    assert.deepEqual(equalsInsensitive, { a: "", b: "" });
+});
 
-() => {
-    var strictNull = qs.stringify({ a: null, b: '' }, { strictNullHandling: true });
-    assert.equal(strictNull, 'a&b=');
-}
+(() => {
+    var strictNull = qs.stringify({ a: null, b: "" }, { strictNullHandling: true });
+    assert.equal(strictNull, "a&b=");
+});
 
-() => {
-    var parsedStrictNull = qs.parse('a&b=', { strictNullHandling: true });
-    assert.deepEqual(parsedStrictNull, { a: null, b: '' });
-}
+(() => {
+    var parsedStrictNull = qs.parse("a&b=", { strictNullHandling: true });
+    assert.deepEqual(parsedStrictNull, { a: null, b: "" });
+});
 
-() => {
-    var parsedQueryPrefix = qs.parse('?a&b=', { ignoreQueryPrefix: true });
-    assert.deepEqual(parsedQueryPrefix, { a: '', b: '' });
-}
+(() => {
+    var parsedQueryPrefix = qs.parse("?a&b=", { ignoreQueryPrefix: true });
+    assert.deepEqual(parsedQueryPrefix, { a: "", b: "" });
+});
 
-() => {
-    var parsedCommaSeparatedArray = qs.parse('?a=b,c', { comma: true });
-    assert.equal(parsedCommaSeparatedArray, { a: ['b', 'c']});
-}
+(() => {
+    var parsedCommaSeparatedArray = qs.parse("?a=b,c", { comma: true });
+    assert.equal(parsedCommaSeparatedArray, { a: ["b", "c"] });
+});
 
-() => {
-    var nullsSkipped = qs.stringify({ a: 'b', c: null }, { skipNulls: true });
-    assert.equal(nullsSkipped, 'a=b');
-}
+(() => {
+    var nullsSkipped = qs.stringify({ a: "b", c: null }, { skipNulls: true });
+    assert.equal(nullsSkipped, "a=b");
+});
 
-() => {
-    var shiftJISEncoded = qs.stringify({ a: 'こんにちは！' });
-    assert.equal(shiftJISEncoded, 'a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I');
-}
+(() => {
+    var shiftJISEncoded = qs.stringify({ a: "こんにちは！" });
+    assert.equal(shiftJISEncoded, "a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I");
+});
 
-() => {
-    let obj = qs.parse('a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I');
-    assert.deepEqual(obj, { a: 'こんにちは！' });
-}
+(() => {
+    let obj = qs.parse("a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I");
+    assert.deepEqual(obj, { a: "こんにちは！" });
+});
 
-() => {
-    var sorted = qs.stringify({ a: 1, c: 3, b: 2 }, { sort: (a, b) => a.localeCompare(b) })
-    assert.equal(sorted, 'a=1&b=2&c=3')
-}
+(() => {
+    var sorted = qs.stringify({ a: 1, c: 3, b: 2 }, { sort: (a, b) => a.localeCompare(b) });
+    assert.equal(sorted, "a=1&b=2&c=3");
+});
 
-() => {
+(() => {
     var date = new Date(7);
     assert.equal(
-        qs.stringify({ a: date }, { serializeDate: function (d) { return d.getTime().toString(); } }),
-        'a=7'
+        qs.stringify({ a: date }, {
+            serializeDate: function(d) {
+                return d.getTime().toString();
+            },
+        }),
+        "a=7",
     );
-}
+});
 
-() => {
-    assert.equal(qs.stringify({ a: 'b c' }, { format : 'RFC3986' }), 'a=b%20c');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "b c" }, { format: "RFC3986" }), "a=b%20c");
+});
 
-() => {
-    assert.equal(qs.stringify({ a: 'b c' }, { format : 'RFC1738' }), 'a=b+c');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "b c" }, { format: "RFC1738" }), "a=b+c");
+});
 
-() => {
+(() => {
     var encodedValues = qs.stringify(
-        { a: 'b', c: ['d', 'e=f'], f: [['g'], ['h']] },
-        { encodeValuesOnly: true }
+        { a: "b", c: ["d", "e=f"], f: [["g"], ["h"]] },
+        { encodeValuesOnly: true },
     );
-    assert.equal(encodedValues,'a=b&c[0]=d&c[1]=e%3Df&f[0][0]=g&f[1][0]=h');
-}
+    assert.equal(encodedValues, "a=b&c[0]=d&c[1]=e%3Df&f[0][0]=g&f[1][0]=h");
+});
 
-() => {
-    assert.equal(qs.stringify({ a: 'b' }, { addQueryPrefix: true }), '?a=b');
-}
+(() => {
+    assert.equal(qs.stringify({ a: "b" }, { addQueryPrefix: true }), "?a=b");
+});
 
-() => {
-    assert.equal(qs.stringify({ a: { b: { c: 'd', e: 'f' } } }, { allowDots: true }), 'a.b.c=d&a.b.e=f');
-};
+(() => {
+    assert.equal(qs.stringify({ a: { b: { c: "d", e: "f" } } }, { allowDots: true }), "a.b.c=d&a.b.e=f");
+});
 
-() => {
-    assert.deepEqual(qs.parse({ 'array[0][name]': 'John', 'array[0][surname]': 'Smith' }), {
-        array: [{ name: 'John', surname: 'Smith' }],
+(() => {
+    assert.deepEqual(qs.parse({ "array[0][name]": "John", "array[0][surname]": "Smith" }), {
+        array: [{ name: "John", surname: "Smith" }],
     });
-}
+});
 
-declare const myQuery: { a: string; b?: string | undefined }
+declare const myQuery: { a: string; b?: string | undefined };
 const myQueryCopy: qs.ParsedQs = myQuery;
 
 interface MyQuery extends qs.ParsedQs {

--- a/types/qtip2/index.d.ts
+++ b/types/qtip2/index.d.ts
@@ -14,7 +14,6 @@
 declare namespace QTip2 {
     type EventApiFunc = (event: Event, api: Api) => void;
 
-
     /**
      * Content property
      */
@@ -27,7 +26,6 @@ declare namespace QTip2 {
         attr?: string | undefined;
         button?: string | JQuery | boolean | undefined;
     }
-
 
     /**
      * Position property
@@ -53,7 +51,6 @@ declare namespace QTip2 {
         adjust?: PositionAdjust | undefined;
     }
 
-
     /**
      * Show property
      */
@@ -67,15 +64,13 @@ declare namespace QTip2 {
         modal?: boolean | Modal | undefined;
     }
 
-    interface Modal
-    {
+    interface Modal {
         on?: boolean | undefined;
         blur?: boolean | undefined;
         escape?: boolean | undefined;
         stealfocus?: boolean | undefined;
         effect?: boolean | ((state: any) => void) | undefined;
     }
-
 
     /**
      * Hide property
@@ -90,7 +85,6 @@ declare namespace QTip2 {
         distance?: number | boolean | undefined;
         effect?: boolean | ((offset: any) => void) | undefined;
     }
-
 
     /**
      * Style property
@@ -113,7 +107,6 @@ declare namespace QTip2 {
         offset?: number | undefined;
     }
 
-
     /**
      * Events property
      */
@@ -128,7 +121,6 @@ declare namespace QTip2 {
         focus?: EventApiFunc | undefined;
         blur?: EventApiFunc | undefined;
     }
-
 
     /**
      * Options
@@ -147,115 +139,114 @@ declare namespace QTip2 {
         events?: Events | undefined;
     }
 
-
     /**
      * API
      */
     interface Api {
-        get(propertyName: 'id'): string | boolean;
-        get(propertyName: 'prerender'): boolean;
-        get(propertyName: 'overwrite'): boolean;
-        get(propertyName: 'suppress'): boolean;
-        get(propertyName: 'metadata'): any;
-        get(propertyName: 'content'): Content;
-        get(propertyName: 'content.text'): Text;
-        get(propertyName: 'content.attr'): string;
-        get(propertyName: 'content.title'): Title;
-        get(propertyName: 'content.button'): string | JQuery | boolean;
-        get(propertyName: 'position'): Position;
-        get(propertyName: 'position.my'): string | boolean;
-        get(propertyName: 'position.at'): string | boolean;
-        get(propertyName: 'position.target'): Target | boolean;
-        get(propertyName: 'position.container'): JQuery | boolean;
-        get(propertyName: 'position.viewport'): JQuery | boolean;
-        get(propertyName: 'position.effect'): boolean | ((api: any, pos: any, viewport: any) => void);
-        get(propertyName: 'position.adjust'): PositionAdjust;
-        get(propertyName: 'show'): Show;
-        get(propertyName: 'show.target'): JQuery | boolean;
-        get(propertyName: 'show.event'): string | boolean;
-        get(propertyName: 'show.delay'): number;
-        get(propertyName: 'show.solo'): JQuery | string | boolean;
-        get(propertyName: 'show.ready'): boolean;
-        get(propertyName: 'show.effect'): boolean | ((offset: any) => void);
-        get(propertyName: 'show.modal'): boolean | Modal;
-        get(propertyName: 'hide'): Hide;
-        get(propertyName: 'hide.target'): JQuery | boolean;
-        get(propertyName: 'hide.event'): string | boolean;
-        get(propertyName: 'hide.delay'): number;
-        get(propertyName: 'hide.leave'): string | boolean;
-        get(propertyName: 'hide.distance'): number | boolean;
-        get(propertyName: 'hide.effect'): boolean | ((offset: any) => void);
-        get(propertyName: 'style'): Style;
-        get(propertyName: 'style.classes'): string | boolean;
-        get(propertyName: 'style.def'): boolean;
-        get(propertyName: 'style.widget'): boolean;
-        get(propertyName: 'style.width'): string | number | boolean;
-        get(propertyName: 'style.height'): string | number | boolean;
-        get(propertyName: 'style.tip'): string | boolean | Tip;
-        get(propertyName: 'events'): Events;
-        get(propertyName: 'events.render'): EventApiFunc;
-        get(propertyName: 'events.show'): EventApiFunc;
-        get(propertyName: 'events.hide'): EventApiFunc;
-        get(propertyName: 'events.toggle'): EventApiFunc;
-        get(propertyName: 'events.visible'): EventApiFunc;
-        get(propertyName: 'events.hidden'): EventApiFunc;
-        get(propertyName: 'events.move'): EventApiFunc;
-        get(propertyName: 'events.focus'): EventApiFunc;
-        get(propertyName: 'events.blur'): EventApiFunc;
+        get(propertyName: "id"): string | boolean;
+        get(propertyName: "prerender"): boolean;
+        get(propertyName: "overwrite"): boolean;
+        get(propertyName: "suppress"): boolean;
+        get(propertyName: "metadata"): any;
+        get(propertyName: "content"): Content;
+        get(propertyName: "content.text"): Text;
+        get(propertyName: "content.attr"): string;
+        get(propertyName: "content.title"): Title;
+        get(propertyName: "content.button"): string | JQuery | boolean;
+        get(propertyName: "position"): Position;
+        get(propertyName: "position.my"): string | boolean;
+        get(propertyName: "position.at"): string | boolean;
+        get(propertyName: "position.target"): Target | boolean;
+        get(propertyName: "position.container"): JQuery | boolean;
+        get(propertyName: "position.viewport"): JQuery | boolean;
+        get(propertyName: "position.effect"): boolean | ((api: any, pos: any, viewport: any) => void);
+        get(propertyName: "position.adjust"): PositionAdjust;
+        get(propertyName: "show"): Show;
+        get(propertyName: "show.target"): JQuery | boolean;
+        get(propertyName: "show.event"): string | boolean;
+        get(propertyName: "show.delay"): number;
+        get(propertyName: "show.solo"): JQuery | string | boolean;
+        get(propertyName: "show.ready"): boolean;
+        get(propertyName: "show.effect"): boolean | ((offset: any) => void);
+        get(propertyName: "show.modal"): boolean | Modal;
+        get(propertyName: "hide"): Hide;
+        get(propertyName: "hide.target"): JQuery | boolean;
+        get(propertyName: "hide.event"): string | boolean;
+        get(propertyName: "hide.delay"): number;
+        get(propertyName: "hide.leave"): string | boolean;
+        get(propertyName: "hide.distance"): number | boolean;
+        get(propertyName: "hide.effect"): boolean | ((offset: any) => void);
+        get(propertyName: "style"): Style;
+        get(propertyName: "style.classes"): string | boolean;
+        get(propertyName: "style.def"): boolean;
+        get(propertyName: "style.widget"): boolean;
+        get(propertyName: "style.width"): string | number | boolean;
+        get(propertyName: "style.height"): string | number | boolean;
+        get(propertyName: "style.tip"): string | boolean | Tip;
+        get(propertyName: "events"): Events;
+        get(propertyName: "events.render"): EventApiFunc;
+        get(propertyName: "events.show"): EventApiFunc;
+        get(propertyName: "events.hide"): EventApiFunc;
+        get(propertyName: "events.toggle"): EventApiFunc;
+        get(propertyName: "events.visible"): EventApiFunc;
+        get(propertyName: "events.hidden"): EventApiFunc;
+        get(propertyName: "events.move"): EventApiFunc;
+        get(propertyName: "events.focus"): EventApiFunc;
+        get(propertyName: "events.blur"): EventApiFunc;
         get(propertyName: string): any;
 
         set(properties: QTipOptions): Api;
-        set(propertyName: 'id', value: string | boolean): Api;
-        set(propertyName: 'prerender', value: boolean): Api;
-        set(propertyName: 'overwrite', value: boolean): Api;
-        set(propertyName: 'suppress', value: boolean): Api;
-        set(propertyName: 'metadata', value: any): Api;
-        set(propertyName: 'content', value: Text | Content): Api;
-        set(propertyName: 'content.title', value: Title | { text: Title }): Api;
-        set(propertyName: 'content.text', value: Text): Api;
-        set(propertyName: 'content.attr', value: string): Api;
-        set(propertyName: 'content.button', value: string | JQuery | boolean): Api;
-        set(propertyName: 'position', value: Position): Api;
-        set(propertyName: 'position.my', value: string | boolean): Api;
-        set(propertyName: 'position.at', value: string | boolean): Api;
-        set(propertyName: 'position.target', value: Target | boolean): Api;
-        set(propertyName: 'position.container', value: JQuery | boolean): Api;
-        set(propertyName: 'position.viewport', value: JQuery | boolean): Api;
-        set(propertyName: 'position.effect', value: boolean | ((api: Api, pos: any, viewport: any) => void) ): Api;
-        set(propertyName: 'position.adjust', value: PositionAdjust): Api;
-        set(propertyName: 'show', value: Show): Api;
-        set(propertyName: 'show.target', value: JQuery | boolean): Api;
-        set(propertyName: 'show.event', value: string | boolean): Api;
-        set(propertyName: 'show.delay', value: number): Api;
-        set(propertyName: 'show.solo', value: JQuery | string | boolean): Api;
-        set(propertyName: 'show.ready', value: boolean): Api;
-        set(propertyName: 'show.effect', value: boolean | ((offset: any) => void)): Api;
-        set(propertyName: 'show.modal', value: boolean | Modal): Api;
-        set(propertyName: 'hide', value: Hide): Api;
-        set(propertyName: 'hide.target', value: JQuery | boolean): Api;
-        set(propertyName: 'hide.event', value: string | boolean): Api;
-        set(propertyName: 'hide.inactive', value: number | boolean): Api;
-        set(propertyName: 'hide.fixed', value: boolean): Api;
-        set(propertyName: 'hide.leave', value: string | boolean): Api;
-        set(propertyName: 'hide.distance', value: number | boolean): Api;
-        set(propertyName: 'hide.effect', value: boolean | ((offset: any) => void)): Api
-        set(propertyName: 'style', value: Style): Api;
-        set(propertyName: 'style.classes', value: string | boolean): Api;
-        set(propertyName: 'style.def', value: boolean): Api;
-        set(propertyName: 'style.widget', value: boolean): Api;
-        set(propertyName: 'style.width', value: string | number | boolean): Api;
-        set(propertyName: 'style.height', value: string | number | boolean): Api;
-        set(propertyName: 'style.tip', value: string | boolean | Tip): Api;
-        set(propertyName: 'events', value: Events): Api;
-        set(propertyName: 'events.render', value: EventApiFunc): Api;
-        set(propertyName: 'events.show', value: EventApiFunc): Api;
-        set(propertyName: 'events.hide', value: EventApiFunc): Api;
-        set(propertyName: 'events.toggle', value: EventApiFunc): Api;
-        set(propertyName: 'events.visible', value: EventApiFunc): Api;
-        set(propertyName: 'events.hidden', value: EventApiFunc): Api;
-        set(propertyName: 'events.move', value: EventApiFunc): Api;
-        set(propertyName: 'events.focus', value: EventApiFunc): Api;
-        set(propertyName: 'events.blur', value: EventApiFunc): Api;
+        set(propertyName: "id", value: string | boolean): Api;
+        set(propertyName: "prerender", value: boolean): Api;
+        set(propertyName: "overwrite", value: boolean): Api;
+        set(propertyName: "suppress", value: boolean): Api;
+        set(propertyName: "metadata", value: any): Api;
+        set(propertyName: "content", value: Text | Content): Api;
+        set(propertyName: "content.title", value: Title | { text: Title }): Api;
+        set(propertyName: "content.text", value: Text): Api;
+        set(propertyName: "content.attr", value: string): Api;
+        set(propertyName: "content.button", value: string | JQuery | boolean): Api;
+        set(propertyName: "position", value: Position): Api;
+        set(propertyName: "position.my", value: string | boolean): Api;
+        set(propertyName: "position.at", value: string | boolean): Api;
+        set(propertyName: "position.target", value: Target | boolean): Api;
+        set(propertyName: "position.container", value: JQuery | boolean): Api;
+        set(propertyName: "position.viewport", value: JQuery | boolean): Api;
+        set(propertyName: "position.effect", value: boolean | ((api: Api, pos: any, viewport: any) => void)): Api;
+        set(propertyName: "position.adjust", value: PositionAdjust): Api;
+        set(propertyName: "show", value: Show): Api;
+        set(propertyName: "show.target", value: JQuery | boolean): Api;
+        set(propertyName: "show.event", value: string | boolean): Api;
+        set(propertyName: "show.delay", value: number): Api;
+        set(propertyName: "show.solo", value: JQuery | string | boolean): Api;
+        set(propertyName: "show.ready", value: boolean): Api;
+        set(propertyName: "show.effect", value: boolean | ((offset: any) => void)): Api;
+        set(propertyName: "show.modal", value: boolean | Modal): Api;
+        set(propertyName: "hide", value: Hide): Api;
+        set(propertyName: "hide.target", value: JQuery | boolean): Api;
+        set(propertyName: "hide.event", value: string | boolean): Api;
+        set(propertyName: "hide.inactive", value: number | boolean): Api;
+        set(propertyName: "hide.fixed", value: boolean): Api;
+        set(propertyName: "hide.leave", value: string | boolean): Api;
+        set(propertyName: "hide.distance", value: number | boolean): Api;
+        set(propertyName: "hide.effect", value: boolean | ((offset: any) => void)): Api;
+        set(propertyName: "style", value: Style): Api;
+        set(propertyName: "style.classes", value: string | boolean): Api;
+        set(propertyName: "style.def", value: boolean): Api;
+        set(propertyName: "style.widget", value: boolean): Api;
+        set(propertyName: "style.width", value: string | number | boolean): Api;
+        set(propertyName: "style.height", value: string | number | boolean): Api;
+        set(propertyName: "style.tip", value: string | boolean | Tip): Api;
+        set(propertyName: "events", value: Events): Api;
+        set(propertyName: "events.render", value: EventApiFunc): Api;
+        set(propertyName: "events.show", value: EventApiFunc): Api;
+        set(propertyName: "events.hide", value: EventApiFunc): Api;
+        set(propertyName: "events.toggle", value: EventApiFunc): Api;
+        set(propertyName: "events.visible", value: EventApiFunc): Api;
+        set(propertyName: "events.hidden", value: EventApiFunc): Api;
+        set(propertyName: "events.move", value: EventApiFunc): Api;
+        set(propertyName: "events.focus", value: EventApiFunc): Api;
+        set(propertyName: "events.blur", value: EventApiFunc): Api;
         set(propertyName: string, value: any): Api;
 
         toggle(state?: boolean, event?: Event): Api;
@@ -280,136 +271,142 @@ declare namespace QTip2 {
     interface Plugin {
         defaults: QTipOptions;
 
-        (methodName: 'api'): QTip2.Api;
+        (methodName: "api"): QTip2.Api;
 
-        (methodName: 'option', propertyName: 'id'): string | boolean;
-        (methodName: 'option', propertyName: 'prerender'): boolean;
-        (methodName: 'option', propertyName: 'overwrite'): boolean;
-        (methodName: 'option', propertyName: 'suppress'): boolean;
-        (methodName: 'option', propertyName: 'metadata'): any;
-        (methodName: 'option', propertyName: 'content'): QTip2.Content;
-        (methodName: 'option', propertyName: 'content.text'): QTip2.Text;
-        (methodName: 'option', propertyName: 'content.attr'): string;
-        (methodName: 'option', propertyName: 'content.title'): QTip2.Title;
-        (methodName: 'option', propertyName: 'content.button'): string | JQuery | boolean;
-        (methodName: 'option', propertyName: 'position'): QTip2.Position;
-        (methodName: 'option', propertyName: 'position.my'): string | boolean;
-        (methodName: 'option', propertyName: 'position.at'): string | boolean;
-        (methodName: 'option', propertyName: 'position.target'): QTip2.Target | boolean;
-        (methodName: 'option', propertyName: 'position.container'): JQuery | boolean;
-        (methodName: 'option', propertyName: 'position.viewport'): JQuery | boolean;
-        (methodName: 'option', propertyName: 'position.effect'): boolean | ((api: QTip2.Api, pos: any, viewport: any) => void);
-        (methodName: 'option', propertyName: 'position.adjust'): QTip2.PositionAdjust;
-        (methodName: 'option', propertyName: 'show'): QTip2.Show;
-        (methodName: 'option', propertyName: 'show.target'): JQuery | boolean;
-        (methodName: 'option', propertyName: 'show.event'): string | boolean;
-        (methodName: 'option', propertyName: 'show.delay'): number;
-        (methodName: 'option', propertyName: 'show.solo'): JQuery | string | boolean;
-        (methodName: 'option', propertyName: 'show.ready'): boolean;
-        (methodName: 'option', propertyName: 'show.effect'): boolean | ((offset: any) => void);
-        (methodName: 'option', propertyName: 'show.modal'): boolean | QTip2.Modal;
-        (methodName: 'option', propertyName: 'hide'): QTip2.Hide;
-        (methodName: 'option', propertyName: 'hide.target'): JQuery | boolean;
-        (methodName: 'option', propertyName: 'hide.event'): string | boolean;
-        (methodName: 'option', propertyName: 'hide.delay'): number;
-        (methodName: 'option', propertyName: 'hide.leave'): string | boolean;
-        (methodName: 'option', propertyName: 'hide.distance'): number | boolean;
-        (methodName: 'option', propertyName: 'hide.effect'): boolean | ((offset: any) => void);
-        (methodName: 'option', propertyName: 'style'): QTip2.Style;
-        (methodName: 'option', propertyName: 'style.classes'): string | boolean;
-        (methodName: 'option', propertyName: 'style.def'): boolean;
-        (methodName: 'option', propertyName: 'style.widget'): boolean;
-        (methodName: 'option', propertyName: 'style.width'): string | number | boolean;
-        (methodName: 'option', propertyName: 'style.height'): string | number | boolean;
-        (methodName: 'option', propertyName: 'style.tip'): string | boolean | QTip2.Tip;
-        (methodName: 'option', propertyName: 'events'): QTip2.Events;
-        (methodName: 'option', propertyName: 'events.render'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.show'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.hide'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.toggle'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.visible'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.hidden'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.move'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.focus'): QTip2.EventApiFunc;
-        (methodName: 'option', propertyName: 'events.blur'): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "id"): string | boolean;
+        (methodName: "option", propertyName: "prerender"): boolean;
+        (methodName: "option", propertyName: "overwrite"): boolean;
+        (methodName: "option", propertyName: "suppress"): boolean;
+        (methodName: "option", propertyName: "metadata"): any;
+        (methodName: "option", propertyName: "content"): QTip2.Content;
+        (methodName: "option", propertyName: "content.text"): QTip2.Text;
+        (methodName: "option", propertyName: "content.attr"): string;
+        (methodName: "option", propertyName: "content.title"): QTip2.Title;
+        (methodName: "option", propertyName: "content.button"): string | JQuery | boolean;
+        (methodName: "option", propertyName: "position"): QTip2.Position;
+        (methodName: "option", propertyName: "position.my"): string | boolean;
+        (methodName: "option", propertyName: "position.at"): string | boolean;
+        (methodName: "option", propertyName: "position.target"): QTip2.Target | boolean;
+        (methodName: "option", propertyName: "position.container"): JQuery | boolean;
+        (methodName: "option", propertyName: "position.viewport"): JQuery | boolean;
+        (
+            methodName: "option",
+            propertyName: "position.effect",
+        ): boolean | ((api: QTip2.Api, pos: any, viewport: any) => void);
+        (methodName: "option", propertyName: "position.adjust"): QTip2.PositionAdjust;
+        (methodName: "option", propertyName: "show"): QTip2.Show;
+        (methodName: "option", propertyName: "show.target"): JQuery | boolean;
+        (methodName: "option", propertyName: "show.event"): string | boolean;
+        (methodName: "option", propertyName: "show.delay"): number;
+        (methodName: "option", propertyName: "show.solo"): JQuery | string | boolean;
+        (methodName: "option", propertyName: "show.ready"): boolean;
+        (methodName: "option", propertyName: "show.effect"): boolean | ((offset: any) => void);
+        (methodName: "option", propertyName: "show.modal"): boolean | QTip2.Modal;
+        (methodName: "option", propertyName: "hide"): QTip2.Hide;
+        (methodName: "option", propertyName: "hide.target"): JQuery | boolean;
+        (methodName: "option", propertyName: "hide.event"): string | boolean;
+        (methodName: "option", propertyName: "hide.delay"): number;
+        (methodName: "option", propertyName: "hide.leave"): string | boolean;
+        (methodName: "option", propertyName: "hide.distance"): number | boolean;
+        (methodName: "option", propertyName: "hide.effect"): boolean | ((offset: any) => void);
+        (methodName: "option", propertyName: "style"): QTip2.Style;
+        (methodName: "option", propertyName: "style.classes"): string | boolean;
+        (methodName: "option", propertyName: "style.def"): boolean;
+        (methodName: "option", propertyName: "style.widget"): boolean;
+        (methodName: "option", propertyName: "style.width"): string | number | boolean;
+        (methodName: "option", propertyName: "style.height"): string | number | boolean;
+        (methodName: "option", propertyName: "style.tip"): string | boolean | QTip2.Tip;
+        (methodName: "option", propertyName: "events"): QTip2.Events;
+        (methodName: "option", propertyName: "events.render"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.show"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.hide"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.toggle"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.visible"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.hidden"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.move"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.focus"): QTip2.EventApiFunc;
+        (methodName: "option", propertyName: "events.blur"): QTip2.EventApiFunc;
 
-        (methodName: 'option', properties: QTip2.QTipOptions): QTip2.Api;
-        (methodName: 'option', propertyName: 'id', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'prerender', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'overwrite', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'suppress', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'metadata', value: any): QTip2.Api;
-        (methodName: 'option', propertyName: 'content', value: QTip2.Text | QTip2.Content): QTip2.Api;
-        (methodName: 'option', propertyName: 'content.title', value: QTip2.Title | { text: QTip2.Title }): QTip2.Api;
-        (methodName: 'option', propertyName: 'content.text', value: QTip2.Text): QTip2.Api;
-        (methodName: 'option', propertyName: 'content.attr', value: string): QTip2.Api;
-        (methodName: 'option', propertyName: 'content.button', value: string | JQuery | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position', value: QTip2.Position): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.my', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.at', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.target', value: QTip2.Target | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.container', value: JQuery | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.viewport', value: JQuery | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.effect', value: boolean | ((api: QTip2.Api, pos: any, viewport: any) => void) ): QTip2.Api;
-        (methodName: 'option', propertyName: 'position.adjust', value: QTip2.PositionAdjust): QTip2.Api;
-        (methodName: 'option', propertyName: 'show', value: QTip2.Show): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.target', value: JQuery | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.event', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.delay', value: number): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.solo', value: JQuery | string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.ready', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.effect', value: boolean | ((offset: any) => void)): QTip2.Api;
-        (methodName: 'option', propertyName: 'show.modal', value: boolean | QTip2.Modal): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide', value: QTip2.Hide): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.target', value: JQuery | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.event', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.inactive', value: number | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.fixed', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.leave', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.distance', value: number | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'hide.effect', value: boolean | ((offset: any) => void)): QTip2.Api
-        (methodName: 'option', propertyName: 'style', value: QTip2.Style): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.classes', value: string | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.def', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.widget', value: boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.width', value: string | number | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.height', value: string | number | boolean): QTip2.Api;
-        (methodName: 'option', propertyName: 'style.tip', value: string | boolean | QTip2.Tip): QTip2.Api;
-        (methodName: 'option', propertyName: 'events', value: QTip2.Events): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.render', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.show', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.hide', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.toggle', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.visible', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.hidden', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.move', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.focus', value: QTip2.EventApiFunc): QTip2.Api;
-        (methodName: 'option', propertyName: 'events.blur', value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", properties: QTip2.QTipOptions): QTip2.Api;
+        (methodName: "option", propertyName: "id", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "prerender", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "overwrite", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "suppress", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "metadata", value: any): QTip2.Api;
+        (methodName: "option", propertyName: "content", value: QTip2.Text | QTip2.Content): QTip2.Api;
+        (methodName: "option", propertyName: "content.title", value: QTip2.Title | { text: QTip2.Title }): QTip2.Api;
+        (methodName: "option", propertyName: "content.text", value: QTip2.Text): QTip2.Api;
+        (methodName: "option", propertyName: "content.attr", value: string): QTip2.Api;
+        (methodName: "option", propertyName: "content.button", value: string | JQuery | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "position", value: QTip2.Position): QTip2.Api;
+        (methodName: "option", propertyName: "position.my", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "position.at", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "position.target", value: QTip2.Target | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "position.container", value: JQuery | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "position.viewport", value: JQuery | boolean): QTip2.Api;
+        (
+            methodName: "option",
+            propertyName: "position.effect",
+            value: boolean | ((api: QTip2.Api, pos: any, viewport: any) => void),
+        ): QTip2.Api;
+        (methodName: "option", propertyName: "position.adjust", value: QTip2.PositionAdjust): QTip2.Api;
+        (methodName: "option", propertyName: "show", value: QTip2.Show): QTip2.Api;
+        (methodName: "option", propertyName: "show.target", value: JQuery | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "show.event", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "show.delay", value: number): QTip2.Api;
+        (methodName: "option", propertyName: "show.solo", value: JQuery | string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "show.ready", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "show.effect", value: boolean | ((offset: any) => void)): QTip2.Api;
+        (methodName: "option", propertyName: "show.modal", value: boolean | QTip2.Modal): QTip2.Api;
+        (methodName: "option", propertyName: "hide", value: QTip2.Hide): QTip2.Api;
+        (methodName: "option", propertyName: "hide.target", value: JQuery | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.event", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.inactive", value: number | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.fixed", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.leave", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.distance", value: number | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "hide.effect", value: boolean | ((offset: any) => void)): QTip2.Api;
+        (methodName: "option", propertyName: "style", value: QTip2.Style): QTip2.Api;
+        (methodName: "option", propertyName: "style.classes", value: string | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "style.def", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "style.widget", value: boolean): QTip2.Api;
+        (methodName: "option", propertyName: "style.width", value: string | number | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "style.height", value: string | number | boolean): QTip2.Api;
+        (methodName: "option", propertyName: "style.tip", value: string | boolean | QTip2.Tip): QTip2.Api;
+        (methodName: "option", propertyName: "events", value: QTip2.Events): QTip2.Api;
+        (methodName: "option", propertyName: "events.render", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.show", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.hide", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.toggle", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.visible", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.hidden", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.move", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.focus", value: QTip2.EventApiFunc): QTip2.Api;
+        (methodName: "option", propertyName: "events.blur", value: QTip2.EventApiFunc): QTip2.Api;
 
-        (methodName: 'toggle', state?: boolean, event?: Event): JQuery;
+        (methodName: "toggle", state?: boolean, event?: Event): JQuery;
 
-        (methodName: 'show', event?: Event): JQuery;
+        (methodName: "show", event?: Event): JQuery;
 
-        (methodName: 'hide', event?: Event): JQuery;
+        (methodName: "hide", event?: Event): JQuery;
 
-        (methodName: 'disable', state?: boolean): JQuery;
+        (methodName: "disable", state?: boolean): JQuery;
 
-        (methodName: 'enable'): JQuery
+        (methodName: "enable"): JQuery;
 
-        (methodName: 'reposition', event?: Event, effect?: boolean): JQuery;
+        (methodName: "reposition", event?: Event, effect?: boolean): JQuery;
 
-        (methodName: 'focus', event?: Event): JQuery;
+        (methodName: "focus", event?: Event): JQuery;
 
-        (methodName: 'blur', event?: Event): JQuery;
+        (methodName: "blur", event?: Event): JQuery;
 
-        (methodName: 'destroy', immediate?: boolean): JQuery;
+        (methodName: "destroy", immediate?: boolean): JQuery;
 
         (methodName: string, p1?: any, p2?: any, p3?: any): any;
 
         (options?: QTip2.QTipOptions): JQuery;
     }
 }
-
 
 interface JQuery {
     qtip: QTip2.Plugin;

--- a/types/qtip2/qtip2-tests.ts
+++ b/types/qtip2/qtip2-tests.ts
@@ -1,7 +1,4 @@
-
-
-var $a = $('_');
-
+var $a = $("_");
 
 /**
  * Test core properties (http://qtip2.com/options#core)
@@ -9,29 +6,28 @@ var $a = $('_');
 function testCoreProperties() {
     // Test with all core options specififed
     $a.qtip({
-        content: 'Jan Jansen',
-        id: 'jan-jansen',
+        content: "Jan Jansen",
+        id: "jan-jansen",
         prerender: true,
         overwrite: true,
         suppress: true,
         metadata: {
-            type: 'html5',
-            name: 'qtipopts'
-        }
+            type: "html5",
+            name: "qtipopts",
+        },
     });
 
     // Test ID as boolean
     $a.qtip({
-        content: 'yoshimo',
-        id: false
+        content: "yoshimo",
+        id: false,
     });
 
     // Test with no options specified
     $a.qtip({
-        content: 'aerie'
+        content: "aerie",
     });
 }
-
 
 /**
  * http://qtip2.com/options#content.text
@@ -39,79 +35,84 @@ function testCoreProperties() {
 function testContentText() {
     // Shorthand string
     $a.qtip({
-        content: 'valygar'
+        content: "valygar",
     });
 
     // Regular string
     $a.qtip({
-        content: { text: 'kivan' }
+        content: { text: "kivan" },
     });
 
     // Shorthand boolean
     $a.qtip({
-        content: true
+        content: true,
     });
 
     // Regular boolean
     $a.qtip({
-        content: { text: true }
+        content: { text: true },
     });
 
     // Shorthand Deferred / Promise
     $a.qtip({
-        content: $.Deferred().resolve('cernd')
+        content: $.Deferred().resolve("cernd"),
     });
 
     $a.qtip({
-        content: $.Deferred().reject().promise()
+        content: $.Deferred().reject().promise(),
     });
 
     // Regular Deferred / Promise
     $a.qtip({
-        content: { text: $.Deferred().resolve('horatio') }
+        content: { text: $.Deferred().resolve("horatio") },
     });
 
     $a.qtip({
-        content: { text: $.Deferred().reject().promise() }
+        content: { text: $.Deferred().reject().promise() },
     });
 
     // Shorthand function
     $a.qtip({
-        content: function(event: Event, api: QTip2.Api) {    }
+        content: function(event: Event, api: QTip2.Api) {},
     });
 
     $a.qtip({
-        content: function(event: Event) { return 2; }
+        content: function(event: Event) {
+            return 2;
+        },
     });
 
     $a.qtip({
-        content: function() { }
+        content: function() {},
     });
 
     // Regular function
     $a.qtip({
-        content: { text: function(event: Event, api: QTip2.Api) {} }
+        content: { text: function(event: Event, api: QTip2.Api) {} },
     });
 
     $a.qtip({
-        content: { text: function(event: Event) { return 2; } }
+        content: {
+            text: function(event: Event) {
+                return 2;
+            },
+        },
     });
 
     $a.qtip({
-        content: { text: function() { } }
+        content: { text: function() {} },
     });
 
     // Shorthand jQuery elements
     $a.qtip({
-        content: $('.irenicus')
+        content: $(".irenicus"),
     });
 
     // Regular jQuery elements
     $a.qtip({
-        content: { text: $('.irenicus') }
+        content: { text: $(".irenicus") },
     });
 }
-
 
 /**
  * http://qtip2.com/options#content.title
@@ -119,130 +120,137 @@ function testContentText() {
 function testContentTitle() {
     // Shorthand string
     $a.qtip({
-        content: { title: 'keldorn' }
+        content: { title: "keldorn" },
     });
 
     // Regular string
     $a.qtip({
         content: {
-            title: { text: 'nalia' }
-        }
+            title: { text: "nalia" },
+        },
     });
 
     // Shorthand boolean
     $a.qtip({
-        content: { title: true }
+        content: { title: true },
     });
 
     // Regular boolean
     $a.qtip({
         content: {
-            title: { text: true }
-        }
+            title: { text: true },
+        },
     });
 
     // Shorthand Deferred / Promise
     $a.qtip({
-        content: { title: $.Deferred().resolve('mazzy') }
+        content: { title: $.Deferred().resolve("mazzy") },
     });
 
     $a.qtip({
-        content: { title: $.Deferred().reject().promise() }
+        content: { title: $.Deferred().reject().promise() },
     });
 
     // Regular Deferred / Promise
     $a.qtip({
-        content: { title: { text: $.Deferred().resolve('bodhi') } }
+        content: { title: { text: $.Deferred().resolve("bodhi") } },
     });
 
     $a.qtip({
-        content: { title: { text: $.Deferred().reject().promise() } }
+        content: { title: { text: $.Deferred().reject().promise() } },
     });
 
     // Shorthand function
     $a.qtip({
-        content: { title: function(event: Event, api: QTip2.Api) {} }
+        content: { title: function(event: Event, api: QTip2.Api) {} },
     });
 
     $a.qtip({
-        content: { title: function(event: Event) { return 2; } }
+        content: {
+            title: function(event: Event) {
+                return 2;
+            },
+        },
     });
 
     $a.qtip({
-        content: { title: function() { } }
+        content: { title: function() {} },
     });
 
     // Regular function
     $a.qtip({
-        content: { title: { text: function(event: Event, api: QTip2.Api) { } } }
+        content: { title: { text: function(event: Event, api: QTip2.Api) {} } },
     });
 
     $a.qtip({
-        content: { title: { text: function(event: Event) { return 2; } } }
+        content: {
+            title: {
+                text: function(event: Event) {
+                    return 2;
+                },
+            },
+        },
     });
 
     $a.qtip({
-        content: { title: { text: function() { } } }
+        content: { title: { text: function() {} } },
     });
 
     // Shorthand jQuery elements
     $a.qtip({
-        content: { title: $('.irenicus') }
+        content: { title: $(".irenicus") },
     });
 
     // Regular jQuery elements
     $a.qtip({
-        content: { title: { text: $('.irenicus') } }
+        content: { title: { text: $(".irenicus") } },
     });
 }
-
 
 /**
  * http://qtip2.com/options#content.button
  */
 function testContentButtonProperty() {
     $a.qtip({
-        content: { button: $('.minsc') }
+        content: { button: $(".minsc") },
     });
 
     $a.qtip({
-        content: { button: 'jaheira' }
+        content: { button: "jaheira" },
     });
 
     $a.qtip({
-        content: { button: true }
+        content: { button: true },
     });
 }
-
 
 /**
  * http://qtip2.com/options#content.attr
  */
 function testContentAttrProperty() {
     $a.qtip({
-        content: { attr: 'viconia' }
+        content: { attr: "viconia" },
     });
 }
-
 
 /**
  * http://qtip2.com/options#position
  */
 function testPositionProperty() {
     // Shorthand
-    $a.qtip({ position: 'top left' });
+    $a.qtip({ position: "top left" });
 
     // The below four calls test all combinations of all sub-properties
     $a.qtip({
         position: {
-            target: $('.khalid'),
-            my: 'top left',
-            at: 'bottom right',
-            container: $('.edwin-odesseiron'),
-            viewport: $('.dynaheir'),
-            effect: function(api: QTip2.Api, pos: any, viewport: any) { },
-            adjust: { x: 2 }
-        }
+            target: $(".khalid"),
+            my: "top left",
+            at: "bottom right",
+            container: $(".edwin-odesseiron"),
+            viewport: $(".dynaheir"),
+            effect: function(api: QTip2.Api, pos: any, viewport: any) {},
+            adjust: { x: 2 },
+        },
     });
 
     $a.qtip({
@@ -252,17 +260,19 @@ function testPositionProperty() {
             at: true,
             container: false,
             viewport: true,
-            effect: function(api: QTip2.Api, pos: any) { return 2; },
-            adjust: { y: 2 }
-        }
+            effect: function(api: QTip2.Api, pos: any) {
+                return 2;
+            },
+            adjust: { y: 2 },
+        },
     });
 
     $a.qtip({
         position: {
-            target: 'mouse',
+            target: "mouse",
             effect: function(api: QTip2.Api) {},
-            adjust: { x: 2, y: 2 }
-        }
+            adjust: { x: 2, y: 2 },
+        },
     });
 
     $a.qtip({
@@ -273,18 +283,17 @@ function testPositionProperty() {
                 mouse: true,
                 resize: true,
                 scroll: false,
-                method: 'flipinvert'
-            }
-        }
+                method: "flipinvert",
+            },
+        },
     });
 
     $a.qtip({
         position: {
-            adjust: { }
-        }
+            adjust: {},
+        },
     });
 }
-
 
 /**
  * http://qtip2.com/options#show
@@ -292,109 +301,107 @@ function testPositionProperty() {
 function testShowProperty() {
     // Shorthand
     $a.qtip({ show: true });
-    $a.qtip({ show: 'mouseenter' });
-    $a.qtip({ show: $('.korgan') });
+    $a.qtip({ show: "mouseenter" });
+    $a.qtip({ show: $(".korgan") });
 
     // The below calls test all combinations of all sub-properties
     $a.qtip({
         show: {
-            target: $('.gorion'),
+            target: $(".gorion"),
             event: false,
             delay: 42,
-            solo: $('.imoen'),
+            solo: $(".imoen"),
             ready: true,
             effect: function(offset) {
             },
-            modal: true
-        }
+            modal: true,
+        },
     });
 
     $a.qtip({
         show: {
             target: false,
-            event: 'mouseenter',
-            solo: '.qtips',
+            event: "mouseenter",
+            solo: ".qtips",
             effect: true,
             modal: {
                 on: true,
                 blur: false,
                 escape: true,
                 stealfocus: true,
-                effect: true
-            }
-        }
+                effect: true,
+            },
+        },
     });
 
     $a.qtip({
         show: {
             solo: false,
             modal: {
-                effect: function(state) {}
-            }
-        }
+                effect: function(state) {},
+            },
+        },
     });
 
     $a.qtip({
         show: {
-            modal: {}
-        }
+            modal: {},
+        },
     });
 }
-
 
 /**
  * http://qtip2.com/options#hide
  */
 function testHideProperty() {
     // Shorthand
-    $a.qtip({ hide: 'mouseenter' });
-    $a.qtip({ hide: $('.montaron') });
+    $a.qtip({ hide: "mouseenter" });
+    $a.qtip({ hide: $(".montaron") });
 
     // The below calls test all combinations of all sub-properties
     $a.qtip({
         hide: {
-            target: $('.gorion'),
+            target: $(".gorion"),
             event: false,
             delay: 42,
             inactive: 64,
             fixed: true,
-            leave: 'window',
+            leave: "window",
             distance: 32,
             effect: function(offset) {
             },
-        }
+        },
     });
 
     $a.qtip({
         hide: {
             target: false,
-            event: 'mouseenter',
+            event: "mouseenter",
             inactive: false,
             leave: false,
             distance: false,
             effect: true,
-        }
+        },
     });
 }
-
 
 /**
  * http://qtip2.com/options#style
  */
 function testStyleProperty() {
     // Shorthand
-    $a.qtip({ style: 'kagain' });
+    $a.qtip({ style: "kagain" });
 
     // The below calls test all combinations of all sub-properties
     $a.qtip({
         style: {
-            classes: 'anomen',
+            classes: "anomen",
             def: true,
             widget: true,
-            width: '24pt',
-            height: '24pt',
-            tip: 'top left'
-        }
+            width: "24pt",
+            height: "24pt",
+            tip: "top left",
+        },
     });
 
     $a.qtip({
@@ -402,8 +409,8 @@ function testStyleProperty() {
             classes: false,
             width: 24,
             height: 24,
-            tip: false
-        }
+            tip: false,
+        },
     });
 
     $a.qtip({
@@ -412,14 +419,14 @@ function testStyleProperty() {
             width: false,
             height: false,
             tip: {
-                corner: 'bottom right',
-                mimic: 'bottom right',
+                corner: "bottom right",
+                mimic: "bottom right",
                 border: 3,
                 width: 27,
                 height: 32,
-                offset: 1
-            }
-        }
+                offset: 1,
+            },
+        },
     });
 
     $a.qtip({
@@ -427,28 +434,26 @@ function testStyleProperty() {
             tip: {
                 corner: true,
                 mimic: true,
-                border: false
-            }
-        }
+                border: false,
+            },
+        },
     });
 
     $a.qtip({
         style: {
-            tip: { }
-        }
+            tip: {},
+        },
     });
 }
-
 
 function baseCase() {
     $a.qtip();
     $a.qtip({});
 
-    $a.qtip('horatio');
-    $a.qtip('activate');
-    $a.qtip('deactivate');
+    $a.qtip("horatio");
+    $a.qtip("activate");
+    $a.qtip("deactivate");
 }
-
 
 /**
  * Test with all options specified. Copied from http://qtip2.com/options#global and amended.
@@ -461,32 +466,33 @@ function allTogetherNow() {
         suppress: true,
         content: {
             title: true,
-            attr: 'title',
+            attr: "title",
             text: false,
-            button: false
+            button: false,
         },
         position: {
-            my: 'top left',
-            at: 'bottom right',
+            my: "top left",
+            at: "bottom right",
             target: false,
             container: false,
             viewport: false,
             adjust: {
-                x: 0, y: 0,
+                x: 0,
+                y: 0,
                 mouse: true,
                 resize: true,
-                method: 'flip flip'
+                method: "flip flip",
             },
             effect: function(api, pos, viewport) {
                 $(this).animate(pos, {
                     duration: 200,
-                    queue: false
+                    queue: false,
                 });
-            }
+            },
         },
         show: {
             target: false,
-            event: 'mouseenter',
+            event: "mouseenter",
             effect: true,
             delay: 90,
             solo: false,
@@ -495,21 +501,21 @@ function allTogetherNow() {
                 on: false,
                 effect: true,
                 blur: true,
-                escape: true
-            }
+                escape: true,
+            },
         },
         hide: {
             target: false,
-            event: 'mouseleave',
+            event: "mouseleave",
             effect: true,
             delay: 0,
             fixed: false,
             inactive: false,
-            leave: 'window',
-            distance: false
+            leave: "window",
+            distance: false,
         },
         style: {
-            classes: '',
+            classes: "",
             widget: false,
             width: false,
             height: false,
@@ -519,8 +525,8 @@ function allTogetherNow() {
                 width: 8,
                 height: 8,
                 border: true,
-                offset: 0
-            }
+                offset: 0,
+            },
         },
         events: {
             render: null,
@@ -531,11 +537,10 @@ function allTogetherNow() {
             visible: null,
             hidden: null,
             focus: null,
-            blur: null
-        }
+            blur: null,
+        },
     });
 }
-
 
 /**
  * http://qtip2.com/api#api-methods.get
@@ -543,67 +548,65 @@ function allTogetherNow() {
 function testApiGetViaObject() {
     $a.qtip({});
 
-    var api = $a.qtip('api');
+    var api = $a.qtip("api");
 
-    <string | boolean> api.get('id');
-    <boolean> api.get('prerender');
-    <boolean> api.get('overwrite');
-    <boolean> api.get('suppress');
-    <any> api.get('metadata');
+    <string | boolean> api.get("id");
+    <boolean> api.get("prerender");
+    <boolean> api.get("overwrite");
+    <boolean> api.get("suppress");
+    <any> api.get("metadata");
 
-    <QTip2.Content> api.get('content');
-    <QTip2.Text> api.get('content.text');
-    <string> api.get('content.attr');
-    <QTip2.Title> api.get('content.title');
-    <string | JQuery | boolean> api.get('content.button');
+    <QTip2.Content> api.get("content");
+    <QTip2.Text> api.get("content.text");
+    <string> api.get("content.attr");
+    <QTip2.Title> api.get("content.title");
+    <string | JQuery | boolean> api.get("content.button");
 
-    <QTip2.Position> api.get('position');
-    <string | boolean> api.get('position.my');
-    <string | boolean> api.get('position.at');
-    <QTip2.Target | boolean> api.get('position.target');
-    <JQuery | boolean> api.get('position.container');
-    <JQuery | boolean> api.get('position.viewport');
-    <boolean | ((api: any, pos: any, viewport: any) => any)>
-        api.get('position.effect');
-    <QTip2.PositionAdjust> api.get('position.adjust');
+    <QTip2.Position> api.get("position");
+    <string | boolean> api.get("position.my");
+    <string | boolean> api.get("position.at");
+    <QTip2.Target | boolean> api.get("position.target");
+    <JQuery | boolean> api.get("position.container");
+    <JQuery | boolean> api.get("position.viewport");
+    <boolean | ((api: any, pos: any, viewport: any) => any)> api.get("position.effect");
+    <QTip2.PositionAdjust> api.get("position.adjust");
 
-    <QTip2.Show> api.get('show');
-    <JQuery | boolean> api.get('show.target');
-    <string | boolean> api.get('show.event');
-    <number> api.get('show.delay');
-    <JQuery | string | boolean> api.get('show.solo');
-    <boolean> api.get('show.ready');
-    <boolean | ((offset: any) => any)> api.get('show.effect');
-    <boolean | QTip2.Modal> api.get('show.modal');
+    <QTip2.Show> api.get("show");
+    <JQuery | boolean> api.get("show.target");
+    <string | boolean> api.get("show.event");
+    <number> api.get("show.delay");
+    <JQuery | string | boolean> api.get("show.solo");
+    <boolean> api.get("show.ready");
+    <boolean | ((offset: any) => any)> api.get("show.effect");
+    <boolean | QTip2.Modal> api.get("show.modal");
 
-    <QTip2.Hide> api.get('hide');
-    <JQuery | boolean> api.get('hide.target');
-    <string | boolean> api.get('hide.event');
-    <number> api.get('hide.delay');
-    <string | boolean> api.get('hide.leave');
-    <number | boolean> api.get('hide.distance');
-    <boolean | ((offset: any) => any)> api.get('hide.effect');
+    <QTip2.Hide> api.get("hide");
+    <JQuery | boolean> api.get("hide.target");
+    <string | boolean> api.get("hide.event");
+    <number> api.get("hide.delay");
+    <string | boolean> api.get("hide.leave");
+    <number | boolean> api.get("hide.distance");
+    <boolean | ((offset: any) => any)> api.get("hide.effect");
 
-    <QTip2.Style> api.get('style');
-    <string | boolean> api.get('style.classes');
-    <boolean> api.get('style.def');
-    <boolean> api.get('style.widget');
-    <string | number | boolean> api.get('style.width');
-    <string | number | boolean> api.get('style.height');
-    <string | boolean | QTip2.Tip> api.get('style.tip');
+    <QTip2.Style> api.get("style");
+    <string | boolean> api.get("style.classes");
+    <boolean> api.get("style.def");
+    <boolean> api.get("style.widget");
+    <string | number | boolean> api.get("style.width");
+    <string | number | boolean> api.get("style.height");
+    <string | boolean | QTip2.Tip> api.get("style.tip");
 
-    <QTip2.Events> api.get('events');
-    <QTip2.EventApiFunc> api.get('events.render');
-    <QTip2.EventApiFunc> api.get('events.show');
-    <QTip2.EventApiFunc> api.get('events.hide');
-    <QTip2.EventApiFunc> api.get('events.toggle');
-    <QTip2.EventApiFunc> api.get('events.visible');
-    <QTip2.EventApiFunc> api.get('events.hidde');
-    <QTip2.EventApiFunc> api.get('events.move');
-    <QTip2.EventApiFunc> api.get('events.focus');
-    <QTip2.EventApiFunc> api.get('events.blur');
+    <QTip2.Events> api.get("events");
+    <QTip2.EventApiFunc> api.get("events.render");
+    <QTip2.EventApiFunc> api.get("events.show");
+    <QTip2.EventApiFunc> api.get("events.hide");
+    <QTip2.EventApiFunc> api.get("events.toggle");
+    <QTip2.EventApiFunc> api.get("events.visible");
+    <QTip2.EventApiFunc> api.get("events.hidde");
+    <QTip2.EventApiFunc> api.get("events.move");
+    <QTip2.EventApiFunc> api.get("events.focus");
+    <QTip2.EventApiFunc> api.get("events.blur");
 }
-
 
 /**
  * http://qtip2.com/api#api.updating
@@ -611,75 +614,72 @@ function testApiGetViaObject() {
 function testApiGetViaString() {
     $a.qtip({});
 
-    <string | boolean> $a.qtip('option', 'id');
-    <boolean> $a.qtip('option', 'prerender');
-    <boolean> $a.qtip('option', 'overwrite');
-    <boolean> $a.qtip('option', 'suppress');
-    <any> $a.qtip('option', 'metadata');
+    <string | boolean> $a.qtip("option", "id");
+    <boolean> $a.qtip("option", "prerender");
+    <boolean> $a.qtip("option", "overwrite");
+    <boolean> $a.qtip("option", "suppress");
+    <any> $a.qtip("option", "metadata");
 
-    <QTip2.Content> $a.qtip('option', 'content');
-    <QTip2.Text> $a.qtip('option', 'content.text');
-    <string> $a.qtip('option', 'content.attr');
-    <QTip2.Title> $a.qtip('option', 'content.title');
-    <string | JQuery | boolean> $a.qtip('option', 'content.button');
+    <QTip2.Content> $a.qtip("option", "content");
+    <QTip2.Text> $a.qtip("option", "content.text");
+    <string> $a.qtip("option", "content.attr");
+    <QTip2.Title> $a.qtip("option", "content.title");
+    <string | JQuery | boolean> $a.qtip("option", "content.button");
 
-    <QTip2.Position> $a.qtip('option', 'position');
-    <string | boolean> $a.qtip('option', 'position.my');
-    <string | boolean> $a.qtip('option', 'position.at');
-    <QTip2.Target | boolean> $a.qtip('option', 'position.target');
-    <JQuery | boolean> $a.qtip('option', 'position.container');
-    <JQuery | boolean> $a.qtip('option', 'position.viewport');
-    <boolean | ((api: any, pos: any, viewport: any) => any)>
-        $a.qtip('option', 'position.effect');
-    <QTip2.PositionAdjust> $a.qtip('option', 'position.adjust');
+    <QTip2.Position> $a.qtip("option", "position");
+    <string | boolean> $a.qtip("option", "position.my");
+    <string | boolean> $a.qtip("option", "position.at");
+    <QTip2.Target | boolean> $a.qtip("option", "position.target");
+    <JQuery | boolean> $a.qtip("option", "position.container");
+    <JQuery | boolean> $a.qtip("option", "position.viewport");
+    <boolean | ((api: any, pos: any, viewport: any) => any)> $a.qtip("option", "position.effect");
+    <QTip2.PositionAdjust> $a.qtip("option", "position.adjust");
 
-    <QTip2.Show> $a.qtip('option', 'show');
-    <JQuery | boolean> $a.qtip('option', 'show.target');
-    <string | boolean> $a.qtip('option', 'show.event');
-    <number> $a.qtip('option', 'show.delay');
-    <JQuery | string | boolean> $a.qtip('option', 'show.solo');
-    <boolean> $a.qtip('option', 'show.ready');
-    <boolean | ((offset: any) => any)> $a.qtip('option', 'show.effect');
-    <boolean | QTip2.Modal> $a.qtip('option', 'show.modal');
+    <QTip2.Show> $a.qtip("option", "show");
+    <JQuery | boolean> $a.qtip("option", "show.target");
+    <string | boolean> $a.qtip("option", "show.event");
+    <number> $a.qtip("option", "show.delay");
+    <JQuery | string | boolean> $a.qtip("option", "show.solo");
+    <boolean> $a.qtip("option", "show.ready");
+    <boolean | ((offset: any) => any)> $a.qtip("option", "show.effect");
+    <boolean | QTip2.Modal> $a.qtip("option", "show.modal");
 
-    <QTip2.Hide> $a.qtip('option', 'hide');
-    <JQuery | boolean> $a.qtip('option', 'hide.target');
-    <string | boolean> $a.qtip('option', 'hide.event');
-    <number> $a.qtip('option', 'hide.delay');
-    <string | boolean> $a.qtip('option', 'hide.leave');
-    <number | boolean> $a.qtip('option', 'hide.distance');
-    <boolean | ((offset: any) => any)> $a.qtip('option', 'hide.effect');
+    <QTip2.Hide> $a.qtip("option", "hide");
+    <JQuery | boolean> $a.qtip("option", "hide.target");
+    <string | boolean> $a.qtip("option", "hide.event");
+    <number> $a.qtip("option", "hide.delay");
+    <string | boolean> $a.qtip("option", "hide.leave");
+    <number | boolean> $a.qtip("option", "hide.distance");
+    <boolean | ((offset: any) => any)> $a.qtip("option", "hide.effect");
 
-    <QTip2.Style> $a.qtip('option', 'style');
-    <string | boolean> $a.qtip('option', 'style.classes');
-    <boolean> $a.qtip('option', 'style.def');
-    <boolean> $a.qtip('option', 'style.widget');
-    <string | number | boolean> $a.qtip('option', 'style.width');
-    <string | number | boolean> $a.qtip('option', 'style.height');
-    <string | boolean | QTip2.Tip> $a.qtip('option', 'style.tip');
+    <QTip2.Style> $a.qtip("option", "style");
+    <string | boolean> $a.qtip("option", "style.classes");
+    <boolean> $a.qtip("option", "style.def");
+    <boolean> $a.qtip("option", "style.widget");
+    <string | number | boolean> $a.qtip("option", "style.width");
+    <string | number | boolean> $a.qtip("option", "style.height");
+    <string | boolean | QTip2.Tip> $a.qtip("option", "style.tip");
 
-    <QTip2.Events> $a.qtip('option', 'events');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.render');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.show');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.hide');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.toggle');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.visible');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.hidde');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.move');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.focus');
-    <QTip2.EventApiFunc> $a.qtip('option', 'events.blur');
+    <QTip2.Events> $a.qtip("option", "events");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.render");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.show");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.hide");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.toggle");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.visible");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.hidde");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.move");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.focus");
+    <QTip2.EventApiFunc> $a.qtip("option", "events.blur");
 }
-
 
 /**
  * http://qtip2.com/api#api-methods.set
  */
 function testApiSetViaObject() {
-
     // TODO
     $a.qtip({});
 
-    var api = $a.qtip('api');
+    var api = $a.qtip("api");
 
     <QTip2.Api> api.set({
         prerender: false,
@@ -688,32 +688,33 @@ function testApiSetViaObject() {
         suppress: true,
         content: {
             title: true,
-            attr: 'title',
+            attr: "title",
             text: false,
-            button: false
+            button: false,
         },
         position: {
-            my: 'top left',
-            at: 'bottom right',
+            my: "top left",
+            at: "bottom right",
             target: false,
             container: false,
             viewport: false,
             adjust: {
-                x: 0, y: 0,
+                x: 0,
+                y: 0,
                 mouse: true,
                 resize: true,
-                method: 'flip flip'
+                method: "flip flip",
             },
             effect: function(api, pos, viewport) {
                 $(this).animate(pos, {
                     duration: 200,
-                    queue: false
+                    queue: false,
                 });
-            }
+            },
         },
         show: {
             target: false,
-            event: 'mouseenter',
+            event: "mouseenter",
             effect: true,
             delay: 90,
             solo: false,
@@ -722,21 +723,21 @@ function testApiSetViaObject() {
                 on: false,
                 effect: true,
                 blur: true,
-                escape: true
-            }
+                escape: true,
+            },
         },
         hide: {
             target: false,
-            event: 'mouseleave',
+            event: "mouseleave",
             effect: true,
             delay: 0,
             fixed: false,
             inactive: false,
-            leave: 'window',
-            distance: false
+            leave: "window",
+            distance: false,
         },
         style: {
-            classes: '',
+            classes: "",
             widget: false,
             width: false,
             height: false,
@@ -746,8 +747,8 @@ function testApiSetViaObject() {
                 width: 8,
                 height: 8,
                 border: true,
-                offset: 0
-            }
+                offset: 0,
+            },
         },
         events: {
             render: null,
@@ -758,69 +759,68 @@ function testApiSetViaObject() {
             visible: null,
             hidden: null,
             focus: null,
-            blur: null
-        }
+            blur: null,
+        },
     });
 
-    <QTip2.Api> api.set('id', <string | boolean> null);
-    <QTip2.Api> api.set('prerender', <boolean> null);
-    <QTip2.Api> api.set('overwrite', <boolean> null);
-    <QTip2.Api> api.set('suppress', <boolean> null);
-    <QTip2.Api> api.set('metadata', <any> null);
+    <QTip2.Api> api.set("id", <string | boolean> null);
+    <QTip2.Api> api.set("prerender", <boolean> null);
+    <QTip2.Api> api.set("overwrite", <boolean> null);
+    <QTip2.Api> api.set("suppress", <boolean> null);
+    <QTip2.Api> api.set("metadata", <any> null);
 
-    <QTip2.Api> api.set('content', <QTip2.Text | QTip2.Content> null);
-    <QTip2.Api> api.set('content.title', <QTip2.Title | { text: QTip2.Title }> null);
-    <QTip2.Api> api.set('content.text', <QTip2.Text> null);
-    <QTip2.Api> api.set('content.attr', <string> null);
-    <QTip2.Api> api.set('content.button', <string | JQuery | boolean> null);
+    <QTip2.Api> api.set("content", <QTip2.Text | QTip2.Content> null);
+    <QTip2.Api> api.set("content.title", <QTip2.Title | { text: QTip2.Title }> null);
+    <QTip2.Api> api.set("content.text", <QTip2.Text> null);
+    <QTip2.Api> api.set("content.attr", <string> null);
+    <QTip2.Api> api.set("content.button", <string | JQuery | boolean> null);
 
-    <QTip2.Api> api.set('position', <string | QTip2.Position> null);
-    <QTip2.Api> api.set('position.my', <string | boolean> null);
-    <QTip2.Api> api.set('position.at', <string | boolean> null);
-    <QTip2.Api> api.set('position.target', <QTip2.Target | boolean> null);
-    <QTip2.Api> api.set('position.container', <JQuery | boolean> null);
-    <QTip2.Api> api.set('position.viewport', <JQuery | boolean> null);
-    <QTip2.Api> api.set('position.effect', <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null);
-    <QTip2.Api> api.set('position.adjust', <QTip2.PositionAdjust> null);
+    <QTip2.Api> api.set("position", <string | QTip2.Position> null);
+    <QTip2.Api> api.set("position.my", <string | boolean> null);
+    <QTip2.Api> api.set("position.at", <string | boolean> null);
+    <QTip2.Api> api.set("position.target", <QTip2.Target | boolean> null);
+    <QTip2.Api> api.set("position.container", <JQuery | boolean> null);
+    <QTip2.Api> api.set("position.viewport", <JQuery | boolean> null);
+    <QTip2.Api> api.set("position.effect", <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null);
+    <QTip2.Api> api.set("position.adjust", <QTip2.PositionAdjust> null);
 
-    <QTip2.Api> api.set('show', <QTip2.Show> null);
-    <QTip2.Api> api.set('show.target', <JQuery | boolean> null);
-    <QTip2.Api> api.set('show.event', <string | boolean> null);
-    <QTip2.Api> api.set('show.delay', <number> null);
-    <QTip2.Api> api.set('show.solo', <JQuery | string | boolean> null);
-    <QTip2.Api> api.set('show.ready', <boolean> null);
-    <QTip2.Api> api.set('show.effect', <boolean | ((offset: any) => void)> null);
-    <QTip2.Api> api.set('show.modal', <boolean | QTip2.Modal> null);
+    <QTip2.Api> api.set("show", <QTip2.Show> null);
+    <QTip2.Api> api.set("show.target", <JQuery | boolean> null);
+    <QTip2.Api> api.set("show.event", <string | boolean> null);
+    <QTip2.Api> api.set("show.delay", <number> null);
+    <QTip2.Api> api.set("show.solo", <JQuery | string | boolean> null);
+    <QTip2.Api> api.set("show.ready", <boolean> null);
+    <QTip2.Api> api.set("show.effect", <boolean | ((offset: any) => void)> null);
+    <QTip2.Api> api.set("show.modal", <boolean | QTip2.Modal> null);
 
-    <QTip2.Api> api.set('hide', <QTip2.Hide> null);
-    <QTip2.Api> api.set('hide.target', <JQuery | boolean> null);
-    <QTip2.Api> api.set('hide.event', <string | boolean> null);
-    <QTip2.Api> api.set('hide.inactive', <number | boolean> null);
-    <QTip2.Api> api.set('hide.fixed', <boolean> null);
-    <QTip2.Api> api.set('hide.leave', <string | boolean> null);
-    <QTip2.Api> api.set('hide.distance', <number | boolean> null);
-    <QTip2.Api> api.set('hide.effect', <boolean | ((offset: any) => void)> null);
+    <QTip2.Api> api.set("hide", <QTip2.Hide> null);
+    <QTip2.Api> api.set("hide.target", <JQuery | boolean> null);
+    <QTip2.Api> api.set("hide.event", <string | boolean> null);
+    <QTip2.Api> api.set("hide.inactive", <number | boolean> null);
+    <QTip2.Api> api.set("hide.fixed", <boolean> null);
+    <QTip2.Api> api.set("hide.leave", <string | boolean> null);
+    <QTip2.Api> api.set("hide.distance", <number | boolean> null);
+    <QTip2.Api> api.set("hide.effect", <boolean | ((offset: any) => void)> null);
 
-    <QTip2.Api> api.set('style', <QTip2.Style> null);
-    <QTip2.Api> api.set('style.classes', <string | boolean> null);
-    <QTip2.Api> api.set('style.def', <boolean> null);
-    <QTip2.Api> api.set('style.widget', <boolean> null);
-    <QTip2.Api> api.set('style.width', <string | number | boolean> null);
-    <QTip2.Api> api.set('style.height', <string | number | boolean> null);
-    <QTip2.Api> api.set('style.tip', <string | boolean | QTip2.Tip> null);
+    <QTip2.Api> api.set("style", <QTip2.Style> null);
+    <QTip2.Api> api.set("style.classes", <string | boolean> null);
+    <QTip2.Api> api.set("style.def", <boolean> null);
+    <QTip2.Api> api.set("style.widget", <boolean> null);
+    <QTip2.Api> api.set("style.width", <string | number | boolean> null);
+    <QTip2.Api> api.set("style.height", <string | number | boolean> null);
+    <QTip2.Api> api.set("style.tip", <string | boolean | QTip2.Tip> null);
 
-    <QTip2.Api> api.set('events', <QTip2.Events> null);
-    <QTip2.Api> api.set('events.render', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.show', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.hide', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.toggle', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.visible', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.hidden', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.move', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.focus', <QTip2.EventApiFunc> null);
-    <QTip2.Api> api.set('events.blur', <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events", <QTip2.Events> null);
+    <QTip2.Api> api.set("events.render", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.show", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.hide", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.toggle", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.visible", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.hidden", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.move", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.focus", <QTip2.EventApiFunc> null);
+    <QTip2.Api> api.set("events.blur", <QTip2.EventApiFunc> null);
 }
-
 
 /**
  * http://qtip2.com/api#api.updating
@@ -828,39 +828,40 @@ function testApiSetViaObject() {
 function testApiSetViaString() {
     $a.qtip({});
 
-    <QTip2.Api> $a.qtip('option', {
+    <QTip2.Api> $a.qtip("option", {
         prerender: false,
         id: false,
         overwrite: true,
         suppress: true,
         content: {
             title: true,
-            attr: 'title',
+            attr: "title",
             text: false,
-            button: false
+            button: false,
         },
         position: {
-            my: 'top left',
-            at: 'bottom right',
+            my: "top left",
+            at: "bottom right",
             target: false,
             container: false,
             viewport: false,
             adjust: {
-                x: 0, y: 0,
+                x: 0,
+                y: 0,
                 mouse: true,
                 resize: true,
-                method: 'flip flip'
+                method: "flip flip",
             },
             effect: function(api: QTip2.Api, pos: any, viewport: any) {
                 $(this).animate(pos, {
                     duration: 200,
-                    queue: false
+                    queue: false,
                 });
-            }
+            },
         },
         show: {
             target: false,
-            event: 'mouseenter',
+            event: "mouseenter",
             effect: true,
             delay: 90,
             solo: false,
@@ -869,21 +870,21 @@ function testApiSetViaString() {
                 on: false,
                 effect: true,
                 blur: true,
-                escape: true
-            }
+                escape: true,
+            },
         },
         hide: {
             target: false,
-            event: 'mouseleave',
+            event: "mouseleave",
             effect: true,
             delay: 0,
             fixed: false,
             inactive: false,
-            leave: 'window',
-            distance: false
+            leave: "window",
+            distance: false,
         },
         style: {
-            classes: '',
+            classes: "",
             widget: false,
             width: false,
             height: false,
@@ -893,8 +894,8 @@ function testApiSetViaString() {
                 width: 8,
                 height: 8,
                 border: true,
-                offset: 0
-            }
+                offset: 0,
+            },
         },
         events: {
             render: null,
@@ -905,69 +906,72 @@ function testApiSetViaString() {
             visible: null,
             hidden: null,
             focus: null,
-            blur: null
-        }
+            blur: null,
+        },
     });
 
-    <QTip2.Api> $a.qtip('option', 'id', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'prerender', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'overwrite', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'suppress', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'metadata', <any> null);
+    <QTip2.Api> $a.qtip("option", "id", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "prerender", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "overwrite", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "suppress", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "metadata", <any> null);
 
-    <QTip2.Api> $a.qtip('option', 'content', <QTip2.Text | QTip2.Content> null);
-    <QTip2.Api> $a.qtip('option', 'content.title', <QTip2.Title | { text: QTip2.Title }> null);
-    <QTip2.Api> $a.qtip('option', 'content.text', <QTip2.Text> null);
-    <QTip2.Api> $a.qtip('option', 'content.attr', <string> null);
-    <QTip2.Api> $a.qtip('option', 'content.button', <string | JQuery | boolean> null);
+    <QTip2.Api> $a.qtip("option", "content", <QTip2.Text | QTip2.Content> null);
+    <QTip2.Api> $a.qtip("option", "content.title", <QTip2.Title | { text: QTip2.Title }> null);
+    <QTip2.Api> $a.qtip("option", "content.text", <QTip2.Text> null);
+    <QTip2.Api> $a.qtip("option", "content.attr", <string> null);
+    <QTip2.Api> $a.qtip("option", "content.button", <string | JQuery | boolean> null);
 
-    <QTip2.Api> $a.qtip('option', 'position', <string | QTip2.Position> null);
-    <QTip2.Api> $a.qtip('option', 'position.my', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'position.at', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'position.target', <QTip2.Target | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'position.container', <JQuery | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'position.viewport', <JQuery | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'position.effect', <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null);
-    <QTip2.Api> $a.qtip('option', 'position.adjust', <QTip2.PositionAdjust> null);
+    <QTip2.Api> $a.qtip("option", "position", <string | QTip2.Position> null);
+    <QTip2.Api> $a.qtip("option", "position.my", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "position.at", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "position.target", <QTip2.Target | boolean> null);
+    <QTip2.Api> $a.qtip("option", "position.container", <JQuery | boolean> null);
+    <QTip2.Api> $a.qtip("option", "position.viewport", <JQuery | boolean> null);
+    <QTip2.Api> $a.qtip(
+        "option",
+        "position.effect",
+        <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null,
+    );
+    <QTip2.Api> $a.qtip("option", "position.adjust", <QTip2.PositionAdjust> null);
 
-    <QTip2.Api> $a.qtip('option', 'show', <QTip2.Show> null);
-    <QTip2.Api> $a.qtip('option', 'show.target', <JQuery | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'show.event', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'show.delay', <number> null);
-    <QTip2.Api> $a.qtip('option', 'show.solo', <JQuery | string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'show.ready', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'show.effect', <boolean | ((offset: any) => void)> null);
-    <QTip2.Api> $a.qtip('option', 'show.modal', <boolean | QTip2.Modal> null);
+    <QTip2.Api> $a.qtip("option", "show", <QTip2.Show> null);
+    <QTip2.Api> $a.qtip("option", "show.target", <JQuery | boolean> null);
+    <QTip2.Api> $a.qtip("option", "show.event", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "show.delay", <number> null);
+    <QTip2.Api> $a.qtip("option", "show.solo", <JQuery | string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "show.ready", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "show.effect", <boolean | ((offset: any) => void)> null);
+    <QTip2.Api> $a.qtip("option", "show.modal", <boolean | QTip2.Modal> null);
 
-    <QTip2.Api> $a.qtip('option', 'hide', <QTip2.Hide> null);
-    <QTip2.Api> $a.qtip('option', 'hide.target', <JQuery | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.event', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.inactive', <number | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.fixed', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.leave', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.distance', <number | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'hide.effect', <boolean | ((offset: any) => void)> null);
+    <QTip2.Api> $a.qtip("option", "hide", <QTip2.Hide> null);
+    <QTip2.Api> $a.qtip("option", "hide.target", <JQuery | boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.event", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.inactive", <number | boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.fixed", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.leave", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.distance", <number | boolean> null);
+    <QTip2.Api> $a.qtip("option", "hide.effect", <boolean | ((offset: any) => void)> null);
 
-    <QTip2.Api> $a.qtip('option', 'style', <QTip2.Style> null);
-    <QTip2.Api> $a.qtip('option', 'style.classes', <string | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'style.def', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'style.widget', <boolean> null);
-    <QTip2.Api> $a.qtip('option', 'style.width', <string | number | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'style.height', <string | number | boolean> null);
-    <QTip2.Api> $a.qtip('option', 'style.tip', <string | boolean | QTip2.Tip> null);
+    <QTip2.Api> $a.qtip("option", "style", <QTip2.Style> null);
+    <QTip2.Api> $a.qtip("option", "style.classes", <string | boolean> null);
+    <QTip2.Api> $a.qtip("option", "style.def", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "style.widget", <boolean> null);
+    <QTip2.Api> $a.qtip("option", "style.width", <string | number | boolean> null);
+    <QTip2.Api> $a.qtip("option", "style.height", <string | number | boolean> null);
+    <QTip2.Api> $a.qtip("option", "style.tip", <string | boolean | QTip2.Tip> null);
 
-    <QTip2.Api> $a.qtip('option', 'events', <QTip2.Events> null);
-    <QTip2.Api> $a.qtip('option', 'events.render', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.show', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.hide', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.toggle', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.visible', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.hidden', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.move', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.focus', <QTip2.EventApiFunc> null);
-    <QTip2.Api> $a.qtip('option', 'events.blur', <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events", <QTip2.Events> null);
+    <QTip2.Api> $a.qtip("option", "events.render", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.show", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.hide", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.toggle", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.visible", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.hidden", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.move", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.focus", <QTip2.EventApiFunc> null);
+    <QTip2.Api> $a.qtip("option", "events.blur", <QTip2.EventApiFunc> null);
 }
-
 
 /**
  * http://qtip2.com/api#api-methods
@@ -975,7 +979,7 @@ function testApiSetViaString() {
 function testApiViaObject() {
     $a.qtip({});
 
-    var api = $a.qtip('api');
+    var api = $a.qtip("api");
 
     <QTip2.Api> api.toggle();
     <QTip2.Api> api.toggle(true);
@@ -1006,40 +1010,38 @@ function testApiViaObject() {
     <QTip2.Api> api.destroy(true);
 }
 
-
 /**
  * http://qtip2.com/api#api.updating
  */
 function testApiMethodsViaString() {
-    <JQuery> $a.qtip('toggle');
-    <JQuery> $a.qtip('toggle', true);
-    <JQuery> $a.qtip('toggle', true, <Event> null);
+    <JQuery> $a.qtip("toggle");
+    <JQuery> $a.qtip("toggle", true);
+    <JQuery> $a.qtip("toggle", true, <Event> null);
 
-    <JQuery> $a.qtip('show');
-    <JQuery> $a.qtip('show', <Event> null);
+    <JQuery> $a.qtip("show");
+    <JQuery> $a.qtip("show", <Event> null);
 
-    <JQuery> $a.qtip('hide');
-    <JQuery> $a.qtip('hide', <Event> null);
+    <JQuery> $a.qtip("hide");
+    <JQuery> $a.qtip("hide", <Event> null);
 
-    <JQuery> $a.qtip('disable');
-    <JQuery> $a.qtip('disable', true);
+    <JQuery> $a.qtip("disable");
+    <JQuery> $a.qtip("disable", true);
 
-    <JQuery> $a.qtip('enable');
+    <JQuery> $a.qtip("enable");
 
-    <JQuery> $a.qtip('reposition');
-    <JQuery> $a.qtip('reposition', <Event> null);
-    <JQuery> $a.qtip('reposition', <Event> null, true);
+    <JQuery> $a.qtip("reposition");
+    <JQuery> $a.qtip("reposition", <Event> null);
+    <JQuery> $a.qtip("reposition", <Event> null, true);
 
-    <JQuery> $a.qtip('focus');
-    <JQuery> $a.qtip('focus', <Event> null);
+    <JQuery> $a.qtip("focus");
+    <JQuery> $a.qtip("focus", <Event> null);
 
-    <JQuery> $a.qtip('blur');
-    <JQuery> $a.qtip('blur', <Event> null);
+    <JQuery> $a.qtip("blur");
+    <JQuery> $a.qtip("blur", <Event> null);
 
-    <JQuery> $a.qtip('destroy');
-    <JQuery> $a.qtip('destroy', true);
+    <JQuery> $a.qtip("destroy");
+    <JQuery> $a.qtip("destroy", true);
 }
-
 
 /**
  * http://qtip2.com/options#global

--- a/types/quantize/quantize-tests.ts
+++ b/types/quantize/quantize-tests.ts
@@ -1,4 +1,4 @@
-import quantize = require('quantize');
+import quantize = require("quantize");
 
 // $ExpectType false | ColorMap
 const colorMap = quantize(
@@ -34,4 +34,4 @@ quantize([[255, 0]], 2);
 quantize([[255, 0, 0]]);
 
 // @ts-expect-error
-quantize([[255, 0, 0]], '2');
+quantize([[255, 0, 0]], "2");

--- a/types/quaternion/index.d.ts
+++ b/types/quaternion/index.d.ts
@@ -31,12 +31,14 @@ type Matrix4 = [
 type Matrix3_2D = [[number, number, number], [number, number, number], [number, number, number]];
 type Matrix3 = [number, number, number, number, number, number, number, number, number];
 
-type QuaternionRecord = { w?: number; x?: number; y?: number; z?: number } & (
-    | { w: number }
-    | { x: number }
-    | { y: number }
-    | { z: number }
-);
+type QuaternionRecord =
+    & { w?: number; x?: number; y?: number; z?: number }
+    & (
+        | { w: number }
+        | { x: number }
+        | { y: number }
+        | { z: number }
+    );
 interface QuaternionComplexRecord {
     re: number;
     im: number;

--- a/types/quaternion/quaternion-tests.ts
+++ b/types/quaternion/quaternion-tests.ts
@@ -1,4 +1,4 @@
-import Quaternion = require('quaternion');
+import Quaternion = require("quaternion");
 
 // Constructor
 new Quaternion(); // $ExpectType Quaternion
@@ -6,10 +6,10 @@ new Quaternion(1, 0, 0, 0); // $ExpectType Quaternion
 new Quaternion({ re: 0, im: 1 }); // $ExpectType Quaternion
 new Quaternion({ x: 0 }); // $ExpectType Quaternion
 new Quaternion({ w: 0, x: 0, y: 0, z: 0 }); // $ExpectType Quaternion
-new Quaternion('99'); // $ExpectType Quaternion
+new Quaternion("99"); // $ExpectType Quaternion
 
 // @ts-expect-error
-new Quaternion('99', 0);
+new Quaternion("99", 0);
 // @ts-expect-error
 new Quaternion({ x: 0, im: 1 });
 // @ts-expect-error
@@ -22,7 +22,7 @@ const quaternion = new Quaternion();
 
 // add
 quaternion.add(0); // $ExpectType Quaternion
-quaternion.add('0'); // $ExpectType Quaternion
+quaternion.add("0"); // $ExpectType Quaternion
 quaternion.add({ x: 0 }); // $ExpectType Quaternion
 quaternion.add({ re: 0, im: 0 }); // $ExpectType Quaternion
 quaternion.add([0, 0, 1]); // $ExpectType Quaternion
@@ -31,7 +31,7 @@ quaternion.add([0, 0, 1, 1]); // $ExpectType Quaternion
 // @ts-expect-error
 quaternion.add();
 // @ts-expect-error
-quaternion.add('0', 1);
+quaternion.add("0", 1);
 // @ts-expect-error
 quaternion.add({});
 // @ts-expect-error
@@ -41,7 +41,7 @@ quaternion.add([0, 1]);
 
 // sub
 quaternion.sub(0); // $ExpectType Quaternion
-quaternion.sub('0'); // $ExpectType Quaternion
+quaternion.sub("0"); // $ExpectType Quaternion
 quaternion.sub({ x: 0 }); // $ExpectType Quaternion
 quaternion.sub({ re: 0, im: 0 }); // $ExpectType Quaternion
 quaternion.sub([0, 0, 1]); // $ExpectType Quaternion
@@ -50,7 +50,7 @@ quaternion.sub([0, 0, 1, 1]); // $ExpectType Quaternion
 // @ts-expect-error
 quaternion.sub();
 // @ts-expect-error
-quaternion.sub('0', 1);
+quaternion.sub("0", 1);
 // @ts-expect-error
 quaternion.sub({});
 // @ts-expect-error
@@ -62,29 +62,29 @@ quaternion.sub([0, 1]);
 quaternion.neg(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.neg('');
+quaternion.neg("");
 
 // norm
 quaternion.norm(); // $ExpectType number
 
 // @ts-expect-error
-quaternion.norm('');
+quaternion.norm("");
 
 // normSq
 quaternion.normSq(); // $ExpectType number
 
 // @ts-expect-error
-quaternion.normSq('');
+quaternion.normSq("");
 
 // normalize
 quaternion.normalize(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.normalize('');
+quaternion.normalize("");
 
 // mul
 quaternion.mul(0); // $ExpectType Quaternion
-quaternion.mul('0'); // $ExpectType Quaternion
+quaternion.mul("0"); // $ExpectType Quaternion
 quaternion.mul({ x: 0 }); // $ExpectType Quaternion
 quaternion.mul({ re: 0, im: 0 }); // $ExpectType Quaternion
 quaternion.mul([0, 0, 1]); // $ExpectType Quaternion
@@ -93,7 +93,7 @@ quaternion.mul([0, 0, 1, 1]); // $ExpectType Quaternion
 // @ts-expect-error
 quaternion.mul();
 // @ts-expect-error
-quaternion.mul('0', 1);
+quaternion.mul("0", 1);
 // @ts-expect-error
 quaternion.mul({});
 // @ts-expect-error
@@ -109,7 +109,7 @@ quaternion.scale();
 
 // dot
 quaternion.dot(0); // $ExpectType number
-quaternion.dot('0'); // $ExpectType number
+quaternion.dot("0"); // $ExpectType number
 quaternion.dot({ x: 0 }); // $ExpectType number
 quaternion.dot({ re: 0, im: 0 }); // $ExpectType number
 quaternion.dot([0, 0, 1]); // $ExpectType number
@@ -118,7 +118,7 @@ quaternion.dot([0, 0, 1, 1]); // $ExpectType number
 // @ts-expect-error
 quaternion.dot();
 // @ts-expect-error
-quaternion.dot('0', 1);
+quaternion.dot("0", 1);
 // @ts-expect-error
 quaternion.dot({});
 // @ts-expect-error
@@ -130,11 +130,11 @@ quaternion.dot([0, 1]);
 quaternion.inverse(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.inverse('');
+quaternion.inverse("");
 
 // div
 quaternion.div(0); // $ExpectType Quaternion
-quaternion.div('0'); // $ExpectType Quaternion
+quaternion.div("0"); // $ExpectType Quaternion
 quaternion.div({ x: 0 }); // $ExpectType Quaternion
 quaternion.div({ re: 0, im: 0 }); // $ExpectType Quaternion
 quaternion.div([0, 0, 1]); // $ExpectType Quaternion
@@ -143,7 +143,7 @@ quaternion.div([0, 0, 1, 1]); // $ExpectType Quaternion
 // @ts-expect-error
 quaternion.div();
 // @ts-expect-error
-quaternion.div('0', 1);
+quaternion.div("0", 1);
 // @ts-expect-error
 quaternion.div({});
 // @ts-expect-error
@@ -155,23 +155,23 @@ quaternion.div([0, 1]);
 quaternion.inverse(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.inverse('');
+quaternion.inverse("");
 
 // inverse
 quaternion.inverse(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.inverse('');
+quaternion.inverse("");
 
 // inverse
 quaternion.inverse(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.inverse('');
+quaternion.inverse("");
 
 // pow
 quaternion.pow(0); // $ExpectType Quaternion
-quaternion.pow('0'); // $ExpectType Quaternion
+quaternion.pow("0"); // $ExpectType Quaternion
 quaternion.pow({ x: 0 }); // $ExpectType Quaternion
 quaternion.pow({ re: 0, im: 0 }); // $ExpectType Quaternion
 quaternion.pow([0, 0, 1]); // $ExpectType Quaternion
@@ -180,7 +180,7 @@ quaternion.pow([0, 0, 1, 1]); // $ExpectType Quaternion
 // @ts-expect-error
 quaternion.pow();
 // @ts-expect-error
-quaternion.pow('0', 1);
+quaternion.pow("0", 1);
 // @ts-expect-error
 quaternion.pow({});
 // @ts-expect-error
@@ -190,7 +190,7 @@ quaternion.pow([0, 1]);
 
 // equals
 quaternion.equals(0); // $ExpectType boolean
-quaternion.equals('0'); // $ExpectType boolean
+quaternion.equals("0"); // $ExpectType boolean
 quaternion.equals({ x: 0 }); // $ExpectType boolean
 quaternion.equals({ re: 0, im: 0 }); // $ExpectType boolean
 quaternion.equals([0, 0, 1]); // $ExpectType boolean
@@ -199,7 +199,7 @@ quaternion.equals([0, 0, 1, 1]); // $ExpectType boolean
 // @ts-expect-error
 quaternion.equals();
 // @ts-expect-error
-quaternion.equals('0', 1);
+quaternion.equals("0", 1);
 // @ts-expect-error
 quaternion.equals({});
 // @ts-expect-error
@@ -211,37 +211,37 @@ quaternion.equals([0, 1]);
 quaternion.isFinite(); // $ExpectType boolean
 
 // @ts-expect-error
-quaternion.isFinite('');
+quaternion.isFinite("");
 
 // isNaN
 quaternion.isNaN(); // $ExpectType boolean
 
 // @ts-expect-error
-quaternion.isNaN('');
+quaternion.isNaN("");
 
 // toString
 quaternion.toString(); // $ExpectType string
 
 // @ts-expect-error
-quaternion.toString('');
+quaternion.toString("");
 
 // real
 quaternion.real(); // $ExpectType number
 
 // @ts-expect-error
-quaternion.real('');
+quaternion.real("");
 
 // imag
 quaternion.imag(); // $ExpectType [number, number, number]
 
 // @ts-expect-error
-quaternion.imag('');
+quaternion.imag("");
 
 // toVector
 quaternion.toVector(); // $ExpectType [number, number, number, number]
 
 // @ts-expect-error
-quaternion.toVector('');
+quaternion.toVector("");
 
 // toMatrix
 quaternion.toMatrix(true); // $ExpectType Matrix3_2D
@@ -261,13 +261,13 @@ quaternion.toMatrix4();
 quaternion.toEuler(); // $ExpectType { roll: number; pitch: number; yaw: number; }
 
 // @ts-expect-error
-quaternion.toEuler('');
+quaternion.toEuler("");
 
 // clone
 quaternion.clone(); // $ExpectType Quaternion
 
 // @ts-expect-error
-quaternion.clone('');
+quaternion.clone("");
 
 // rotateVector
 quaternion.rotateVector([1, 2, 0]); // $ExpectType [number, number, number]
@@ -279,7 +279,7 @@ quaternion.rotateVector([1, 2]);
 
 // slerp
 quaternion.slerp(0); // $ExpectType (pct: number) => Quaternion
-quaternion.slerp('0'); // $ExpectType (pct: number) => Quaternion
+quaternion.slerp("0"); // $ExpectType (pct: number) => Quaternion
 quaternion.slerp({ x: 0 }); // $ExpectType (pct: number) => Quaternion
 quaternion.slerp({ re: 0, im: 0 }); // $ExpectType (pct: number) => Quaternion
 quaternion.slerp([0, 0, 1]); // $ExpectType (pct: number) => Quaternion
@@ -288,7 +288,7 @@ quaternion.slerp([0, 0, 1, 1]); // $ExpectType (pct: number) => Quaternion
 // @ts-expect-error
 quaternion.slerp();
 // @ts-expect-error
-quaternion.slerp('0', 1);
+quaternion.slerp("0", 1);
 // @ts-expect-error
 quaternion.slerp({});
 // @ts-expect-error
@@ -322,7 +322,7 @@ Quaternion.random(1);
 
 // fromEuler
 Quaternion.fromEuler(1, 2, 3); // $ExpectType Quaternion
-Quaternion.fromEuler(1, 2, 3, 'XYZ'); // $ExpectType Quaternion
+Quaternion.fromEuler(1, 2, 3, "XYZ"); // $ExpectType Quaternion
 
 // @ts-expect-error
 Quaternion.fromEuler(1, 2, 3, 3);

--- a/types/query-selector-shadow-dom/index.d.ts
+++ b/types/query-selector-shadow-dom/index.d.ts
@@ -18,16 +18,20 @@
  * @license Apache-2.0
  */
 export function querySelectorDeep<K extends keyof HTMLElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null,
 ): HTMLElementTagNameMap[K] | null;
 export function querySelectorDeep<K extends keyof SVGElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null,
 ): SVGElementTagNameMap[K] | null;
-export function querySelectorDeep(selector: string, root?: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement | null;
+export function querySelectorDeep(
+    selector: string,
+    root?: Document | HTMLElement,
+    cachedElements?: readonly HTMLElement[] | null,
+): HTMLElement | null;
 
 /**
  * Finds first matching elements on the page that may be in a shadow root using a complex selector of n-depth
@@ -39,16 +43,20 @@ export function querySelectorDeep(selector: string, root?: Document | HTMLElemen
  * @license Apache-2.0
  */
 export function querySelectorAllDeep<K extends keyof HTMLElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null,
 ): Array<HTMLElementTagNameMap[K]>;
 export function querySelectorAllDeep<K extends keyof SVGElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null,
 ): Array<SVGElementTagNameMap[K]>;
-export function querySelectorAllDeep(selector: string, root?: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement[];
+export function querySelectorAllDeep(
+    selector: string,
+    root?: Document | HTMLElement,
+    cachedElements?: readonly HTMLElement[] | null,
+): HTMLElement[];
 
 /**
  * Finds all elements on the page, inclusive of those within shadow roots
@@ -59,13 +67,17 @@ export function querySelectorAllDeep(selector: string, root?: Document | HTMLEle
  * @license Apache-2.0
  */
 export function collectAllElementsDeep<K extends keyof HTMLElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null,
 ): Array<HTMLElementTagNameMap[K]>;
 export function collectAllElementsDeep<K extends keyof SVGElementTagNameMap>(
-  selector: K,
-  root?: Document | HTMLElement,
-  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+    selector: K,
+    root?: Document | HTMLElement,
+    cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null,
 ): Array<SVGElementTagNameMap[K]>;
-export function collectAllElementsDeep(selector: string | null, root: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement[];
+export function collectAllElementsDeep(
+    selector: string | null,
+    root: Document | HTMLElement,
+    cachedElements?: readonly HTMLElement[] | null,
+): HTMLElement[];

--- a/types/query-selector-shadow-dom/query-selector-shadow-dom-tests.ts
+++ b/types/query-selector-shadow-dom/query-selector-shadow-dom-tests.ts
@@ -1,16 +1,16 @@
-import { querySelectorDeep, querySelectorAllDeep, collectAllElementsDeep } from 'query-selector-shadow-dom';
+import { collectAllElementsDeep, querySelectorAllDeep, querySelectorDeep } from "query-selector-shadow-dom";
 
 // $ExpectType HTMLElement | null
-const doc = querySelectorDeep('document');
+const doc = querySelectorDeep("document");
 
 // $ExpectType HTMLDivElement | null
-const div = querySelectorDeep('div');
+const div = querySelectorDeep("div");
 
 // $ExpectType SVGGElement | null
-const g = querySelectorDeep('g');
+const g = querySelectorDeep("g");
 
 // $ExpectType HTMLElement | null
-const divTest = querySelectorDeep('div.test');
+const divTest = querySelectorDeep("div.test");
 
 // @ts-expect-error
 querySelectorDeep(42);
@@ -20,16 +20,16 @@ querySelectorDeep(true);
 querySelectorDeep({});
 
 // $ExpectType HTMLElement[]
-const docs = querySelectorAllDeep('document');
+const docs = querySelectorAllDeep("document");
 
 // $ExpectType HTMLDivElement[]
-const divs = querySelectorAllDeep('div');
+const divs = querySelectorAllDeep("div");
 
 // $ExpectType SVGGElement[]
-const gs = querySelectorAllDeep('g');
+const gs = querySelectorAllDeep("g");
 
 // $ExpectType HTMLElement[]
-const divTests = querySelectorAllDeep('div.test');
+const divTests = querySelectorAllDeep("div.test");
 
 // @ts-expect-error
 querySelectorAllDeep(42);
@@ -42,10 +42,10 @@ querySelectorAllDeep({});
 const whole1 = collectAllElementsDeep(null, document);
 
 // $Expect HTMLDivElement[]
-const allDivs = collectAllElementsDeep('div', document);
+const allDivs = collectAllElementsDeep("div", document);
 
 // $Expect SVGGElement[]
-const allGs = collectAllElementsDeep('svg', document);
+const allGs = collectAllElementsDeep("svg", document);
 
 // @ts-expect-error
 const whole2 = collectAllElementsDeep();

--- a/types/query-string-params/query-string-params-tests.ts
+++ b/types/query-string-params/query-string-params-tests.ts
@@ -1,9 +1,9 @@
-import { urlToProperty, urlToList, propertyToUrl } from 'query-string-params';
+import { propertyToUrl, urlToList, urlToProperty } from "query-string-params";
 
-urlToProperty(''); // $ExpectType SearchParamOptions
-urlToList(''); // $ExpectType SearchParamOptions[]
+urlToProperty(""); // $ExpectType SearchParamOptions
+urlToList(""); // $ExpectType SearchParamOptions[]
 propertyToUrl({}); // $ExpectType string
 
-urlToProperty('foo=x,y&bar=z'); // $ExpectType SearchParamOptions
-urlToList('foo=x,y&bar=z'); // $ExpectType SearchParamOptions[]
-propertyToUrl({ foo: ['a', 'b'], bar: ['c'] }); // $ExpectType string
+urlToProperty("foo=x,y&bar=z"); // $ExpectType SearchParamOptions
+urlToList("foo=x,y&bar=z"); // $ExpectType SearchParamOptions[]
+propertyToUrl({ foo: ["a", "b"], bar: ["c"] }); // $ExpectType string

--- a/types/querystringify/querystringify-tests.ts
+++ b/types/querystringify/querystringify-tests.ts
@@ -1,11 +1,11 @@
 import * as qs from "querystringify";
 
-qs.parse('?foo=bar');         // { foo: 'bar' }
-qs.parse('foo=bar');          // { foo: 'bar' }
-qs.parse('foo=bar&bar=foo');  // { foo: 'bar', bar: 'foo' }
-qs.parse('foo&bar=foo');      // { foo: '', bar: 'foo' }
+qs.parse("?foo=bar"); // { foo: 'bar' }
+qs.parse("foo=bar"); // { foo: 'bar' }
+qs.parse("foo=bar&bar=foo"); // { foo: 'bar', bar: 'foo' }
+qs.parse("foo&bar=foo"); // { foo: '', bar: 'foo' }
 
-qs.stringify({ foo: 'bar' });       // foo=bar
-qs.stringify({ foo: 'bar' }, true); // ?foo=bar
-qs.stringify({ foo: 'bar' }, '&');  // &foo=bar
-qs.stringify({ foo: '' }, '&');     // &foo=
+qs.stringify({ foo: "bar" }); // foo=bar
+qs.stringify({ foo: "bar" }, true); // ?foo=bar
+qs.stringify({ foo: "bar" }, "&"); // &foo=bar
+qs.stringify({ foo: "" }, "&"); // &foo=

--- a/types/quick-format-unescaped/quick-format-unescaped-tests.ts
+++ b/types/quick-format-unescaped/quick-format-unescaped-tests.ts
@@ -1,6 +1,6 @@
-import format = require('quick-format-unescaped');
+import format = require("quick-format-unescaped");
 
-format('%o %s', [{ foo: 1 }, 'Hello World']);
+format("%o %s", [{ foo: 1 }, "Hello World"]);
 
 const options: format.Options = { stringify: o => JSON.stringify(o) };
-format('Hello world!', [], options);
+format("Hello world!", [], options);

--- a/types/quick-hash/quick-hash-tests.ts
+++ b/types/quick-hash/quick-hash-tests.ts
@@ -1,3 +1,3 @@
-import hash = require('quick-hash');
-hash('Any string'); // $ExpectType string
-hash('Another string', 100); // $ExpectType string
+import hash = require("quick-hash");
+hash("Any string"); // $ExpectType string
+hash("Another string", 100); // $ExpectType string

--- a/types/quick-picker/index.d.ts
+++ b/types/quick-picker/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Tamas Illes <https://github.com/illestomas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as React from 'react';
-import { TextStyle, ViewStyle } from 'react-native';
+import * as React from "react";
+import { TextStyle, ViewStyle } from "react-native";
 
 export default class QuickPicker extends React.Component {
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
@@ -13,7 +13,7 @@ export default class QuickPicker extends React.Component {
 }
 
 // tslint:disable-next-line
-type PickerType = 'normal' | 'time';
+type PickerType = "normal" | "time";
 
 // tslint:disable-next-line
 type ItemType = {
@@ -21,10 +21,10 @@ type ItemType = {
     readonly label: string;
 };
 
-type PickerMode = 'date' | 'time' | 'datetime' | 'countdown';
+type PickerMode = "date" | "time" | "datetime" | "countdown";
 
 // tslint:disable-next-line
-type PickerDisplayType = 'default' | 'spinner' | 'calendar' | 'clock';
+type PickerDisplayType = "default" | "spinner" | "calendar" | "clock";
 interface QuickPickerOpenOptions<T = ItemType> {
     /**
      * Picker's selected item
@@ -197,4 +197,4 @@ interface QuickPickerOpenOptions<T = ItemType> {
     readonly useNativeDriver?: boolean;
 }
 
-export { QuickPickerOpenOptions, ItemType };
+export { ItemType, QuickPickerOpenOptions };

--- a/types/quick-picker/quick-picker-tests.tsx
+++ b/types/quick-picker/quick-picker-tests.tsx
@@ -1,5 +1,5 @@
-import QuickPicker from 'quick-picker';
-import * as React from 'react';
+import QuickPicker from "quick-picker";
+import * as React from "react";
 
 interface CustomItem {
     foo: string;
@@ -8,18 +8,18 @@ interface CustomItem {
 
 const items: CustomItem[] = [
     {
-        foo: 'foo',
+        foo: "foo",
         bar: 1,
     },
     {
-        foo: 'baz',
+        foo: "baz",
         bar: 2,
     },
 ];
 
 QuickPicker.open<CustomItem>({
     item: {
-        foo: 'bar',
+        foo: "bar",
         bar: 1,
     },
     items,
@@ -29,9 +29,9 @@ QuickPicker.open<CustomItem>({
     onPressDone: item => {
         // typeof item is CustomItem
     },
-    display: 'calendar',
-    doneButtonText: 'Picking is done',
-    pickerType: 'normal',
+    display: "calendar",
+    doneButtonText: "Picking is done",
+    pickerType: "normal",
     topRow: <div>asdasddas</div>,
     disableTopRow: false,
     is24Hour: true,

--- a/types/quick-store/index.d.ts
+++ b/types/quick-store/index.d.ts
@@ -5,7 +5,9 @@
 
 export = QuickStore;
 
-interface DatabaseContents { [key: string]: Value; }
+interface DatabaseContents {
+    [key: string]: Value;
+}
 type Value = string | number | DatabaseContents | Value[] | boolean | null;
 type Callback<Value> = (data: Value) => void;
 

--- a/types/quick-store/quick-store-tests.ts
+++ b/types/quick-store/quick-store-tests.ts
@@ -1,8 +1,8 @@
 import * as database from "quick-store";
 
 // valid database creations
-database();                                // $ExpectType Database
-database("./testdb.json");                 // $ExpectType Database
+database(); // $ExpectType Database
+database("./testdb.json"); // $ExpectType Database
 database("./testdb.json", { foo: "bar" }); // $ExpectType Database
 
 // invalid database creations
@@ -14,30 +14,30 @@ database("./testdb.json", 123);
 const db = database();
 
 // valid functions
-db.put({ foo: "bar" });             // $ExpectType void
-db.put({ foo: { foo: "bar" }});     // $ExpectType void
-db.put({ foo: "bar" }, () => {});   // $ExpectType void
+db.put({ foo: "bar" }); // $ExpectType void
+db.put({ foo: { foo: "bar" } }); // $ExpectType void
+db.put({ foo: "bar" }, () => {}); // $ExpectType void
 
-db.setItem("foo", "bar");           // $ExpectType void
-db.setItem("foo", 123);             // $ExpectType void
-db.setItem("foo", { foo: "bar" });  // $ExpectType void
-db.setItem("foo", [ "bar" ]);       // $ExpectType void
-db.setItem("foo", true);            // $ExpectType void
-db.setItem("foo", null);            // $ExpectType void
+db.setItem("foo", "bar"); // $ExpectType void
+db.setItem("foo", 123); // $ExpectType void
+db.setItem("foo", { foo: "bar" }); // $ExpectType void
+db.setItem("foo", ["bar"]); // $ExpectType void
+db.setItem("foo", true); // $ExpectType void
+db.setItem("foo", null); // $ExpectType void
 db.setItem("foo", "bar", () => {}); // $ExpectType void
 
-db.getItem("foo", data => {});      // $ExpectType void
+db.getItem("foo", data => {}); // $ExpectType void
 
-db.removeItem("foo");               // $ExpectType void
-db.removeItem("foo", () => {});     // $ExpectType void
+db.removeItem("foo"); // $ExpectType void
+db.removeItem("foo", () => {}); // $ExpectType void
 
-db.clear();                         // $ExpectType void
-db.clear(() => {});                 // $ExpectType void
+db.clear(); // $ExpectType void
+db.clear(() => {}); // $ExpectType void
 
-db.get();                           // $ExpectedType dbContents
-db.get(() => {});                   // $ExpectedType void
+db.get(); // $ExpectedType dbContents
+db.get(() => {}); // $ExpectedType void
 
-db.change("./testdb.json");         // $ExpectedType void
+db.change("./testdb.json"); // $ExpectedType void
 
 // invalid functions
 // @ts-expect-error
@@ -58,7 +58,7 @@ db.setItem("foo", new Date());
 // @ts-expect-error
 db.setItem("foo", { foo: new Date() });
 // @ts-expect-error
-db.setItem("foo", [ new Date() ]);
+db.setItem("foo", [new Date()]);
 // @ts-expect-error
 db.setItem("foo", "bar", null);
 // @ts-expect-error

--- a/types/quicklink/index.d.ts
+++ b/types/quicklink/index.d.ts
@@ -97,7 +97,10 @@ interface ListenOptions {
      *
      * Defaults to `[]`.
      */
-    ignores: RegExp | ((url: string, el: Element) => boolean) | ReadonlyArray<string | RegExp | ((url: string, el: Element) => boolean)>;
+    ignores:
+        | RegExp
+        | ((url: string, el: Element) => boolean)
+        | ReadonlyArray<string | RegExp | ((url: string, el: Element) => boolean)>;
     /**
      * An optional error handler that will receive any errors from prefetched requests.
      *

--- a/types/quicklink/quicklink-tests.ts
+++ b/types/quicklink/quicklink-tests.ts
@@ -1,62 +1,62 @@
-import { listen, prefetch, prerender } from 'quicklink';
+import { listen, prefetch, prerender } from "quicklink";
 
 // $ExpectType () => void
 listen();
 
 listen({
-    timeout: 4000
+    timeout: 4000,
 });
 
 listen({
-    el: document.getElementById('carousel')!
+    el: document.getElementById("carousel")!,
 });
 
-prefetch('2.html');
+prefetch("2.html");
 
-prefetch(['2.html', '3.html', '4.js']);
+prefetch(["2.html", "3.html", "4.js"]);
 
-prefetch(['2.html', '3.html', '4.js'], true);
+prefetch(["2.html", "3.html", "4.js"], true);
 
-prerender('2.html');
+prerender("2.html");
 
-prerender(['2.html', '3.html', '4.js']);
+prerender(["2.html", "3.html", "4.js"]);
 
 listen({ priority: true });
 
 listen({
     origins: [
         // add mine
-        'my-website.com',
-        'api.my-website.com',
+        "my-website.com",
+        "api.my-website.com",
         // add third-parties
-        'other-website.com',
-        'example.com',
+        "other-website.com",
+        "example.com",
         // ...
-    ]
+    ],
 });
 
 listen({
-    origins: true
+    origins: true,
 });
 
 listen({
-    origins: []
+    origins: [],
 });
 
 listen({
     ignores: [
         /\/api\/?/,
-        uri => uri.includes('.zip'),
-        (uri, elem) => elem.hasAttribute('noprefetch')
-    ]
+        uri => uri.includes(".zip"),
+        (uri, elem) => elem.hasAttribute("noprefetch"),
+    ],
 });
 
 listen({
     ignores: [
-        uri => uri.includes('#')
-    ]
+        uri => uri.includes("#"),
+    ],
 });
 
-prefetch(['1.html', '2.html']).catch(err => {
+prefetch(["1.html", "2.html"]).catch(err => {
     // Handle own errors
 });

--- a/types/quicksettings/index.d.ts
+++ b/types/quicksettings/index.d.ts
@@ -176,7 +176,7 @@ export interface QuickSettingsPanel<M = AnyModel, S = string> {
     addPassword(title: KeyWhereType<M, string>, text: string, callback?: ChangeHandler<string>): this;
     bindPassword<K extends KeyWhereType<M, string>>(title: K, text: string, object: Record<K, string>): this;
 
-    addProgressBar(title: string, max: number, value: number, valueDisplay?: 'numbers' | 'percent'): this;
+    addProgressBar(title: string, max: number, value: number, valueDisplay?: "numbers" | "percent"): this;
     setProgressMax(title: string, max: number): this;
 
     addText(title: KeyWhereType<M, string>, text: string, callback?: ChangeHandler<string>): this;

--- a/types/quicksettings/quicksettings-tests.ts
+++ b/types/quicksettings/quicksettings-tests.ts
@@ -1,4 +1,4 @@
-import QuickSettings, { AnyModel, DropDownSelection } from 'quicksettings';
+import QuickSettings, { AnyModel, DropDownSelection } from "quicksettings";
 
 /**
  * QuickSettings module tests
@@ -9,7 +9,7 @@ import QuickSettings, { AnyModel, DropDownSelection } from 'quicksettings';
 QuickSettings.create(); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 QuickSettings.create(100); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 QuickSettings.create(100, 200); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-QuickSettings.create(100, 200, 'Test Panel', document.createElement('div')); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+QuickSettings.create(100, 200, "Test Panel", document.createElement("div")); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 
 // QuickSettings.useExtStyleSheet
 QuickSettings.useExtStyleSheet(); // $ExpectType void
@@ -24,15 +24,15 @@ interface TestModel {
 }
 
 const testModelFull: TestModel = {
-    testString: 'foo',
+    testString: "foo",
     testNumber: 10,
     testBoolean: true,
     testDate: new Date(),
-    testFile: new File([], 'my-file.png'),
+    testFile: new File([], "my-file.png"),
 };
 
 const qsAnyModel = QuickSettings.create();
-const qsTestModel = QuickSettings.create<TestModel, 'testStatic'>();
+const qsTestModel = QuickSettings.create<TestModel, "testStatic">();
 
 /**
  * QuickSettingsPanel - Model independent methods
@@ -48,12 +48,12 @@ qsAnyModel.destroy(); // $ExpectType void
 qsTestModel.destroy(); // $ExpectType void
 
 // QuickSettingsPanel.saveInLocalStorage
-qsAnyModel.saveInLocalStorage('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.saveInLocalStorage('foo'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.saveInLocalStorage("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.saveInLocalStorage("foo"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 // QuickSettingsPanel.saveInLocalStorage
-qsAnyModel.clearLocalStorage('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.clearLocalStorage('foo'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.clearLocalStorage("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.clearLocalStorage("foo"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 // QuickSettingsPanel.setPosition
 qsAnyModel.setPosition(100, 100); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
@@ -104,8 +104,8 @@ qsAnyModel.toggleCollapsed(); // $ExpectType QuickSettingsPanel<Record<string, a
 qsTestModel.toggleCollapsed(); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 // QuickSettingsPanel.setKey
-qsAnyModel.setKey('h'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setKey('h'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setKey("h"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setKey("h"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 // QuickSettingsPanel.showAllTitle
 qsAnyModel.showAllTitles(); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
@@ -130,22 +130,24 @@ qsAnyModel.setGlobalChangeHandler((model: AnyModel) => {}); // $ExpectType Quick
 qsAnyModel.setGlobalChangeHandler((model: string) => {});
 qsTestModel.setGlobalChangeHandler((model: TestModel) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // prettier-ignore
-qsTestModel.setGlobalChangeHandler((model: { testNumber: number; testBoolean: boolean; testDate: string | Date }) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.setGlobalChangeHandler(
+    (model: { testNumber: number; testBoolean: boolean; testDate: string | Date }) => {},
+); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
 qsTestModel.setGlobalChangeHandler((model: { foo: string }) => {});
 
 // QuickSettingsPanel.getValue
-qsAnyModel.getValue('testString'); // $ExpectType any
-qsTestModel.getValue('testString'); // $ExpectType string
-qsTestModel.getValue('testNumber'); // $ExpectType number
-qsTestModel.getValue('testDate'); // $ExpectType string | Date
+qsAnyModel.getValue("testString"); // $ExpectType any
+qsTestModel.getValue("testString"); // $ExpectType string
+qsTestModel.getValue("testNumber"); // $ExpectType number
+qsTestModel.getValue("testDate"); // $ExpectType string | Date
 
 // QuickSettingsPanel.setValue
-qsAnyModel.setValue('testString', 'foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsAnyModel.setValue('testString', 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setValue('testString', 'foo'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setValue("testString", "foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.setValue("testString", 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setValue("testString", "foo"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.setValue('testString', 10);
+qsTestModel.setValue("testString", 10);
 
 // QuickSettingsPanel.getValueAsJSON
 qsAnyModel.getValuesAsJSON(true); // $ExpectType string
@@ -156,11 +158,11 @@ qsTestModel.getValuesAsJSON(false); // $ExpectType TestModel
 qsTestModel.getValuesAsJSON(); // $ExpectType TestModel
 
 // QuickSettingsPanel.setValuesFromJSON
-qsAnyModel.setValuesFromJSON('{ "foo": "bar" }'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsAnyModel.setValuesFromJSON({ foo: 'bar' }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setValuesFromJSON('{ "foo": "bar" }'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setValuesFromJSON("{ \"foo\": \"bar\" }"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.setValuesFromJSON({ foo: "bar" }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setValuesFromJSON("{ \"foo\": \"bar\" }"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.setValuesFromJSON({ foo: 'bar' });
+qsTestModel.setValuesFromJSON({ foo: "bar" });
 qsTestModel.setValuesFromJSON(testModelFull); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 /**
@@ -174,52 +176,52 @@ qsTestModel.setValuesFromJSON(testModelFull); // $ExpectType QuickSettingsPanel<
  */
 
 // QuickSettingsPanel.removeControl
-qsAnyModel.removeControl('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.removeControl('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.removeControl("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.removeControl("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.removeControl('foo');
+qsTestModel.removeControl("foo");
 
 // QuickSettingsPanel.enableControl
-qsAnyModel.enableControl('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.enableControl('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.enableControl("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.enableControl("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.enableControl('foo');
+qsTestModel.enableControl("foo");
 
 // QuickSettingsPanel.disableControl
-qsAnyModel.disableControl('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.disableControl('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.disableControl("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.disableControl("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.disableControl('foo');
+qsTestModel.disableControl("foo");
 
 // QuickSettingsPanel.hideControl
-qsAnyModel.hideControl('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.hideControl('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.hideControl("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.hideControl("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.hideControl('foo');
+qsTestModel.hideControl("foo");
 
 // QuickSettingsPanel.showControl
-qsAnyModel.showControl('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.showControl('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.showControl("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.showControl("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.showControl('foo');
+qsTestModel.showControl("foo");
 
 // QuickSettingsPanel.overrideStyle
-qsAnyModel.overrideStyle('foo', 'color', '#fff'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.overrideStyle('testString', 'color', '#fff'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.overrideStyle("foo", "color", "#fff"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.overrideStyle("testString", "color", "#fff"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.overrideStyle('foo', 'color', '#fff');
+qsTestModel.overrideStyle("foo", "color", "#fff");
 
 // QuickSettingsPanel.hideTitle
-qsAnyModel.hideTitle('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.hideTitle('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.hideTitle("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.hideTitle("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.hideTitle('foo');
+qsTestModel.hideTitle("foo");
 
 // QuickSettingsPanel.showTitle
-qsAnyModel.showTitle('foo'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.showTitle('testString'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.showTitle("foo"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.showTitle("testString"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.showTitle('foo');
+qsTestModel.showTitle("foo");
 
 /**
  * QuickSettingsPanel – Field creation methods
@@ -237,231 +239,231 @@ qsTestModel.showTitle('foo');
  */
 
 // QuickSettingsPanel.addBoolean
-qsAnyModel.addBoolean('foo', true, (value: boolean) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addBoolean("foo", true, (value: boolean) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addBoolean('foo', 10, (value: number) => {});
+qsAnyModel.addBoolean("foo", 10, (value: number) => {});
 
-qsTestModel.addBoolean('testBoolean', true, (value: boolean) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addBoolean("testBoolean", true, (value: boolean) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addBoolean('foo', true, (value: boolean) => {});
+qsTestModel.addBoolean("foo", true, (value: boolean) => {});
 // @ts-expect-error
-qsTestModel.addBoolean('testNumber', true, (value: boolean) => {});
+qsTestModel.addBoolean("testNumber", true, (value: boolean) => {});
 // @ts-expect-error
-qsTestModel.addBoolean('testBoolean', 10, (value: number) => {});
+qsTestModel.addBoolean("testBoolean", 10, (value: number) => {});
 
 // QuickSettingsPanel.bindBoolean
-qsAnyModel.bindBoolean('foo', true, { foo: false }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindBoolean("foo", true, { foo: false }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindBoolean('foo', true, { baz: false });
+qsAnyModel.bindBoolean("foo", true, { baz: false });
 // @ts-expect-error
-qsAnyModel.bindBoolean('foo', 10, { foo: 10 });
+qsAnyModel.bindBoolean("foo", 10, { foo: 10 });
 
-qsTestModel.bindBoolean('testBoolean', true, { testBoolean: false }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindBoolean("testBoolean", true, { testBoolean: false }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindBoolean('foo', true, { foo: false });
+qsTestModel.bindBoolean("foo", true, { foo: false });
 // @ts-expect-error
-qsTestModel.bindBoolean('testBoolean', true, { foo: false });
+qsTestModel.bindBoolean("testBoolean", true, { foo: false });
 // @ts-expect-error
-qsTestModel.bindBoolean('testBoolean', 10, { testBoolean: 10 });
+qsTestModel.bindBoolean("testBoolean", 10, { testBoolean: 10 });
 
 // QuickSettingsPanel.addText
-qsAnyModel.addText('foo', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addText("foo", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addText('foo', 10, (value: number) => {});
+qsAnyModel.addText("foo", 10, (value: number) => {});
 
-qsTestModel.addText('testString', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addText("testString", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addText('foo', 'bar', (value: string) => {});
+qsTestModel.addText("foo", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addText('testNumber', 'bar', (value: string) => {});
+qsTestModel.addText("testNumber", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addText('testString', 10, (value: number) => {});
+qsTestModel.addText("testString", 10, (value: number) => {});
 
 // QuickSettingsPanel.bindText
-qsAnyModel.bindText('foo', 'bar', { foo: 'bar' }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindText("foo", "bar", { foo: "bar" }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindText('foo', 'bar', { baz: 'bar' });
+qsAnyModel.bindText("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsAnyModel.bindText('foo', 10, { foo: 10 });
+qsAnyModel.bindText("foo", 10, { foo: 10 });
 
-qsTestModel.bindText('testString', 'bar', { testString: 'baz' }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindText("testString", "bar", { testString: "baz" }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindText('foo', 'bar', { baz: 'bar' });
+qsTestModel.bindText("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsTestModel.bindText('testString', 'bar', { foo: 'bar' });
+qsTestModel.bindText("testString", "bar", { foo: "bar" });
 // @ts-expect-error
-qsTestModel.bindText('testString', 10, { testString: 10 });
+qsTestModel.bindText("testString", 10, { testString: 10 });
 
 // QuickSettingsPanel.addColor
-qsAnyModel.addColor('foo', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addColor("foo", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addColor('foo', 10, (value: number) => {});
+qsAnyModel.addColor("foo", 10, (value: number) => {});
 
-qsTestModel.addColor('testString', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addColor("testString", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addColor('foo', 'bar', (value: string) => {});
+qsTestModel.addColor("foo", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addColor('testNumber', 'bar', (value: string) => {});
+qsTestModel.addColor("testNumber", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addColor('testString', 10, (value: number) => {});
+qsTestModel.addColor("testString", 10, (value: number) => {});
 
 // QuickSettingsPanel.bindColor
-qsAnyModel.bindColor('foo', 'bar', { foo: 'bar' }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindColor("foo", "bar", { foo: "bar" }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindColor('foo', 'bar', { baz: 'bar' });
+qsAnyModel.bindColor("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsAnyModel.bindColor('foo', 10, { foo: 10 });
+qsAnyModel.bindColor("foo", 10, { foo: 10 });
 
-qsTestModel.bindColor('testString', 'bar', { testString: 'baz' }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindColor("testString", "bar", { testString: "baz" }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindColor('foo', 'bar', { baz: 'bar' });
+qsTestModel.bindColor("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsTestModel.bindColor('testString', 'bar', { foo: 'bar' });
+qsTestModel.bindColor("testString", "bar", { foo: "bar" });
 // @ts-expect-error
-qsTestModel.bindColor('testString', 10, { testString: 10 });
+qsTestModel.bindColor("testString", 10, { testString: 10 });
 
 // QuickSettingsPanel.addPassword
-qsAnyModel.addPassword('foo', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addPassword("foo", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addPassword('foo', 10, (value: number) => {});
+qsAnyModel.addPassword("foo", 10, (value: number) => {});
 
-qsTestModel.addPassword('testString', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addPassword("testString", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addPassword('foo', 'bar', (value: string) => {});
+qsTestModel.addPassword("foo", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addPassword('testNumber', 'bar', (value: string) => {});
+qsTestModel.addPassword("testNumber", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addPassword('testString', 10, (value: number) => {});
+qsTestModel.addPassword("testString", 10, (value: number) => {});
 
 // QuickSettingsPanel.bindPassword
-qsAnyModel.bindPassword('foo', 'bar', { foo: 'bar' }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindPassword("foo", "bar", { foo: "bar" }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindPassword('foo', 'bar', { baz: 'bar' });
+qsAnyModel.bindPassword("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsAnyModel.bindPassword('foo', 10, { foo: 10 });
+qsAnyModel.bindPassword("foo", 10, { foo: 10 });
 
-qsTestModel.bindPassword('testString', 'bar', { testString: 'baz' }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindPassword("testString", "bar", { testString: "baz" }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindPassword('foo', 'bar', { baz: 'bar' });
+qsTestModel.bindPassword("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsTestModel.bindPassword('testString', 'bar', { foo: 'bar' });
+qsTestModel.bindPassword("testString", "bar", { foo: "bar" });
 // @ts-expect-error
-qsTestModel.bindPassword('testString', 10, { testString: 10 });
+qsTestModel.bindPassword("testString", 10, { testString: 10 });
 
 // QuickSettingsPanel.addProgressBar
-qsAnyModel.addProgressBar('foo', 100, 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsAnyModel.addProgressBar('foo', 100, 10, 'numbers'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addProgressBar("foo", 100, 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addProgressBar("foo", 100, 10, "numbers"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 
 // QuickSettingsPanel.addTextArea
-qsAnyModel.addTextArea('foo', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addTextArea("foo", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addTextArea('foo', 10, (value: number) => {});
+qsAnyModel.addTextArea("foo", 10, (value: number) => {});
 
-qsTestModel.addTextArea('testString', 'bar', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addTextArea("testString", "bar", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addTextArea('foo', 'bar', (value: string) => {});
+qsTestModel.addTextArea("foo", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addTextArea('testNumber', 'bar', (value: string) => {});
+qsTestModel.addTextArea("testNumber", "bar", (value: string) => {});
 // @ts-expect-error
-qsTestModel.addTextArea('testString', 10, (value: number) => {});
+qsTestModel.addTextArea("testString", 10, (value: number) => {});
 
 // QuickSettingsPanel.bindTextArea
-qsAnyModel.bindTextArea('foo', 'bar', { foo: 'bar' }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindTextArea("foo", "bar", { foo: "bar" }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindTextArea('foo', 'bar', { baz: 'bar' });
+qsAnyModel.bindTextArea("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsAnyModel.bindTextArea('foo', 10, { foo: 10 });
+qsAnyModel.bindTextArea("foo", 10, { foo: 10 });
 
-qsTestModel.bindTextArea('testString', 'bar', { testString: 'baz' }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindTextArea("testString", "bar", { testString: "baz" }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindTextArea('foo', 'bar', { baz: 'bar' });
+qsTestModel.bindTextArea("foo", "bar", { baz: "bar" });
 // @ts-expect-error
-qsTestModel.bindTextArea('testString', 'bar', { foo: 'bar' });
+qsTestModel.bindTextArea("testString", "bar", { foo: "bar" });
 // @ts-expect-error
-qsTestModel.bindTextArea('testString', 10, { testString: 10 });
+qsTestModel.bindTextArea("testString", 10, { testString: 10 });
 
 // QuickSettingsPanel.setTextAreaRows
-qsAnyModel.setTextAreaRows('foo', 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setTextAreaRows('testString', 10); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setTextAreaRows("foo", 10); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setTextAreaRows("testString", 10); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.setTextAreaRows('foo', 10);
+qsTestModel.setTextAreaRows("foo", 10);
 
 // QuickSettingsPanel.addNumber
-qsAnyModel.addNumber('foo', 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addNumber("foo", 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addNumber('foo', 0, 100, 'foo', 1, (value: number) => {});
+qsAnyModel.addNumber("foo", 0, 100, "foo", 1, (value: number) => {});
 
-qsTestModel.addNumber('testNumber', 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addNumber("testNumber", 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addNumber('foo', 0, 100, 10, 1, (value: number) => {});
+qsTestModel.addNumber("foo", 0, 100, 10, 1, (value: number) => {});
 // @ts-expect-error
-qsTestModel.addNumber('testString', 0, 100, 10, 1, (value: number) => {});
+qsTestModel.addNumber("testString", 0, 100, 10, 1, (value: number) => {});
 // @ts-expect-error
-qsTestModel.addNumber('testNumber', 0, 100, '10', 1, (value: number) => {});
+qsTestModel.addNumber("testNumber", 0, 100, "10", 1, (value: number) => {});
 
 // QuickSettingsPanel.bindNumber
-qsAnyModel.bindNumber('foo', 0, 100, 10, 1, { foo: 12 }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindNumber("foo", 0, 100, 10, 1, { foo: 12 }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindNumber('foo', 0, 100, 10, 1, { baz: 12 });
+qsAnyModel.bindNumber("foo", 0, 100, 10, 1, { baz: 12 });
 // @ts-expect-error
-qsAnyModel.bindNumber('foo', 0, 100, 10, 1, { foo: '12' });
+qsAnyModel.bindNumber("foo", 0, 100, 10, 1, { foo: "12" });
 
-qsTestModel.bindNumber('testNumber', 0, 100, 10, 1, { testNumber: 12 }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindNumber("testNumber", 0, 100, 10, 1, { testNumber: 12 }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindNumber('foo', 0, 100, 10, 1, { foo: 12 });
+qsTestModel.bindNumber("foo", 0, 100, 10, 1, { foo: 12 });
 // @ts-expect-error
-qsTestModel.bindNumber('testNumber', 0, 100, 10, 1, { foo: 12 });
+qsTestModel.bindNumber("testNumber", 0, 100, 10, 1, { foo: 12 });
 // @ts-expect-error
-qsTestModel.bindNumber('testNumber', 0, 100, 10, 1, { testNumber: '12' });
+qsTestModel.bindNumber("testNumber", 0, 100, 10, 1, { testNumber: "12" });
 
 // QuickSettingsPanel.setNumberParameters
-qsAnyModel.setNumberParameters('foo', 0, 100, 1); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setNumberParameters('testNumber', 0, 100, 1); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setNumberParameters("foo", 0, 100, 1); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setNumberParameters("testNumber", 0, 100, 1); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.setNumberParameters('foo', 0, 100, 1);
+qsTestModel.setNumberParameters("foo", 0, 100, 1);
 
 // QuickSettingsPanel.addRange
-qsAnyModel.addRange('foo', 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addRange("foo", 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.addRange('foo', 0, 100, 'foo', 1, (value: number) => {});
+qsAnyModel.addRange("foo", 0, 100, "foo", 1, (value: number) => {});
 
-qsTestModel.addRange('testNumber', 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addRange("testNumber", 0, 100, 10, 1, (value: number) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addRange('foo', 0, 100, 10, 1, (value: number) => {});
+qsTestModel.addRange("foo", 0, 100, 10, 1, (value: number) => {});
 // @ts-expect-error
-qsTestModel.addRange('testString', 0, 100, 10, 1, (value: number) => {});
+qsTestModel.addRange("testString", 0, 100, 10, 1, (value: number) => {});
 // @ts-expect-error
-qsTestModel.addRange('testNumber', 0, 100, '10', 1, (value: number) => {});
+qsTestModel.addRange("testNumber", 0, 100, "10", 1, (value: number) => {});
 
 // QuickSettingsPanel.bindRange
-qsAnyModel.bindRange('foo', 0, 100, 10, 1, { foo: 12 }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.bindRange("foo", 0, 100, 10, 1, { foo: 12 }); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
 // @ts-expect-error
-qsAnyModel.bindRange('foo', 0, 100, 10, 1, { baz: 12 });
+qsAnyModel.bindRange("foo", 0, 100, 10, 1, { baz: 12 });
 // @ts-expect-error
-qsAnyModel.bindRange('foo', 0, 100, 10, 1, { foo: '12' });
+qsAnyModel.bindRange("foo", 0, 100, 10, 1, { foo: "12" });
 
-qsTestModel.bindRange('testNumber', 0, 100, 10, 1, { testNumber: 12 }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.bindRange("testNumber", 0, 100, 10, 1, { testNumber: 12 }); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.bindRange('foo', 0, 100, 10, 1, { foo: 12 });
+qsTestModel.bindRange("foo", 0, 100, 10, 1, { foo: 12 });
 // @ts-expect-error
-qsTestModel.bindRange('testNumber', 0, 100, 10, 1, { foo: 12 });
+qsTestModel.bindRange("testNumber", 0, 100, 10, 1, { foo: 12 });
 // @ts-expect-error
-qsTestModel.bindRange('testNumber', 0, 100, 10, 1, { testNumber: '12' });
+qsTestModel.bindRange("testNumber", 0, 100, 10, 1, { testNumber: "12" });
 
 // QuickSettingsPanel.setRangeParameters
-qsAnyModel.setRangeParameters('foo', 0, 100, 1); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.setRangeParameters('testNumber', 0, 100, 1); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.setRangeParameters("foo", 0, 100, 1); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.setRangeParameters("testNumber", 0, 100, 1); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.setRangeParameters('foo', 0, 100, 1);
+qsTestModel.setRangeParameters("foo", 0, 100, 1);
 
 // QuickSettingsPanel.addDate
 {
-    qsAnyModel.addDate('myDateProperty', '2019-12-30', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.addDate('myDateProperty', new Date('2019-12-30'), (value: Date) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+    qsAnyModel.addDate("myDateProperty", "2019-12-30", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+    qsAnyModel.addDate("myDateProperty", new Date("2019-12-30"), (value: Date) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
     // @ts-expect-error
-    qsAnyModel.addDate('myDateProperty', '2019-12-30', (value: Date) => {});
+    qsAnyModel.addDate("myDateProperty", "2019-12-30", (value: Date) => {});
     // @ts-expect-error
-    qsAnyModel.addDate('myDateProperty', new Date(), (value: string) => {});
+    qsAnyModel.addDate("myDateProperty", new Date(), (value: string) => {});
 
     interface TestModelDate {
         testString: string;
@@ -470,39 +472,39 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     }
 
     const qsTestModelDate = QuickSettings.create<TestModelDate>();
-    qsTestModelDate.addDate('testString', '2019-12-30', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModelDate, string>
+    qsTestModelDate.addDate("testString", "2019-12-30", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModelDate, string>
     // @ts-expect-error
-    qsTestModelDate.addDate('testString', new Date('2019-12-30'), (value: Date) => {});
+    qsTestModelDate.addDate("testString", new Date("2019-12-30"), (value: Date) => {});
     // @ts-expect-error
-    qsTestModelDate.addDate('testDate', '2019-12-30', (value: string) => {});
-    qsTestModelDate.addDate('testDateOrString', '2019-12-30', (value: string) => {});
-    qsTestModelDate.addDate('testDateOrString', new Date('2019-12-30'), (value: Date) => {});
+    qsTestModelDate.addDate("testDate", "2019-12-30", (value: string) => {});
+    qsTestModelDate.addDate("testDateOrString", "2019-12-30", (value: string) => {});
+    qsTestModelDate.addDate("testDateOrString", new Date("2019-12-30"), (value: Date) => {});
     // @ts-expect-error
-    qsTestModelDate.addDate('testDateOrString', new Date('2019-12-30'), (value: string) => {});
+    qsTestModelDate.addDate("testDateOrString", new Date("2019-12-30"), (value: string) => {});
     // @ts-expect-error
-    qsTestModelDate.addDate('testDateOrString', '2019-12-31', (value: Date) => {});
+    qsTestModelDate.addDate("testDateOrString", "2019-12-31", (value: Date) => {});
 }
 
 // QuickSettingsPanel.bindDate
 {
     // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.bindDate('myDateProperty', '2019-12-30', {
-        myDateProperty: '2019-12-31',
+    qsAnyModel.bindDate("myDateProperty", "2019-12-30", {
+        myDateProperty: "2019-12-31",
     });
 
     // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.bindDate('myDateProperty', new Date('2019-12-30'), {
+    qsAnyModel.bindDate("myDateProperty", new Date("2019-12-30"), {
         myDateProperty: new Date(),
     });
 
     // @ts-expect-error
-    qsAnyModel.bindDate('myDateProperty', '2019-12-30', { myDateProperty: new Date() });
+    qsAnyModel.bindDate("myDateProperty", "2019-12-30", { myDateProperty: new Date() });
 
     // @ts-expect-error
-    qsAnyModel.bindDate('myDateProperty', new Date(), { myDateProperty: '2019-12-31' });
+    qsAnyModel.bindDate("myDateProperty", new Date(), { myDateProperty: "2019-12-31" });
 
     // @ts-expect-error
-    qsAnyModel.bindDate('myDateProperty', new Date(), { foo: new Date() });
+    qsAnyModel.bindDate("myDateProperty", new Date(), { foo: new Date() });
 
     interface TestModelDate {
         testString: string;
@@ -511,37 +513,37 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     }
 
     const qsTestModelDate = QuickSettings.create<TestModelDate>();
-    qsTestModelDate.bindDate('testString', '2019-12-30', {
-        testString: '2019-12-31',
+    qsTestModelDate.bindDate("testString", "2019-12-30", {
+        testString: "2019-12-31",
     });
 
     // @ts-expect-error
-    qsTestModelDate.bindDate('testString', new Date('2019-12-30'), { testString: new Date() });
+    qsTestModelDate.bindDate("testString", new Date("2019-12-30"), { testString: new Date() });
 
     // @ts-expect-error
-    qsTestModelDate.bindDate('testDate', '2019-12-30', { testDate: '2019-12-30' });
+    qsTestModelDate.bindDate("testDate", "2019-12-30", { testDate: "2019-12-30" });
 
     // $ExpectType QuickSettingsPanel<TestModelDate, string>
-    qsTestModelDate.bindDate('testDateOrString', '2019-12-30', { testDateOrString: '2019-12-31' });
+    qsTestModelDate.bindDate("testDateOrString", "2019-12-30", { testDateOrString: "2019-12-31" });
 
     // $ExpectType QuickSettingsPanel<TestModelDate, string>
-    qsTestModelDate.bindDate('testDateOrString', new Date('2019-12-30'), { testDateOrString: new Date() });
+    qsTestModelDate.bindDate("testDateOrString", new Date("2019-12-30"), { testDateOrString: new Date() });
 
     // @ts-expect-error
-    qsTestModelDate.bindDate('testDateOrString', new Date('2019-12-30'), { testDateOrString: '2019-12-31' });
+    qsTestModelDate.bindDate("testDateOrString", new Date("2019-12-30"), { testDateOrString: "2019-12-31" });
 
     // @ts-expect-error
-    qsTestModelDate.bindDate('testDateOrString', '2019-12-31', { testDateOrString: new Date() });
+    qsTestModelDate.bindDate("testDateOrString", "2019-12-31", { testDateOrString: new Date() });
 }
 
 // QuickSettingsPanel.addTime
 {
-    qsAnyModel.addTime('myDateProperty', '01:00:00', (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.addTime('myDateProperty', new Date('01:00:00'), (value: Date) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+    qsAnyModel.addTime("myDateProperty", "01:00:00", (value: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+    qsAnyModel.addTime("myDateProperty", new Date("01:00:00"), (value: Date) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
     // @ts-expect-error
-    qsAnyModel.addTime('myDateProperty', '01:00:00', (value: Date) => {});
+    qsAnyModel.addTime("myDateProperty", "01:00:00", (value: Date) => {});
     // @ts-expect-error
-    qsAnyModel.addTime('myDateProperty', new Date(), (value: string) => {});
+    qsAnyModel.addTime("myDateProperty", new Date(), (value: string) => {});
 
     interface TestModelDate {
         testString: string;
@@ -550,39 +552,39 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     }
 
     const qsTestModelDate = QuickSettings.create<TestModelDate>();
-    qsTestModelDate.addTime('testString', '01:00:00', (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModelDate, string>
+    qsTestModelDate.addTime("testString", "01:00:00", (value: string) => {}); // $ExpectType QuickSettingsPanel<TestModelDate, string>
     // @ts-expect-error
-    qsTestModelDate.addTime('testString', new Date('01:00:00'), (value: Date) => {});
+    qsTestModelDate.addTime("testString", new Date("01:00:00"), (value: Date) => {});
     // @ts-expect-error
-    qsTestModelDate.addTime('testDate', '01:00:00', (value: string) => {});
-    qsTestModelDate.addTime('testDateOrString', '01:00:00', (value: string) => {});
-    qsTestModelDate.addTime('testDateOrString', new Date('01:00:00'), (value: Date) => {});
+    qsTestModelDate.addTime("testDate", "01:00:00", (value: string) => {});
+    qsTestModelDate.addTime("testDateOrString", "01:00:00", (value: string) => {});
+    qsTestModelDate.addTime("testDateOrString", new Date("01:00:00"), (value: Date) => {});
     // @ts-expect-error
-    qsTestModelDate.addTime('testDateOrString', new Date('01:00:00'), (value: string) => {});
+    qsTestModelDate.addTime("testDateOrString", new Date("01:00:00"), (value: string) => {});
     // @ts-expect-error
-    qsTestModelDate.addTime('testDateOrString', '02:00:00', (value: Date) => {});
+    qsTestModelDate.addTime("testDateOrString", "02:00:00", (value: Date) => {});
 }
 
 // QuickSettingsPanel.bindTime
 {
     // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.bindTime('myDateProperty', '01:00:00', {
-        myDateProperty: '02:00:00',
+    qsAnyModel.bindTime("myDateProperty", "01:00:00", {
+        myDateProperty: "02:00:00",
     });
 
     // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-    qsAnyModel.bindTime('myDateProperty', new Date('01:00:00'), {
+    qsAnyModel.bindTime("myDateProperty", new Date("01:00:00"), {
         myDateProperty: new Date(),
     });
 
     // @ts-expect-error
-    qsAnyModel.bindTime('myDateProperty', '01:00:00', { myDateProperty: new Date() });
+    qsAnyModel.bindTime("myDateProperty", "01:00:00", { myDateProperty: new Date() });
 
     // @ts-expect-error
-    qsAnyModel.bindTime('myDateProperty', new Date(), { myDateProperty: '02:00:00' });
+    qsAnyModel.bindTime("myDateProperty", new Date(), { myDateProperty: "02:00:00" });
 
     // @ts-expect-error
-    qsAnyModel.bindTime('myDateProperty', new Date(), { foo: new Date() });
+    qsAnyModel.bindTime("myDateProperty", new Date(), { foo: new Date() });
 
     interface TestModelDate {
         testString: string;
@@ -591,27 +593,27 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     }
 
     const qsTestModelDate = QuickSettings.create<TestModelDate>();
-    qsTestModelDate.bindTime('testString', '01:00:00', {
-        testString: '02:00:00',
+    qsTestModelDate.bindTime("testString", "01:00:00", {
+        testString: "02:00:00",
     });
 
     // @ts-expect-error
-    qsTestModelDate.bindTime('testString', new Date('01:00:00'), { testString: new Date() });
+    qsTestModelDate.bindTime("testString", new Date("01:00:00"), { testString: new Date() });
 
     // @ts-expect-error
-    qsTestModelDate.bindTime('testDate', '01:00:00', { testDate: '01:00:00' });
+    qsTestModelDate.bindTime("testDate", "01:00:00", { testDate: "01:00:00" });
 
     // $ExpectType QuickSettingsPanel<TestModelDate, string>
-    qsTestModelDate.bindTime('testDateOrString', '01:00:00', { testDateOrString: '02:00:00' });
+    qsTestModelDate.bindTime("testDateOrString", "01:00:00", { testDateOrString: "02:00:00" });
 
     // $ExpectType QuickSettingsPanel<TestModelDate, string>
-    qsTestModelDate.bindTime('testDateOrString', new Date('01:00:00'), { testDateOrString: new Date() });
+    qsTestModelDate.bindTime("testDateOrString", new Date("01:00:00"), { testDateOrString: new Date() });
 
     // @ts-expect-error
-    qsTestModelDate.bindTime('testDateOrString', new Date('01:00:00'), { testDateOrString: '02:00:00' });
+    qsTestModelDate.bindTime("testDateOrString", new Date("01:00:00"), { testDateOrString: "02:00:00" });
 
     // @ts-expect-error
-    qsTestModelDate.bindTime('testDateOrString', '02:00:00', { testDateOrString: new Date() });
+    qsTestModelDate.bindTime("testDateOrString", "02:00:00", { testDateOrString: new Date() });
 }
 
 // QuickSettingsPanel.addDropDown
@@ -628,75 +630,83 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     const qsDropDown = QuickSettings.create<TestModelDropDown>();
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.addDropDown('testString', ['one', 'two', 'three'], (value: DropDownSelection<string>) => {});
+    qsDropDown.addDropDown("testString", ["one", "two", "three"], (value: DropDownSelection<string>) => {});
     qsDropDown.addDropDown(
-        'testString',
+        "testString",
         [
-            { label: 'Opt 1', value: 'one' },
-            { label: 'Opt 2', value: 'two' },
-            { label: 'Opt 3', value: '3' },
+            { label: "Opt 1", value: "one" },
+            { label: "Opt 2", value: "two" },
+            { label: "Opt 3", value: "3" },
         ],
         (value: DropDownSelection<string>) => {},
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.addDropDown('testNumber', [1, 2, 3], (value: DropDownSelection<number>) => {});
+    qsDropDown.addDropDown("testNumber", [1, 2, 3], (value: DropDownSelection<number>) => {});
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.addDropDown(
-        'testNumber',
+        "testNumber",
         [
-            { label: 'Opt 1', value: 1 },
-            { label: 'Opt 2', value: 2 },
-            { label: 'Opt 3', value: 3 },
+            { label: "Opt 1", value: 1 },
+            { label: "Opt 2", value: 2 },
+            { label: "Opt 3", value: 3 },
         ],
         (value: DropDownSelection<number>) => {},
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.addDropDown('testStringOrNumber', [1, 'two', 3], (value: DropDownSelection<string | number>) => {});
+    qsDropDown.addDropDown("testStringOrNumber", [1, "two", 3], (value: DropDownSelection<string | number>) => {});
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.addDropDown(
-        'testStringOrNumber',
+        "testStringOrNumber",
         [
-            { label: 'Opt 1', value: 1 },
-            { label: 'Opt 2', value: 'two' },
-            { label: 'Opt 3', value: 3 },
+            { label: "Opt 1", value: 1 },
+            { label: "Opt 2", value: "two" },
+            { label: "Opt 3", value: 3 },
         ],
         (value: DropDownSelection<string | number>) => {},
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.addDropDown(
-        'testComplex',
+        "testComplex",
         [
-            { label: 'Opt 1', value: { foo: 'one' } },
-            { label: 'Opt 2', value: { foo: 'two' } },
-            { label: 'Opt 3', value: { foo: 'three' } },
+            { label: "Opt 1", value: { foo: "one" } },
+            { label: "Opt 2", value: { foo: "two" } },
+            { label: "Opt 3", value: { foo: "three" } },
         ],
         (value: DropDownSelection<{ foo: string }>) => {},
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.addDropDown(
-        'testString',
-        ['one', { label: 'Opt 2', value: 'two' }, 'three'],
+        "testString",
+        ["one", { label: "Opt 2", value: "two" }, "three"],
         (value: DropDownSelection<string>) => {},
     );
 
     // @ts-expect-error
-    qsDropDown.addDropDown('testString', [1, 2, 3], (value: DropDownSelection<number>) => {});
+    qsDropDown.addDropDown("testString", [1, 2, 3], (value: DropDownSelection<number>) => {});
     // @ts-expect-error
-    qsDropDown.addDropDown('testNumber', ['one', 'two', 'three'], (value: DropDownSelection<string>) => {});
+    qsDropDown.addDropDown("testNumber", ["one", "two", "three"], (value: DropDownSelection<string>) => {});
     // @ts-expect-error
-    qsDropDown.addDropDown('testString', [1, 'two', 3], (value: DropDownSelection<string | number>) => {});
+    qsDropDown.addDropDown("testString", [1, "two", 3], (value: DropDownSelection<string | number>) => {});
     // prettier-ignore
     // @ts-expect-error
-    qsDropDown.addDropDown('testComplex', [{ foo: 'one' }, { foo: 'two' }, { foo: 'three' }], (value: DropDownSelection<{ foo: string }>) => {});
+    qsDropDown.addDropDown(
+        "testComplex",
+        [{ foo: "one" }, { foo: "two" }, { foo: "three" }],
+        (value: DropDownSelection<{ foo: string }>) => {},
+    );
     // prettier-ignore
     // @ts-expect-error
-    qsDropDown.addDropDown('testString', ['one', { label: 'Opt 2', value: 2 }, 'three'], (value: DropDownSelection<string>) => {});
+    qsDropDown.addDropDown(
+        "testString",
+        ["one", { label: "Opt 2", value: 2 }, "three"],
+        (value: DropDownSelection<string>) => {},
+    );
 }
 
 // QuickSettingsPanel.bindDropDown
@@ -713,32 +723,32 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     const qsDropDown = QuickSettings.create<TestModelDropDown>();
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.bindDropDown('testString', ['one', 'two', 'three'], { testString: 'one' });
+    qsDropDown.bindDropDown("testString", ["one", "two", "three"], { testString: "one" });
     qsDropDown.bindDropDown(
-        'testString',
+        "testString",
         [
-            { label: 'Opt 1', value: 'one' },
-            { label: 'Opt 2', value: 'two' },
-            { label: 'Opt 3', value: '3' },
+            { label: "Opt 1", value: "one" },
+            { label: "Opt 2", value: "two" },
+            { label: "Opt 3", value: "3" },
         ],
         {
-            testString: 'one',
+            testString: "one",
         },
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.bindDropDown('testNumber', [1, 2, 3], { testNumber: 10 });
+    qsDropDown.bindDropDown("testNumber", [1, 2, 3], { testNumber: 10 });
 
     // @ts-expect-error
-    qsDropDown.bindDropDown('testNumber', [1, 2, 3], { testNumber: 'foo' });
+    qsDropDown.bindDropDown("testNumber", [1, 2, 3], { testNumber: "foo" });
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.bindDropDown(
-        'testNumber',
+        "testNumber",
         [
-            { label: 'Opt 1', value: 1 },
-            { label: 'Opt 2', value: 2 },
-            { label: 'Opt 3', value: 3 },
+            { label: "Opt 1", value: 1 },
+            { label: "Opt 2", value: 2 },
+            { label: "Opt 3", value: 3 },
         ],
         {
             testNumber: 10,
@@ -746,79 +756,79 @@ qsTestModel.setRangeParameters('foo', 0, 100, 1);
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.bindDropDown('testStringOrNumber', [1, 'two', 3], { testStringOrNumber: 1 });
+    qsDropDown.bindDropDown("testStringOrNumber", [1, "two", 3], { testStringOrNumber: 1 });
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.bindDropDown('testStringOrNumber', [1, 'two', 3], { testStringOrNumber: 'two' });
+    qsDropDown.bindDropDown("testStringOrNumber", [1, "two", 3], { testStringOrNumber: "two" });
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.bindDropDown(
-        'testStringOrNumber',
+        "testStringOrNumber",
         [
-            { label: 'Opt 1', value: 1 },
-            { label: 'Opt 2', value: 'two' },
-            { label: 'Opt 3', value: 3 },
+            { label: "Opt 1", value: 1 },
+            { label: "Opt 2", value: "two" },
+            { label: "Opt 3", value: 3 },
         ],
         { testStringOrNumber: 1 },
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
     qsDropDown.bindDropDown(
-        'testComplex',
+        "testComplex",
         [
-            { label: 'Opt 1', value: { foo: 'one' } },
-            { label: 'Opt 2', value: { foo: 'two' } },
-            { label: 'Opt 3', value: { foo: 'three' } },
+            { label: "Opt 1", value: { foo: "one" } },
+            { label: "Opt 2", value: { foo: "two" } },
+            { label: "Opt 3", value: { foo: "three" } },
         ],
-        { testComplex: { foo: 'bar' } },
+        { testComplex: { foo: "bar" } },
     );
 
     // $ExpectType QuickSettingsPanel<TestModelDropDown, string>
-    qsDropDown.bindDropDown('testString', ['one', { label: 'Opt 2', value: 'two' }, 'three'], { testString: 'foo' });
+    qsDropDown.bindDropDown("testString", ["one", { label: "Opt 2", value: "two" }, "three"], { testString: "foo" });
 
     // @ts-expect-error
-    qsDropDown.bindDropDown('testString', [1, 2, 3], { testString: 'foo' });
+    qsDropDown.bindDropDown("testString", [1, 2, 3], { testString: "foo" });
     // @ts-expect-error
-    qsDropDown.bindDropDown('testNumber', ['one', 'two', 'three'], { testNumber: 10 });
+    qsDropDown.bindDropDown("testNumber", ["one", "two", "three"], { testNumber: 10 });
     // @ts-expect-error
-    qsDropDown.bindDropDown('testString', [1, 'two', 3], { testString: 'foo' });
+    qsDropDown.bindDropDown("testString", [1, "two", 3], { testString: "foo" });
     // @ts-expect-error
-    qsDropDown.bindDropDown('testComplex', [{ foo: 'one' }, { foo: 'two' }, { foo: 'three' }], {
-        testComplex: { foo: 'bar' },
+    qsDropDown.bindDropDown("testComplex", [{ foo: "one" }, { foo: "two" }, { foo: "three" }], {
+        testComplex: { foo: "bar" },
     });
     // @ts-expect-error
-    qsDropDown.bindDropDown('testString', ['one', { label: 'Opt 2', value: 2 }, 'three'], { testString: 'foo' });
+    qsDropDown.bindDropDown("testString", ["one", { label: "Opt 2", value: 2 }, "three"], { testString: "foo" });
 }
 
 // QuickSettingsPanel.addHTML
-qsAnyModel.addHTML('foo', '<div></div>'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.addHTML('testString', '<div></div>'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.addHTML("foo", "<div></div>"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.addHTML("testString", "<div></div>"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addHTML('foo', '<div></div>');
+qsTestModel.addHTML("foo", "<div></div>");
 // @ts-expect-error
-qsTestModel.addHTML('testNumber', '<div></div>');
+qsTestModel.addHTML("testNumber", "<div></div>");
 
 // QuickSettingsPanel.addImage
-qsAnyModel.addImage('foo', 'https://static.com/my-image.png', (url: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string>
-qsAnyModel.addImage('foo', 'https://static.com/my-image.png'); // $ExpectType QuickSettingsPanel<Record<string, any>, string>
-qsTestModel.addImage('testString', 'https://static.com/my-image.png', (url: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
-qsTestModel.addImage('testString', 'https://static.com/my-image.png'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.addImage("foo", "https://static.com/my-image.png", (url: string) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string>
+qsAnyModel.addImage("foo", "https://static.com/my-image.png"); // $ExpectType QuickSettingsPanel<Record<string, any>, string>
+qsTestModel.addImage("testString", "https://static.com/my-image.png", (url: string) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addImage("testString", "https://static.com/my-image.png"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 
 // @ts-expect-error
-qsTestModel.addImage('foo', 'https://static.com/my-image.png', (url: string) => {});
+qsTestModel.addImage("foo", "https://static.com/my-image.png", (url: string) => {});
 
 // @ts-expect-error
-qsTestModel.addImage('testNumber', 'https://static.com/my-image.png', (url: string) => {});
+qsTestModel.addImage("testNumber", "https://static.com/my-image.png", (url: string) => {});
 
 // QuickSettingsPanel.addFileChooser
-qsAnyModel.addFileChooser('foo', 'Upload', 'image/*', (value: File) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsAnyModel.addFileChooser('foo', 'Upload', 'image/*'); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.addFileChooser('testFile', 'Upload', 'image/*', (value: File) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
-qsTestModel.addFileChooser('testFile', 'Upload', 'image/*'); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.addFileChooser("foo", "Upload", "image/*", (value: File) => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsAnyModel.addFileChooser("foo", "Upload", "image/*"); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.addFileChooser("testFile", "Upload", "image/*", (value: File) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsTestModel.addFileChooser("testFile", "Upload", "image/*"); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addFileChooser('testString', 'Upload', 'image/*');
+qsTestModel.addFileChooser("testString", "Upload", "image/*");
 // @ts-expect-error
-qsTestModel.addFileChooser('foo', 'Upload', 'image/*');
+qsTestModel.addFileChooser("foo", "Upload", "image/*");
 
 /**
  * QuickSettingsPanel – Static field creation methods
@@ -830,17 +840,17 @@ qsTestModel.addFileChooser('foo', 'Upload', 'image/*');
  */
 
 // QuickSettingsPanel.addButton
-qsAnyModel.addButton('foo', () => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.addButton('testStatic', () => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.addButton("foo", () => {}); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.addButton("testStatic", () => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addButton('foo', () => {});
+qsTestModel.addButton("foo", () => {});
 // @ts-expect-error
-qsTestModel.addButton('testString', () => {});
+qsTestModel.addButton("testString", () => {});
 
 // QuickSettingsPanel.addElement
-qsAnyModel.addElement('foo', document.createElement('div')); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
-qsTestModel.addElement('testStatic', document.createElement('div')); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+qsAnyModel.addElement("foo", document.createElement("div")); // $ExpectType QuickSettingsPanel<Record<string, any>, string> || QuickSettingsPanel<AnyModel, string>
+qsTestModel.addElement("testStatic", document.createElement("div")); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 // @ts-expect-error
-qsTestModel.addElement('foo', document.createElement('div'));
+qsTestModel.addElement("foo", document.createElement("div"));
 // @ts-expect-error
-qsTestModel.addElement('testString', document.createElement('div'));
+qsTestModel.addElement("testString", document.createElement("div"));

--- a/types/quicksettings/quicksettings-tests.ts
+++ b/types/quicksettings/quicksettings-tests.ts
@@ -129,10 +129,10 @@ qsAnyModel.setGlobalChangeHandler((model: AnyModel) => {}); // $ExpectType Quick
 // @ts-expect-error
 qsAnyModel.setGlobalChangeHandler((model: string) => {});
 qsTestModel.setGlobalChangeHandler((model: TestModel) => {}); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
-// prettier-ignore
+// $ExpectType QuickSettingsPanel<TestModel, "testStatic">
 qsTestModel.setGlobalChangeHandler(
     (model: { testNumber: number; testBoolean: boolean; testDate: string | Date }) => {},
-); // $ExpectType QuickSettingsPanel<TestModel, "testStatic">
+);
 // @ts-expect-error
 qsTestModel.setGlobalChangeHandler((model: { foo: string }) => {});
 
@@ -694,16 +694,16 @@ qsTestModel.setRangeParameters("foo", 0, 100, 1);
     // @ts-expect-error
     qsDropDown.addDropDown("testString", [1, "two", 3], (value: DropDownSelection<string | number>) => {});
     // prettier-ignore
-    // @ts-expect-error
     qsDropDown.addDropDown(
         "testComplex",
+        // @ts-expect-error
         [{ foo: "one" }, { foo: "two" }, { foo: "three" }],
         (value: DropDownSelection<{ foo: string }>) => {},
     );
     // prettier-ignore
-    // @ts-expect-error
     qsDropDown.addDropDown(
         "testString",
+        // @ts-expect-error
         ["one", { label: "Opt 2", value: 2 }, "three"],
         (value: DropDownSelection<string>) => {},
     );

--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -20,7 +20,9 @@ import Delta = require("quill-delta");
  *
  *  But this would break a lot of existing code as it would require manual discrimination of the union types.
  */
-export type DeltaOperation = { insert?: any; delete?: number | undefined; retain?: number | undefined } & OptionalAttributes;
+export type DeltaOperation =
+    & { insert?: any; delete?: number | undefined; retain?: number | undefined }
+    & OptionalAttributes;
 interface SourceMap {
     API: "api";
     SILENT: "silent";

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -1,5 +1,5 @@
-import { Quill, RangeStatic, StringMap } from "quill";
 import { Blot } from "parchment/src/blot/abstract/blot";
+import { Quill, RangeStatic, StringMap } from "quill";
 import Delta = require("quill-delta");
 
 function test_quill() {
@@ -406,9 +406,9 @@ function test_KeyboardBool() {
 }
 
 function test_history() {
-  const quillEditor = new Quill("#editor");
-  quillEditor.history.undo();
-  quillEditor.history.redo();
-  quillEditor.history.cutoff();
-  quillEditor.history.clear();
+    const quillEditor = new Quill("#editor");
+    quillEditor.history.undo();
+    quillEditor.history.redo();
+    quillEditor.history.cutoff();
+    quillEditor.history.clear();
 }

--- a/types/quixote/index.d.ts
+++ b/types/quixote/index.d.ts
@@ -11,39 +11,39 @@ interface Quixote {
 interface QFrame {
     // Reset the frame back to the state it was in immediately after you called quixote.createFrame()
     reset(): void;
-    
+
     // Remove the test frame entirely.
     remove(): void;
-    
+
     // Retrieve an element matching a selector. Throws an exception unless exactly one matching element is found
     get(selector: string, nickname?: string): QElement;
-    
+
     // Retrieve a list of elements matching a selector. If you want to ensure that exactly one element is retrieved, use frame.get() instead.
     getAll(selector: string, nickname?: string): QElementList;
-    
+
     // Create an element and append it to the frame's body. Throws an exception unless exactly one element is created. (But that one element may contain children.)
     add(html: string, nickname?: string): QElement;
-    
+
     // Provides access to descriptors for the frame's viewport (the part of the page that you can see in the frame, not including scrollbars)
     viewport(): QElement;
-    
+
     // Provides access to descriptors for the frame's page (everything you can see or scroll to, not including scrollbars)
     page(): QElement;
-    
+
     // Retrieves the frame's body element.
     body(): QElement;
-    
+
     // Changes the size of the frame.
     resize(width: number, height: number): void;
-    
+
     // Scroll the page so that top-left corner of the frame is as close as possible to an (x, y) coordinate.
     scroll(x: number, y: number): void;
-    
+
     // Determine the (x, y) coordinate of the top-left corner of the frame. This uses pageXOffset and pageYOffset under the covers. (On IE 8, it uses scrollLeft and scrollTop.)
     getRawScrollPosition(x: number, y: number): Object;
-    
+
     // Retrieve the underlying HTMLIFrameElement DOM element for the frame.
-    toDomElement(): HTMLIFrameElement;    
+    toDomElement(): HTMLIFrameElement;
 }
 
 interface QElement {
@@ -52,13 +52,13 @@ interface QElement {
 
     // Compare the element's descriptors to a set of expected values.
     diff(expected: ElementDescriptor): string;
-    
+
     // Determine how the browser is actually rendering an element's style. This uses getComputedStyle() under the covers. (On IE 8, it uses currentStyle)
     getRawStyle(property: string): string;
-    
+
     // Determine where an element is displayed within the frame viewport, as computed by the browser
     getRawPosition(): RawPositionObject;
-    
+
     // Retrieve the underlying HTMLElement DOM element for the frame.
     toDomElement(): HTMLElement;
 }
@@ -66,34 +66,34 @@ interface QElement {
 interface QElementList {
     // Determine the number of elements in the list.
     length(): number;
-    
+
     // Retrieve an element from the list. Positive and negative indices are allowed. Throws an exception if the index is out of bounds.
-    at(index: number, nickname?: string): QElement;    
+    at(index: number, nickname?: string): QElement;
 }
 
 // Element positions and sizes are available on all QElement instances.
 interface ElementDescriptor {
     // The top edge of the element
     top?: PositionDescriptor | undefined;
-    
+
     // The right edge of the element
     right?: PositionDescriptor | undefined;
-    
+
     // The bottom edge of the element
     bottom?: PositionDescriptor | undefined;
-    
+
     // The left edge of the element
     left?: PositionDescriptor | undefined;
-    
+
     // Horizontal center: midway between the right and left edges.
     center?: PositionDescriptor | undefined;
-    
+
     // Vertical middle: midway between the top and bottom edges.
     middle?: PositionDescriptor | undefined;
-    
+
     // Width of the element.
     width?: SizeDescriptor | undefined;
-    
+
     // Height of the element.
     height?: SizeDescriptor | undefined;
 }
@@ -102,25 +102,25 @@ interface ElementDescriptor {
 interface ViewportDescriptor {
     // The highest visible part of the page.
     top: PositionDescriptor;
-    
+
     // The rightmost visible part of the page.
     right: PositionDescriptor;
-    
+
     // The lowest visible part of the page.
     bottom: PositionDescriptor;
-    
+
     // The leftmost visible part of the page.
     left: PositionDescriptor;
-    
+
     // Horizontal center: midway between right and left
     center: PositionDescriptor;
-    
+
     // Vertical middle: midway between top and bottom.
     middle: PositionDescriptor;
-    
+
     // Width of the viewport.
     width: SizeDescriptor;
-    
+
     // Height of the viewport.
     height: SizeDescriptor;
 }
@@ -129,25 +129,25 @@ interface ViewportDescriptor {
 interface PageDescriptor {
     // The top of the page.
     top: PositionDescriptor;
-    
+
     // The right side of the page.
     right: PositionDescriptor;
-    
+
     // The bottom of the page.
     bottom: PositionDescriptor;
-    
+
     // The left side of the page.
     left: PositionDescriptor;
-    
+
     // Horizontal center: midway between right and left.
     center: PositionDescriptor;
-    
+
     // Vertical middle: midway between top and bottom.
     middle: PositionDescriptor;
-    
+
     // Width of the page.
     width: SizeDescriptor;
-    
+
     // Height of the page.
     height: SizeDescriptor;
 }
@@ -156,13 +156,13 @@ interface PageDescriptor {
 interface PositionDescriptor {
     // Create a new descriptor that is further down the page or to the right.
     plus(amount: SizeDescriptor): PositionDescriptor;
-    
+
     // Create a new descriptor that is further down the page or to the right.
     plus(amount: number): PositionDescriptor;
-    
+
     // Create a new descriptor that is further down the page or to the right.
     minus(amount: SizeDescriptor): PositionDescriptor;
-    
+
     // Create a new descriptor that is further down the page or to the right.
     minus(amount: number): PositionDescriptor;
 }
@@ -171,16 +171,16 @@ interface PositionDescriptor {
 interface SizeDescriptor {
     // Create a descriptor that's bigger than this one.
     plus(amount: SizeDescriptor): SizeDescriptor;
-    
+
     // Create a descriptor that's bigger than this one.
     plus(amount: number): SizeDescriptor;
-    
+
     // Create a descriptor that's smaller than this one.
     minus(amount: SizeDescriptor): SizeDescriptor;
-    
+
     // Create a descriptor that's smaller than this one.
     minus(amount: number): SizeDescriptor;
-    
+
     // Create a new descriptor that's a multiple or fraction of the size of this one.
     times(multiple: number): SizeDescriptor;
 }
@@ -202,19 +202,19 @@ interface QuixoteFrameOptions {
 interface RawPositionObject {
     // top edge
     top: number;
-    
+
     // right edge
     right: number;
-    
+
     // bottom edge
     bottom: number;
-    
+
     // left edge
     left: number;
-    
+
     // width (right edge minus left edge)
     width: number;
-    
+
     // height (bottom edge minus top edge)
     height: number;
 }
@@ -222,10 +222,9 @@ interface RawPositionObject {
 declare var quixote: Quixote;
 
 declare module "quixote" {
-
     class Quixote {
         constructor();
-        
+
         createFrame(options: QuixoteFrameOptions, callback: (err: Error, loadedFrame: QFrame) => void): QFrame;
     }
 

--- a/types/quixote/quixote-tests.ts
+++ b/types/quixote/quixote-tests.ts
@@ -1,6 +1,9 @@
 // Stub mocha functions
-const {describe, it, before, after, beforeEach, afterEach} = null as any as {
-    [s: string]: ((s: string, cb: (done: any) => void) => void) & ((cb: (done: any) => void) => void) & {only: any, skip: any};
+const { describe, it, before, after, beforeEach, afterEach } = null as any as {
+    [s: string]: ((s: string, cb: (done: any) => void) => void) & ((cb: (done: any) => void) => void) & {
+        only: any;
+        skip: any;
+    };
 };
 
 function test_createFrame() {
@@ -17,7 +20,7 @@ function test_resetFrame() {
         var options = { src: "" };
         frame = quixote.createFrame(options, done());
     });
-    
+
     beforeEach(() => {
         frame.reset();
     });
@@ -29,10 +32,8 @@ function test_removeFrame() {
         var options = { src: "" };
         frame = quixote.createFrame(options, done());
     });
-    
+
     after(function() {
         frame.remove();
     });
 }
-
-

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -1,574 +1,595 @@
-QUnit.module( "group a" );
+QUnit.module("group a");
 
-QUnit.test( "a basic test example", function( assert ) {
-  assert.timeout(5_000);
+QUnit.test("a basic test example", function(assert) {
+    assert.timeout(5_000);
 
-  assert.ok( true, "this test is fine" );
+    assert.ok(true, "this test is fine");
 });
-QUnit.test( "a basic test example 2", function( assert ) {
-  assert.ok( true, "this test is fine" );
-});
-
-QUnit.module( "group b" );
-QUnit.test( "a basic test example 3", function( assert ) {
-  assert.ok( true, "this test is fine" );
-});
-QUnit.test( "a basic test example 4", function( assert ) {
-  assert.ok( true, "this test is fine" );
+QUnit.test("a basic test example 2", function(assert) {
+    assert.ok(true, "this test is fine");
 });
 
-
-QUnit.module( "module a", function() {
-  QUnit.test( "a basic test example", function( assert ) {
-    assert.ok( true, "this test is fine" );
-  });
+QUnit.module("group b");
+QUnit.test("a basic test example 3", function(assert) {
+    assert.ok(true, "this test is fine");
+});
+QUnit.test("a basic test example 4", function(assert) {
+    assert.ok(true, "this test is fine");
 });
 
-QUnit.module( "module b", function() {
-  QUnit.test( "a basic test example 2", function( assert ) {
-    assert.ok( true, "this test is fine" );
-  });
-
-  QUnit.module( "nested module b.1", function() {
-
-    // This test will be prefixed with the following module label:
-    // "module b > nested module b.1"
-    QUnit.test( "a basic test example 3", function( assert ) {
-      assert.ok( true, "this test is fine" );
+QUnit.module("module a", function() {
+    QUnit.test("a basic test example", function(assert) {
+        assert.ok(true, "this test is fine");
     });
-  });
 });
 
-QUnit.module( "module A", {
-  before: function() {
-    // prepare something once for all tests
-  },
-  beforeEach: function() {
-    // prepare something before each test
-  },
-  afterEach: function() {
-    // clean up after each test
-  },
-  after: function() {
-    // clean up once after all tests are done
-  }
+QUnit.module("module b", function() {
+    QUnit.test("a basic test example 2", function(assert) {
+        assert.ok(true, "this test is fine");
+    });
+
+    QUnit.module("nested module b.1", function() {
+        // This test will be prefixed with the following module label:
+        // "module b > nested module b.1"
+        QUnit.test("a basic test example 3", function(assert) {
+            assert.ok(true, "this test is fine");
+        });
+    });
 });
 
-QUnit.module( "Machine Maker", {
-  beforeEach: function() {
-    let Maker: any = () => {};
-    this.maker = new Maker();
-    this.parts = [ "wheels", "motor", "chassis" ];
-  }
-});
-
-QUnit.hooks.beforeEach(function (assert) {
-  assert.ok(true)
-});
-
-QUnit.hooks.afterEach(function (assert) {
-  assert.ok(true)
-});
-
-QUnit.test( "makes a robot", function( assert ) {
-  this.parts.push( "arduino" );
-  assert.equal( this.maker.build( this.parts ), "robot" );
-  assert.deepEqual( this.maker.made, [ "robot" ] );
-});
-
-QUnit.test( "makes a car", function( assert ) {
-  assert.equal( this.maker.build( this.parts ), "car" );
-  this.maker.duplicate();
-  assert.deepEqual( this.maker.made, [ "car", "car" ] );
-});
-
-QUnit.module( "grouped tests argument hooks", function( hooks ) {
-
-  hooks.beforeEach( function( assert ) {
-    assert.ok( true, "beforeEach called" );
-  } );
-
-  hooks.afterEach( function( assert ) {
-    assert.ok( true, "afterEach called" );
-  } );
-
-  QUnit.test( "call hooks", function( assert ) {
-    assert.expect( 2 );
-  } );
-
-  QUnit.module( "stacked hooks", function( hooks ) {
-
-    // This will run after the parent module's beforeEach hook
-    hooks.beforeEach( function( assert ) {
-      assert.ok( true, "nested beforeEach called" );
-    } );
-
-    // This will run before the parent module's afterEach
-    hooks.afterEach( function( assert ) {
-      assert.ok( true, "nested afterEach called" );
-    } );
-
-    QUnit.test( "call hooks", function( assert ) {
-      assert.expect( 4 );
-    } );
-  } );
-} );
-
-QUnit.module.only( "exclusive module" , function( hooks ) {
-  hooks.beforeEach( function( assert ) {
-    assert.ok( true, "beforeEach called" );
-  } );
-
-  hooks.afterEach( function( assert ) {
-    assert.ok( true, "afterEach called" );
-  } );
-
-  QUnit.test( "call hooks", function( assert ) {
-    assert.expect( 2 );
-  } );
-
-  QUnit.module.only( "nested exclusive module", {
-    // This will run after the parent module's beforeEach hook
-    beforeEach: assert  => {
-      assert.ok( true, "nested beforeEach called" );
+QUnit.module("module A", {
+    before: function() {
+        // prepare something once for all tests
     },
-    // This will run before the parent module's afterEach
-    afterEach: assert => {
-      assert.ok( true, "nested afterEach called" );
+    beforeEach: function() {
+        // prepare something before each test
+    },
+    afterEach: function() {
+        // clean up after each test
+    },
+    after: function() {
+        // clean up once after all tests are done
+    },
+});
+
+QUnit.module("Machine Maker", {
+    beforeEach: function() {
+        let Maker: any = () => {};
+        this.maker = new Maker();
+        this.parts = ["wheels", "motor", "chassis"];
+    },
+});
+
+QUnit.hooks.beforeEach(function(assert) {
+    assert.ok(true);
+});
+
+QUnit.hooks.afterEach(function(assert) {
+    assert.ok(true);
+});
+
+QUnit.test("makes a robot", function(assert) {
+    this.parts.push("arduino");
+    assert.equal(this.maker.build(this.parts), "robot");
+    assert.deepEqual(this.maker.made, ["robot"]);
+});
+
+QUnit.test("makes a car", function(assert) {
+    assert.equal(this.maker.build(this.parts), "car");
+    this.maker.duplicate();
+    assert.deepEqual(this.maker.made, ["car", "car"]);
+});
+
+QUnit.module("grouped tests argument hooks", function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
+
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
+
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    });
+
+    QUnit.module("stacked hooks", function(hooks) {
+        // This will run after the parent module's beforeEach hook
+        hooks.beforeEach(function(assert) {
+            assert.ok(true, "nested beforeEach called");
+        });
+
+        // This will run before the parent module's afterEach
+        hooks.afterEach(function(assert) {
+            assert.ok(true, "nested afterEach called");
+        });
+
+        QUnit.test("call hooks", function(assert) {
+            assert.expect(4);
+        });
+    });
+});
+
+QUnit.module.only("exclusive module", function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
+
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
+
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    });
+
+    QUnit.module.only("nested exclusive module", {
+        // This will run after the parent module's beforeEach hook
+        beforeEach: assert => {
+            assert.ok(true, "nested beforeEach called");
+        },
+        // This will run before the parent module's afterEach
+        afterEach: assert => {
+            assert.ok(true, "nested afterEach called");
+        },
+    });
+
+    QUnit.test("call nested hooks", function(assert) {
+        assert.expect(4);
+    });
+});
+
+QUnit.test("`ok` assertion defined in the callback parameter", function(assert) {
+    assert.ok(true, "on the object passed to the `test` function");
+});
+
+QUnit.begin(function(details) {
+    console.log("Test amount:", details.totalTests);
+    for (const { name, moduleId } of details.modules) {
+        console.log(name, moduleId);
     }
-  } );
-
-  QUnit.test( "call nested hooks", function( assert ) {
-    assert.expect( 4 );
-  } );
-});
-
-QUnit.test( "`ok` assertion defined in the callback parameter", function( assert ) {
- assert.ok( true, "on the object passed to the `test` function" );
-});
-
-QUnit.begin(function( details ) {
-  console.log( "Test amount:", details.totalTests );
-  for (const {name, moduleId} of details.modules) {
-    console.log(name, moduleId)
-  }
 });
 
 QUnit.config.autostart = false;
 // require(
 //   [ "tests/testModule1", "tests/testModule2" ],
-  (function() {
+(function() {
     QUnit.start();
-  }())
+})();
 // );
 
 QUnit.test("some test", function() {
-  // a few regular assertions
-  // then a call to another tool
-  let codeUnderTest = () => {};
-  let speedTest = (name: string, cb: () => void) => cb();
-  speedTest( QUnit.config.current.testName, codeUnderTest );
+    // a few regular assertions
+    // then a call to another tool
+    let codeUnderTest = () => {};
+    let speedTest = (name: string, cb: () => void) => cb();
+    speedTest(QUnit.config.current.testName, codeUnderTest);
 });
 
 QUnit.config.urlConfig.push({
-  id: "min",
-  label: "Minified source",
-  tooltip: "Load minified source files instead of the regular unminified ones."
+    id: "min",
+    label: "Minified source",
+    tooltip: "Load minified source files instead of the regular unminified ones.",
 });
 
 QUnit.config.urlConfig.push({
-  id: "jquery",
-  label: "jQuery version",
-  value: [ "1.7.2", "1.8.3", "1.9.1" ],
-  tooltip: "What jQuery Core version to test against"
+    id: "jquery",
+    label: "jQuery version",
+    value: ["1.7.2", "1.8.3", "1.9.1"],
+    tooltip: "What jQuery Core version to test against",
 });
 
-QUnit.done(function( details ) {
-  console.log( "Total: ", details.total, " Failed: ", details.failed, " Passed: ", details.passed, " Runtime: ", details.runtime );
+QUnit.done(function(details) {
+    console.log(
+        "Total: ",
+        details.total,
+        " Failed: ",
+        details.failed,
+        " Passed: ",
+        details.passed,
+        " Runtime: ",
+        details.runtime,
+    );
 });
 
-QUnit.log(function( obj ) {
-
+QUnit.log(function(obj) {
     // Parse some stuff before sending it.
-    var actual = QUnit.dump.parse( obj.actual );
-    var expected = QUnit.dump.parse( obj.expected );
+    var actual = QUnit.dump.parse(obj.actual);
+    var expected = QUnit.dump.parse(obj.expected);
 
     // Send it.
     //   sendMessage( "qunit.log", obj.result, actual, expected, obj.message, obj.source );
     console.log("qunit.log", obj.result, actual, expected, obj.message, obj.source);
 });
 
-var qHeader = document.getElementById( "qunit-header" ),
-  parsed = QUnit.dump.parse( qHeader );
+var qHeader = document.getElementById("qunit-header"),
+    parsed = QUnit.dump.parse(qHeader);
 
-console.log( parsed );
+console.log(parsed);
 
 var input: any = {
-  parts: {
-    front: [],
-    back: []
-  }
+    parts: {
+        front: [],
+        back: [],
+    },
 };
 QUnit.dump.maxDepth = 1;
-console.log( QUnit.dump.parse( input ) );
+console.log(QUnit.dump.parse(input));
 // Logs: { "parts": [object Object] }
 
 QUnit.dump.maxDepth = 2;
-console.log( QUnit.dump.parse( input ) );
+console.log(QUnit.dump.parse(input));
 // Logs: { "parts": { "back": [object Array], "front": [object Array] } }
 
-QUnit.test( "QUnit.extend", function( assert ) {
-  var base: any = {
-    a: 1,
-    b: 2,
-    z: 3
-  };
-  QUnit.extend( base, {
-    b: 2.5,
-    c: 3,
-    z: undefined
-  } );
+QUnit.test("QUnit.extend", function(assert) {
+    var base: any = {
+        a: 1,
+        b: 2,
+        z: 3,
+    };
+    QUnit.extend(base, {
+        b: 2.5,
+        c: 3,
+        z: undefined,
+    });
 
-  assert.equal( base.a, 1, "Unspecified values are not modified" );
-  assert.equal( base.b, 2.5, "Existing values are updated" );
-  assert.equal( base.c, 3, "New values are defined" );
-  assert.ok( !( "z" in base ), "Values specified as `undefined` are removed" );
+    assert.equal(base.a, 1, "Unspecified values are not modified");
+    assert.equal(base.b, 2.5, "Existing values are updated");
+    assert.equal(base.c, 3, "New values are defined");
+    assert.ok(!("z" in base), "Values specified as `undefined` are removed");
 });
 
-QUnit.log(function( details ) {
-  console.log( "Log: ", details.result, details.message );
+QUnit.log(function(details) {
+    console.log("Log: ", details.result, details.message);
 });
 
-QUnit.log(function( details ) {
-  if ( details.result ) {
-    return;
-  }
-  var loc = details.module + ": " + details.name + ": ",
-    output = "FAILED: " + loc + ( details.message ? details.message + ", " : "" );
+QUnit.log(function(details) {
+    if (details.result) {
+        return;
+    }
+    var loc = details.module + ": " + details.name + ": ",
+        output = "FAILED: " + loc + (details.message ? details.message + ", " : "");
 
-  if ( details.actual ) {
-    output += "expected: " + details.expected + ", actual: " + details.actual;
-  }
-  if ( details.source ) {
-    output += ", " + details.source;
-  }
-  console.log( output );
+    if (details.actual) {
+        output += "expected: " + details.expected + ", actual: " + details.actual;
+    }
+    if (details.source) {
+        output += ", " + details.source;
+    }
+    console.log(output);
 });
 
-QUnit.log(function( details: QUnit.LogDetails ) {
-  let x: { actual: number; expected: number; message: string; module: string; name: string; result: boolean; runtime: number; source: string } = details;
-  x = details;
+QUnit.log(function(details: QUnit.LogDetails) {
+    let x: {
+        actual: number;
+        expected: number;
+        message: string;
+        module: string;
+        name: string;
+        result: boolean;
+        runtime: number;
+        source: string;
+    } = details;
+    x = details;
 });
 
-QUnit.begin(function( details: QUnit.BeginDetails ) {
-  console.log( "Total tests running: ", details.totalTests);
+QUnit.begin(function(details: QUnit.BeginDetails) {
+    console.log("Total tests running: ", details.totalTests);
 });
 
-QUnit.done(function( details: QUnit.DoneDetails ) {
-  console.log( "Finished. Failed/total: ", details.failed, details.total, details.passed, details.runtime );
+QUnit.done(function(details: QUnit.DoneDetails) {
+    console.log("Finished. Failed/total: ", details.failed, details.total, details.passed, details.runtime);
 });
 
-QUnit.moduleDone(function( details: QUnit.ModuleDoneDetails ) {
-  console.log( "Finished running: ", details.name, "Failed/total: ", details.failed, details.total, details.passed, details.runtime );
+QUnit.moduleDone(function(details: QUnit.ModuleDoneDetails) {
+    console.log(
+        "Finished running: ",
+        details.name,
+        "Failed/total: ",
+        details.failed,
+        details.total,
+        details.passed,
+        details.runtime,
+    );
 });
 
-QUnit.moduleStart(function( details: QUnit.ModuleStartDetails ) {
-  console.log( "Now running: ", details.name );
+QUnit.moduleStart(function(details: QUnit.ModuleStartDetails) {
+    console.log("Now running: ", details.name);
 });
-QUnit.testDone(function( details: QUnit.TestDoneDetails ) {
-  console.log( "Finished running: ", details.name, "Failed/total: ", details.failed, details.total, details.passed, details.runtime);
+QUnit.testDone(function(details: QUnit.TestDoneDetails) {
+    console.log(
+        "Finished running: ",
+        details.name,
+        "Failed/total: ",
+        details.failed,
+        details.total,
+        details.passed,
+        details.runtime,
+    );
 });
 
-QUnit.testStart(function( details: QUnit.TestStartDetails ) {
-  console.log( "Now running: ", details.name, ' from module ', details.module );
+QUnit.testStart(function(details: QUnit.TestStartDetails) {
+    console.log("Now running: ", details.name, " from module ", details.module);
 });
 
 let Robot: any = () => {};
 
-QUnit.module( "robot", {
-  beforeEach: function() {
-    this.robot = new Robot();
-  }
+QUnit.module("robot", {
+    beforeEach: function() {
+        this.robot = new Robot();
+    },
 });
 
-QUnit.test( "say", function( assert ) {
-  assert.ok( false, "I'm not quite ready yet" );
+QUnit.test("say", function(assert) {
+    assert.ok(false, "I'm not quite ready yet");
 });
 
-QUnit.test( "stomp", function( assert ) {
-  assert.ok( false, "I'm not quite ready yet" );
+QUnit.test("stomp", function(assert) {
+    assert.ok(false, "I'm not quite ready yet");
 });
 
 // You're currently working on the laser feature, so we run only this test
-QUnit.only( "laser", function( assert ) {
-  assert.ok( this.robot.laser() );
+QUnit.only("laser", function(assert) {
+    assert.ok(this.robot.laser());
 });
 
-
-QUnit.module( "robot", {
-  beforeEach: function() {
-    this.robot = new Robot();
-  }
+QUnit.module("robot", {
+    beforeEach: function() {
+        this.robot = new Robot();
+    },
 });
 
-QUnit.test( "say", function( assert ) {
-  assert.strictEqual( this.robot.say(), "Exterminate!" );
+QUnit.test("say", function(assert) {
+    assert.strictEqual(this.robot.say(), "Exterminate!");
 });
 
 // Robot doesn't have a laser method, yet, skip this test
 // Will show up as skipped in the results
-QUnit.skip( "laser", function( assert ) {
-  assert.ok( this.robot.laser() );
+QUnit.skip("laser", function(assert) {
+    assert.ok(this.robot.laser());
 });
 
-QUnit.log( function( details ) {
-  if ( details.result ) {
+QUnit.log(function(details) {
+    if (details.result) {
+        // 5 is the line reference for the assertion method, not the following line.
+        console.log(QUnit.stack(5));
+    }
+});
 
-    // 5 is the line reference for the assertion method, not the following line.
-    console.log( QUnit.stack( 5 ) );
-  }
-} );
-
-QUnit.test( "foo", function( assert ) {
-
-  // the log callback will report the position of the following line.
-  assert.ok( true );
-} );
+QUnit.test("foo", function(assert) {
+    // the log callback will report the position of the following line.
+    assert.ok(true);
+});
 
 QUnit.config.autostart = false;
 
 // require(["test/tests1.js", "test/tests2.js"], function() {
-  (() => { QUnit.start(); })()
+(() => {
+    QUnit.start();
+})();
 // });
 
-QUnit.test( "a test", function( assert ) {
+QUnit.test("a test", function(assert) {
+    function square(x: number) {
+        return x * x;
+    }
 
-  function square( x: number ) {
-    return x * x;
-  }
+    var result = square(2);
 
-  var result = square( 2 );
-
-  assert.equal( result, 4, "square(2) equals 4" );
+    assert.equal(result, 4, "square(2) equals 4");
 });
 
 // declare var Promise: any;
-QUnit.test( "a Promise-returning test", function( assert ) {
-  assert.expect( 0 );
-  var thenable = new Promise<void>(function( resolve: any, reject: any ) {
-    setTimeout(function() {
-      resolve();
-    }, 500 );
-  });
-  return thenable;
+QUnit.test("a Promise-returning test", function(assert) {
+    assert.expect(0);
+    var thenable = new Promise<void>(function(resolve: any, reject: any) {
+        setTimeout(function() {
+            resolve();
+        }, 500);
+    });
+    return thenable;
 });
-
 
 declare var $: any;
-QUnit.test( "assert.async() test", function( assert ) {
-  var done = assert.async();
-  var input = $( "#test-input" ).focus();
-  setTimeout(function() {
-    assert.equal( document.activeElement, input[0], "Input was focused" );
-    done();
-  });
+QUnit.test("assert.async() test", function(assert) {
+    var done = assert.async();
+    var input = $("#test-input").focus();
+    setTimeout(function() {
+        assert.equal(document.activeElement, input[0], "Input was focused");
+        done();
+    });
 });
 
-QUnit.test( "two async calls", function( assert ) {
-  assert.expect( 2 );
+QUnit.test("two async calls", function(assert) {
+    assert.expect(2);
 
-  var done1 = assert.async();
-  var done2 = assert.async();
-  setTimeout(function() {
-    assert.ok( true, "test resumed from async operation 1" );
-    done1();
-  }, 500 );
-  setTimeout(function() {
-    assert.ok( true, "test resumed from async operation 2" );
-    done2();
-  }, 150);
+    var done1 = assert.async();
+    var done2 = assert.async();
+    setTimeout(function() {
+        assert.ok(true, "test resumed from async operation 1");
+        done1();
+    }, 500);
+    setTimeout(function() {
+        assert.ok(true, "test resumed from async operation 2");
+        done2();
+    }, 150);
 });
 
-QUnit.test( "multiple call done()", function( assert ) {
-  assert.expect( 3 );
-  var done = assert.async( 3 );
+QUnit.test("multiple call done()", function(assert) {
+    assert.expect(3);
+    var done = assert.async(3);
 
-  setTimeout(function() {
-    assert.ok( true, "first call done." );
-    done();
-  }, 500 );
+    setTimeout(function() {
+        assert.ok(true, "first call done.");
+        done();
+    }, 500);
 
-  setTimeout(function() {
-    assert.ok( true, "second call done." );
-    done();
-  }, 500 );
+    setTimeout(function() {
+        assert.ok(true, "second call done.");
+        done();
+    }, 500);
 
-  setTimeout(function() {
-    assert.ok( true, "third call done." );
-    done();
-  }, 500 );
+    setTimeout(function() {
+        assert.ok(true, "third call done.");
+        done();
+    }, 500);
 });
 
+QUnit.test("deepEqual test", function(assert) {
+    var obj = { foo: "bar" };
 
-QUnit.test( "deepEqual test", function( assert ) {
-  var obj = { foo: "bar" };
-
-  assert.deepEqual( obj, { foo: "bar" }, "Two objects can be the same in value" );
+    assert.deepEqual(obj, { foo: "bar" }, "Two objects can be the same in value");
 });
 
-QUnit.test( "false assertion test", function( assert ) {
-  var foo = false;
+QUnit.test("false assertion test", function(assert) {
+    var foo = false;
 
-  assert.false( foo );
-  assert.false( foo, "some message" );
+    assert.false(foo);
+    assert.false(foo, "some message");
 });
 
-QUnit.test( "ok test", function( assert ) {
-  assert.ok( true, "true succeeds" );
-  assert.ok( "non-empty", "non-empty string succeeds" );
+QUnit.test("ok test", function(assert) {
+    assert.ok(true, "true succeeds");
+    assert.ok("non-empty", "non-empty string succeeds");
 
-  assert.ok( false, "false fails" );
-  assert.ok( 0, "0 fails" );
-  assert.ok( NaN, "NaN fails" );
-  assert.ok( "", "empty string fails" );
-  assert.ok( null, "null fails" );
-  assert.ok( undefined, "undefined fails" );
+    assert.ok(false, "false fails");
+    assert.ok(0, "0 fails");
+    assert.ok(NaN, "NaN fails");
+    assert.ok("", "empty string fails");
+    assert.ok(null, "null fails");
+    assert.ok(undefined, "undefined fails");
 });
 
-QUnit.test( "a test", function( assert ) {
-  assert.equal( 1, "1", "String '1' and number 1 have the same value" );
+QUnit.test("a test", function(assert) {
+    assert.equal(1, "1", "String '1' and number 1 have the same value");
 });
 
+QUnit.test("equal test", function(assert) {
+    assert.equal(0, 0, "Zero, Zero; equal succeeds");
+    assert.equal("", 0, "Empty, Zero; equal succeeds");
+    assert.equal("", "", "Empty, Empty; equal succeeds");
 
-QUnit.test( "equal test", function( assert ) {
-  assert.equal( 0, 0, "Zero, Zero; equal succeeds" );
-  assert.equal( "", 0, "Empty, Zero; equal succeeds" );
-  assert.equal( "", "", "Empty, Empty; equal succeeds" );
-
-  assert.equal( "three", 3, "Three, 3; equal fails" );
-  assert.equal( null, false, "null, false; equal fails" );
+    assert.equal("three", 3, "Three, 3; equal fails");
+    assert.equal(null, false, "null, false; equal fails");
 });
 
-QUnit.test( "a test", function( assert ) {
-  assert.expect( 2 );
+QUnit.test("a test", function(assert) {
+    assert.expect(2);
 
-  function calc( x: number, operation: (x:number)=> number ) {
-    return operation( x );
-  }
-
-  var result = calc( 2, function( x ) {
-    assert.ok( true, "calc() calls operation function" );
-    return x * x;
-  });
-
-  assert.equal( result, 4, "2 squared equals 4" );
-});
-
-
-QUnit.test( "notDeepEqual test", function( assert ) {
-  var obj = { foo: "bar" };
-
-  assert.notDeepEqual( obj, { foo: "bla" }, "Different object, same key, different value, not equal" );
-});
-
-
-QUnit.test( "a test", function( assert ) {
-  assert.notEqual( 1, "2", "String '2' and number 1 don't have the same value" );
-});
-
-QUnit.test( "notOk test", function( assert ) {
-  assert.notOk( false, "false succeeds" );
-  assert.notOk( "", "empty string succeeds" );
-  assert.notOk( NaN, "NaN succeeds" );
-  assert.notOk( null, "null succeeds" );
-  assert.notOk( undefined, "undefined succeeds" );
-
-  assert.notOk( true, "true fails" );
-  assert.notOk( 1, "1 fails" );
-  assert.notOk( "not-empty", "not-empty string fails" );
-});
-
-QUnit.test( "notPropContains test", function( assert ) {
-    const obj = { foo: 1, bar: "baz" }
-
-    assert.notPropContains( obj, { foo: 1 }, "Subset of values are strictly compared." );
-    assert.notPropContains( obj, { bar: { length: 3 } }, "Subset of values are strictly compared." );
-});
-
-QUnit.test( "notPropEqual test", function( assert ) {
-  class Foo {
-    x: any;
-    y: any;
-    z: any;
-    constructor( x: any, y: any, z: any ) {
-      this.x = x;
-      this.y = y;
-      this.z = z;
+    function calc(x: number, operation: (x: number) => number) {
+        return operation(x);
     }
 
-    doA = function () {};
-    doB = function () {};
-    bar = 'prototype';
-  }
-  var foo = new Foo( 1, "2", [] );
-  var bar = new Foo( "1", 2, {} );
-  assert.notPropEqual( foo, bar, "Properties values are strictly compared." );
+    var result = calc(2, function(x) {
+        assert.ok(true, "calc() calls operation function");
+        return x * x;
+    });
+
+    assert.equal(result, 4, "2 squared equals 4");
 });
 
+QUnit.test("notDeepEqual test", function(assert) {
+    var obj = { foo: "bar" };
 
-QUnit.test( "a test", function( assert ) {
-  assert.notStrictEqual( 1, "1", "String '1' and number 1 have the same value but not the same type" );
+    assert.notDeepEqual(obj, { foo: "bla" }, "Different object, same key, different value, not equal");
 });
 
-QUnit.test( "propContains test", function( assert ) {
-    const obj = { foo: 1, bar: "baz" }
-
-    assert.propContains( obj, { foo: 1 }, "Subset of values are strictly compared." );
-    assert.propContains( obj, { bar: { length: 3 } }, "Subset of values are strictly compared." );
+QUnit.test("a test", function(assert) {
+    assert.notEqual(1, "2", "String '2' and number 1 don't have the same value");
 });
 
-QUnit.test( "propEqual test", function( assert ) {
-  class Foo {
-    x: any;
-    y: any;
-    z: any;
-    constructor( x: any, y: any, z: any ) {
-      this.x = x;
-      this.y = y;
-      this.z = z;
+QUnit.test("notOk test", function(assert) {
+    assert.notOk(false, "false succeeds");
+    assert.notOk("", "empty string succeeds");
+    assert.notOk(NaN, "NaN succeeds");
+    assert.notOk(null, "null succeeds");
+    assert.notOk(undefined, "undefined succeeds");
+
+    assert.notOk(true, "true fails");
+    assert.notOk(1, "1 fails");
+    assert.notOk("not-empty", "not-empty string fails");
+});
+
+QUnit.test("notPropContains test", function(assert) {
+    const obj = { foo: 1, bar: "baz" };
+
+    assert.notPropContains(obj, { foo: 1 }, "Subset of values are strictly compared.");
+    assert.notPropContains(obj, { bar: { length: 3 } }, "Subset of values are strictly compared.");
+});
+
+QUnit.test("notPropEqual test", function(assert) {
+    class Foo {
+        x: any;
+        y: any;
+        z: any;
+        constructor(x: any, y: any, z: any) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        doA = function() {};
+        doB = function() {};
+        bar = "prototype";
+    }
+    var foo = new Foo(1, "2", []);
+    var bar = new Foo("1", 2, {});
+    assert.notPropEqual(foo, bar, "Properties values are strictly compared.");
+});
+
+QUnit.test("a test", function(assert) {
+    assert.notStrictEqual(1, "1", "String '1' and number 1 have the same value but not the same type");
+});
+
+QUnit.test("propContains test", function(assert) {
+    const obj = { foo: 1, bar: "baz" };
+
+    assert.propContains(obj, { foo: 1 }, "Subset of values are strictly compared.");
+    assert.propContains(obj, { bar: { length: 3 } }, "Subset of values are strictly compared.");
+});
+
+QUnit.test("propEqual test", function(assert) {
+    class Foo {
+        x: any;
+        y: any;
+        z: any;
+        constructor(x: any, y: any, z: any) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        doA = function() {};
+        doB = function() {};
+        bar = "prototype";
     }
 
-    doA = function () {};
-    doB = function () {};
-    bar = 'prototype';
-  }
-
-  var foo = new Foo( 1, "2", [] );
-  var bar: any = {
-    x : 1,
-    y : "2",
-    z : []
-  };
-  assert.propEqual( foo, bar, "Strictly the same properties without comparing objects constructors." );
+    var foo = new Foo(1, "2", []);
+    var bar: any = {
+        x: 1,
+        y: "2",
+        z: [],
+    };
+    assert.propEqual(foo, bar, "Strictly the same properties without comparing objects constructors.");
 });
 
-QUnit.test( "Assert plugin", function ( assert ) {
+QUnit.test("Assert plugin", function(assert) {
     const actual = 42;
     const from = 40;
     const to = 50;
-    const isBetween = (actual >= from && actual <= to);
+    const isBetween = actual >= from && actual <= to;
     assert.pushResult({
         result: isBetween,
         actual: actual,
         expected: `between ${from} and ${to} inclusive`,
-        message: 'message'
+        message: "message",
     });
 
     // without message
     assert.pushResult({
         result: isBetween,
         actual: actual,
-        expected: `between ${from} and ${to} inclusive`
+        expected: `between ${from} and ${to} inclusive`,
     });
 
     // with stack
@@ -576,266 +597,262 @@ QUnit.test( "Assert plugin", function ( assert ) {
         result: isBetween,
         actual: actual,
         expected: `between ${from} and ${to} inclusive`,
-        message: 'message',
-        source: new Error().stack
+        message: "message",
+        source: new Error().stack,
     });
 });
 
-QUnit.test( "throws", function( assert ) {
-
- class CustomError {
-   message: string;
-   constructor(message: string) {
-      this.message = message;
-   }
-   toString = function() {
-      return this.message;
+QUnit.test("throws", function(assert) {
+    class CustomError {
+        message: string;
+        constructor(message: string) {
+            this.message = message;
+        }
+        toString = function() {
+            return this.message;
+        };
     }
- }
 
-  assert.throws(
-    function() {
-      throw "error"
-    },
-    "throws with just a message, not using the 'expected' argument"
-  );
+    assert.throws(
+        function() {
+            throw "error";
+        },
+        "throws with just a message, not using the 'expected' argument",
+    );
 
-  assert.throws(
-    function() {
-      throw new CustomError("some error description");
-    },
-    /description/,
-    "raised error message contains 'description'"
-  );
+    assert.throws(
+        function() {
+            throw new CustomError("some error description");
+        },
+        /description/,
+        "raised error message contains 'description'",
+    );
 
-  assert.throws(
-    function() {
-      throw new Error();
-    },
-    CustomError,
-    "raised error is an instance of CustomError"
-  );
+    assert.throws(
+        function() {
+            throw new Error();
+        },
+        CustomError,
+        "raised error is an instance of CustomError",
+    );
 
-  assert.throws(
-    function() {
-      throw new CustomError("some error description");
-    },
-    new CustomError("some error description"),
-    "raised error instance matches the CustomError instance"
-  );
+    assert.throws(
+        function() {
+            throw new CustomError("some error description");
+        },
+        new CustomError("some error description"),
+        "raised error instance matches the CustomError instance",
+    );
 
-  assert.throws(
-    function() {
-      throw new CustomError("some error description");
-    },
-    function( err: any ) {
-      return err.toString() === "some error description";
-    },
-    "raised error instance satisfies the callback function"
-  );
+    assert.throws(
+        function() {
+            throw new CustomError("some error description");
+        },
+        function(err: any) {
+            return err.toString() === "some error description";
+        },
+        "raised error instance satisfies the callback function",
+    );
 });
 
-QUnit.test( "true assertion test", function( assert ) {
+QUnit.test("true assertion test", function(assert) {
     var foo = true;
 
-    assert.true( foo );
-    assert.true( foo, "some message" );
-  });
+    assert.true(foo);
+    assert.true(foo, "some message");
+});
 
-QUnit.test( "rejects", function( assert ) {
+QUnit.test("rejects", function(assert) {
+    assert.rejects(Promise.reject("some error description"));
 
-  assert.rejects(Promise.reject("some error description"));
+    assert.rejects(
+        Promise.reject(new Error("some error description")),
+        "rejects with just a message, not using the 'expectedMatcher' argument",
+    );
 
-  assert.rejects(
-    Promise.reject(new Error("some error description")),
-    "rejects with just a message, not using the 'expectedMatcher' argument"
-  );
+    assert.rejects(
+        Promise.reject(new Error("some error description")),
+        /description/,
+        "`rejectionValue.toString()` contains `description`",
+    );
 
-  assert.rejects(
-    Promise.reject(new Error("some error description")),
-    /description/,
-    "`rejectionValue.toString()` contains `description`"
-  );
-
-  // Using a custom error like object
-  class CustomError {
-    message?: string | undefined;
-    constructor(message?: string) {
-       this.message = message;
+    // Using a custom error like object
+    class CustomError {
+        message?: string | undefined;
+        constructor(message?: string) {
+            this.message = message;
+        }
+        toString() {
+            return this.message;
+        }
     }
-    toString() {
-       return this.message;
+
+    assert.rejects(
+        Promise.reject(new CustomError()),
+        CustomError,
+        "raised error is an instance of CustomError",
+    );
+
+    assert.rejects(
+        Promise.reject(new CustomError("some error description")),
+        new CustomError("some error description"),
+        "raised error instance matches the CustomError instance",
+    );
+
+    assert.rejects(
+        Promise.reject(new CustomError("some error description")),
+        function(err) {
+            return err.toString() === "some error description";
+        },
+        "raised error instance satisfies the callback function",
+    );
+});
+
+QUnit.test("stateful rejects example", async assert => {
+    let value;
+
+    function asyncChecker() {
+        return (value < 5) ? Promise.resolve(true) : Promise.reject("bad value: " + value);
     }
-  }
 
-  assert.rejects(
-    Promise.reject(new CustomError()),
-    CustomError,
-    "raised error is an instance of CustomError"
-  );
+    value = 8;
+    await assert.rejects(asyncChecker(), /bad value: 8/);
 
-  assert.rejects(
-    Promise.reject(new CustomError("some error description")),
-    new CustomError("some error description"),
-    "raised error instance matches the CustomError instance"
-  );
+    value = Infinity;
+    await assert.rejects(asyncChecker(), /bad value: Infinity/);
+});
 
-  assert.rejects(
-    Promise.reject(new CustomError("some error description")),
-    function( err ) {
-      return err.toString() === "some error description";
+QUnit.module("module", {
+    beforeEach: function(assert) {
+        assert.ok(true, "one extra assert per test");
     },
-    "raised error instance satisfies the callback function"
-  );
+    afterEach: function(assert) {
+        assert.ok(true, "and one extra assert after each test");
+    },
+});
+QUnit.test("test with beforeEach and afterEach", function(assert) {
+    assert.expect(2);
 });
 
-QUnit.test('stateful rejects example', async assert => {
-  let value;
-
-  function asyncChecker () {
-    return (value < 5) ? Promise.resolve(true) : Promise.reject('bad value: ' + value);
-  }
-
-  value = 8;
-  await assert.rejects(asyncChecker(), /bad value: 8/);
-
-  value = Infinity;
-  await assert.rejects(asyncChecker(), /bad value: Infinity/);
-});
-
-QUnit.module( "module", {
-  beforeEach: function( assert ) {
-    assert.ok( true, "one extra assert per test" );
-  }, afterEach: function( assert ) {
-    assert.ok( true, "and one extra assert after each test" );
-  }
-});
-QUnit.test( "test with beforeEach and afterEach", function( assert ) {
-  assert.expect( 2 );
-});
-
-QUnit.todo( "a todo test", function( assert ) {
-  assert.equal( 0, 1, "0 does not equal 1, so this todo should pass" );
+QUnit.todo("a todo test", function(assert) {
+    assert.equal(0, 1, "0 does not equal 1, so this todo should pass");
 });
 
 let equivResult: boolean;
 equivResult = QUnit.equiv({}, {});
 equivResult = QUnit.equiv(1, 2);
-equivResult = QUnit.equiv('foo', 'bar');
-equivResult = QUnit.equiv(['foo'], ['bar']);
+equivResult = QUnit.equiv("foo", "bar");
+equivResult = QUnit.equiv(["foo"], ["bar"]);
 
-
-QUnit.test('steps', assert => {
-  assert.step('one');
-  assert.step('two');
-  assert.step('three');
-  assert.verifySteps(['one', 'two', 'three'], 'Counting to three correctly');
+QUnit.test("steps", assert => {
+    assert.step("one");
+    assert.step("two");
+    assert.step("three");
+    assert.verifySteps(["one", "two", "three"], "Counting to three correctly");
 });
 
 async function timeout() {
-  return new Promise(resolve => setTimeout(resolve, 1));
+    return new Promise(resolve => setTimeout(resolve, 1));
 }
 
 // These async tests are intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
 // However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
 // so we can't properly test it.
 QUnit.begin(async function() {
-  await timeout();
+    await timeout();
 });
 
 QUnit.done(async function() {
-  await timeout();
+    await timeout();
 });
 
 QUnit.moduleDone(async function() {
-  await timeout();
+    await timeout();
 });
 
 QUnit.moduleStart(async function() {
-  await timeout();
+    await timeout();
 });
 
 QUnit.testDone(async function() {
-  await timeout();
+    await timeout();
 });
 
 QUnit.testStart(async function() {
-  await timeout();
+    await timeout();
 });
 
-QUnit.test( "async test", async function( assert ) {
-  await timeout();
-  assert.ok(true);
+QUnit.test("async test", async function(assert) {
+    await timeout();
+    assert.ok(true);
 });
 
-QUnit.only( "async only", async function( assert ) {
-  await timeout();
-  assert.ok(true);
+QUnit.only("async only", async function(assert) {
+    await timeout();
+    assert.ok(true);
 });
 
-
-QUnit.skip( "async skip", async function( assert ) {
-  await timeout();
-  assert.ok(true);
+QUnit.skip("async skip", async function(assert) {
+    await timeout();
+    assert.ok(true);
 });
 
-QUnit.hooks.beforeEach(async function () {
-  await timeout();
+QUnit.hooks.beforeEach(async function() {
+    await timeout();
 });
 
-QUnit.hooks.afterEach(async function () {
-  await timeout();
+QUnit.hooks.afterEach(async function() {
+    await timeout();
 });
 
+QUnit.module("async", {
+    async after(assert) {
+        await timeout();
+        assert.ok(true, "async after called");
+    },
 
-QUnit.module( "async", {
-  async after( assert ) {
-    await timeout();
-    assert.ok( true, "async after called" );
-  },
+    async before(assert) {
+        await timeout();
+        assert.ok(true, "async before called");
+    },
 
-  async before( assert ) {
-    await timeout();
-    assert.ok( true, "async before called" );
-  },
+    async beforeEach(assert) {
+        await timeout();
+        assert.ok(true, "async beforeEach called");
+    },
 
-  async beforeEach( assert ) {
-    await timeout();
-    assert.ok( true, "async beforeEach called" );
-  },
-
-  async afterEach( assert ) {
-    await timeout();
-    assert.ok( true, "async afterEach called" );
-  }
+    async afterEach(assert) {
+        await timeout();
+        assert.ok(true, "async afterEach called");
+    },
 });
 
-QUnit.module( "async nested hooks", function( hooks ) {
-  hooks.after( async function( assert ) {
-    await timeout();
-    assert.ok( true, "async after called" );
-  } );
+QUnit.module("async nested hooks", function(hooks) {
+    hooks.after(async function(assert) {
+        await timeout();
+        assert.ok(true, "async after called");
+    });
 
-  hooks.before( async function( assert ) {
-    await timeout();
-    assert.ok( true, "async before called" );
-  } );
+    hooks.before(async function(assert) {
+        await timeout();
+        assert.ok(true, "async before called");
+    });
 
-  hooks.beforeEach( async function( assert ) {
-    await timeout();
-    assert.ok( true, "async beforeEach called" );
-  } );
+    hooks.beforeEach(async function(assert) {
+        await timeout();
+        assert.ok(true, "async beforeEach called");
+    });
 
-  hooks.afterEach( async function( assert ) {
-    await timeout();
-    assert.ok( true, "async afterEach called" );
-  } );
+    hooks.afterEach(async function(assert) {
+        await timeout();
+        assert.ok(true, "async afterEach called");
+    });
 });
 
 QUnit.onUncaughtException = (error: unknown) => {
-  if (error instanceof Error) {
-    console.log(error.message);
-  }
+    if (error instanceof Error) {
+        console.log(error.message);
+    }
 };
 
 QUnit.config.testTimeout = null;

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -1,33 +1,31 @@
-import * as QUnit from 'qunit';
+import * as QUnit from "qunit";
 
-QUnit.module( "basic tests for importing QUnit", function( hooks ) {
+QUnit.module("basic tests for importing QUnit", function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
 
-  hooks.beforeEach( function( assert ) {
-    assert.ok( true, "beforeEach called" );
-  } );
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
 
-  hooks.afterEach( function( assert ) {
-    assert.ok( true, "afterEach called" );
-  } );
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    });
 
-  QUnit.test( "call hooks", function( assert ) {
-    assert.expect( 2 );
-  } );
+    QUnit.module("stacked hooks", function(hooks) {
+        // This will run after the parent module's beforeEach hook
+        hooks.beforeEach(function(assert) {
+            assert.ok(true, "nested beforeEach called");
+        });
 
-  QUnit.module( "stacked hooks", function( hooks ) {
+        // This will run before the parent module's afterEach
+        hooks.afterEach(function(assert) {
+            assert.ok(true, "nested afterEach called");
+        });
 
-    // This will run after the parent module's beforeEach hook
-    hooks.beforeEach( function( assert ) {
-      assert.ok( true, "nested beforeEach called" );
-    } );
-
-    // This will run before the parent module's afterEach
-    hooks.afterEach( function( assert ) {
-      assert.ok( true, "nested afterEach called" );
-    } );
-
-    QUnit.test( "call hooks", function( assert ) {
-      assert.expect( 4 );
-    } );
-  } );
-} );
+        QUnit.test("call hooks", function(assert) {
+            assert.expect(4);
+        });
+    });
+});

--- a/types/qunit/v1/index.d.ts
+++ b/types/qunit/v1/index.d.ts
@@ -3,128 +3,127 @@
 // Definitions by: Diullei Gomes <https://github.com/diullei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 interface DoneCallbackObject {
     /**
-    * The number of failed assertions
-    */
+     * The number of failed assertions
+     */
     failed: number;
 
     /**
-    * The number of passed assertions
-    */
+     * The number of passed assertions
+     */
     passed: number;
 
     /**
-    * The total number of assertions
-    */
+     * The total number of assertions
+     */
     total: number;
 
     /**
-    * The time in milliseconds it took tests to run from start to finish.
-    */
+     * The time in milliseconds it took tests to run from start to finish.
+     */
     runtime: number;
 }
 
 interface LogCallbackObject {
     /**
-    * The boolean result of an assertion, true means passed, false means failed.
-    */
+     * The boolean result of an assertion, true means passed, false means failed.
+     */
     result: boolean;
 
     /**
-    * One side of a comparision assertion. Can be undefined when ok() is used.
-    */
+     * One side of a comparision assertion. Can be undefined when ok() is used.
+     */
     actual: Object;
 
     /**
-    * One side of a comparision assertion. Can be undefined when ok() is used.
-    */
+     * One side of a comparision assertion. Can be undefined when ok() is used.
+     */
     expected: Object;
 
     /**
-    * A string description provided by the assertion.
-    */
+     * A string description provided by the assertion.
+     */
     message: string;
 
     /**
-    * The associated stacktrace, either from an exception or pointing to the source 
-    * of the assertion. Depends on browser support for providing stacktraces, so can be 
-    * undefined.
-    */
+     * The associated stacktrace, either from an exception or pointing to the source
+     * of the assertion. Depends on browser support for providing stacktraces, so can be
+     * undefined.
+     */
     source: string;
 }
 
 interface ModuleStartCallbackObject {
     /**
-    * Name of the next module to run
-    */
+     * Name of the next module to run
+     */
     name: string;
 }
 
 interface ModuleDoneCallbackObject {
     /**
-    * Name of this module
-    */
+     * Name of this module
+     */
     name: string;
 
     /**
-    * The number of failed assertions
-    */
+     * The number of failed assertions
+     */
     failed: number;
 
     /**
-    * The number of passed assertions
-    */
+     * The number of passed assertions
+     */
     passed: number;
 
     /**
-    * The total number of assertions
-    */
+     * The total number of assertions
+     */
     total: number;
 }
 
 interface TestDoneCallbackObject {
     /**
-    * TName of the next test to run
-    */
+     * TName of the next test to run
+     */
     name: string;
 
     /**
-    * Name of the current module
-    */
+     * Name of the current module
+     */
     module: string;
 
     /**
-    * The number of failed assertions
-    */
+     * The number of failed assertions
+     */
     failed: number;
 
     /**
-    * The number of passed assertions
-    */
+     * The number of passed assertions
+     */
     passed: number;
 
     /**
-    * The total number of assertions
-    */
+     * The total number of assertions
+     */
     total: number;
 
     /**
-    * The total runtime, including setup and teardown
-    */
+     * The total runtime, including setup and teardown
+     */
     duration: number;
 }
 
 interface TestStartCallbackObject {
     /**
-    * Name of the next test to run
-    */
+     * Name of the next test to run
+     */
     name: string;
 
     /**
-    * Name of the current module
-    */
+     * Name of the current module
+     */
     module: string;
 }
 
@@ -183,79 +182,79 @@ interface QUnitAssert {
     jsDump: any;
 
     /**
-    * Instruct QUnit to wait for an asynchronous operation.
-    * 
-    * When your test has any asynchronous exit points, call assert.async() to get a unique
-    * resolution callback for each async operation. The callback returned from assert.async()
-    * will throw an Error if is invoked more than once.
-    */
+     * Instruct QUnit to wait for an asynchronous operation.
+     *
+     * When your test has any asynchronous exit points, call assert.async() to get a unique
+     * resolution callback for each async operation. The callback returned from assert.async()
+     * will throw an Error if is invoked more than once.
+     */
     async(): () => void;
 
     /**
-    * A deep recursive comparison assertion, working on primitive types, arrays, objects, 
-    * regular expressions, dates and functions.
-    *
-    * The deepEqual() assertion can be used just like equal() when comparing the value of 
-    * objects, such that { key: value } is equal to { key: value }. For non-scalar values, 
-    * identity will be disregarded by deepEqual.
-    *
-    * @param actual Object or Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+     * A deep recursive comparison assertion, working on primitive types, arrays, objects,
+     * regular expressions, dates and functions.
+     *
+     * The deepEqual() assertion can be used just like equal() when comparing the value of
+     * objects, such that { key: value } is equal to { key: value }. For non-scalar values,
+     * identity will be disregarded by deepEqual.
+     *
+     * @param actual Object or Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     deepEqual(actual: any, expected: any, message?: string): any;
 
-    /** 
-    * A non-strict comparison assertion, roughly equivalent to JUnit assertEquals.
-    *
-    * The equal assertion uses the simple comparison operator (==) to compare the actual 
-    * and expected arguments. When they are equal, the assertion passes: any; otherwise, it fails. 
-    * When it fails, both actual and expected values are displayed in the test result, 
-    * in addition to a given message.
-    * 
-    * @param actual Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+    /**
+     * A non-strict comparison assertion, roughly equivalent to JUnit assertEquals.
+     *
+     * The equal assertion uses the simple comparison operator (==) to compare the actual
+     * and expected arguments. When they are equal, the assertion passes: any; otherwise, it fails.
+     * When it fails, both actual and expected values are displayed in the test result,
+     * in addition to a given message.
+     *
+     * @param actual Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     equal(actual: any, expected: any, message?: string): any;
 
     /**
-    * Specify how many assertions are expected to run within a test.
-    *
-    * To ensure that an explicit number of assertions are run within any test, use 
-    * expect( number ) to register an expected count. If the number of assertions 
-    * run does not match the expected count, the test will fail.
-    *
-    * @param amount Number of assertions in this test.
-    */
+     * Specify how many assertions are expected to run within a test.
+     *
+     * To ensure that an explicit number of assertions are run within any test, use
+     * expect( number ) to register an expected count. If the number of assertions
+     * run does not match the expected count, the test will fail.
+     *
+     * @param amount Number of assertions in this test.
+     */
     expect(amount: number): any;
 
     /**
-    * An inverted deep recursive comparison assertion, working on primitive types, 
-    * arrays, objects, regular expressions, dates and functions.
-    *
-    * The notDeepEqual() assertion can be used just like equal() when comparing the 
-    * value of objects, such that { key: value } is equal to { key: value }. For non-scalar 
-    * values, identity will be disregarded by notDeepEqual.
-    * 
-    * @param actual Object or Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+     * An inverted deep recursive comparison assertion, working on primitive types,
+     * arrays, objects, regular expressions, dates and functions.
+     *
+     * The notDeepEqual() assertion can be used just like equal() when comparing the
+     * value of objects, such that { key: value } is equal to { key: value }. For non-scalar
+     * values, identity will be disregarded by notDeepEqual.
+     *
+     * @param actual Object or Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     notDeepEqual(actual: any, expected: any, message?: string): any;
 
     /**
-    * A non-strict comparison assertion, checking for inequality.
-    *
-    * The notEqual assertion uses the simple inverted comparison operator (!=) to compare 
-    * the actual and expected arguments. When they aren't equal, the assertion passes: any; 
-    * otherwise, it fails. When it fails, both actual and expected values are displayed 
-    * in the test result, in addition to a given message.
-    * 
-    * @param actual Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+     * A non-strict comparison assertion, checking for inequality.
+     *
+     * The notEqual assertion uses the simple inverted comparison operator (!=) to compare
+     * the actual and expected arguments. When they aren't equal, the assertion passes: any;
+     * otherwise, it fails. When it fails, both actual and expected values are displayed
+     * in the test result, in addition to a given message.
+     *
+     * @param actual Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     notEqual(actual: any, expected: any, message?: string): any;
 
     notPropEqual(actual: any, expected: any, message?: string): any;
@@ -263,525 +262,525 @@ interface QUnitAssert {
     propEqual(actual: any, expected: any, message?: string): any;
 
     /**
-    * A non-strict comparison assertion, checking for inequality.
-    *
-    * The notStrictEqual assertion uses the strict inverted comparison operator (!==) 
-    * to compare the actual and expected arguments. When they aren't equal, the assertion 
-    * passes: any; otherwise, it fails. When it fails, both actual and expected values are 
-    * displayed in the test result, in addition to a given message.
-    * 
-    * @param actual Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+     * A non-strict comparison assertion, checking for inequality.
+     *
+     * The notStrictEqual assertion uses the strict inverted comparison operator (!==)
+     * to compare the actual and expected arguments. When they aren't equal, the assertion
+     * passes: any; otherwise, it fails. When it fails, both actual and expected values are
+     * displayed in the test result, in addition to a given message.
+     *
+     * @param actual Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     notStrictEqual(actual: any, expected: any, message?: string): any;
 
     /**
-    * A boolean assertion, equivalent to CommonJS’s assert.ok() and JUnit’s assertTrue(). 
-    * Passes if the first argument is truthy.
-    *
-    * The most basic assertion in QUnit, ok() requires just one argument. If the argument 
-    * evaluates to true, the assertion passes; otherwise, it fails. If a second message 
-    * argument is provided, it will be displayed in place of the result.
-    * 
-    * @param state Expression being tested
-    * @param message A short description of the assertion
-    */
+     * A boolean assertion, equivalent to CommonJS’s assert.ok() and JUnit’s assertTrue().
+     * Passes if the first argument is truthy.
+     *
+     * The most basic assertion in QUnit, ok() requires just one argument. If the argument
+     * evaluates to true, the assertion passes; otherwise, it fails. If a second message
+     * argument is provided, it will be displayed in place of the result.
+     *
+     * @param state Expression being tested
+     * @param message A short description of the assertion
+     */
     ok(state: any, message?: string): any;
 
     /**
-    * A strict type and value comparison assertion.
-    *
-    * The strictEqual() assertion provides the most rigid comparison of type and value with 
-    * the strict equality operator (===)
-    * 
-    * @param actual Expression being tested
-    * @param expected Known comparison value
-    * @param message A short description of the assertion
-    */
+     * A strict type and value comparison assertion.
+     *
+     * The strictEqual() assertion provides the most rigid comparison of type and value with
+     * the strict equality operator (===)
+     *
+     * @param actual Expression being tested
+     * @param expected Known comparison value
+     * @param message A short description of the assertion
+     */
     strictEqual(actual: any, expected: any, message?: string): any;
 
     /**
-    * Assertion to test if a callback throws an exception when run.
-    * 
-    * When testing code that is expected to throw an exception based on a specific set of 
-    * circumstances, use throws() to catch the error object for testing and comparison.
-    * 
-    * @param block Function to execute
-    * @param expected Error Object to compare
-    * @param message A short description of the assertion
-    */
+     * Assertion to test if a callback throws an exception when run.
+     *
+     * When testing code that is expected to throw an exception based on a specific set of
+     * circumstances, use throws() to catch the error object for testing and comparison.
+     *
+     * @param block Function to execute
+     * @param expected Error Object to compare
+     * @param message A short description of the assertion
+     */
     throws(block: () => any, expected: any, message?: string): any;
 
     /**
-    * @param block Function to execute
-    * @param message A short description of the assertion
-    */
+     * @param block Function to execute
+     * @param message A short description of the assertion
+     */
     throws(block: () => any, message?: string): any;
 
     /**
-    * Alias of throws.
-    * 
-    * In very few environments, like Closure Compiler, throws is considered a reserved word
-    * and will cause an error. For that case, an alias is bundled called raises. It has the
-    * same signature and behaviour, just a different name.
-    * 
-    * @param block Function to execute
-    * @param expected Error Object to compare
-    * @param message A short description of the assertion
-    */
+     * Alias of throws.
+     *
+     * In very few environments, like Closure Compiler, throws is considered a reserved word
+     * and will cause an error. For that case, an alias is bundled called raises. It has the
+     * same signature and behaviour, just a different name.
+     *
+     * @param block Function to execute
+     * @param expected Error Object to compare
+     * @param message A short description of the assertion
+     */
     raises(block: () => any, expected: any, message?: string): any;
 
     /**
-    * Alias of throws.
-    * 
-    * In very few environments, like Closure Compiler, throws is considered a reserved word
-    * and will cause an error. For that case, an alias is bundled called raises. It has the
-    * same signature and behaviour, just a different name.
-    * 
-    * @param block Function to execute
-    * @param message A short description of the assertion
-    */
+     * Alias of throws.
+     *
+     * In very few environments, like Closure Compiler, throws is considered a reserved word
+     * and will cause an error. For that case, an alias is bundled called raises. It has the
+     * same signature and behaviour, just a different name.
+     *
+     * @param block Function to execute
+     * @param message A short description of the assertion
+     */
     raises(block: () => any, message?: string): any;
 }
 
-interface QUnitStatic extends QUnitAssert {    
+interface QUnitStatic extends QUnitAssert {
     /* ASYNC CONTROL */
 
     /**
-    * Start running tests again after the testrunner was stopped. See stop().
-    *
-    * When your async test has multiple exit points, call start() for the corresponding number of stop() increments.
-    * 
-    * @param decrement Optional argument to merge multiple start() calls into one. Use with multiple corrsponding stop() calls.
-    */
+     * Start running tests again after the testrunner was stopped. See stop().
+     *
+     * When your async test has multiple exit points, call start() for the corresponding number of stop() increments.
+     *
+     * @param decrement Optional argument to merge multiple start() calls into one. Use with multiple corrsponding stop() calls.
+     */
     start(decrement?: number): any;
 
     /**
-    * Stop the testrunner to wait for async tests to run. Call start() to continue.
-    *
-    * When your async test has multiple exit points, call stop() with the increment argument, corresponding to the number of start() calls you need.
-    *
-    * On Blackberry 5.0, window.stop is a native read-only function. If you deal with that browser, use QUnit.stop() instead, which will work anywhere.
-    *
-    * @param decrement Optional argument to merge multiple stop() calls into one. Use with multiple corrsponding start() calls.
-    */
-    stop(increment? : number): any;
-    
+     * Stop the testrunner to wait for async tests to run. Call start() to continue.
+     *
+     * When your async test has multiple exit points, call stop() with the increment argument, corresponding to the number of start() calls you need.
+     *
+     * On Blackberry 5.0, window.stop is a native read-only function. If you deal with that browser, use QUnit.stop() instead, which will work anywhere.
+     *
+     * @param decrement Optional argument to merge multiple stop() calls into one. Use with multiple corrsponding start() calls.
+     */
+    stop(increment?: number): any;
+
     /* CALLBACKS */
 
     /**
-    * Register a callback to fire whenever the test suite begins.
-    *
-    * QUnit.begin() is called once before running any tests. (a better would've been QUnit.start, 
-    * but thats already in use elsewhere and can't be changed.)
-    *
-    * @param callback Callback to execute
-    */
+     * Register a callback to fire whenever the test suite begins.
+     *
+     * QUnit.begin() is called once before running any tests. (a better would've been QUnit.start,
+     * but thats already in use elsewhere and can't be changed.)
+     *
+     * @param callback Callback to execute
+     */
     begin(callback: () => any): any;
 
     /**
-    * Register a callback to fire whenever the test suite ends.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever the test suite ends.
+     *
+     * @param callback Callback to execute.
+     */
     done(callback: (details: DoneCallbackObject) => any): any;
 
     /**
-    * Register a callback to fire whenever an assertion completes.
-    *
-    * This is one of several callbacks QUnit provides. Its intended for integration scenarios like 
-    * PhantomJS or Jenkins. The properties of the details argument are listed below as options.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever an assertion completes.
+     *
+     * This is one of several callbacks QUnit provides. Its intended for integration scenarios like
+     * PhantomJS or Jenkins. The properties of the details argument are listed below as options.
+     *
+     * @param callback Callback to execute.
+     */
     log(callback: (details: LogCallbackObject) => any): any;
 
     /**
-    * Register a callback to fire whenever a module ends.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever a module ends.
+     *
+     * @param callback Callback to execute.
+     */
     moduleDone(callback: (details: ModuleDoneCallbackObject) => any): any;
 
     /**
-    * Register a callback to fire whenever a module begins.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever a module begins.
+     *
+     * @param callback Callback to execute.
+     */
     moduleStart(callback: (details: ModuleStartCallbackObject) => any): any;
 
     /**
-    * Register a callback to fire whenever a test ends.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever a test ends.
+     *
+     * @param callback Callback to execute.
+     */
     testDone(callback: (details: TestDoneCallbackObject) => any): any;
 
     /**
-    * Register a callback to fire whenever a test begins.
-    *
-    * @param callback Callback to execute.
-    */
+     * Register a callback to fire whenever a test begins.
+     *
+     * @param callback Callback to execute.
+     */
     testStart(callback: (details: TestStartCallbackObject) => any): any;
-    
+
     /* CONFIGURATION */
 
     /**
-    * QUnit has a bunch of internal configuration defaults, some of which are 
-    * useful to override. Check the description for each option for details.
-    */
+     * QUnit has a bunch of internal configuration defaults, some of which are
+     * useful to override. Check the description for each option for details.
+     */
     config: Config;
-    
+
     /* TEST */
 
     /**
-    * Add an asynchronous test to run. The test must include a call to start().
-    *
-    * For testing asynchronous code, asyncTest will automatically stop the test runner 
-    * and wait for your code to call start() to continue.
-    *
-    * @param name Title of unit being tested
-    * @param expected Number of assertions in this test
-    * @param test Function to close over assertions
-    */
+     * Add an asynchronous test to run. The test must include a call to start().
+     *
+     * For testing asynchronous code, asyncTest will automatically stop the test runner
+     * and wait for your code to call start() to continue.
+     *
+     * @param name Title of unit being tested
+     * @param expected Number of assertions in this test
+     * @param test Function to close over assertions
+     */
     asyncTest(name: string, expected: number, test: (assert: QUnitAssert) => any): any;
 
     /**
-    * Add an asynchronous test to run. The test must include a call to start().
-    *
-    * For testing asynchronous code, asyncTest will automatically stop the test runner 
-    * and wait for your code to call start() to continue.
-    *
-    * @param name Title of unit being tested
-    * @param test Function to close over assertions
-    */
+     * Add an asynchronous test to run. The test must include a call to start().
+     *
+     * For testing asynchronous code, asyncTest will automatically stop the test runner
+     * and wait for your code to call start() to continue.
+     *
+     * @param name Title of unit being tested
+     * @param test Function to close over assertions
+     */
     asyncTest(name: string, test: (assert: QUnitAssert) => any): any;
 
     /**
-    * Specify how many assertions are expected to run within a test.
-    *
-    * To ensure that an explicit number of assertions are run within any test, use 
-    * expect( number ) to register an expected count. If the number of assertions 
-    * run does not match the expected count, the test will fail.
-    *
-    * @param amount Number of assertions in this test.
-    * @deprecated since version 1.16
-    */
+     * Specify how many assertions are expected to run within a test.
+     *
+     * To ensure that an explicit number of assertions are run within any test, use
+     * expect( number ) to register an expected count. If the number of assertions
+     * run does not match the expected count, the test will fail.
+     *
+     * @param amount Number of assertions in this test.
+     * @deprecated since version 1.16
+     */
     expect(amount: number): any;
-    
+
     /**
-    * Copy the properties defined by the mixin object into the target object.
-    * 
-    * This method will modify the target object to contain the "own" properties defined 
-    * by the mixin. If the mixin object specifies the value of any attribute as undefined, 
-    * this property will instead be removed from the target object.
-    *
-    * @param target An object whose properties are to be modified
-    * @param mixin An object describing which properties should be modified
-    */
+     * Copy the properties defined by the mixin object into the target object.
+     *
+     * This method will modify the target object to contain the "own" properties defined
+     * by the mixin. If the mixin object specifies the value of any attribute as undefined,
+     * this property will instead be removed from the target object.
+     *
+     * @param target An object whose properties are to be modified
+     * @param mixin An object describing which properties should be modified
+     */
     extend(target: any, mixin: any): any;
 
     /**
-    * Group related tests under a single label.
-    *
-    * All tests that occur after a call to module() will be grouped into that module. 
-    * The test names will all be preceded by the module name in the test results. 
-    * You can then use that module name to select tests to run.
-    *
-    * @param name Label for this group of tests
-    * @param lifecycle Callbacks to run before and after each test
-    */
+     * Group related tests under a single label.
+     *
+     * All tests that occur after a call to module() will be grouped into that module.
+     * The test names will all be preceded by the module name in the test results.
+     * You can then use that module name to select tests to run.
+     *
+     * @param name Label for this group of tests
+     * @param lifecycle Callbacks to run before and after each test
+     */
     module(name: string, lifecycle?: LifecycleObject): any;
 
     /**
-    * Add a test to run.
-    *
-    * When testing the most common, synchronous code, use test().
-    * The assert argument to the callback contains all of QUnit's assertion methods. 
-    * If you are avoiding using any of QUnit's globals, you can use the assert 
-    * argument instead.
-    * 
-    * @param title Title of unit being tested
-    * @param expected Number of assertions in this test
-    * @param test Function to close over assertions
-    */
+     * Add a test to run.
+     *
+     * When testing the most common, synchronous code, use test().
+     * The assert argument to the callback contains all of QUnit's assertion methods.
+     * If you are avoiding using any of QUnit's globals, you can use the assert
+     * argument instead.
+     *
+     * @param title Title of unit being tested
+     * @param expected Number of assertions in this test
+     * @param test Function to close over assertions
+     */
     test(title: string, expected: number, test: (assert: QUnitAssert) => any): any;
 
     /**
-    * @param title Title of unit being tested
-    * @param test Function to close over assertions
-    */
+     * @param title Title of unit being tested
+     * @param test Function to close over assertions
+     */
     test(title: string, test: (assert: QUnitAssert) => any): any;
 
     /**
-    * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L1568
-    */
+     * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L1568
+     */
     equiv(a: any, b: any): any;
 
     /**
-    * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L897
-    */
+     * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L897
+     */
     push(result: any, actual: any, expected: any, message: string): any;
 
     /**
-    * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L839
-    */
+     * https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L839
+     */
     reset(): any;
 }
 
 /* ASSERT */
 
 /**
-* A deep recursive comparison assertion, working on primitive types, arrays, objects, 
-* regular expressions, dates and functions.
-*
-* The deepEqual() assertion can be used just like equal() when comparing the value of 
-* objects, such that { key: value } is equal to { key: value }. For non-scalar values, 
-* identity will be disregarded by deepEqual.
-*
-* @param actual Object or Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+ * A deep recursive comparison assertion, working on primitive types, arrays, objects,
+ * regular expressions, dates and functions.
+ *
+ * The deepEqual() assertion can be used just like equal() when comparing the value of
+ * objects, such that { key: value } is equal to { key: value }. For non-scalar values,
+ * identity will be disregarded by deepEqual.
+ *
+ * @param actual Object or Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function deepEqual(actual: any, expected: any, message?: string): any;
 
-/** 
-* A non-strict comparison assertion, roughly equivalent to JUnit assertEquals.
-*
-* The equal assertion uses the simple comparison operator (==) to compare the actual 
-* and expected arguments. When they are equal, the assertion passes: any; otherwise, it fails. 
-* When it fails, both actual and expected values are displayed in the test result, 
-* in addition to a given message.
-* 
-* @param actual Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+/**
+ * A non-strict comparison assertion, roughly equivalent to JUnit assertEquals.
+ *
+ * The equal assertion uses the simple comparison operator (==) to compare the actual
+ * and expected arguments. When they are equal, the assertion passes: any; otherwise, it fails.
+ * When it fails, both actual and expected values are displayed in the test result,
+ * in addition to a given message.
+ *
+ * @param actual Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function equal(actual: any, expected: any, message?: string): any;
 
 /**
-* An inverted deep recursive comparison assertion, working on primitive types, 
-* arrays, objects, regular expressions, dates and functions.
-*
-* The notDeepEqual() assertion can be used just like equal() when comparing the 
-* value of objects, such that { key: value } is equal to { key: value }. For non-scalar 
-* values, identity will be disregarded by notDeepEqual.
-* 
-* @param actual Object or Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+ * An inverted deep recursive comparison assertion, working on primitive types,
+ * arrays, objects, regular expressions, dates and functions.
+ *
+ * The notDeepEqual() assertion can be used just like equal() when comparing the
+ * value of objects, such that { key: value } is equal to { key: value }. For non-scalar
+ * values, identity will be disregarded by notDeepEqual.
+ *
+ * @param actual Object or Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function notDeepEqual(actual: any, expected: any, message?: string): any;
 
 /**
-* A non-strict comparison assertion, checking for inequality.
-*
-* The notEqual assertion uses the simple inverted comparison operator (!=) to compare 
-* the actual and expected arguments. When they aren't equal, the assertion passes; 
-* otherwise, it fails. When it fails, both actual and expected values are displayed 
-* in the test result, in addition to a given message.
-* 
-* @param actual Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+ * A non-strict comparison assertion, checking for inequality.
+ *
+ * The notEqual assertion uses the simple inverted comparison operator (!=) to compare
+ * the actual and expected arguments. When they aren't equal, the assertion passes;
+ * otherwise, it fails. When it fails, both actual and expected values are displayed
+ * in the test result, in addition to a given message.
+ *
+ * @param actual Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function notEqual(actual: any, expected: any, message?: string): any;
 
 /**
-* A non-strict comparison assertion, checking for inequality.
-*
-* The notStrictEqual assertion uses the strict inverted comparison operator (!==) 
-* to compare the actual and expected arguments. When they aren't equal, the assertion 
-* passes; otherwise, it fails. When it fails, both actual and expected values are 
-* displayed in the test result, in addition to a given message.
-* 
-* @param actual Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+ * A non-strict comparison assertion, checking for inequality.
+ *
+ * The notStrictEqual assertion uses the strict inverted comparison operator (!==)
+ * to compare the actual and expected arguments. When they aren't equal, the assertion
+ * passes; otherwise, it fails. When it fails, both actual and expected values are
+ * displayed in the test result, in addition to a given message.
+ *
+ * @param actual Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function notStrictEqual(actual: any, expected: any, message?: string): any;
 
 /**
-* A boolean assertion, equivalent to CommonJS’s assert.ok() and JUnit’s assertTrue(). 
-* Passes if the first argument is truthy.
-*
-* The most basic assertion in QUnit, ok() requires just one argument. If the argument 
-* evaluates to true, the assertion passes; otherwise, it fails. If a second message 
-* argument is provided, it will be displayed in place of the result.
-* 
-* @param state Expression being tested
-* @param message A short description of the assertion
-*/
+ * A boolean assertion, equivalent to CommonJS’s assert.ok() and JUnit’s assertTrue().
+ * Passes if the first argument is truthy.
+ *
+ * The most basic assertion in QUnit, ok() requires just one argument. If the argument
+ * evaluates to true, the assertion passes; otherwise, it fails. If a second message
+ * argument is provided, it will be displayed in place of the result.
+ *
+ * @param state Expression being tested
+ * @param message A short description of the assertion
+ */
 declare function ok(state: any, message?: string): any;
 
 /**
-* A strict type and value comparison assertion.
-*
-* The strictEqual() assertion provides the most rigid comparison of type and value with 
-* the strict equality operator (===)
-* 
-* @param actual Expression being tested
-* @param expected Known comparison value
-* @param message A short description of the assertion
-*/
+ * A strict type and value comparison assertion.
+ *
+ * The strictEqual() assertion provides the most rigid comparison of type and value with
+ * the strict equality operator (===)
+ *
+ * @param actual Expression being tested
+ * @param expected Known comparison value
+ * @param message A short description of the assertion
+ */
 declare function strictEqual(actual: any, expected: any, message?: string): any;
 
 /**
-* Assertion to test if a callback throws an exception when run.
-* 
-* When testing code that is expected to throw an exception based on a specific set of 
-* circumstances, use throws() to catch the error object for testing and comparison.
-* 
-* @param block Function to execute
-* @param expected Error Object to compare
-* @param message A short description of the assertion
-*/
+ * Assertion to test if a callback throws an exception when run.
+ *
+ * When testing code that is expected to throw an exception based on a specific set of
+ * circumstances, use throws() to catch the error object for testing and comparison.
+ *
+ * @param block Function to execute
+ * @param expected Error Object to compare
+ * @param message A short description of the assertion
+ */
 declare function throws(block: () => any, expected: any, message?: string): any;
 
 /**
-* @param block Function to execute
-* @param message A short description of the assertion
-*/
+ * @param block Function to execute
+ * @param message A short description of the assertion
+ */
 declare function throws(block: () => any, message?: string): any;
 
 /* ASYNC CONTROL */
 
 /**
-* Start running tests again after the testrunner was stopped. See stop().
-*
-* When your async test has multiple exit points, call start() for the corresponding number of stop() increments.
-* 
-* @param decrement Optional argument to merge multiple start() calls into one. Use with multiple corrsponding stop() calls.
-*/
+ * Start running tests again after the testrunner was stopped. See stop().
+ *
+ * When your async test has multiple exit points, call start() for the corresponding number of stop() increments.
+ *
+ * @param decrement Optional argument to merge multiple start() calls into one. Use with multiple corrsponding stop() calls.
+ */
 declare function start(decrement?: number): any;
 
 /**
-* Stop the testrunner to wait for async tests to run. Call start() to continue.
-*
-* When your async test has multiple exit points, call stop() with the increment argument, corresponding to the number of start() calls you need.
-*
-* On Blackberry 5.0, window.stop is a native read-only function. If you deal with that browser, use QUnit.stop() instead, which will work anywhere.
-*
-* @param decrement Optional argument to merge multiple stop() calls into one. Use with multiple corrsponding start() calls.
-*/
-declare function stop(increment? : number): any;
-    
+ * Stop the testrunner to wait for async tests to run. Call start() to continue.
+ *
+ * When your async test has multiple exit points, call stop() with the increment argument, corresponding to the number of start() calls you need.
+ *
+ * On Blackberry 5.0, window.stop is a native read-only function. If you deal with that browser, use QUnit.stop() instead, which will work anywhere.
+ *
+ * @param decrement Optional argument to merge multiple stop() calls into one. Use with multiple corrsponding start() calls.
+ */
+declare function stop(increment?: number): any;
+
 /* CALLBACKS */
 
 /**
-* Register a callback to fire whenever the test suite begins.
-*
-* QUnit.begin() is called once before running any tests. (a better would've been QUnit.start, 
-* but thats already in use elsewhere and can't be changed.)
-*
-* @param callback Callback to execute
-*/
+ * Register a callback to fire whenever the test suite begins.
+ *
+ * QUnit.begin() is called once before running any tests. (a better would've been QUnit.start,
+ * but thats already in use elsewhere and can't be changed.)
+ *
+ * @param callback Callback to execute
+ */
 declare function begin(callback: () => any): any;
 
 /**
-* Register a callback to fire whenever the test suite ends.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever the test suite ends.
+ *
+ * @param callback Callback to execute.
+ */
 declare function done(callback: (details: DoneCallbackObject) => any): any;
 
 /**
-* Register a callback to fire whenever an assertion completes.
-*
-* This is one of several callbacks QUnit provides. Its intended for integration scenarios like 
-* PhantomJS or Jenkins. The properties of the details argument are listed below as options.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever an assertion completes.
+ *
+ * This is one of several callbacks QUnit provides. Its intended for integration scenarios like
+ * PhantomJS or Jenkins. The properties of the details argument are listed below as options.
+ *
+ * @param callback Callback to execute.
+ */
 declare function log(callback: (details: LogCallbackObject) => any): any;
 
 /**
-* Register a callback to fire whenever a module ends.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever a module ends.
+ *
+ * @param callback Callback to execute.
+ */
 declare function moduleDone(callback: (details: ModuleDoneCallbackObject) => any): any;
 
 /**
-* Register a callback to fire whenever a module begins.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever a module begins.
+ *
+ * @param callback Callback to execute.
+ */
 declare function moduleStart(callback: (name: string) => any): any;
 
 /**
-* Register a callback to fire whenever a test ends.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever a test ends.
+ *
+ * @param callback Callback to execute.
+ */
 declare function testDone(callback: (details: TestDoneCallbackObject) => any): any;
 
 /**
-* Register a callback to fire whenever a test begins.
-*
-* @param callback Callback to execute.
-*/
+ * Register a callback to fire whenever a test begins.
+ *
+ * @param callback Callback to execute.
+ */
 declare function testStart(callback: (details: TestStartCallbackObject) => any): any;
-    
+
 /* TEST */
 
 /**
-* Add an asynchronous test to run. The test must include a call to start().
-*
-* For testing asynchronous code, asyncTest will automatically stop the test runner 
-* and wait for your code to call start() to continue.
-*
-* @param name Title of unit being tested
-* @param expected Number of assertions in this test
-* @param test Function to close over assertions
-*/
+ * Add an asynchronous test to run. The test must include a call to start().
+ *
+ * For testing asynchronous code, asyncTest will automatically stop the test runner
+ * and wait for your code to call start() to continue.
+ *
+ * @param name Title of unit being tested
+ * @param expected Number of assertions in this test
+ * @param test Function to close over assertions
+ */
 declare function asyncTest(name: string, expected?: any, test?: (assert: QUnitAssert) => any): any;
 
 /**
-* Add an asynchronous test to run. The test must include a call to start().
-*
-* For testing asynchronous code, asyncTest will automatically stop the test runner 
-* and wait for your code to call start() to continue.
-*
-* @param name Title of unit being tested
-* @param test Function to close over assertions
-*/
+ * Add an asynchronous test to run. The test must include a call to start().
+ *
+ * For testing asynchronous code, asyncTest will automatically stop the test runner
+ * and wait for your code to call start() to continue.
+ *
+ * @param name Title of unit being tested
+ * @param test Function to close over assertions
+ */
 declare function asyncTest(name: string, test: (assert: QUnitAssert) => any): any;
 
 /**
-* Specify how many assertions are expected to run within a test.
-*
-* To ensure that an explicit number of assertions are run within any test, use 
-* expect( number ) to register an expected count. If the number of assertions 
-* run does not match the expected count, the test will fail.
-*
-* @param amount Number of assertions in this test.
-* @deprecated since version 1.16
-*/
+ * Specify how many assertions are expected to run within a test.
+ *
+ * To ensure that an explicit number of assertions are run within any test, use
+ * expect( number ) to register an expected count. If the number of assertions
+ * run does not match the expected count, the test will fail.
+ *
+ * @param amount Number of assertions in this test.
+ * @deprecated since version 1.16
+ */
 declare function expect(amount: number): any;
 
 // ** conflict with TypeScript module keyword. Must be used on QUnit namespace
-//declare var module: (name: string, lifecycle?: LifecycleObject) => any;
+// declare var module: (name: string, lifecycle?: LifecycleObject) => any;
 
 /**
-* Add a test to run.
-*
-* When testing the most common, synchronous code, use test().
-* The assert argument to the callback contains all of QUnit's assertion methods. 
-* If you are avoiding using any of QUnit's globals, you can use the assert 
-* argument instead.
-* 
-* @param title Title of unit being tested
-* @param expected Number of assertions in this test
-* @param test Function to close over assertions
-*/
+ * Add a test to run.
+ *
+ * When testing the most common, synchronous code, use test().
+ * The assert argument to the callback contains all of QUnit's assertion methods.
+ * If you are avoiding using any of QUnit's globals, you can use the assert
+ * argument instead.
+ *
+ * @param title Title of unit being tested
+ * @param expected Number of assertions in this test
+ * @param test Function to close over assertions
+ */
 declare function test(title: string, expected: number, test: (assert?: QUnitAssert) => any): any;
 
 /**
-* @param title Title of unit being tested
-* @param test Function to close over assertions
-*/
+ * @param title Title of unit being tested
+ * @param test Function to close over assertions
+ */
 declare function test(title: string, test: (assert?: QUnitAssert) => any): any;
 
 declare function notPropEqual(actual: any, expected: any, message?: string): any;

--- a/types/qunit/v1/qunit-tests.ts
+++ b/types/qunit/v1/qunit-tests.ts
@@ -1,42 +1,41 @@
-QUnit.test("assert.async() test", function (assert) {
+QUnit.test("assert.async() test", function(assert) {
     var done = assert.async();
     var input = [];
-    setTimeout(function () {
+    setTimeout(function() {
         assert.equal(document.activeElement, input[0], "Input was focused");
         done();
     });
 });
 
-QUnit.test("deepEqual test", function () {
+QUnit.test("deepEqual test", function() {
     var obj = { foo: "bar" };
 
     QUnit.deepEqual(obj, { foo: "bar" }, "Two objects can be the same in value");
 });
 
-test("deepEqual test", function () {
+test("deepEqual test", function() {
     var obj = { foo: "bar" };
 
     deepEqual(obj, { foo: "bar" }, "Two objects can be the same in value");
 });
 
-QUnit.test("a test", function () {
+QUnit.test("a test", function() {
     QUnit.equal(1, "1", "String '1' and number 1 have the same value");
 });
 
-test("a test", function () {
+test("a test", function() {
     equal(1, "1", "String '1' and number 1 have the same value");
 });
 
-test("test Array 1", function () {
-    equal([1,2,3], ["test", "foo"], "String '1' and number 1 have the same value");
+test("test Array 1", function() {
+    equal([1, 2, 3], ["test", "foo"], "String '1' and number 1 have the same value");
 });
 
-test("test Array 2", function () {
-    QUnit.equal([1,2,3], ["test", "foo"], "String '1' and number 1 have the same value");
+test("test Array 2", function() {
+    QUnit.equal([1, 2, 3], ["test", "foo"], "String '1' and number 1 have the same value");
 });
 
-
-QUnit.test("equal test", function () {
+QUnit.test("equal test", function() {
     QUnit.equal(0, 0, "Zero; equal succeeds");
     QUnit.equal("", 0, "Empty, Zero; equal succeeds");
     QUnit.equal("", "", "Empty, Empty; equal succeeds");
@@ -46,7 +45,7 @@ QUnit.test("equal test", function () {
     QUnit.equal(null, false, "null, false; equal fails");
 });
 
-test("equal test", function () {
+test("equal test", function() {
     equal(0, 0, "Zero; equal succeeds");
     equal("", 0, "Empty, Zero; equal succeeds");
     equal("", "", "Empty, Empty; equal succeeds");
@@ -56,35 +55,35 @@ test("equal test", function () {
     equal(null, false, "null, false; equal fails");
 });
 
-QUnit.test("notDeepEqual test", function () {
+QUnit.test("notDeepEqual test", function() {
     var obj = { foo: "bar" };
 
     QUnit.notDeepEqual(obj, { foo: "bla" }, "Different object, same key, different value, not equal");
 });
 
-test("notDeepEqual test", function () {
+test("notDeepEqual test", function() {
     var obj = { foo: "bar" };
 
     notDeepEqual(obj, { foo: "bla" }, "Different object, same key, different value, not equal");
 });
 
-QUnit.test("a test", function () {
+QUnit.test("a test", function() {
     QUnit.notEqual(1, "2", "String '2' and number 1 don't have the same value");
 });
 
-test("a test", function () {
+test("a test", function() {
     notEqual(1, "2", "String '2' and number 1 don't have the same value");
 });
 
-QUnit.test("a test", function () {
+QUnit.test("a test", function() {
     QUnit.notStrictEqual(1, "1", "String '1' and number 1 don't have the same value");
 });
 
-test("a test", function () {
+test("a test", function() {
     notStrictEqual(1, "1", "String '1' and number 1 don't have the same value");
 });
 
-QUnit.test("ok test", function () {
+QUnit.test("ok test", function() {
     QUnit.ok(true, "true succeeds");
     QUnit.ok("non-empty", "non-empty string succeeds");
 
@@ -96,7 +95,7 @@ QUnit.test("ok test", function () {
     QUnit.ok(undefined, "undefined fails");
 });
 
-test("ok test", function () {
+test("ok test", function() {
     ok(true, "true succeeds");
     ok("non-empty", "non-empty string succeeds");
 
@@ -108,20 +107,20 @@ test("ok test", function () {
     ok(undefined, "undefined fails");
 });
 
-QUnit.test("strictEqual test", function () {
+QUnit.test("strictEqual test", function() {
     QUnit.strictEqual(1, 1, "1 and 1 are the same value and type");
 });
 
-test("strictEqual test", function () {
+test("strictEqual test", function() {
     strictEqual(1, 1, "1 and 1 are the same value and type");
 });
 
-QUnit.test("a test", function () {
+QUnit.test("a test", function() {
     QUnit.stop();
     QUnit.start();
 });
 
-test("a test", function () {
+test("a test", function() {
     stop();
     start();
 });
@@ -129,71 +128,72 @@ test("a test", function () {
 QUnit.config.autostart = false;
 QUnit.start();
 
-QUnit.config.urlConfig.push(<any>{
-    id: "min",
-    label: "Minified source",
-    tooltip: "Load minified source files instead of the regular unminified ones."
-});
+QUnit.config.urlConfig.push(
+    <any> {
+        id: "min",
+        label: "Minified source",
+        tooltip: "Load minified source files instead of the regular unminified ones.",
+    },
+);
 
-QUnit.asyncTest("asynchronous test: one second later!", function () {
+QUnit.asyncTest("asynchronous test: one second later!", function() {
     QUnit.expect(1);
 });
 
-asyncTest("asynchronous test: one second later!", function () {
+asyncTest("asynchronous test: one second later!", function() {
     expect(1);
 });
 
 QUnit.module("group a");
-QUnit.test("a basic test example", function () {
+QUnit.test("a basic test example", function() {
     QUnit.ok(true, "this test is fine");
 });
-QUnit.test("a basic test example 2", function () {
+QUnit.test("a basic test example 2", function() {
     QUnit.ok(true, "this test is fine");
 });
 
 QUnit.module("group b");
-QUnit.test("a basic test example 3", function () {
+QUnit.test("a basic test example 3", function() {
     QUnit.ok(true, "this test is fine");
 });
-QUnit.test("a basic test example 4", function () {
+QUnit.test("a basic test example 4", function() {
     QUnit.ok(true, "this test is fine");
 });
 
 QUnit.module("module A", {
-    setup: function () {
+    setup: function() {
         // prepare something for all following tests
     },
-    teardown: function () {
+    teardown: function() {
         // clean up after each test
-    }
+    },
 });
 
 QUnit.module("module with async setup and teardown", {
-    setup: function (assert) {
+    setup: function(assert) {
         var done = assert.async();
-        setTimeout(function () {
+        setTimeout(function() {
             // prepare something for all following tests
         });
     },
-    teardown: function (assert) {
+    teardown: function(assert) {
         // clean up after each test
-    }
+    },
 });
 
 QUnit.module("module with async setup and teardown", {
-    beforeEach: function (assert: QUnitAssert) {
+    beforeEach: function(assert: QUnitAssert) {
         var done = assert.async();
-        setTimeout(function () {
+        setTimeout(function() {
             // prepare something for all following tests
         });
     },
-    afterEach: function () {
+    afterEach: function() {
         // clean up after each test
-    }
+    },
 });
 
-QUnit.test("a test", function (assert) {
-
+QUnit.test("a test", function(assert) {
     function square(x) {
         return x * x;
     }
@@ -203,67 +203,66 @@ QUnit.test("a test", function (assert) {
     assert.equal(result, 4, "square(2) equals 4");
 });
 
-test( "throws", function() {
- 
-  function CustomError( message ) {
-    this.message = message;
-  }
- 
-  CustomError.prototype.toString = function() {
-    return this.message;
-  };
- 
-  throws(
-    function() {
-      throw "error"
-    },
-    "throws with just a message, no expected"
-  );
- 
-  throws(
-    function() {
-      throw new Error();
-    },
-    Error,
-    "raised error is an instance of CustomError"
-  );
- 
-  throws(
-    function() {
-      throw new Error("some error description");
-    },
-    /description/,
-    "raised error message contains 'description'"
-  );
+test("throws", function() {
+    function CustomError(message) {
+        this.message = message;
+    }
 
-   QUnit.throws(
-    function() {
-      throw "error"
-    },
-    "throws with just a message, no expected"
-  );
- 
-  QUnit.throws(
-    function() {
-      throw new Error();
-    },
-    Error,
-    "raised error is an instance of CustomError"
-  );
- 
-  QUnit.throws(
-    function() {
-      throw new Error("some error description");
-    },
-    /description/,
-    "raised error message contains 'description'"
-  ); 
+    CustomError.prototype.toString = function() {
+        return this.message;
+    };
+
+    throws(
+        function() {
+            throw "error";
+        },
+        "throws with just a message, no expected",
+    );
+
+    throws(
+        function() {
+            throw new Error();
+        },
+        Error,
+        "raised error is an instance of CustomError",
+    );
+
+    throws(
+        function() {
+            throw new Error("some error description");
+        },
+        /description/,
+        "raised error message contains 'description'",
+    );
+
+    QUnit.throws(
+        function() {
+            throw "error";
+        },
+        "throws with just a message, no expected",
+    );
+
+    QUnit.throws(
+        function() {
+            throw new Error();
+        },
+        Error,
+        "raised error is an instance of CustomError",
+    );
+
+    QUnit.throws(
+        function() {
+            throw new Error("some error description");
+        },
+        /description/,
+        "raised error message contains 'description'",
+    );
 });
 
-QUnit.test("raises", function () {
-    QUnit.test("raises, alias for throws", function (assert) {
+QUnit.test("raises", function() {
+    QUnit.test("raises, alias for throws", function(assert) {
         assert.expect(1);
-        assert.raises(function () {
+        assert.raises(function() {
             throw "my error";
         });
     });
@@ -271,14 +270,13 @@ QUnit.test("raises", function () {
 
 QUnit.module("equiv");
 
-
-test("Primitive types and constants", function () {
+test("Primitive types and constants", function() {
     equal(QUnit.equiv(null, null), true, "null");
     equal(QUnit.equiv(null, {}), false, "null");
     equal(QUnit.equiv(null, undefined), false, "null");
     equal(QUnit.equiv(null, 0), false, "null");
     equal(QUnit.equiv(null, false), false, "null");
-    equal(QUnit.equiv(null, ''), false, "null");
+    equal(QUnit.equiv(null, ""), false, "null");
     equal(QUnit.equiv(null, []), false, "null");
 
     equal(QUnit.equiv(undefined, undefined), true, "undefined");
@@ -291,24 +289,24 @@ test("Primitive types and constants", function () {
 
     // Nan usually doest not equal to Nan using the '==' operator.
     // Only isNaN() is able to do it.
-    equal(QUnit.equiv(0/0, 0/0), true, "NaN"); // NaN VS NaN
-    equal(QUnit.equiv(1/0, 2/0), true, "Infinity"); // Infinity VS Infinity
-    equal(QUnit.equiv(-1/0, 2/0), false, "-Infinity, Infinity"); // -Infinity VS Infinity
-    equal(QUnit.equiv(-1/0, -2/0), true, "-Infinity, -Infinity"); // -Infinity VS -Infinity
-    equal(QUnit.equiv(0/0, 1/0), false, "NaN, Infinity"); // Nan VS Infinity
-    equal(QUnit.equiv(1/0, 0/0), false, "NaN, Infinity"); // Nan VS Infinity
-    equal(QUnit.equiv(0/0, null), false, "NaN");
-    equal(QUnit.equiv(0/0, undefined), false, "NaN");
-    equal(QUnit.equiv(0/0, 0), false, "NaN");
-    equal(QUnit.equiv(0/0, false), false, "NaN");
-    equal(QUnit.equiv(0/0, function () {}), false, "NaN");
-    equal(QUnit.equiv(1/0, null), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, undefined), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, 0), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, 1), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, false), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, true), false, "NaN, Infinity");
-    equal(QUnit.equiv(1/0, function () {}), false, "NaN, Infinity");
+    equal(QUnit.equiv(0 / 0, 0 / 0), true, "NaN"); // NaN VS NaN
+    equal(QUnit.equiv(1 / 0, 2 / 0), true, "Infinity"); // Infinity VS Infinity
+    equal(QUnit.equiv(-1 / 0, 2 / 0), false, "-Infinity, Infinity"); // -Infinity VS Infinity
+    equal(QUnit.equiv(-1 / 0, -2 / 0), true, "-Infinity, -Infinity"); // -Infinity VS -Infinity
+    equal(QUnit.equiv(0 / 0, 1 / 0), false, "NaN, Infinity"); // Nan VS Infinity
+    equal(QUnit.equiv(1 / 0, 0 / 0), false, "NaN, Infinity"); // Nan VS Infinity
+    equal(QUnit.equiv(0 / 0, null), false, "NaN");
+    equal(QUnit.equiv(0 / 0, undefined), false, "NaN");
+    equal(QUnit.equiv(0 / 0, 0), false, "NaN");
+    equal(QUnit.equiv(0 / 0, false), false, "NaN");
+    equal(QUnit.equiv(0 / 0, function() {}), false, "NaN");
+    equal(QUnit.equiv(1 / 0, null), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, undefined), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, 0), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, 1), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, false), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, true), false, "NaN, Infinity");
+    equal(QUnit.equiv(1 / 0, function() {}), false, "NaN, Infinity");
 
     equal(QUnit.equiv(0, 0), true, "number");
     equal(QUnit.equiv(0, 1), false, "number");
@@ -316,9 +314,9 @@ test("Primitive types and constants", function () {
     equal(QUnit.equiv(1, 1), true, "number");
     equal(QUnit.equiv(1.1, 1.1), true, "number");
     equal(QUnit.equiv(0.0000005, 0.0000005), true, "number");
-    equal(QUnit.equiv(0, ''), false, "number");
-    equal(QUnit.equiv(0, '0'), false, "number");
-    equal(QUnit.equiv(1, '1'), false, "number");
+    equal(QUnit.equiv(0, ""), false, "number");
+    equal(QUnit.equiv(0, "0"), false, "number");
+    equal(QUnit.equiv(1, "1"), false, "number");
     equal(QUnit.equiv(0, false), false, "number");
     equal(QUnit.equiv(1, true), false, "number");
 
@@ -332,14 +330,14 @@ test("Primitive types and constants", function () {
     equal(QUnit.equiv(true, null), false, "boolean");
     equal(QUnit.equiv(true, undefined), false, "boolean");
 
-    equal(QUnit.equiv('', ''), true, "string");
-    equal(QUnit.equiv('a', 'a'), true, "string");
+    equal(QUnit.equiv("", ""), true, "string");
+    equal(QUnit.equiv("a", "a"), true, "string");
     equal(QUnit.equiv("foobar", "foobar"), true, "string");
     equal(QUnit.equiv("foobar", "foo"), false, "string");
-    equal(QUnit.equiv('', 0), false, "string");
-    equal(QUnit.equiv('', false), false, "string");
-    equal(QUnit.equiv('', null), false, "string");
-    equal(QUnit.equiv('', undefined), false, "string");
+    equal(QUnit.equiv("", 0), false, "string");
+    equal(QUnit.equiv("", false), false, "string");
+    equal(QUnit.equiv("", null), false, "string");
+    equal(QUnit.equiv("", undefined), false, "string");
 
     // Rename for lint validation.
     // We know this is bad, we are asserting whether we can coop with bad code like this.
@@ -374,10 +372,10 @@ test("Primitive types and constants", function () {
 
     equal(QUnit.equiv(new SafeObject(), {}), true, "object literal vs. instantiation");
     equal(QUnit.equiv({}, new SafeObject()), true, "object literal vs. instantiation");
-    equal(QUnit.equiv(new SafeObject(), {a:1}), false, "object literal vs. instantiation");
-    equal(QUnit.equiv({a:1}, new SafeObject()), false, "object literal vs. instantiation");
-    equal(QUnit.equiv({a:undefined}, new SafeObject()), false, "object literal vs. instantiation");
-    equal(QUnit.equiv(new SafeObject(), {a:undefined}), false, "object literal vs. instantiation");
+    equal(QUnit.equiv(new SafeObject(), { a: 1 }), false, "object literal vs. instantiation");
+    equal(QUnit.equiv({ a: 1 }, new SafeObject()), false, "object literal vs. instantiation");
+    equal(QUnit.equiv({ a: undefined }, new SafeObject()), false, "object literal vs. instantiation");
+    equal(QUnit.equiv(new SafeObject(), { a: undefined }), false, "object literal vs. instantiation");
 });
 
 test("Objects Basics.", function() {
@@ -394,28 +392,31 @@ test("Objects Basics.", function() {
     //      3) Their properties are the same (doesn't exists)
     equal(QUnit.equiv({}, []), false);
 
-    equal(QUnit.equiv({a:1}, {a:1}), true);
-    equal(QUnit.equiv({a:1}, {a:"1"}), false);
-    equal(QUnit.equiv({a:[]}, {a:[]}), true);
-    equal(QUnit.equiv({a:{}}, {a:null}), false);
-    equal(QUnit.equiv({a:1}, {}), false);
-    equal(QUnit.equiv({}, {a:1}), false);
+    equal(QUnit.equiv({ a: 1 }, { a: 1 }), true);
+    equal(QUnit.equiv({ a: 1 }, { a: "1" }), false);
+    equal(QUnit.equiv({ a: [] }, { a: [] }), true);
+    equal(QUnit.equiv({ a: {} }, { a: null }), false);
+    equal(QUnit.equiv({ a: 1 }, {}), false);
+    equal(QUnit.equiv({}, { a: 1 }), false);
 
     // Hard ones
-    equal(QUnit.equiv({a:undefined}, {}), false);
-    equal(QUnit.equiv({}, {a:undefined}), false);
-    equal(QUnit.equiv(
-        {
-            a: [{ bar: undefined }]
-        },
-        {
-            a: [{ bat: undefined }]
-        }
-    ), false);
+    equal(QUnit.equiv({ a: undefined }, {}), false);
+    equal(QUnit.equiv({}, { a: undefined }), false);
+    equal(
+        QUnit.equiv(
+            {
+                a: [{ bar: undefined }],
+            },
+            {
+                a: [{ bat: undefined }],
+            },
+        ),
+        false,
+    );
 
     // Objects with no prototype, created via Object.create(null), are used e.g. as dictionaries.
     // Being able to test equivalence against object literals is quite useful.
-    if (typeof Object.create === 'function') {
+    if (typeof Object.create === "function") {
         equal(QUnit.equiv(Object.create(null), {}), true, "empty object without prototype VS empty object");
 
         var nonEmptyWithNoProto = Object.create(null);
@@ -425,9 +426,7 @@ test("Objects Basics.", function() {
     }
 });
 
-
 test("Arrays Basics.", function() {
-
     equal(QUnit.equiv([], []), true);
 
     // May be a hard one, can invoke a crash at execution.
@@ -444,25 +443,34 @@ test("Arrays Basics.", function() {
     // than {} with [] (note the order)
     equal(QUnit.equiv([], {}), false);
 
-    equal(QUnit.equiv([null],[]), false);
-    equal(QUnit.equiv([undefined],[]), false);
-    equal(QUnit.equiv([],[null]), false);
-    equal(QUnit.equiv([],[undefined]), false);
-    equal(QUnit.equiv([null],[undefined]), false);
-    equal(QUnit.equiv([[]],[[]]), true);
-    equal(QUnit.equiv([[],[],[]],[[],[],[]]), true);
-    equal(QUnit.equiv(
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]),
-                            true);
-    equal(QUnit.equiv(
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // shorter
-                            false);
-    equal(QUnit.equiv(
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[{}]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-                            [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // deepest element not an array
-                            false);
+    equal(QUnit.equiv([null], []), false);
+    equal(QUnit.equiv([undefined], []), false);
+    equal(QUnit.equiv([], [null]), false);
+    equal(QUnit.equiv([], [undefined]), false);
+    equal(QUnit.equiv([null], [undefined]), false);
+    equal(QUnit.equiv([[]], [[]]), true);
+    equal(QUnit.equiv([[], [], []], [[], [], []]), true);
+    equal(
+        QUnit.equiv(
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+        ),
+        true,
+    );
+    equal(
+        QUnit.equiv(
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+        ), // shorter
+        false,
+    );
+    equal(
+        QUnit.equiv(
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[{}]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+            [[], [], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+        ), // deepest element not an array
+        false,
+    );
 });
 
 test("Prototypal inheritance", function() {
@@ -480,7 +488,7 @@ test("Prototypal inheritance", function() {
 
     // Try this test many times after test on instances that hold function
     // to make sure that our code does not mess with last object constructor memoization.
-    equal(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function() {}, function() {}), false);
 
     // Hoozit inherit from Gizmo
     // hoozit instanceof Hoozit; // true
@@ -496,7 +504,7 @@ test("Prototypal inheritance", function() {
     // Make sure this is still true !important
     // The reason for this is that I forgot to reset the last
     // caller to where it were called from.
-    equal(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function() {}, function() {}), false);
 
     // Make sure this is still true !important
     equal(QUnit.equiv(hoozit, gizmo), true);
@@ -510,9 +518,8 @@ test("Prototypal inheritance", function() {
     equal(QUnit.equiv(hoozit, gizmo), false);
 
     // Make sure this is still true !important
-    equal(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function() {}, function() {}), false);
 });
-
 
 test("Instances", function() {
     function A() {}
@@ -520,7 +527,7 @@ test("Instances", function() {
     var a2 = new A();
 
     function B() {
-        this.fn = function () {};
+        this.fn = function() {};
     }
     var b1 = new B();
     var b2 = new B();
@@ -554,12 +561,12 @@ test("Instances", function() {
     var human = new Human(30);
 
     var diff = {
-        year: 30
+        year: 30,
     };
 
     var same = {
         year: 30,
-        isOld: function () {}
+        isOld: function() {},
     };
 
     equal(QUnit.equiv(car, car), true);
@@ -568,19 +575,18 @@ test("Instances", function() {
     equal(QUnit.equiv(car, human), false);
 });
 
-
 test("Complex Instances Nesting (with function value in literals and/or in nested instances)", function() {
     function A(fn) {
         this.a = {};
         this.fn = fn;
-        this.b = {a: []};
+        this.b = { a: [] };
         this.o = {};
         this.fn1 = fn;
     }
     function B(fn) {
         this.fn = fn;
-        this.fn1 = function () {};
-        this.a = new A(function () {});
+        this.fn1 = function() {};
+        this.a = new A(function() {});
     }
 
     function fnOutside() {
@@ -591,22 +597,22 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
         }
         this.x = 10;
         this.fn = fn;
-        this.fn1 = function () {};
+        this.fn1 = function() {};
         this.fn2 = fnInside;
         this.fn3 = {
             a: true,
-            b: fnOutside // ok make reference to a function in all instances scope
+            b: fnOutside, // ok make reference to a function in all instances scope
         };
         this.o1 = {};
 
         // This function will be ignored.
         // Even if it is not visible for all instances (e.g. locked in a closures),
         // it is from a  property that makes part of an instance (e.g. from the C constructor)
-        this.b1 = new B(function () {});
+        this.b1 = new B(function() {});
         this.b2 = new B({
             x: {
-                b2: new B(function() {})
-            }
+                b2: new B(function() {}),
+            },
         });
     }
 
@@ -615,7 +621,7 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
         }
         this.x = 10;
         this.fn = fn;
-        this.fn1 = function () {};
+        this.fn1 = function() {};
         this.fn2 = fnInside;
         this.fn3 = {
             a: true,
@@ -624,18 +630,18 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
             // This function won't be ingored.
             // It isn't visible for all C insances
             // and it is not in a property of an instance. (in an Object instances e.g. the object literal)
-            c: fnInside
+            c: fnInside,
         };
         this.o1 = {};
 
         // This function will be ignored.
         // Even if it is not visible for all instances (e.g. locked in a closures),
         // it is from a  property that makes part of an instance (e.g. from the C constructor)
-        this.b1 = new B(function () {});
+        this.b1 = new B(function() {});
         this.b2 = new B({
             x: {
-                b2: new B(function() {})
-            }
+                b2: new B(function() {}),
+            },
         });
     }
 
@@ -644,58 +650,56 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
         }
         this.x = 10;
         this.fn = fn;
-        this.fn1 = function () {};
+        this.fn1 = function() {};
         this.fn2 = fnInside;
         this.fn3 = {
             a: true,
-            b: fnOutside // ok make reference to a function in all instances scope
+            b: fnOutside, // ok make reference to a function in all instances scope
         };
         this.o1 = {};
 
         // This function will be ignored.
         // Even if it is not visible for all instances (e.g. locked in a closures),
         // it is from a  property that makes part of an instance (e.g. from the C constructor)
-        this.b1 = new B(function () {});
+        this.b1 = new B(function() {});
         this.b2 = new B({
             x: {
-                b1: new B({a: function() {}}),
-                b2: new B(function() {})
-            }
+                b1: new B({ a: function() {} }),
+                b2: new B(function() {}),
+            },
         });
     }
 
-
-    var a1 = new A(function () {});
-    var a2 = new A(function () {});
+    var a1 = new A(function() {});
+    var a2 = new A(function() {});
     equal(QUnit.equiv(a1, a2), true);
 
     equal(QUnit.equiv(a1, a2), true); // different instances
 
-    var b1 = new B(function () {});
-    var b2 = new B(function () {});
+    var b1 = new B(function() {});
+    var b2 = new B(function() {});
     equal(QUnit.equiv(b1, b2), true);
 
-    var c1 = new C(function () {});
-    var c2 = new C(function () {});
+    var c1 = new C(function() {});
+    var c2 = new C(function() {});
     equal(QUnit.equiv(c1, c2), true);
 
-    var d1 = new D(function () {});
-    var d2 = new D(function () {});
+    var d1 = new D(function() {});
+    var d2 = new D(function() {});
     equal(QUnit.equiv(d1, d2), false);
 
-    var e1 = new E(function () {});
-    var e2 = new E(function () {});
+    var e1 = new E(function() {});
+    var e2 = new E(function() {});
     equal(QUnit.equiv(e1, e2), false);
-
 });
 
-
-test('object with references to self wont loop', function() {
-    var circularA = <any>{
-        abc:null
-    }, circularB = <any>{
-        abc:null
-    };
+test("object with references to self wont loop", function() {
+    var circularA = <any> {
+            abc: null,
+        },
+        circularB = <any> {
+            abc: null,
+        };
     circularA.abc = circularA;
     circularB.abc = circularB;
     equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
@@ -709,25 +713,25 @@ test('object with references to self wont loop', function() {
     equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambigous test)");
 });
 
-test('array with references to self wont loop', function() {
+test("array with references to self wont loop", function() {
     var circularA = [],
         circularB = [];
     circularA.push(circularA);
     circularB.push(circularB);
     equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
 
-    circularA.push( 'abc' );
-    circularB.push( 'abc' );
+    circularA.push("abc");
+    circularB.push("abc");
     equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
 
-    circularA.push( 'hello' );
-    circularB.push( 'goodbye' );
+    circularA.push("hello");
+    circularB.push("goodbye");
     equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambigous test)");
 });
 
-test('mixed object/array with references to self wont loop', function() {
-    var circularA = <any>[{abc:null}],
-        circularB = <any>[{abc:null}];
+test("mixed object/array with references to self wont loop", function() {
+    var circularA = <any> [{ abc: null }],
+        circularB = <any> [{ abc: null }];
     circularA[0].abc = circularA;
     circularB[0].abc = circularB;
 
@@ -747,15 +751,19 @@ test('mixed object/array with references to self wont loop', function() {
 test("Test that must be done at the end because they extend some primitive's prototype", function() {
     // Try that a function looks like our regular expression.
     // This tests if we check that a and b are really both instance of RegExp
-    //Function.prototype.global = true;
-    //Function.prototype.multiline = true;
-    //Function.prototype.ignoreCase = false;
-    //Function.prototype.source = "my regex";
+    // Function.prototype.global = true;
+    // Function.prototype.multiline = true;
+    // Function.prototype.ignoreCase = false;
+    // Function.prototype.source = "my regex";
     var re = /my regex/gm;
-    equal(QUnit.equiv(re, function () {}), false, "A function that looks that a regex isn't a regex");
+    equal(QUnit.equiv(re, function() {}), false, "A function that looks that a regex isn't a regex");
     // This test will ensures it works in both ways, and ALSO especially that we can make differences
     // between RegExp and Function constructor because typeof on a RegExpt instance is "function"
-    equal(QUnit.equiv(function () {}, re), false, "Same conversely, but ensures that function and regexp are distinct because their constructor are different");
+    equal(
+        QUnit.equiv(function() {}, re),
+        false,
+        "Same conversely, but ensures that function and regexp are distinct because their constructor are different",
+    );
 });
 
 QUnit.start();
@@ -803,125 +811,124 @@ QUnit.log(function(context) {
 QUnit.module("logs1");
 
 QUnit.test("test1", 15, function() {
-    equal( begin, 1, "QUnit.begin calls" );
-    equal( moduleStart, 1, "QUnit.moduleStart calls" );
-    equal( testStart, 1, "QUnit.testStart calls" );
-    equal( testDone, 0, "QUnit.testDone calls" );
-    equal( moduleDone, 0, "QUnit.moduleDone calls" );
-    deepEqual( logContext, {
+    equal(begin, 1, "QUnit.begin calls");
+    equal(moduleStart, 1, "QUnit.moduleStart calls");
+    equal(testStart, 1, "QUnit.testStart calls");
+    equal(testDone, 0, "QUnit.testDone calls");
+    equal(moduleDone, 0, "QUnit.moduleDone calls");
+    deepEqual(logContext, {
         name: "test1",
         module: "logs1",
         result: true,
         message: "QUnit.moduleDone calls",
         actual: 0,
-        expected: 0
-    }, "log context after equal(actual, expected, message)" );
+        expected: 0,
+    }, "log context after equal(actual, expected, message)");
 
-    equal( "foo", "foo" );
+    equal("foo", "foo");
     deepEqual(logContext, {
         name: "test1",
         module: "logs1",
         result: true,
         message: undefined,
         actual: "foo",
-        expected: "foo"
-    }, "log context after equal(actual, expected)" );
+        expected: "foo",
+    }, "log context after equal(actual, expected)");
 
-    ok( true, "ok(true, message)" );
-    deepEqual( logContext, {
+    ok(true, "ok(true, message)");
+    deepEqual(logContext, {
         module: "logs1",
         name: "test1",
         result: true,
-        message: "ok(true, message)"
-    }, "log context after ok(true, message)" );
+        message: "ok(true, message)",
+    }, "log context after ok(true, message)");
 
-    strictEqual( testDoneContext, undefined, "testDone context" );
-    deepEqual( testContext, {
+    strictEqual(testDoneContext, undefined, "testDone context");
+    deepEqual(testContext, {
         module: "logs1",
-        name: "test1"
-    }, "test context" );
-    strictEqual( moduleDoneContext, undefined, "moduleDone context" );
-    deepEqual( moduleContext, {
-        name: "logs1"
-    }, "module context" );
+        name: "test1",
+    }, "test context");
+    strictEqual(moduleDoneContext, undefined, "moduleDone context");
+    deepEqual(moduleContext, {
+        name: "logs1",
+    }, "module context");
 
-    equal( log, 14, "QUnit.log calls" );
+    equal(log, 14, "QUnit.log calls");
 });
 QUnit.test("test2", 11, function() {
-    equal( begin, 1, "QUnit.begin calls" );
-    equal( moduleStart, 1, "QUnit.moduleStart calls" );
-    equal( testStart, 2, "QUnit.testStart calls" );
-    equal( testDone, 1, "QUnit.testDone calls" );
-    equal( moduleDone, 0, "QUnit.moduleDone calls" );
+    equal(begin, 1, "QUnit.begin calls");
+    equal(moduleStart, 1, "QUnit.moduleStart calls");
+    equal(testStart, 2, "QUnit.testStart calls");
+    equal(testDone, 1, "QUnit.testDone calls");
+    equal(moduleDone, 0, "QUnit.moduleDone calls");
 
-    ok( typeof testDoneContext.duration === "number" , "testDone context: duration" );
+    ok(typeof testDoneContext.duration === "number", "testDone context: duration");
     delete testDoneContext.duration;
-    deepEqual( testDoneContext, {
+    deepEqual(testDoneContext, {
         module: "logs1",
         name: "test1",
         failed: 0,
         passed: 15,
-        total: 15
-    }, "testDone context" );
-    deepEqual( testContext, {
+        total: 15,
+    }, "testDone context");
+    deepEqual(testContext, {
         module: "logs1",
-        name: "test2"
-    }, "test context" );
-    strictEqual( moduleDoneContext, undefined, "moduleDone context" );
-    deepEqual( moduleContext, {
-        name: "logs1"
-    }, "module context" );
+        name: "test2",
+    }, "test context");
+    strictEqual(moduleDoneContext, undefined, "moduleDone context");
+    deepEqual(moduleContext, {
+        name: "logs1",
+    }, "module context");
 
-    equal( log, 25, "QUnit.log calls" );
+    equal(log, 25, "QUnit.log calls");
 });
 
 QUnit.module("logs2");
 
-QUnit.test( "test1", 9, function() {
-    equal( begin, 1, "QUnit.begin calls" );
-    equal( moduleStart, 2, "QUnit.moduleStart calls" );
-    equal( testStart, 3, "QUnit.testStart calls" );
-    equal( testDone, 2, "QUnit.testDone calls" );
-    equal( moduleDone, 1, "QUnit.moduleDone calls" );
+QUnit.test("test1", 9, function() {
+    equal(begin, 1, "QUnit.begin calls");
+    equal(moduleStart, 2, "QUnit.moduleStart calls");
+    equal(testStart, 3, "QUnit.testStart calls");
+    equal(testDone, 2, "QUnit.testDone calls");
+    equal(moduleDone, 1, "QUnit.moduleDone calls");
 
-    deepEqual( testContext, {
+    deepEqual(testContext, {
         module: "logs2",
-        name: "test1"
-    }, "test context" );
-    deepEqual( moduleDoneContext, {
+        name: "test1",
+    }, "test context");
+    deepEqual(moduleDoneContext, {
         name: "logs1",
         failed: 0,
         passed: 26,
-        total: 26
-    }, "moduleDone context" );
-    deepEqual( moduleContext, {
-        name: "logs2"
-    }, "module context" );
+        total: 26,
+    }, "moduleDone context");
+    deepEqual(moduleContext, {
+        name: "logs2",
+    }, "module context");
 
-    equal( log, 34, "QUnit.log calls" );
+    equal(log, 34, "QUnit.log calls");
 });
-QUnit.test( "test2", 8, function() {
-    equal( begin, 1, "QUnit.begin calls" );
-    equal( moduleStart, 2, "QUnit.moduleStart calls" );
-    equal( testStart, 4, "QUnit.testStart calls" );
-    equal( testDone, 3, "QUnit.testDone calls" );
-    equal( moduleDone, 1, "QUnit.moduleDone calls" );
+QUnit.test("test2", 8, function() {
+    equal(begin, 1, "QUnit.begin calls");
+    equal(moduleStart, 2, "QUnit.moduleStart calls");
+    equal(testStart, 4, "QUnit.testStart calls");
+    equal(testDone, 3, "QUnit.testDone calls");
+    equal(moduleDone, 1, "QUnit.moduleDone calls");
 
-    deepEqual( testContext, {
+    deepEqual(testContext, {
         module: "logs2",
-        name: "test2"
-    }, "test context" );
-    deepEqual( moduleContext, {
-        name: "logs2"
-    }, "module context" );
+        name: "test2",
+    }, "test context");
+    deepEqual(moduleContext, {
+        name: "logs2",
+    }, "module context");
 
-    equal( log, 42, "QUnit.log calls" );
+    equal(log, 42, "QUnit.log calls");
 });
 
 var testAutorun = true;
 
 QUnit.done(function() {
-
     if (!testAutorun) {
         return;
     }
@@ -932,7 +939,7 @@ QUnit.done(function() {
 
     QUnit.test("reset", 0, function() {});
 
-    //moduleStart = moduleDone = 0;
+    // moduleStart = moduleDone = 0;
 
     test("first", function() {
         equal(moduleStart, 1, "test started");
@@ -989,27 +996,27 @@ test("expect query and multiple issue", function() {
 
 QUnit.module("assertion helpers");
 
-QUnit.test( "QUnit.assert compatibility", 5, function( assert ) {
-    assert.ok( true, "Calling method on `assert` argument to test() callback" );
+QUnit.test("QUnit.assert compatibility", 5, function(assert) {
+    assert.ok(true, "Calling method on `assert` argument to test() callback");
 
     // Should also work, although discouraged and not documented
-    QUnit.assert.ok( true, "Calling method on QUnit.assert object" );
+    QUnit.assert.ok(true, "Calling method on QUnit.assert object");
 
     // Test compatibility aliases
-    QUnit.ok( true, "Calling aliased method in QUnit root object" );
-    ok( true, "Calling aliased function in global namespace" );
+    QUnit.ok(true, "Calling aliased method in QUnit root object");
+    ok(true, "Calling aliased function in global namespace");
 
     // Regression fix for #341
     // The assert-context way of testing discouraged global variables,
     // it doesn't make sense of it itself to be a global variable.
     // Only allows for mistakes (e.g. forgetting to list 'assert' as parameter)
-    //assert.notStrictEqual( /*window.assert*/null, QUnit.assert, "Assert does not get exposed as a global variable" );
+    // assert.notStrictEqual( /*window.assert*/null, QUnit.assert, "Assert does not get exposed as a global variable" );
 });
 
 QUnit.module("setup test", {
     setup: function() {
         ok(true);
-    }
+    },
 });
 
 test("module with setup", function() {
@@ -1029,17 +1036,17 @@ QUnit.module("<script id='qunit-unescaped-module'>'module';</script>", {
         // don't evaluate script tags inserted through innerHTML after domready.
         // Counting them before/after doesn't cover everything either as qunit-modulefilter
         // is created before any test is ran. So use ids instead.
-        if (document.getElementById('qunit-unescaped-module')) {
+        if (document.getElementById("qunit-unescaped-module")) {
             // This can either be from in #qunit-modulefilter or #qunit-testresult
-            ok(false, 'Unscaped module name');
+            ok(false, "Unscaped module name");
         }
-        if (document.getElementById('qunit-unescaped-test')) {
-            ok(false, 'Unscaped test name');
+        if (document.getElementById("qunit-unescaped-test")) {
+            ok(false, "Unscaped test name");
         }
-        if (document.getElementById('qunit-unescaped-assertion')) {
-            ok(false, 'Unscaped test name');
+        if (document.getElementById("qunit-unescaped-assertion")) {
+            ok(false, "Unscaped test name");
         }
-    }
+    },
 });
 
 QUnit.test("<script id='qunit-unescaped-test'>'test';</script>", 1, function() {
@@ -1064,8 +1071,8 @@ QUnit.module("setup/teardown test", {
             @if (@_jscript_version < 9)
                 x = 1;
             @else @*/
-                //window.x = 1;
-            /*@end
+        // window.x = 1;
+        /*@end
         @*/
     },
     teardown: function() {
@@ -1075,10 +1082,10 @@ QUnit.module("setup/teardown test", {
             @if (@_jscript_version < 9)
                 delete x;
             @else @*/
-                //delete window.x;
-            /*@end
+        // delete window.x;
+        /*@end
         @*/
-    }
+    },
 });
 
 test("module with setup/teardown", function() {
@@ -1098,142 +1105,142 @@ var orgDate;
 QUnit.module("Date test", {
     setup: function() {
         orgDate = Date;
-        var Date = function () {
-            ok( false, 'QUnit should internally be independant from Date-related manipulation and testing' );
+        var Date = function() {
+            ok(false, "QUnit should internally be independant from Date-related manipulation and testing");
             return new orgDate();
         };
     },
     teardown: function() {
         var date = orgDate;
-    }
+    },
 });
 
-test("sample test for Date test", function () {
+test("sample test for Date test", function() {
     expect(1);
     ok(true);
 });
 
-if (typeof setTimeout !== 'undefined') {
-state = 'fail';
+if (typeof setTimeout !== "undefined") {
+    state = "fail";
 
-QUnit.module("teardown and stop", {
-    teardown: function() {
-        equal(state, "done", "Test teardown.");
-    }
-});
+    QUnit.module("teardown and stop", {
+        teardown: function() {
+            equal(state, "done", "Test teardown.");
+        },
+    });
 
-test("teardown must be called after test ended", function() {
-    expect(1);
-    stop();
-    setTimeout(function() {
-        state = "done";
+    test("teardown must be called after test ended", function() {
+        expect(1);
+        stop();
+        setTimeout(function() {
+            state = "done";
+            start();
+        }, 13);
+    });
+
+    test("parameter passed to stop increments semaphore n times", function() {
+        expect(1);
+        stop(3);
+        setTimeout(function() {
+            state = "not enough starts";
+            start();
+            start();
+        }, 13);
+        setTimeout(function() {
+            state = "done";
+            start();
+        }, 15);
+    });
+
+    test("parameter passed to start decrements semaphore n times", function() {
+        expect(1);
+        stop();
+        stop();
+        stop();
+        setTimeout(function() {
+            state = "done";
+            start(3);
+        }, 18);
+    });
+
+    QUnit.module("async setup test", {
+        setup: function() {
+            stop();
+            setTimeout(function() {
+                ok(true);
+                start();
+            }, 500);
+        },
+    });
+
+    asyncTest("module with async setup", function() {
+        expect(2);
+        ok(true);
         start();
-    }, 13);
-});
+    });
 
-test("parameter passed to stop increments semaphore n times", function() {
-    expect(1);
-    stop(3);
-    setTimeout(function() {
-        state = "not enough starts";
-        start();
-        start();
-    }, 13);
-    setTimeout(function() {
-        state = "done";
-        start();
-    }, 15);
-});
+    QUnit.module("async teardown test", {
+        teardown: function() {
+            stop();
+            setTimeout(function() {
+                ok(true);
+                start();
+            }, 500);
+        },
+    });
 
-test("parameter passed to start decrements semaphore n times", function() {
-    expect(1);
-    stop();
-    stop();
-    stop();
-    setTimeout(function() {
-        state = "done";
-        start(3);
-    }, 18);
-});
+    asyncTest("module with async teardown", function() {
+        expect(2);
+        ok(true);
+        start();
+    });
 
-QUnit.module("async setup test", {
-    setup: function() {
+    QUnit.module("asyncTest");
+
+    asyncTest("asyncTest", function() {
+        expect(2);
+        ok(true);
+        setTimeout(function() {
+            state = "done";
+            ok(true);
+            start();
+        }, 13);
+    });
+
+    asyncTest("asyncTest", 2, function() {
+        ok(true);
+        setTimeout(function() {
+            state = "done";
+            ok(true);
+            start();
+        }, 13);
+    });
+
+    QUnit.test("sync", 2, function() {
         stop();
         setTimeout(function() {
             ok(true);
             start();
-        }, 500);
-    }
-});
-
-asyncTest("module with async setup", function() {
-    expect(2);
-    ok(true);
-    start();
-});
-
-QUnit.module("async teardown test", {
-    teardown: function() {
+        }, 13);
         stop();
         setTimeout(function() {
             ok(true);
             start();
-        }, 500);
-    }
-});
+        }, 125);
+    });
 
-asyncTest("module with async teardown", function() {
-    expect(2);
-    ok(true);
-    start();
-});
-
-QUnit.module("asyncTest");
-
-asyncTest("asyncTest", function() {
-    expect(2);
-    ok(true);
-    setTimeout(function() {
-        state = "done";
-        ok(true);
-        start();
-    }, 13);
-});
-
-asyncTest("asyncTest", 2, function() {
-    ok(true);
-    setTimeout(function() {
-        state = "done";
-        ok(true);
-        start();
-    }, 13);
-});
-
-QUnit.test("sync", 2, function() {
-    stop();
-    setTimeout(function() {
-        ok(true);
-        start();
-    }, 13);
-    stop();
-    setTimeout(function() {
-        ok(true);
-        start();
-    }, 125);
-});
-
-QUnit.test("test synchronous calls to stop", 2, function() {
-    stop();
-    setTimeout(function() {
-        ok(true, 'first');
-        start();
+    QUnit.test("test synchronous calls to stop", 2, function() {
         stop();
         setTimeout(function() {
-            ok(true, 'second');
+            ok(true, "first");
             start();
+            stop();
+            setTimeout(function() {
+                ok(true, "second");
+                start();
+            }, 150);
         }, 150);
-    }, 150);
-});
+    });
 }
 
 QUnit.module("save scope", {
@@ -1242,7 +1249,7 @@ QUnit.module("save scope", {
     },
     teardown: function() {
         deepEqual(this.foo, "bar");
-    }
+    },
 });
 test("scope check", function() {
     expect(2);
@@ -1252,206 +1259,217 @@ test("scope check", function() {
 QUnit.module("simple testEnvironment setup", {
     foo: "bar",
     // example of meta-data
-    bugid: "#5311"
+    bugid: "#5311",
 });
 test("scope check", function() {
     deepEqual(this.foo, "bar");
 });
-test("modify testEnvironment",function() {
+test("modify testEnvironment", function() {
     expect(0);
-    this.foo="hamster";
+    this.foo = "hamster";
 });
-test("testEnvironment reset for next test",function() {
+test("testEnvironment reset for next test", function() {
     deepEqual(this.foo, "bar");
 });
 
 QUnit.module("testEnvironment with object", {
-    options:{
-        recipe:"soup",
-        ingredients:["hamster","onions"]
-    }
+    options: {
+        recipe: "soup",
+        ingredients: ["hamster", "onions"],
+    },
 });
 test("scope check", function() {
-    deepEqual(this.options, {recipe:"soup",ingredients:["hamster","onions"]}) ;
+    deepEqual(this.options, { recipe: "soup", ingredients: ["hamster", "onions"] });
 });
-test("modify testEnvironment",function() {
+test("modify testEnvironment", function() {
     expect(0);
     // since we do a shallow copy, the testEnvironment can be modified
     this.options.ingredients.push("carrots");
 });
-test("testEnvironment reset for next test",function() {
-    deepEqual(this.options, {recipe:"soup",ingredients:["hamster","onions","carrots"]}, "Is this a bug or a feature? Could do a deep copy") ;
+test("testEnvironment reset for next test", function() {
+    deepEqual(
+        this.options,
+        { recipe: "soup", ingredients: ["hamster", "onions", "carrots"] },
+        "Is this a bug or a feature? Could do a deep copy",
+    );
 });
-
 
 QUnit.module("testEnvironment tests");
 
 function makeurl() {
     var testEnv = QUnit.current_testEnvironment;
-    var url = testEnv.url || 'http://example.com/search';
-    var q   = testEnv.q   || 'a search test';
-    return url + '?q='+encodeURIComponent(q);
+    var url = testEnv.url || "http://example.com/search";
+    var q = testEnv.q || "a search test";
+    return url + "?q=" + encodeURIComponent(q);
 }
 
-test("makeurl working",function() {
-    equal( QUnit.current_testEnvironment, this, 'The current testEnvironment is global');
-    equal( makeurl(), 'http://example.com/search?q=a%20search%20test', 'makeurl returns a default url if nothing specified in the testEnvironment');
+test("makeurl working", function() {
+    equal(QUnit.current_testEnvironment, this, "The current testEnvironment is global");
+    equal(
+        makeurl(),
+        "http://example.com/search?q=a%20search%20test",
+        "makeurl returns a default url if nothing specified in the testEnvironment",
+    );
 });
 
 QUnit.module("testEnvironment with makeurl settings", {
-    url: 'http://google.com/',
-    q: 'another_search_test'
+    url: "http://google.com/",
+    q: "another_search_test",
 });
 test("makeurl working with settings from testEnvironment", function() {
-    equal( makeurl(), 'http://google.com/?q=another_search_test', 'rather than passing arguments, we use test metadata to from the url');
+    equal(
+        makeurl(),
+        "http://google.com/?q=another_search_test",
+        "rather than passing arguments, we use test metadata to from the url",
+    );
 });
 
 QUnit.module("jsDump");
 test("jsDump output", function() {
-    equal( QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]" );
-    equal( QUnit.jsDump.parse({top: 5, left: 0}), "{\n  \"left\": 0,\n  \"top\": 5\n}" );
-    if (typeof document !== 'undefined' && document.getElementById("qunit-header")) {
-        equal( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
-        equal( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
+    equal(QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]");
+    equal(QUnit.jsDump.parse({ top: 5, left: 0 }), "{\n  \"left\": 0,\n  \"top\": 5\n}");
+    if (typeof document !== "undefined" && document.getElementById("qunit-header")) {
+        equal(QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>");
+        equal(QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]");
     }
 });
 
 QUnit.module("assertions");
 
-QUnit.test("propEqual", 5, function( assert ) {
-    var objectCreate = Object.create || function ( origin ) {
+QUnit.test("propEqual", 5, function(assert) {
+    var objectCreate = Object.create || function(origin) {
         function O() {}
         O.prototype = origin;
         var r = new O();
         return r;
     };
 
-    function Foo( x, y, z ) {
+    function Foo(x, y, z) {
         this.x = x;
         this.y = y;
         this.z = z;
     }
-    Foo.prototype.doA = function () {};
-    Foo.prototype.doB = function () {};
-    Foo.prototype.bar = 'prototype';
+    Foo.prototype.doA = function() {};
+    Foo.prototype.doB = function() {};
+    Foo.prototype.bar = "prototype";
 
     function Bar() {
     }
-    Bar.prototype = objectCreate( Foo.prototype );
+    Bar.prototype = objectCreate(Foo.prototype);
     Bar.prototype.constructor = Bar;
 
     assert.propEqual(
-        new Foo( 1, '2', [] ),
+        new Foo(1, "2", []),
         {
             x: 1,
-            y: '2',
-            z: []
-        }
+            y: "2",
+            z: [],
+        },
     );
 
     assert.notPropEqual(
-        new Foo( '1', 2, 3 ),
+        new Foo("1", 2, 3),
         {
             x: 1,
-            y: '2',
-            z: 3
+            y: "2",
+            z: 3,
         },
-        'Primitive values are strictly compared'
+        "Primitive values are strictly compared",
     );
 
     assert.notPropEqual(
-        new Foo( 1, '2', [] ),
+        new Foo(1, "2", []),
         {
             x: 1,
-            y: '2',
-            z: {}
+            y: "2",
+            z: {},
         },
-        'Array type is preserved'
+        "Array type is preserved",
     );
 
     assert.notPropEqual(
-        new Foo( 1, '2', {} ),
+        new Foo(1, "2", {}),
         {
             x: 1,
-            y: '2',
-            z: []
+            y: "2",
+            z: [],
         },
-        'Empty array is not the same as empty object'
+        "Empty array is not the same as empty object",
     );
 
     assert.propEqual(
-        new Foo( 1, '2', new Foo( [ 3 ], new Bar(), null ) ),
+        new Foo(1, "2", new Foo([3], new Bar(), null)),
         {
             x: 1,
-            y: '2',
+            y: "2",
             z: {
-                x: [ 3 ],
+                x: [3],
                 y: {},
-                z: null
-            }
+                z: null,
+            },
         },
-        'Complex nesting of different types, inheritance and constructors'
+        "Complex nesting of different types, inheritance and constructors",
     );
 });
 
 if (typeof document !== "undefined") {
-
-QUnit.module("fixture");
-test("setup", function() {
-    expect(0);
-    document.getElementById("qunit-fixture").innerHTML = "foobar";
-});
-
-test("basics", function() {
-    equal( document.getElementById("qunit-fixture").innerHTML, "test markup", "automatically reset" );
-});
-
-test("running test name displayed", function() {
-    expect(2);
-
-    var displaying = document.getElementById("qunit-testresult");
-
-    ok( /running test name displayed/.test(displaying.innerHTML), "Expect test name to be found in displayed text" );
-    ok( /fixture/.test(displaying.innerHTML), "Expect module name to be found in displayed text" );
-});
-
-(function() {
-    var delayNextSetup,
-        sleep = function( n ) {
-            stop();
-            setTimeout( function() { start(); }, n );
-        };
-
-    QUnit.module("timing", {
-        setup: function() {
-            if ( delayNextSetup ) {
-                delayNextSetup = false;
-                sleep( 250 );
-            }
-        }
+    QUnit.module("fixture");
+    test("setup", function() {
+        expect(0);
+        document.getElementById("qunit-fixture").innerHTML = "foobar";
     });
 
-    QUnit.test("setup", 0, function() {
-        delayNextSetup = true;
+    test("basics", function() {
+        equal(document.getElementById("qunit-fixture").innerHTML, "test markup", "automatically reset");
     });
 
-    var getPreviousTests: (...args: any[]) => any;
+    test("running test name displayed", function() {
+        expect(2);
 
-    QUnit.test("basics", 2, function() {
-        var previous = getPreviousTests(/^setup$/, /^timing$/)[0],
-            runtime = previous.lastChild.previousSibling;
-        ok( /(^| )runtime( |$)/.test( runtime.className ), "Runtime element exists" );
-        ok( /^\d+ ms$/.test( runtime.innerHTML ), "Runtime reported in ms" );
+        var displaying = document.getElementById("qunit-testresult");
+
+        ok(/running test name displayed/.test(displaying.innerHTML), "Expect test name to be found in displayed text");
+        ok(/fixture/.test(displaying.innerHTML), "Expect module name to be found in displayed text");
     });
 
-    QUnit.test("values", 2, function() {
-        var basics = getPreviousTests(/^setup$/, /^timing$/)[0],
-            slow = getPreviousTests(/^basics$/, /^timing$/)[0];
-        ok( parseInt( basics.lastChild.previousSibling.innerHTML, 10 ) < 50, "Fast runtime for trivial test" );
-        ok( parseInt( slow.lastChild.previousSibling.innerHTML, 10 ) > 250, "Runtime includes setup" );
-    });
-})();
+    (function() {
+        var delayNextSetup,
+            sleep = function(n) {
+                stop();
+                setTimeout(function() {
+                    start();
+                }, n);
+            };
 
+        QUnit.module("timing", {
+            setup: function() {
+                if (delayNextSetup) {
+                    delayNextSetup = false;
+                    sleep(250);
+                }
+            },
+        });
+
+        QUnit.test("setup", 0, function() {
+            delayNextSetup = true;
+        });
+
+        var getPreviousTests: (...args: any[]) => any;
+
+        QUnit.test("basics", 2, function() {
+            var previous = getPreviousTests(/^setup$/, /^timing$/)[0],
+                runtime = previous.lastChild.previousSibling;
+            ok(/(^| )runtime( |$)/.test(runtime.className), "Runtime element exists");
+            ok(/^\d+ ms$/.test(runtime.innerHTML), "Runtime reported in ms");
+        });
+
+        QUnit.test("values", 2, function() {
+            var basics = getPreviousTests(/^setup$/, /^timing$/)[0],
+                slow = getPreviousTests(/^basics$/, /^timing$/)[0];
+            ok(parseInt(basics.lastChild.previousSibling.innerHTML, 10) < 50, "Fast runtime for trivial test");
+            ok(parseInt(slow.lastChild.previousSibling.innerHTML, 10) > 250, "Runtime includes setup");
+        });
+    })();
 }
 
 QUnit.module("custom assertions");
@@ -1465,7 +1483,6 @@ QUnit.module("custom assertions");
         mod2(3, 1, "3 % 2 == 1");
     });
 })();
-
 
 QUnit.module("recursions");
 
@@ -1485,7 +1502,7 @@ function chainwrap(depth?, first?, prev?) {
         first.wrap = last;
     }
     if (depth > 1) {
-        last = chainwrap(depth-1, first, new Wrap(last));
+        last = chainwrap(depth - 1, first, new Wrap(last));
     }
 
     return last;
@@ -1496,19 +1513,19 @@ test("check jsDump recursion", function() {
 
     var noref = chainwrap(0);
     var nodump = QUnit.jsDump.parse(noref);
-    equal(nodump, '{\n  "first": true,\n  "wrap": undefined\n}');
+    equal(nodump, "{\n  \"first\": true,\n  \"wrap\": undefined\n}");
 
     var selfref = chainwrap(1);
     var selfdump = QUnit.jsDump.parse(selfref);
-    equal(selfdump, '{\n  "first": true,\n  "wrap": recursion(-1)\n}');
+    equal(selfdump, "{\n  \"first\": true,\n  \"wrap\": recursion(-1)\n}");
 
     var parentref = chainwrap(2);
     var parentdump = QUnit.jsDump.parse(parentref);
-    equal(parentdump, '{\n  "wrap": {\n    "first": true,\n    "wrap": recursion(-2)\n  }\n}');
+    equal(parentdump, "{\n  \"wrap\": {\n    \"first\": true,\n    \"wrap\": recursion(-2)\n  }\n}");
 
     var circref = chainwrap(10);
     var circdump = QUnit.jsDump.parse(circref);
-    ok(new RegExp("recursion\\(-10\\)").test(circdump), "(" +circdump + ") should show -10 recursion level");
+    ok(new RegExp("recursion\\(-10\\)").test(circdump), "(" + circdump + ") should show -10 recursion level");
 });
 
 test("check (deep-)equal recursion", function() {
@@ -1525,18 +1542,15 @@ test("check (deep-)equal recursion", function() {
     deepEqual(circref, circref, "... and checked on all levels!");
 });
 
-
-test('Circular reference with arrays', function() {
-
+test("Circular reference with arrays", function() {
     // pure array self-ref
     var arr = [];
     arr.push(arr);
 
     var arrdump = QUnit.jsDump.parse(arr);
 
-    equal(arrdump, '[\n  recursion(-1)\n]');
-    equal(arr, arr[0], 'no endless stack when trying to dump arrays with circular ref');
-
+    equal(arrdump, "[\n  recursion(-1)\n]");
+    equal(arr, arr[0], "no endless stack when trying to dump arrays with circular ref");
 
     // mix obj-arr circular ref
     var obj: any = {};
@@ -1546,23 +1560,21 @@ test('Circular reference with arrays', function() {
     var objdump = QUnit.jsDump.parse(obj);
     var childarrdump = QUnit.jsDump.parse(childarr);
 
-    equal(objdump, '{\n  "childarr": [\n    recursion(-2)\n  ]\n}');
-    equal(childarrdump, '[\n  {\n    "childarr": recursion(-2)\n  }\n]');
+    equal(objdump, "{\n  \"childarr\": [\n    recursion(-2)\n  ]\n}");
+    equal(childarrdump, "[\n  {\n    \"childarr\": recursion(-2)\n  }\n]");
 
-    equal(obj.childarr, childarr, 'no endless stack when trying to dump array/object mix with circular ref');
-    equal(childarr[0], obj, 'no endless stack when trying to dump array/object mix with circular ref');
-
+    equal(obj.childarr, childarr, "no endless stack when trying to dump array/object mix with circular ref");
+    equal(childarr[0], obj, "no endless stack when trying to dump array/object mix with circular ref");
 });
 
-
-test('Circular reference - test reported by soniciq in #105', function() {
+test("Circular reference - test reported by soniciq in #105", function() {
     var MyObject = function() {};
     MyObject.prototype.parent = function(obj) {
-        if (obj === undefined) { return this._parent; }
+        if (obj === undefined) return this._parent;
         this._parent = obj;
     };
     MyObject.prototype.children = function(obj) {
-        if (obj === undefined) { return this._children; }
+        if (obj === undefined) return this._children;
         this._children = obj;
     };
 
@@ -1583,8 +1595,8 @@ test('Circular reference - test reported by soniciq in #105', function() {
     test("reset runs assertions", function() {
         expect(0);
         QUnit.reset = function() {
-            ok( false, "reset should not modify test status" );
-            reset.apply( this, arguments );
+            ok(false, "reset should not modify test status");
+            reset.apply(this, arguments);
         };
     });
     test("reset runs assertions, cleanup", function() {
@@ -1601,8 +1613,8 @@ function testAfterDone() {
         // Because when this does happen, the assertion count parameter doesn't actually
         // work we use this test to check the assertion count.
         QUnit.module("check previous test's assertion counts");
-        test('count previous two test\'s assertions', function () {
-            //var tests = getPreviousTests(/^ensure has correct number of assertions/, /^Synchronous test after load of page$/);
+        test("count previous two test's assertions", function() {
+            // var tests = getPreviousTests(/^ensure has correct number of assertions/, /^Synchronous test after load of page$/);
             var tests: any = {};
 
             equal(tests[0].firstChild.lastChild.getElementsByTagName("b")[1].innerHTML, "99");
@@ -1614,7 +1626,7 @@ function testAfterDone() {
 
     QUnit.module("Synchronous test after load of page");
 
-    asyncTest('Async test', function() {
+    asyncTest("Async test", function() {
         start();
         for (var i = 1; i < 100; i++) {
             ok(i);
@@ -1629,39 +1641,39 @@ function testAfterDone() {
 
     // We need two of these types of tests in order to ensure that assertions
     // don't move between tests.
-    QUnit.test(testName + ' 2', 99, function() {
+    QUnit.test(testName + " 2", 99, function() {
         for (var i = 1; i < 100; i++) {
             ok(i);
         }
     });
 }
 // Example QUnit.extend call taken from: http://api.qunitjs.com/QUnit.extend/
-QUnit.test( "QUnit.extend", function( assert ) {
-  var base = {
-    a: 1,
-    b: 2,
-    z: 3
-  };
-  QUnit.extend( base, {
-    b: 2.5,
-    c: 3,
-    z: undefined
-  } );
-  
-  // Change from documentation example to satisfy tsc:
-  var newBase = <any> base;
- 
-  assert.equal( newBase.a, 1, "Unspecified values are not modified" );
-  assert.equal( newBase.b, 2.5, "Existing values are updated" );
-  assert.equal( newBase.c, 3, "New values are defined" );
-  assert.ok( !( "z" in newBase ), "Values specified as `undefined` are removed" );
+QUnit.test("QUnit.extend", function(assert) {
+    var base = {
+        a: 1,
+        b: 2,
+        z: 3,
+    };
+    QUnit.extend(base, {
+        b: 2.5,
+        c: 3,
+        z: undefined,
+    });
+
+    // Change from documentation example to satisfy tsc:
+    var newBase = <any> base;
+
+    assert.equal(newBase.a, 1, "Unspecified values are not modified");
+    assert.equal(newBase.b, 2.5, "Existing values are updated");
+    assert.equal(newBase.c, 3, "New values are defined");
+    assert.ok(!("z" in newBase), "Values specified as `undefined` are removed");
 });
 
 // Example QUnit.extend usage taken from: https://stackoverflow.com/a/33439774/419956
 QUnit.extend(QUnit.assert, {
-    matches: function (actual, regex, message) {
+    matches: function(actual, regex, message) {
         var success = !!regex && !!actual && (new RegExp(regex)).test(actual);
         var expected = "String matching /" + regex.toString() + "/";
         this.push(success, actual, expected, message);
-    }
+    },
 });

--- a/types/qwest/index.d.ts
+++ b/types/qwest/index.d.ts
@@ -4,9 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Qwest {
-
     interface Static {
-
         /** Base URI for requests. Prepended to request URIs */
         base: string;
 
@@ -27,7 +25,7 @@ declare namespace Qwest {
          * @param url URL that the request is sent to
          * @param data Data to send to the server
          * @param options Configuration options for the AJAX request
-         * */
+         */
         get(url: string, data?: any, options?: Options): Promise;
 
         /**
@@ -35,7 +33,7 @@ declare namespace Qwest {
          * @param url URL that the request is sent to
          * @param data Data to send to the server
          * @param options Configuration options for the AJAX request
-         * */
+         */
         post(url: string, data?: any, options?: Options): Promise;
 
         /**
@@ -43,7 +41,7 @@ declare namespace Qwest {
          * @param url URL that the request is sent to
          * @param data Data to send to the server
          * @param options Configuration options for the AJAX request
-         * */
+         */
         put(url: string, data?: any, options?: Options): Promise;
 
         /**
@@ -51,7 +49,7 @@ declare namespace Qwest {
          * @param url URL that the request is sent to
          * @param data Data to send to the server
          * @param options Configuration options for the AJAX request
-         * */
+         */
         delete(url: string, data?: any, options?: Options): Promise;
     }
 
@@ -60,14 +58,13 @@ declare namespace Qwest {
         then(callback: (xhr: any, response?: any) => any): Promise;
 
         /** Request has failed */
-        catch(callback: (e: any, xhr? : any, response?: any) => any): Promise;
+        catch(callback: (e: any, xhr?: any, response?: any) => any): Promise;
 
         /** Always run */
         complete(callback: () => any): Promise;
     }
 
     interface Options {
-
         /** post (by default), json, text, arraybuffer, blob, document or formdata */
         dataType?: string | undefined;
 
@@ -87,7 +84,7 @@ declare namespace Qwest {
         password?: string | undefined;
 
         /** javascript object containing headers to be sent */
-        headers?: { [key: string]: any; } | undefined;
+        headers?: { [key: string]: any } | undefined;
 
         /** false by default; sends credentials with your XHR2 request */
         withCredentials?: boolean | undefined;
@@ -97,9 +94,7 @@ declare namespace Qwest {
 
         /** the total number of times to attempt the request through timeouts; 1 by default; if you want to remove the limit set it to null */
         attempts?: number | undefined;
-
     }
-
 }
 
 declare module "qwest" {

--- a/types/qwest/qwest-tests.ts
+++ b/types/qwest/qwest-tests.ts
@@ -1,16 +1,14 @@
-
-
 // Examples taken from https://github.com/pyrsmk/qwest/blob/master/README.md
 
-qwest.get('example.com')
+qwest.get("example.com")
     .then(function(response) {
         alert(response);
     });
 
-qwest.post('example.com', {
-    firstname: 'Pedro',
-    lastname: 'Sanchez',
-    age: 30
+qwest.post("example.com", {
+    firstname: "Pedro",
+    lastname: "Sanchez",
+    age: 30,
 })
     .then(function(response) {
         // Make some useful actions
@@ -19,7 +17,7 @@ qwest.post('example.com', {
         // Process the error
     });
 
-qwest.get('example.com')
+qwest.get("example.com")
     .then(function(response) {
         // Blah blah blah
     })
@@ -27,7 +25,7 @@ qwest.get('example.com')
         throw e;
     });
 
-qwest.base = 'http://example.com/';
+qwest.base = "http://example.com/";
 
 qwest.limit(4);
 
@@ -36,7 +34,7 @@ qwest.before(function() {
         // Upload in progress
     };
 })
-    .get('example.com')
+    .get("example.com")
     .then(function(response) {
         // Blah blah blah
     });
@@ -47,36 +45,35 @@ if (qwest.xhr2) {
     // Actions for XHR1
 }
 
-qwest.setDefaultXdrResponseType('text');
-
+qwest.setDefaultXdrResponseType("text");
 
 // Extra tests for anything not covered above
 
 // Tests for method types
-qwest.post('foo')
-qwest.put('foo')
-qwest.delete('foo')
+qwest.post("foo");
+qwest.put("foo");
+qwest.delete("foo");
 
 // Tests for request method options
-qwest.get('foo', null, {
-    dataType: 'foo',
-    responseType: 'bar',
+qwest.get("foo", null, {
+    dataType: "foo",
+    responseType: "bar",
     cache: true,
     async: false,
-    user: 'bob',
-    password: 'pass',
+    user: "bob",
+    password: "pass",
     headers: {
-        'X-Foo': 'Bar',
-        'X-Something': {
-            foo: 'bar'
-        }
+        "X-Foo": "Bar",
+        "X-Something": {
+            foo: "bar",
+        },
     },
     withCredentials: true,
     timeout: 2000,
-    attempts: 7
-})
-qwest.get('foo', null, {})
+    attempts: 7,
+});
+qwest.get("foo", null, {});
 
-qwest.get('foo', null, {}).complete(() => {
-    //done
-})
+qwest.get("foo", null, {}).complete(() => {
+    // done
+});


### PR DESCRIPTION
> 👉 Partial implementation of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65993. If you're seeing this and are surprised it's happening, please read the discussion and give feedback! ❤️ 

Implements the dprint formatting changes on packages whose names start with `q`. We're splitting up the changes to make it a bit easier to apply & review them en masse - and, if we need later on, revert / bisect for issues. These changes generated with roughly:

```shell
git checkout dprint-onboarding -- .dprint.jsonc
time npx dprint fmt "types/q*/**/*.t*"
# Formatted 59 files.
# npx dprint fmt "types/q*/**/*.t*"  2.20s user 0.50s system 166% cpu 1.622 total
rm .dprint.jsonc
```