### PR TITLE
Formatted types/x* packages with dprint

### DIFF
--- a/types/x-axios-progress-bar/index.d.ts
+++ b/types/x-axios-progress-bar/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Claas Augner <https://github.com/caugner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { AxiosRequestConfig, AxiosInstance } from "axios";
+import { AxiosInstance, AxiosRequestConfig } from "axios";
 
-export  function loadProgressBar(
+export function loadProgressBar(
     config?: AxiosRequestConfig,
-    instance?: AxiosInstance
+    instance?: AxiosInstance,
 ): void;
 
 declare module "axios" {

--- a/types/x-editable/index.d.ts
+++ b/types/x-editable/index.d.ts
@@ -7,70 +7,70 @@
 /// <reference types="jquery"/>
 
 interface XEditableOptions {
-  ajaxOptions?: any;
-  anim?: string | undefined;
-  autotext?: string | undefined;
-  defaultValue?: any;
-  disabled?: boolean | undefined;
-  display?: any;
-  emptyclass?: string | undefined;
-  emptytext?: string | undefined;
-  error?: any;
-  highlight?: any;
-  mode?: string | undefined;
-  name?: string | undefined;
-  onblur?: string | undefined;
-  params?: any;
-  pk?: any;
-  placement?: string | undefined;
-  savenochange?: boolean | undefined;
-  selector?: string | undefined;
-  send?: string | undefined;
-  showbuttons?: any;
-  success?: any;
-  toggle?: string | undefined;
-  type?: string | undefined;
-  unsavedclass?: string | undefined;
-  url?: any;
-  validate?: any;
-  value?: any;
+    ajaxOptions?: any;
+    anim?: string | undefined;
+    autotext?: string | undefined;
+    defaultValue?: any;
+    disabled?: boolean | undefined;
+    display?: any;
+    emptyclass?: string | undefined;
+    emptytext?: string | undefined;
+    error?: any;
+    highlight?: any;
+    mode?: string | undefined;
+    name?: string | undefined;
+    onblur?: string | undefined;
+    params?: any;
+    pk?: any;
+    placement?: string | undefined;
+    savenochange?: boolean | undefined;
+    selector?: string | undefined;
+    send?: string | undefined;
+    showbuttons?: any;
+    success?: any;
+    toggle?: string | undefined;
+    type?: string | undefined;
+    unsavedclass?: string | undefined;
+    url?: any;
+    validate?: any;
+    value?: any;
 }
 
 interface XEditableSubmitOptions {
-  url?: any;
-  data?: any;
-  ajaxOptions?: any;
-  error(obj: any): void;
-  success(obj: any, config: any): void;
+    url?: any;
+    data?: any;
+    ajaxOptions?: any;
+    error(obj: any): void;
+    success(obj: any, config: any): void;
 }
 
 interface XEditable {
-  options: XEditableOptions;
-  activate(): void;
-  destroy(): void;
-  disable(): void;
-  enable(): void;
-  getValue(isSingle: boolean): any;
-  hide(): void;
-  option(key: any, value: any): void;
-  setValue(value: any, convertStr: boolean): void;
-  show(closeAll: boolean): void;
-  submit(options: XEditableSubmitOptions): void;
-  toggle(closeAll: boolean): void;
-  toggleDisabled(): void;
-  validate(): void;
+    options: XEditableOptions;
+    activate(): void;
+    destroy(): void;
+    disable(): void;
+    enable(): void;
+    getValue(isSingle: boolean): any;
+    hide(): void;
+    option(key: any, value: any): void;
+    setValue(value: any, convertStr: boolean): void;
+    show(closeAll: boolean): void;
+    submit(options: XEditableSubmitOptions): void;
+    toggle(closeAll: boolean): void;
+    toggleDisabled(): void;
+    validate(): void;
 }
 
 interface JQuery {
-  /**
-    * Initializes editable with the specified options
-    * @param options an object with options specific to the editable instance
-    */
-  editable(options?: any): XEditable;
-  /**
-    * Initializes editable calling the specific method with is parameters
-    * @param method the method to call
-    * @param params the parameters expected by the method
-    */
-  editable(method: string, params?: any): XEditable;
+    /**
+     * Initializes editable with the specified options
+     * @param options an object with options specific to the editable instance
+     */
+    editable(options?: any): XEditable;
+    /**
+     * Initializes editable calling the specific method with is parameters
+     * @param method the method to call
+     * @param params the parameters expected by the method
+     */
+    editable(method: string, params?: any): XEditable;
 }

--- a/types/x-editable/x-editable-tests.ts
+++ b/types/x-editable/x-editable-tests.ts
@@ -1,120 +1,120 @@
 // server post and response
-$('#username').editable({
-    success: function(response : any, newValue : any) {
-        if(response.status == 'error') return response.msg; //msg will be shown in editable form
-    }
+$("#username").editable({
+    success: function(response: any, newValue: any) {
+        if (response.status == "error") return response.msg; // msg will be shown in editable form
+    },
 });
 
 // no post to the server
-$('#username').editable({
-    type: 'text',
-    title: 'Enter username',
-    success: function(response : any, newValue : any) {
+$("#username").editable({
+    type: "text",
+    title: "Enter username",
+    success: function(response: any, newValue: any) {
         // update view model
-    }
+    },
 });
 
 // text
 $("#username").editable({
     url: "/post",
-    title: "Enter username"
+    title: "Enter username",
 });
 
 // text area
-$('#comments').editable({
-    url: '/post',
-    title: 'Enter comments',
-    rows: 10
+$("#comments").editable({
+    url: "/post",
+    title: "Enter comments",
+    rows: 10,
 });
 
 // select
 $("#status").editable({
     value: 2,
     source: [
-          {value: 1, text: 'Active'},
-          {value: 2, text: 'Blocked'},
-          {value: 3, text: 'Deleted'}
-       ]
+        { value: 1, text: "Active" },
+        { value: 2, text: "Blocked" },
+        { value: 3, text: "Deleted" },
+    ],
 });
 
 // date
-$('#dob').editable({
-    format: 'yyyy-mm-dd',
-    viewformat: 'dd/mm/yyyy',
+$("#dob").editable({
+    format: "yyyy-mm-dd",
+    viewformat: "dd/mm/yyyy",
     datepicker: {
-      weekStart: 1
-    }
+        weekStart: 1,
+    },
 });
 
 // datetime
-$('#last_seen').editable({
-    format: 'yyyy-mm-dd hh:ii',
-    viewformat: 'dd/mm/yyyy hh:ii',
+$("#last_seen").editable({
+    format: "yyyy-mm-dd hh:ii",
+    viewformat: "dd/mm/yyyy hh:ii",
     datetimepicker: {
-        weekStart: 1
-     }
+        weekStart: 1,
+    },
 });
 
 // dateui
-$('#dob').editable({
-    format: 'yyyy-mm-dd',
-    viewformat: 'dd/mm/yyyy',
+$("#dob").editable({
+    format: "yyyy-mm-dd",
+    viewformat: "dd/mm/yyyy",
     datepicker: {
-        firstDay: 1
-     }
+        firstDay: 1,
+    },
 });
 
 // combodate
-$('#dob').editable({
-    format: 'YYYY-MM-DD',
-    viewformat: 'DD.MM.YYYY',
-    template: 'D / MMMM / YYYY',
+$("#dob").editable({
+    format: "YYYY-MM-DD",
+    viewformat: "DD.MM.YYYY",
+    template: "D / MMMM / YYYY",
     combodate: {
-          minYear: 2000,
-          maxYear: 2015,
-          minuteStep: 1
-     }
+        minYear: 2000,
+        maxYear: 2015,
+        minuteStep: 1,
+    },
 });
 
 // checklist
-$('#options').editable({
+$("#options").editable({
     value: [2, 3],
     source: [
-          {value: 1, text: 'option1'},
-          {value: 2, text: 'option2'},
-          {value: 3, text: 'option3'}
-       ]
+        { value: 1, text: "option1" },
+        { value: 2, text: "option2" },
+        { value: 3, text: "option3" },
+    ],
 });
 
 // select2 remote source (advanced)
-$('#country').editable({
+$("#country").editable({
     select2: {
-        placeholder: 'Select Country',
+        placeholder: "Select Country",
         allowClear: true,
         minimumInputLength: 3,
-        id: function (item : any) {
+        id: function(item: any) {
             return item.CountryId;
         },
         ajax: {
-            url: '/getCountries',
-            dataType: 'json',
-            data: function (term : any, page : any) {
+            url: "/getCountries",
+            dataType: "json",
+            data: function(term: any, page: any) {
                 return { query: term };
             },
-            results: function (data : any, page : any) {
+            results: function(data: any, page: any) {
                 return { results: data };
-            }
+            },
         },
-        formatResult: function (item : any) {
+        formatResult: function(item: any) {
             return item.CountryName;
         },
-        formatSelection: function (item : any) {
+        formatSelection: function(item: any) {
             return item.CountryName;
         },
-        initSelection: function (element : any, callback : any) {
-            return $.get('/getCountryById', { query: element.val() }, function (data : any) {
+        initSelection: function(element: any, callback: any) {
+            return $.get("/getCountryById", { query: element.val() }, function(data: any) {
                 callback(data);
             });
-        }
-    }
+        },
+    },
 });

--- a/types/x-ray-crawler/index.d.ts
+++ b/types/x-ray-crawler/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import HttpContext = require('http-context');
+import HttpContext = require("http-context");
 
 export = XRayCrawler;
 

--- a/types/x-ray-crawler/x-ray-crawler-tests.ts
+++ b/types/x-ray-crawler/x-ray-crawler-tests.ts
@@ -1,5 +1,5 @@
-import HttpContext = require('http-context');
-import XRayCrawler = require('x-ray-crawler');
+import HttpContext = require("http-context");
+import XRayCrawler = require("x-ray-crawler");
 
 const xRayCrawler: XRayCrawler.Instance = XRayCrawler();
 
@@ -8,17 +8,17 @@ xRayCrawler.driver(driver);
 
 const throttle: number = xRayCrawler.throttle();
 xRayCrawler.throttle(5, 4);
-xRayCrawler.throttle(5, '4ms');
+xRayCrawler.throttle(5, "4ms");
 
 const randomDelay: XRayCrawler.RandomDelay = xRayCrawler.delay();
 const delay: number = randomDelay();
 xRayCrawler.delay(0, 2);
 xRayCrawler.delay(0);
-xRayCrawler.delay('0s', '5s');
+xRayCrawler.delay("0s", "5s");
 
 const timeout: number = xRayCrawler.timeout();
 xRayCrawler.timeout(timeout);
-xRayCrawler.timeout('5s');
+xRayCrawler.timeout("5s");
 
 const concurrency: number = xRayCrawler.concurrency();
 xRayCrawler.concurrency(5);
@@ -39,9 +39,9 @@ const limit: number = xRayCrawler.limit();
 xRayCrawler.limit(limit);
 
 const xRayCrawler2: XRayCrawler.Instance = XRayCrawler()
-    .throttle(5, '10s')
-    .delay('5s', '10s')
-    .timeout('20s')
+    .throttle(5, "10s")
+    .delay("5s", "10s")
+    .timeout("20s")
     .concurrency(4)
     .request((request: HttpContext.Request) => {
         console.log(request);

--- a/types/x-ray/index.d.ts
+++ b/types/x-ray/index.d.ts
@@ -6,8 +6,8 @@
 
 /// <reference types="node" />
 
-import Bluebird = require('bluebird');
-import XRayCrawler = require('x-ray-crawler');
+import Bluebird = require("bluebird");
+import XRayCrawler = require("x-ray-crawler");
 
 export = XRay;
 
@@ -16,16 +16,16 @@ declare function XRay(options?: XRay.Options): XRay.Instance;
 declare namespace XRay {
     type Filter = (value: any, ...args: string[]) => any;
     interface Options {
-        filters: {[key: string]: Filter};
+        filters: { [key: string]: Filter };
     }
     type Callback = (err: Error, data: any) => void;
 
     // circularly references itself
     // https://stackoverflow.com/a/41826582
     type ScalarSelector =
-        string |
-        InstanceInvocation |
-        {[key: string]: Selector};
+        | string
+        | InstanceInvocation
+        | { [key: string]: Selector };
     interface SelectorArray extends Array<ScalarSelector | SelectorArray> {
         [index: number]: ScalarSelector | SelectorArray;
     }
@@ -36,19 +36,19 @@ declare namespace XRay {
     interface Instance extends XRayCrawler.Instance {
         (
             source: string,
-            selector: Selector
+            selector: Selector,
         ): InstanceInvocation;
         (
             source: string,
             context: string,
-            selector: Selector
+            selector: Selector,
         ): InstanceInvocation;
         (
             context: string,
-            selector: Selector
+            selector: Selector,
         ): InstanceInvocation;
         (
-            selector: Selector
+            selector: Selector,
         ): InstanceInvocation;
     }
 

--- a/types/x-ray/x-ray-tests.ts
+++ b/types/x-ray/x-ray-tests.ts
@@ -1,133 +1,135 @@
-import express = require('express');
-import XRay = require('x-ray');
+import express = require("express");
+import XRay = require("x-ray");
 
 const x: XRay.Instance = XRay();
 
 // README Examples
-x('https://blog.ycombinator.com/', '.post', [{
-        title: 'h1 a',
-        link: '.article-title@href'
-    }])
-    .paginate('.nav-previous a@href')
+x("https://blog.ycombinator.com/", ".post", [{
+    title: "h1 a",
+    link: ".article-title@href",
+}])
+    .paginate(".nav-previous a@href")
     .limit(3)
-    .write('results.json');
+    .write("results.json");
 
-x('http://google.com', 'title')((err: Error, title: string) => {
+x("http://google.com", "title")((err: Error, title: string) => {
     console.log(title); // Google
 });
 
 const fn: XRay.Callback = (err: Error, data: any) => {
     console.log(data);
 };
-x('http://reddit.com', '.content')(fn);
-x('http://techcrunch.com', 'img.logo@src')(fn);
-x('http://news.ycombinator.com', 'body@html')(fn);
+x("http://reddit.com", ".content")(fn);
+x("http://techcrunch.com", "img.logo@src")(fn);
+x("http://news.ycombinator.com", "body@html")(fn);
 
-const html = '<body><h2>Pear</h2></body>';
-x(html, 'body', 'h2')((err: Error, header: string) => {
+const html = "<body><h2>Pear</h2></body>";
+x(html, "body", "h2")((err: Error, header: string) => {
     console.log(header); // => Pear
 });
 
 const app = express();
-app.get('/', (req: express.Request, res: express.Response) => {
-    const stream = x('http://google.com', 'title').stream();
+app.get("/", (req: express.Request, res: express.Response) => {
+    const stream = x("http://google.com", "title").stream();
     stream.pipe(res);
 });
 
-x('https://dribbble.com', 'li.group', [{
-        title: '.dribbble-img strong',
-        image: '.dribbble-img [data-src]@data-src',
-    }])
-    .paginate('.next_page@href')
+x("https://dribbble.com", "li.group", [{
+    title: ".dribbble-img strong",
+    image: ".dribbble-img [data-src]@data-src",
+}])
+    .paginate(".next_page@href")
     .limit(3)
-    .then((res: Array<{title: string, image: string}>) => {
+    .then((res: Array<{ title: string; image: string }>) => {
         console.log(res[0]); // prints first result
     })
     .catch((err: Error) => {
         console.log(err); // handle error in promise
     });
 
-x('http://google.com', {
-    main: 'title',
-    image: x('#gbar a@href', 'title'), // follow link to google images
+x("http://google.com", {
+    main: "title",
+    image: x("#gbar a@href", "title"), // follow link to google images
 })(fn);
 
-x('http://mat.io', {
-    title: 'title',
-    items: x('.item', [{
-        title: '.item-content h2',
-        description: '.item-content section'
-    }])
+x("http://mat.io", {
+    title: "title",
+    items: x(".item", [{
+        title: ".item-content h2",
+        description: ".item-content section",
+    }]),
 })(fn);
 
 const x2 = XRay({
     filters: {
         trim: (value: string): string => {
-            return typeof value === 'string' ? value.trim() : value;
+            return typeof value === "string" ? value.trim() : value;
         },
         reverse: (value: string): string => {
-            return typeof value === 'string' ? value.split('').reverse().join('') : value;
+            return typeof value === "string" ? value.split("").reverse().join("") : value;
         },
         slice: (value: string, start: string, end: string): string => {
-            return typeof value === 'string' ? value.slice(+start, +end) : value;
-        }
-    }
+            return typeof value === "string" ? value.slice(+start, +end) : value;
+        },
+    },
 });
-x2('http://mat.io', {
-  title: 'title | trim | reverse | slice:2,3'
+x2("http://mat.io", {
+    title: "title | trim | reverse | slice:2,3",
 })(fn);
 
 // Examples
-x(html, 'h2')(console.log);
+x(html, "h2")(console.log);
 
 x(html, {
-    title: '.title',
-    image: 'img@src',
-    tags: ['li']
+    title: ".title",
+    image: "img@src",
+    tags: ["li"],
 })(console.log);
 
-x(html, ['a'])(console.log);
+x(html, ["a"])(console.log);
 
-x(html, '.item', [{
-    title: 'h2',
-    tags: x('.tags', ['li'])
+x(html, ".item", [{
+    title: "h2",
+    tags: x(".tags", ["li"]),
 }])(console.log);
 
-x(html, '.tags', [['li']])(console.log);
+x(html, ".tags", [["li"]])(console.log);
 
 // Tests
 x({
-    title: 'title@text',
-    image: x('#gbar a@href', 'title'),
-    scoped_title: x('head', 'title'),
-    inner: x('title', {
-        title: '@text'
-    })
-})('http://www.google.com/ncr', fn);
+    title: "title@text",
+    image: x("#gbar a@href", "title"),
+    scoped_title: x("head", "title"),
+    inner: x("title", {
+        title: "@text",
+    }),
+})("http://www.google.com/ncr", fn);
 
 x({
-    list: x('body', {
-      first: x('a@href', 'title')
-    })
+    list: x("body", {
+        first: x("a@href", "title"),
+    }),
 })(fn);
 
-const pagedUrl = 'https://github.com/matthewmueller/x-ray/issues?q=is%3Aissue%20sort%3Acreated-asc%20';
+const pagedUrl = "https://github.com/matthewmueller/x-ray/issues?q=is%3Aissue%20sort%3Acreated-asc%20";
 
-x(pagedUrl, '.js-issue-row', [{ id: '@id', title: 'a.h4' }])
-    .paginate('.next_page@href')
-    .abort((_, url) => url.includes('page=3'));
+x(pagedUrl, ".js-issue-row", [{ id: "@id", title: "a.h4" }])
+    .paginate(".next_page@href")
+    .abort((_, url) => url.includes("page=3"));
 
-const hasStringId = (obj: any): obj is {id: string} => {
+const hasStringId = (obj: any): obj is { id: string } => {
     if (!!obj) return false;
-    if (typeof obj !== 'object') return false;
-    if (!('id' in obj)) return false;
-    if (typeof obj.id !== 'string') return false;
+    if (typeof obj !== "object") return false;
+    if (!("id" in obj)) return false;
+    if (typeof obj.id !== "string") return false;
     return true;
 };
 
-x(pagedUrl, '.js-issue-row', [{ id: '@id', title: 'a.h4' }])
-    .paginate('.next_page@href')
-    .abort((results) => results.some(result => {
-        if (hasStringId(result) && result.id === 'issue_40') return true;
-        return false;
-    }));
+x(pagedUrl, ".js-issue-row", [{ id: "@id", title: "a.h4" }])
+    .paginate(".next_page@href")
+    .abort((results) =>
+        results.some(result => {
+            if (hasStringId(result) && result.id === "issue_40") return true;
+            return false;
+        })
+    );

--- a/types/x509.js/x509.js-tests.ts
+++ b/types/x509.js/x509.js-tests.ts
@@ -1,8 +1,8 @@
-import * as x509js from 'x509.js';
+import * as x509js from "x509.js";
 
-x509js.parseKey('keyString');
+x509js.parseKey("keyString");
 x509js.info();
-const result = x509js.parseCert('certSting');
+const result = x509js.parseCert("certSting");
 result.subject.organizationalUnitName; // $ExpectType string | undefined
 result.issuer.localityName; // $ExpectType string | undefined
 result.issuer.countryName; // $ExpectType string | undefined

--- a/types/xar/index.d.ts
+++ b/types/xar/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node"/>
 
-import { Readable as ReadableStream } from 'stream';
+import { Readable as ReadableStream } from "stream";
 
 export interface TOCHeader {
     cksumAlg: number;
@@ -15,7 +15,7 @@ export interface TOCHeader {
     version: number;
 }
 
-export type Compression = 'none' | 'gzip';
+export type Compression = "none" | "gzip";
 
 export interface PackOptions {
     compression?: Compression | undefined;

--- a/types/xar/xar-tests.ts
+++ b/types/xar/xar-tests.ts
@@ -1,4 +1,4 @@
-import * as xar from 'xar';
+import * as xar from "xar";
 
 const buffer = Buffer.from([]);
 
@@ -21,6 +21,6 @@ xar.extract(buffer, (error, file, content) => {
     content; // $ExpectType string | undefined
 });
 
-xar.pack('dir');
-xar.pack('dir', { compression: 'gzip' });
-xar.create('dir', { compression: 'gzip' });
+xar.pack("dir");
+xar.pack("dir", { compression: "gzip" });
+xar.create("dir", { compression: "gzip" });

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -7,7 +7,7 @@
 //                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from 'unist';
+import type { Data as UnistData, Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from "unist";
 
 // ## Interfaces
 
@@ -174,7 +174,7 @@ export interface Cdata extends Literal {
     /**
      * Node type of XML CDATA sections in xast.
      */
-    type: 'cdata';
+    type: "cdata";
     /**
      * Data associated with the cdata.
      */
@@ -193,7 +193,7 @@ export interface Comment extends Literal {
     /**
      * Node type of XML comments in xast.
      */
-    type: 'comment';
+    type: "comment";
     /**
      * Data associated with the comment.
      */
@@ -212,7 +212,7 @@ export interface Doctype extends Node {
     /**
      * Node type of XML document types in xast.
      */
-    type: 'doctype';
+    type: "doctype";
     /**
      * Name of the root element.
      *
@@ -245,7 +245,7 @@ export interface Instruction extends Literal {
     /**
      * Node type of XML processing instructions in xast.
      */
-    type: 'instruction';
+    type: "instruction";
     /**
      * Name of the instruction.
      *
@@ -270,7 +270,7 @@ export interface Element extends Parent {
     /**
      * Node type of elements.
      */
-    type: 'element';
+    type: "element";
     /**
      * Qualified name (such as `'artist'` or `'svg:rect'`) of the element.
      */
@@ -307,7 +307,7 @@ export interface Root extends Parent {
     /**
      * Node type of xast root.
      */
-    type: 'root';
+    type: "root";
     /**
      * Data associated with the xast root.
      */
@@ -326,7 +326,7 @@ export interface Text extends Literal {
     /**
      * Node type of XML character data (plain text) in xast.
      */
-    type: 'text';
+    type: "text";
     /**
      * Data associated with the text.
      */

--- a/types/xast/v1/index.d.ts
+++ b/types/xast/v1/index.d.ts
@@ -7,7 +7,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+import { Literal as UnistLiteral, Node as UnistNode, Parent as UnistParent } from "unist";
 
 export { UnistNode as Node };
 export { UnistParent as Parent };
@@ -54,7 +54,7 @@ export interface RootChildMap {
  * whole document.
  */
 export interface Root extends UnistParent {
-    type: 'root';
+    type: "root";
     children: Array<RootChildMap[keyof RootChildMap]>;
 }
 
@@ -87,7 +87,7 @@ export interface ElementChildMap {
  * An XML element.
  */
 export interface Element extends UnistParent {
-    type: 'element';
+    type: "element";
     /**
      * The element's qualified name.
      */
@@ -110,21 +110,21 @@ export interface Attributes {
  * XML character data.
  */
 export interface Text extends Literal {
-    type: 'text';
+    type: "text";
 }
 
 /**
  * XML comment.
  */
 export interface Comment extends Literal {
-    type: 'comment';
+    type: "comment";
 }
 
 /**
  * XML doctype.
  */
 export interface Doctype extends UnistNode {
-    type: 'doctype';
+    type: "doctype";
     name: string;
     /**
      * The document’s public identifier.
@@ -140,7 +140,7 @@ export interface Doctype extends UnistNode {
  * XML processing instruction.
  */
 export interface Instruction extends Literal {
-    type: 'instruction';
+    type: "instruction";
     name: string;
 }
 
@@ -148,5 +148,5 @@ export interface Instruction extends Literal {
  * XML CDATA section.
  */
 export interface Cdata extends Literal {
-    type: 'cdata';
+    type: "cdata";
 }

--- a/types/xast/v1/xast-tests.ts
+++ b/types/xast/v1/xast-tests.ts
@@ -1,11 +1,11 @@
-import { Data, Node, Point, Position } from 'unist';
-import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
+import { Data, Node, Point, Position } from "unist";
+import { Attributes, Cdata, Comment, Doctype, Element, Instruction, Literal, Parent, Root, Text } from "xast";
 
 const data: Data = {
-    string: 'string',
+    string: "string",
     number: 1,
     object: {
-        key: 'value',
+        key: "value",
     },
     array: [],
     boolean: true,
@@ -25,76 +25,76 @@ const position: Position = {
 };
 
 const literal: Literal = {
-    type: 'text',
+    type: "text",
     data,
     position,
-    value: 'value',
+    value: "value",
 };
 
 const comment: Comment = {
-    type: 'comment',
+    type: "comment",
     data,
     position,
-    value: 'value',
+    value: "value",
 };
 
 const text: Text = {
-    type: 'text',
+    type: "text",
     data,
     position,
-    value: 'value',
+    value: "value",
 };
 
 const docType: Doctype = {
-    type: 'doctype',
+    type: "doctype",
     data,
     position,
-    name: 'name',
-    public: 'public',
-    system: 'system',
+    name: "name",
+    public: "public",
+    system: "system",
 };
 
 const cdata: Cdata = {
-    type: 'cdata',
+    type: "cdata",
     data,
     position,
-    value: 'value',
+    value: "value",
 };
 
 const instruction: Instruction = {
-    type: 'instruction',
+    type: "instruction",
     data,
     position,
-    name: 'name',
-    value: 'value',
+    name: "name",
+    value: "value",
 };
 
 let element: Element = getElement();
 
 const parent: Parent = {
-    type: 'parent',
+    type: "parent",
     data,
     position,
     children: [getElement(), docType, comment, text, instruction, cdata],
 };
 
 let root: Root = {
-    type: 'root',
+    type: "root",
     data,
     position,
     children: [getElement(), docType, comment, text, instruction, cdata],
 };
 
 const attributes: Attributes = {
-    attributeName1: 'attributeValue',
+    attributeName1: "attributeValue",
     attributeName2: null,
     attributeName3: undefined,
 };
 
 function getElement(): Element {
     return {
-        type: 'element',
-        name: 'name',
+        type: "element",
+        name: "name",
         attributes,
         children: [element, comment, text, cdata, instruction],
     };
@@ -102,10 +102,10 @@ function getElement(): Element {
 
 // Test custom xast node registration
 interface Custom extends Node {
-    type: 'custom';
+    type: "custom";
 }
 
-declare module 'xast' {
+declare module "xast" {
     interface RootChildMap {
         custom: Custom;
     }
@@ -116,33 +116,33 @@ declare module 'xast' {
 }
 
 root = {
-    type: 'root',
+    type: "root",
     data,
     position,
-    children: [{ type: 'custom' }],
+    children: [{ type: "custom" }],
 };
 
 element = {
-    type: 'element',
-    name: 'foo',
+    type: "element",
+    name: "foo",
     data,
     position,
-    children: [{ type: 'custom' }],
+    children: [{ type: "custom" }],
 };
 
 root = {
-    type: 'root',
+    type: "root",
     data,
     position,
     // @ts-expect-error
-    children: [{ type: 'invalid' }],
+    children: [{ type: "invalid" }],
 };
 
 element = {
-    type: 'element',
-    name: 'foo',
+    type: "element",
+    name: "foo",
     data,
     position,
     // @ts-expect-error
-    children: [{ type: 'invalid' }],
+    children: [{ type: "invalid" }],
 };

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -11,7 +11,7 @@ import {
     Parent,
     Root,
     Text,
-} from 'xast';
+} from "xast";
 
 const data: Data = {};
 
@@ -21,52 +21,52 @@ const position = {
 };
 
 const literal: Literal = {
-    type: 'whatever',
-    value: 'value',
+    type: "whatever",
+    value: "value",
     position,
     data,
 };
 
 const comment: Comment = {
-    type: 'comment',
-    value: 'value',
+    type: "comment",
+    value: "value",
     position,
     data,
 };
 
 const text: Text = {
-    type: 'text',
-    value: 'value',
+    type: "text",
+    value: "value",
     position,
     data,
 };
 
 const doctype: Doctype = {
-    type: 'doctype',
-    name: 'name',
-    public: 'public',
-    system: 'system',
+    type: "doctype",
+    name: "name",
+    public: "public",
+    system: "system",
     position,
     data,
 };
 
 const cdata: Cdata = {
-    type: 'cdata',
-    value: 'value',
+    type: "cdata",
+    value: "value",
     position,
     data,
 };
 
 const instruction: Instruction = {
-    type: 'instruction',
-    name: 'name',
-    value: 'value',
+    type: "instruction",
+    name: "name",
+    value: "value",
     position,
     data,
 };
 
 const attributes: Attributes = {
-    attributeName1: 'attributeValue',
+    attributeName1: "attributeValue",
     attributeName2: null,
     attributeName3: undefined,
     // @ts-expect-error: only nullish strings are allowed.
@@ -74,15 +74,15 @@ const attributes: Attributes = {
 };
 
 const element: Element = {
-    type: 'element',
-    name: 'x',
+    type: "element",
+    name: "x",
     attributes,
-    children: [{ type: 'element', name: 'y', attributes: {}, children: [] }, comment, text, cdata, instruction],
+    children: [{ type: "element", name: "y", attributes: {}, children: [] }, comment, text, cdata, instruction],
 };
 
 const elementWithWrongChild: Element = {
-    type: 'element',
-    name: 'z',
+    type: "element",
+    name: "z",
     attributes: {},
     children: [
         // @ts-expect-error: doctypes are not valid in elements.
@@ -91,14 +91,14 @@ const elementWithWrongChild: Element = {
 };
 
 const parent: Parent = {
-    type: 'whatever',
+    type: "whatever",
     data,
     position,
     children: [element, doctype, comment, text, instruction, cdata],
 };
 
 const root: Root = {
-    type: 'root',
+    type: "root",
     data,
     position,
     children: [element, doctype, comment, text, instruction, cdata],
@@ -106,10 +106,10 @@ const root: Root = {
 
 // Test custom xast node registration.
 interface Custom extends Node {
-    type: 'custom';
+    type: "custom";
 }
 
-declare module 'xast' {
+declare module "xast" {
     interface RootContentMap {
         custom: Custom;
     }
@@ -120,44 +120,44 @@ declare module 'xast' {
 }
 
 const rootOther: Root = {
-    type: 'root',
+    type: "root",
     data,
     position,
-    children: [{ type: 'custom' }],
+    children: [{ type: "custom" }],
 };
 
 const elementOther: Element = {
-    type: 'element',
-    name: 'foo',
-    attributes: { key: 'value' },
+    type: "element",
+    name: "foo",
+    attributes: { key: "value" },
     data,
     position,
-    children: [{ type: 'custom' }],
+    children: [{ type: "custom" }],
 };
 
 const rootAnother: Root = {
-    type: 'root',
+    type: "root",
     data,
     position,
     children: [
         // @ts-expect-error: node not registered in `RootContentMap`.
-        { type: 'invalid' },
+        { type: "invalid" },
     ],
 };
 
 const elementAnother: Element = {
-    type: 'element',
-    name: 'foo',
+    type: "element",
+    name: "foo",
     data,
     position,
     children: [
         // @ts-expect-error: node not registered in `ElementContentMap`.
-        { type: 'invalid' },
+        { type: "invalid" },
     ],
 };
 
 // Register a field on `Data`, which will be available on all nodes.
-declare module 'xast' {
+declare module "xast" {
     interface Data {
         someField?: string | undefined;
     }
@@ -168,30 +168,30 @@ declare module 'xast' {
 }
 
 const textWithData: Text = {
-    type: 'text',
-    value: 'value',
+    type: "text",
+    value: "value",
     data: {
-        someField: 'a',
+        someField: "a",
         // @ts-expect-error: not registered on all xast nodes.
         someOtherField: 1,
     },
 };
 
 const textWithOtherData: Text = {
-    type: 'text',
-    value: 'value',
+    type: "text",
+    value: "value",
     data: {
-        someField: 'a',
+        someField: "a",
         // @ts-expect-error: not registered on text nodes.
         someUnknownField: true,
     },
 };
 
 const commentWithData: Comment = {
-    type: 'comment',
-    value: 'value',
+    type: "comment",
+    value: "value",
     data: {
-        someField: 'a',
+        someField: "a",
         someOtherField: 1,
         // @ts-expect-error: not registered.
         someUnknownField: true,

--- a/types/xdate/index.d.ts
+++ b/types/xdate/index.d.ts
@@ -3,52 +3,47 @@
 // Definitions by: yamada28go <https://github.com/yamada28go>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-interface formatters_info
-{
+interface formatters_info {
     i?: string | undefined;
     u?: string | undefined;
-    xxx? : string | undefined;
-    vvv?: ((xdate : XDate , useutc : boolean ) => string) | undefined;
+    xxx?: string | undefined;
+    vvv?: ((xdate: XDate, useutc: boolean) => string) | undefined;
 }
 
-interface locale_detail
-{
-    monthNames? : string [] | undefined;
-    monthNamesShort?: string [] | undefined;
+interface locale_detail {
+    monthNames?: string[] | undefined;
+    monthNamesShort?: string[] | undefined;
     dayNames?: string[] | undefined;
-    dayNamesShort?: string [] | undefined;
+    dayNamesShort?: string[] | undefined;
     amDesignator?: string | undefined;
     pmDesignator?: string | undefined;
 }
 
-
 declare class XDate {
-
-    //------------
-    //Constructors
-    //------------
+    // ------------
+    // Constructors
+    // ------------
 
     public constructor();
 
-    public constructor( utcmode : boolean );
+    public constructor(utcmode: boolean);
 
     /**
      * constructor
      */
-    public constructor(xdate : XDate ,  utcmode? : boolean ) ;
+    public constructor(xdate: XDate, utcmode?: boolean);
 
     /**
      * constructor
      * @param {Date} [nativeDate] - JavaScript native date
      */
-    public constructor(nativeDate : Date ,  utcmode? : boolean ) ;
+    public constructor(nativeDate: Date, utcmode?: boolean);
 
     /**
      * constructor
      * @param {number} [milliseconds] - milliseconds
      */
-    public constructor(milliseconds: number ,  utcmode? : boolean ) ;
+    public constructor(milliseconds: number, utcmode?: boolean);
 
     /**
      * constructor
@@ -60,318 +55,334 @@ declare class XDate {
      * @param {number} [seconds] - seconds
      * @param {number} [milliseconds] - milliseconds
      */
-    public constructor( year : number , month : number , date : number ,
-            hours? : number , minutes? : number , seconds? : number , milliseconds? : number , utcmode? : boolean );
+    public constructor(
+        year: number,
+        month: number,
+        date: number,
+        hours?: number,
+        minutes?: number,
+        seconds?: number,
+        milliseconds?: number,
+        utcmode?: boolean,
+    );
 
     /**
      * constructor
      * @param {string} [dateString] - formatted date string
      */
-    public constructor( dateString : string ,  utcmode? : boolean  );
+    public constructor(dateString: string, utcmode?: boolean);
 
-    //------------
-    //Getters
-    //------------
+    // ------------
+    // Getters
+    // ------------
 
     /**
      * Returns the 4-digit year (ex: 2012)
      * @return {number} 4-digit year (ex: 2012)
      */
-    public getFullYear() : number ;
+    public getFullYear(): number;
 
     /*
-     *Returns the month of the year. (0-11)
-     *Value is zero-index, meaning Jan=0, Feb=1, Mar=2, etc.
+     * Returns the month of the year. (0-11)
+     * Value is zero-index, meaning Jan=0, Feb=1, Mar=2, etc.
      */
-    public getMonth() : number;
+    public getMonth(): number;
 
     /*
-     *Returns the ISO week number of the year. (1-53)
+     * Returns the ISO week number of the year. (1-53)
      */
     public getWeek(): number;
 
     /*
-     *Returns the date of the month. (1-31)
+     * Returns the date of the month. (1-31)
      */
-    public getDate() : number;
+    public getDate(): number;
 
     /*
-     *Returns the day-of-week as a number. (0-6)
-     *Sun=0, Mon=1, Tue=2, etc.
+     * Returns the day-of-week as a number. (0-6)
+     * Sun=0, Mon=1, Tue=2, etc.
      */
-    public getDay() : number;
+    public getDay(): number;
 
     /*
-     *Returns the hour of the day. (0-23)
+     * Returns the hour of the day. (0-23)
      */
-    public getHours() : number;
+    public getHours(): number;
 
     /*
-     *Returns the minute of the hour. (0-59)
+     * Returns the minute of the hour. (0-59)
      */
-    public getMinutes() : number;
+    public getMinutes(): number;
 
     /*
-     *Returns the second of the minute. (0-59)
+     * Returns the second of the minute. (0-59)
      */
-    public getSeconds() : number;
+    public getSeconds(): number;
 
     /*
-     *Returns the millisecond of the second. (0-999)
+     * Returns the millisecond of the second. (0-999)
      */
-    public getMilliseconds() : number;
+    public getMilliseconds(): number;
 
     /*
-     *Returns the number of milliseconds since the epoch.
+     * Returns the number of milliseconds since the epoch.
      */
-    public getTime() : number;
+    public getTime(): number;
 
     /*
-     *Returns the number of milliseconds since the epoch. Identical to getTime.
+     * Returns the number of milliseconds since the epoch. Identical to getTime.
      */
-    public valueOf() : number;
+    public valueOf(): number;
 
-    //------------
-    //Setters
-    //------------
+    // ------------
+    // Setters
+    // ------------
 
     /*
-     *year is a 4-digit year
+     * year is a 4-digit year
      */
-    public setFullYear(year : number , preventOverflow? : boolean) : XDate;
+    public setFullYear(year: number, preventOverflow?: boolean): XDate;
 
     /*
       month is zero-indexed, meaning Jan=0, Feb=1, Mar=2, etc.
     */
-    public setMonth(month : number , preventOverflow? : boolean ) : XDate;
+    public setMonth(month: number, preventOverflow?: boolean): XDate;
 
     /*
-     *Moves the xdate to the Monday of the given week with time 00:00:00.
-     *The week is represented by a given ISO week number and an optional year. If year is omitted, the xdate's year with be used.
+     * Moves the xdate to the Monday of the given week with time 00:00:00.
+     * The week is represented by a given ISO week number and an optional year. If year is omitted, the xdate's year with be used.
      */
-    public setWeek(week : number , year? :  number) : XDate;
+    public setWeek(week: number, year?: number): XDate;
 
     /*
-     *Sets the date of the month. (1-31)
+     * Sets the date of the month. (1-31)
      */
-    public setDate(date : number ) : XDate;
+    public setDate(date: number): XDate;
 
     /*
-     *Sets the hour of the day. (0-23)
+     * Sets the hour of the day. (0-23)
      */
-    public setHours(hours: number ) :XDate;
+    public setHours(hours: number): XDate;
 
     /*
-     *Sets the minute of the hour. (0-59)
+     * Sets the minute of the hour. (0-59)
      */
-    public setMinutes(minutes : number) : XDate;
+    public setMinutes(minutes: number): XDate;
 
     /*
-     *Sets the second of the minute. (0-59)
+     * Sets the second of the minute. (0-59)
      */
-    public setSeconds(seconds : number) : XDate;
+    public setSeconds(seconds: number): XDate;
 
     /*
-     *Sets the millisecond of the second. (0-999)
+     * Sets the millisecond of the second. (0-999)
      */
-    public setMilliseconds(milliseconds : number) : XDate;
+    public setMilliseconds(milliseconds: number): XDate;
 
     /*
-     *Sets the number of milliseconds since the epoch.
+     * Sets the number of milliseconds since the epoch.
      */
-    public setTime(milliseconds : number ) : XDate;
+    public setTime(milliseconds: number): XDate;
 
-    //------------
-    //Adding
-    //------------
-    public addYears(years : number, preventOverflow? : boolean) : XDate;
-    public addMonths(months : number , preventOverflow? : boolean) : XDate;
-    public addWeeks(weeks : number) : XDate;
-    public addDays(days : number) : XDate;
-    public addHours(hours : number) : XDate;
-    public addMinutes(minutes : number) : XDate;
-    public addSeconds(seconds : number) : XDate;
-    public addMilliseconds(milliseconds : number) :XDate;
+    // ------------
+    // Adding
+    // ------------
+    public addYears(years: number, preventOverflow?: boolean): XDate;
+    public addMonths(months: number, preventOverflow?: boolean): XDate;
+    public addWeeks(weeks: number): XDate;
+    public addDays(days: number): XDate;
+    public addHours(hours: number): XDate;
+    public addMinutes(minutes: number): XDate;
+    public addSeconds(seconds: number): XDate;
+    public addMilliseconds(milliseconds: number): XDate;
 
+    // ------------
+    // Diffing
+    // ------------
+    public diffYears(otherDate: string): number;
+    public diffYears(otherDate: XDate): number;
+    public diffMonths(otherDate: string): number;
+    public diffMonths(otherDate: XDate): number;
+    public diffWeeks(otherDate: string): number;
+    public diffWeeks(otherDate: XDate): number;
+    public diffDays(otherDate: string): number;
+    public diffDays(otherDate: XDate): number;
+    public diffHours(otherDate: string): number;
+    public diffHours(otherDate: XDate): number;
+    public diffMinutes(otherDate: string): number;
+    public diffMinutes(otherDate: XDate): number;
+    public diffSeconds(otherDate: string): number;
+    public diffSeconds(otherDate: XDate): number;
+    public diffMilliseconds(otherDate: string): number;
+    public diffMilliseconds(otherDate: XDate): number;
 
-    //------------
-    //Diffing
-    //------------
-    public diffYears(otherDate : string) : number ;
-    public diffYears(otherDate : XDate) : number ;
-    public diffMonths(otherDate : string) : number ;
-    public diffMonths(otherDate : XDate) : number ;
-    public diffWeeks(otherDate : string) : number ;
-    public diffWeeks(otherDate : XDate) : number ;
-    public diffDays(otherDate : string) : number ;
-    public diffDays(otherDate : XDate) : number ;
-    public diffHours(otherDate : string) : number ;
-    public diffHours(otherDate : XDate) : number ;
-    public diffMinutes(otherDate : string) : number ;
-    public diffMinutes(otherDate : XDate) : number ;
-    public diffSeconds(otherDate : string) : number ;
-    public diffSeconds(otherDate : XDate) : number ;
-    public diffMilliseconds(otherDate : string) : number ;
-    public diffMilliseconds(otherDate : XDate) : number ;
-
-
-    //------------
-    //Formatting
-    //------------
+    // ------------
+    // Formatting
+    // ------------
 
     /*
-     *If formatString is not specified, a browser-produced IETF string will be returned.
+     * If formatString is not specified, a browser-produced IETF string will be returned.
      * settings can be a name of an available locale or an object that overrides the default locale's settings.
      */
-    public toString(formatString? : string , settings? : Object) : string;
+    public toString(formatString?: string, settings?: Object): string;
 
     /*
-     *Same as toString but gets its values from the UTC version of the date.
-     *As a result, "Z" will be displayed as the timezone.
+     * Same as toString but gets its values from the UTC version of the date.
+     * As a result, "Z" will be displayed as the timezone.
      */
-    public toUTCString(formatString? : string , settings? : Object) : string;
-    public toGMTString(formatString? : string , settings? : Object) : string;
+    public toUTCString(formatString?: string, settings?: Object): string;
+    public toGMTString(formatString?: string, settings?: Object): string;
 
     /*
-     *Returns an ISO8601 string that has been normalized to UTC. Will have a "Z" timezone indicator.
-     *See the native Date's specs for toISOString.
+     * Returns an ISO8601 string that has been normalized to UTC. Will have a "Z" timezone indicator.
+     * See the native Date's specs for toISOString.
      */
-    public toISOString() : string;
+    public toISOString(): string;
 
     /*
-     *Same as native Date's toDateString
+     * Same as native Date's toDateString
      */
-    public toDateString() : string;
+    public toDateString(): string;
 
     /*
-     *Same as native Date's toTimeString
+     * Same as native Date's toTimeString
      */
-    public toTimeString() : string;
+    public toTimeString(): string;
 
     /*
-     *Same as native Date's toLocaleString
+     * Same as native Date's toLocaleString
      */
-    public toLocaleString() : string;
+    public toLocaleString(): string;
 
     /*
-     *Same as native Date's toLocaleDateString
+     * Same as native Date's toLocaleDateString
      */
-    public toLocaleDateString() : string;
+    public toLocaleDateString(): string;
 
     /*
-     *Same as native Date's toLocaleTimeString
+     * Same as native Date's toLocaleTimeString
      */
-    public toLocaleTimeString() : string;
+    public toLocaleTimeString(): string;
 
+    // ------------
+    // Formatting
+    // ------------
+    public getUTCFullYear(): number;
+    public getUTCMonth(): number;
+    public getUTCWeek(): number;
+    public getUTCDate(): number;
+    public getUTCDay(): number;
+    public getUTCHours(): number;
+    public getUTCMinutes(): number;
+    public getUTCSeconds(): number;
+    public getUTCMilliseconds(): number;
+    public setUTCFullYear(year: number): XDate;
+    public setUTCMonth(month: number): XDate;
+    public setUTCWeek(week: number, year?: number): XDate;
+    public setUTCDate(date: number): XDate;
+    public setUTCHours(hours: number): XDate;
+    public setUTCMinutes(minutes: number): XDate;
+    public setUTCSeconds(seconds: number): XDate;
+    public setUTCMilliseconds(milliseconds: number): XDate;
 
-    //------------
-    //Formatting
-    //------------
-    public getUTCFullYear() : number ;
-    public getUTCMonth()  : number ;
-    public getUTCWeek()  : number ;
-    public getUTCDate()  : number ;
-    public getUTCDay()  : number ;
-    public getUTCHours()  : number ;
-    public getUTCMinutes()  : number ;
-    public getUTCSeconds()  : number ;
-    public getUTCMilliseconds()  : number ;
-    public setUTCFullYear(year : number) : XDate;
-    public setUTCMonth(month : number)  : XDate;
-    public setUTCWeek(week : number , year? : number )  : XDate;
-    public setUTCDate(date : number )  : XDate;
-    public setUTCHours(hours : number )  : XDate;
-    public setUTCMinutes(minutes : number )  : XDate;
-    public setUTCSeconds(seconds : number )  : XDate;
-    public setUTCMilliseconds(milliseconds : number)  : XDate;
-
-    //------------
-    //UTC Mode
-    //------------
+    // ------------
+    // UTC Mode
+    // ------------
 
     /*
-     *Returns true if the date is in UTC-mode and false otherwise
+     * Returns true if the date is in UTC-mode and false otherwise
      */
-    public getUTCMode() : boolean;
+    public getUTCMode(): boolean;
 
     /*
-     *utcMode must be either true or false. If the optional doCoercion parameters is set to true,
-     *the underlying millisecond time of the date will be coerced in such a way that methods like
-     *getDate and getHours will have the same values before and after the conversion.
+     * utcMode must be either true or false. If the optional doCoercion parameters is set to true,
+     * the underlying millisecond time of the date will be coerced in such a way that methods like
+     * getDate and getHours will have the same values before and after the conversion.
      */
-    public setUTCMode(utcMode : boolean , doCoercion? : boolean ) : XDate;
+    public setUTCMode(utcMode: boolean, doCoercion?: boolean): XDate;
 
     /*
-     *Returns the number of minutes from UTC, just like the native Date's getTimezoneOffset.
-     *However, if the XDate is in UTC-mode, 0 will be returned.
+     * Returns the number of minutes from UTC, just like the native Date's getTimezoneOffset.
+     * However, if the XDate is in UTC-mode, 0 will be returned.
      */
-    public getTimezoneOffset() : number;
+    public getTimezoneOffset(): number;
 
-    //------------
-    //Utilities
-    //------------
+    // ------------
+    // Utilities
+    // ------------
 
     /*
-     *returns a copy of the XDate
+     * returns a copy of the XDate
      */
-    public clone() : XDate;
+    public clone(): XDate;
 
     /*
-     *sets the hours, minutes, seconds, and milliseconds to zero
+     * sets the hours, minutes, seconds, and milliseconds to zero
      */
-    public clearTime() : XDate ;
+    public clearTime(): XDate;
 
     /*
-     *return true if the XDate is a valid date, false otherwise
+     * return true if the XDate is a valid date, false otherwise
      */
-    public valid() : boolean ;
+    public valid(): boolean;
 
     /*
-     *Returns a conversion to a native Date
+     * Returns a conversion to a native Date
      */
-    public toDate() : Date;
+    public toDate(): Date;
 
-    //------------
-    //Static function
-    //------------
-
+    // ------------
+    // Static function
+    // ------------
 
     /*
-     *Returns the number of days in the given month
+     * Returns the number of days in the given month
      */
-    public static getDaysInMonth(year : number , month : number) : number;
+    public static getDaysInMonth(year: number, month: number): number;
 
     /*
-     *Parses a date-string and returns milliseconds since the epoch. You'll probably want to use new XDate(dateString) instead.
+     * Parses a date-string and returns milliseconds since the epoch. You'll probably want to use new XDate(dateString) instead.
      */
-    public static parse(dateString : string ) : number;
-
+    public static parse(dateString: string): number;
 
     /*
-     *Returns the current date, as milliseconds since the epoch. You'll probably want to use new XDate() instead.
+     * Returns the current date, as milliseconds since the epoch. You'll probably want to use new XDate() instead.
      */
-    public static now() : number ;
-
+    public static now(): number;
 
     /*
-     *Returns the current date with time cleared, as an XDate object
+     * Returns the current date with time cleared, as an XDate object
      */
-    public static today() : XDate ;
+    public static today(): XDate;
 
     /*
-     *Returns a milliseconds time since the epoch for the given UTC date
+     * Returns a milliseconds time since the epoch for the given UTC date
      */
-    public static UTC(year : number , month : number , date : number , hours : number,
-              minutes : number , seconds : number , milliseconds : number ) : XDate;
+    public static UTC(
+        year: number,
+        month: number,
+        date: number,
+        hours: number,
+        minutes: number,
+        seconds: number,
+        milliseconds: number,
+    ): XDate;
 
-    public static locales : { [key: string]: locale_detail; };
+    public static locales: { [key: string]: locale_detail };
 
-    public static defaultLocale : string;
-    public static formatters : formatters_info;
+    public static defaultLocale: string;
+    public static formatters: formatters_info;
 
-    public static getDaysInMonth(year : number, month : number) : number;
-    public static UTC(year : number, month : number, day : number , hours? : number , minutes? : number , seconds?:number,ms?:number): number;
-
+    public static getDaysInMonth(year: number, month: number): number;
+    public static UTC(
+        year: number,
+        month: number,
+        day: number,
+        hours?: number,
+        minutes?: number,
+        seconds?: number,
+        ms?: number,
+    ): number;
 }
 
 export = XDate;

--- a/types/xdate/xdate-tests.ts
+++ b/types/xdate/xdate-tests.ts
@@ -1,703 +1,632 @@
+// Those classes were tested by compile time only!
 
-
-//Those classes were tested by compile time only!
-
-namespace XDate_Test
-{
-
-    class test_base
-    {
-    public assert( ref : boolean )
-    {
-        if( true == ref)
-        {
-        console.info("OK");
-        }
-        else
-        {
-        console.warn("NG");
+namespace XDate_Test {
+    class test_base {
+        public assert(ref: boolean) {
+            if (true == ref) {
+                console.info("OK");
+            } else {
+                console.warn("NG");
+            }
         }
     }
+
+    // based on  xdate/test/adding.js
+    class adding extends test_base {
+        private addYears(): boolean {
+            var d1 = new XDate(2011, 2, 1);
+            d1.addYears(10);
+            var d2 = new XDate(2011, 2, 1);
+            d2.addYears(-2);
+            return d1.getFullYear() == 2021
+                && d1.getMonth() == 2
+                && d1.getDate() == 1
+                && d2.getFullYear() == 2009
+                && d2.getMonth() == 2
+                && d2.getDate() == 1;
+        }
+
+        private addMonths(): boolean {
+            var d1 = new XDate(2012, 2, 6);
+            d1.addMonths(3);
+            var d2 = new XDate(2012, 2, 6);
+            d2.addMonths(-3);
+            return d1.getFullYear() == 2012
+                && d1.getMonth() == 5
+                && d1.getDate() == 6
+                && d2.getFullYear() == 2011
+                && d2.getMonth() == 11
+                && d2.getDate() == 6;
+        }
+
+        private addMonths_prevent_overflow(): boolean {
+            var d1 = new XDate(2010, 11, 30); // dec 30
+            d1.addMonths(2, true);
+            var d2 = new XDate(2011, 5, 30); // jun 30
+            d2.addMonths(-4, true);
+            return d1.getFullYear() == 2011
+                && d1.getMonth() == 1
+                && d1.getDate() == 28
+                && d2.getFullYear() == 2011
+                && d2.getMonth() == 1
+                && d2.getDate() == 28;
+        }
+
+        private addMonths_prevent_overflow_backwards_january_bug(): boolean {
+            var d1 = new XDate(2013, 0, 28); // Jan 28
+            var d2 = new XDate(2013, 0, 14); // Jan 14
+            return d1.addMonths(-1, true).toString("yyyy-MM-dd") == "2012-12-28" // Dec 28
+                && d2.addMonths(-1, true).toString("yyyy-MM-dd") == "2012-12-14"; // Dec 14
+        }
+
+        private addDays(): boolean {
+            var d1 = new XDate(2009, 5, 8);
+            d1.addDays(30);
+            var d2 = new XDate(2009, 5, 8);
+            d2.addDays(-4);
+            return d1.getFullYear() == 2009
+                && d1.getMonth() == 6
+                && d1.getDate() == 8
+                && d2.getFullYear() == 2009
+                && d2.getMonth() == 5
+                && d2.getDate() == 4;
+        }
+
+        private addHours_addMinutes_addSeconds_addMilliseconds(): boolean {
+            var d = new XDate(2010, 0, 1, 5, 30, 24, 500);
+            d.addHours(2);
+            d.addMinutes(15);
+            d.addSeconds(6);
+            d.addMilliseconds(50);
+            return d.getHours() == 7
+                && d.getMinutes() == 45
+                && d.getSeconds() == 30
+                && d.getMilliseconds() == 550;
+        }
+
+        private addWeeks(): boolean {
+            return new XDate(2011, 7, 12).addWeeks(2).getDate() == 26
+                && new XDate(2011, 7, 12).addWeeks(-2).getDate() == 29;
+        }
+
+        public constructor() {
+            super();
+            super.assert(this.addYears());
+            super.assert(this.addMonths_prevent_overflow());
+            super.assert(this.addMonths_prevent_overflow_backwards_january_bug());
+            super.assert(this.addDays());
+            super.assert(this.addHours_addMinutes_addSeconds_addMilliseconds());
+            super.assert(this.addWeeks());
+        }
     }
 
-    //based on  xdate/test/adding.js
-    class adding extends test_base
-    {
+    class constructors extends test_base {
+        public no_args(): boolean {
+            var xdate = new XDate();
+            var time = +new Date();
+            return Math.abs(xdate.getTime() - time) < 1000 && !xdate.getUTCMode();
+        }
 
-    private addYears() : boolean
-    {
+        public only_utcMode_false(): boolean {
+            var xdate = new XDate(false);
+            var time = +new Date();
+            return Math.abs(xdate.getTime() - time) < 1000 && !xdate.getUTCMode();
+        }
 
-        var d1 = new XDate(2011, 2, 1);
-        d1.addYears(10);
-        var d2 = new XDate(2011, 2, 1);
-        d2.addYears(-2);
-        return d1.getFullYear() == 2021 &&
-        d1.getMonth() == 2 &&
-        d1.getDate() == 1 &&
-        d2.getFullYear() == 2009 &&
-        d2.getMonth() == 2 &&
-        d2.getDate() == 1;
+        public only_utcMode_true(): boolean {
+            var xdate = new XDate(true);
+            var time = +new Date();
+            return Math.abs(xdate.getTime() - time) < 1000 && xdate.getUTCMode();
+        }
 
-    }
+        public from_XDate_XDate(): boolean {
+            var xdate1 = new XDate();
+            var xdate2 = new XDate(xdate1);
+            return xdate1.getTime() == xdate2.getTime()
+                && !xdate1.getUTCMode() && !xdate2.getUTCMode();
+        }
 
-    private addMonths() : boolean
-    {
+        public from_XDate_XDate_with_utcMode_true(): boolean {
+            var xdate1 = new XDate().setUTCMode(true);
+            var xdate2 = new XDate(xdate1);
+            // return xdate1.getTime() == xdate2.getTime() &&
+            // xdate1.getUTCMode() && xdate2.getUTCMode();
+            return true;
+        }
 
-        var d1 = new XDate(2012, 2, 6);
-        d1.addMonths(3);
-        var d2 = new XDate(2012, 2, 6);
-        d2.addMonths(-3);
-        return d1.getFullYear() == 2012 &&
-        d1.getMonth() == 5 &&
-        d1.getDate() == 6 &&
-        d2.getFullYear() == 2011 &&
-        d2.getMonth() == 11 &&
-        d2.getDate() == 6;
-    }
+        public from_XDate_XDate_override_with_utcMode_true(): boolean {
+            var xdate1 = new XDate();
+            var xdate2 = new XDate(xdate1, true);
+            return xdate1.getTime() == xdate2.getTime()
+                && !xdate1.getUTCMode() && xdate2.getUTCMode();
+        }
 
-    private addMonths_prevent_overflow() : boolean
-    {
+        public from_XDate_XDate_override_with_utcMode_false(): boolean {
+            var xdate1 = new XDate().setUTCMode(true);
+            var xdate2 = new XDate(xdate1, false);
+            return xdate1.getTime() == xdate2.getTime()
+                && xdate1.getUTCMode() && !xdate2.getUTCMode();
+        }
 
-        var d1 = new XDate(2010, 11, 30); // dec 30
-        d1.addMonths(2, true);
-        var d2 = new XDate(2011, 5, 30); // jun 30
-        d2.addMonths(-4, true);
-        return d1.getFullYear() == 2011 &&
-        d1.getMonth() == 1 &&
-        d1.getDate() == 28 &&
-        d2.getFullYear() == 2011 &&
-        d2.getMonth() == 1 &&
-        d2.getDate() == 28;
+        public from_native_Date_utcMode_false(): boolean {
+            var date = new Date();
+            var xdate1 = new XDate(date);
+            var xdate2 = new XDate(date, false);
+            return date.getTime() == xdate1.getTime()
+                && date.getTime() == xdate2.getTime()
+                && !xdate1.getUTCMode() && !xdate2.getUTCMode();
+        }
 
-    }
+        public from_native_Date_utcMode_true(): boolean {
+            var date = new Date();
+            var xdate = new XDate(date, true);
+            return date.getTime() == xdate.getTime()
+                && xdate.getUTCMode();
+        }
 
-    private addMonths_prevent_overflow_backwards_january_bug() : boolean {
-        var d1 = new XDate(2013, 0, 28); // Jan 28
-        var d2 = new XDate(2013, 0, 14); // Jan 14
-        return d1.addMonths(-1, true).toString('yyyy-MM-dd') == '2012-12-28' && // Dec 28
-        d2.addMonths(-1, true).toString('yyyy-MM-dd') == '2012-12-14'; // Dec 14
-    }
+        public from_milliseconds_time_utcMode_false(): boolean {
+            var MS = 933490800000;
+            var xdate1 = new XDate(MS);
+            var xdate2 = new XDate(MS, false);
+            return !xdate1.getUTCMode()
+                && !xdate2.getUTCMode()
+                && xdate1.getTime() == MS
+                && xdate2.getTime() == MS;
+        }
 
+        public from_milliseconds_time_utcMode_true(): boolean {
+            var MS = 933490800000;
+            var xdate = new XDate(MS, true);
+            return xdate.getUTCMode() && xdate.getTime() == MS;
+        }
 
-    private addDays() : boolean {
-        var d1 = new XDate(2009, 5, 8);
-        d1.addDays(30);
-        var d2 = new XDate(2009, 5, 8);
-        d2.addDays(-4);
-        return d1.getFullYear() == 2009 &&
-        d1.getMonth() == 6 &&
-        d1.getDate() == 8 &&
-        d2.getFullYear() == 2009 &&
-        d2.getMonth() == 5 &&
-        d2.getDate() == 4;
-    }
+        public year_month_date_utcMode_false(): boolean {
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var xdate1 = new XDate(YEAR, MONTH, DATE);
+            // var xdate2 = new XDate(YEAR, MONTH, DATE, false);
+            var xdate2 = new XDate(YEAR, MONTH, DATE);
+            xdate2.setUTCMode(false);
+            return !xdate1.getUTCMode() && !xdate2.getUTCMode()
+                && xdate1.getTime() == xdate2.getTime()
+                && xdate1.getFullYear() == YEAR
+                && xdate1.getMonth() == MONTH
+                && xdate1.getDate() == DATE
+                && !xdate1.getHours()
+                && !xdate1.getMinutes()
+                && !xdate1.getSeconds()
+                && !xdate1.getMilliseconds();
+        }
 
+        public toString_utcMode_undefined_true(): boolean {
+            var xdate1 = new XDate("2012-09-21");
+            var xdate2 = new XDate("2012-09-21", true);
+            return xdate1.toString("yyyy-MM-dd HH-mm-ss") == "2012-09-21 00-00-00"
+                && xdate2.toString("yyyy-MM-dd HH-mm-ss") == "2012-09-21 00-00-00";
+        }
 
-    private addHours_addMinutes_addSeconds_addMilliseconds() : boolean {
-        var d = new XDate(2010, 0, 1, 5, 30, 24, 500);
-        d.addHours(2);
-        d.addMinutes(15);
-        d.addSeconds(6);
-        d.addMilliseconds(50);
-        return d.getHours() == 7 &&
-        d.getMinutes() == 45 &&
-        d.getSeconds() == 30 &&
-        d.getMilliseconds() == 550;
-    }
+        public year_month_date_minutes_seconds_milliseconds_utcMode_false(): boolean {
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            var xdate1 = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS);
+            var xdate2 = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS, false);
+            return !xdate1.getUTCMode() && !xdate2.getUTCMode()
+                && xdate1.getTime() == xdate2.getTime()
+                && xdate1.getFullYear() == YEAR
+                && xdate1.getMonth() == MONTH
+                && xdate1.getDate() == DATE
+                && xdate1.getHours() == HOURS
+                && xdate1.getMinutes() == MINUTES
+                && xdate1.getSeconds() == SECONDS
+                && xdate1.getMilliseconds() == MILLISECONDS;
+        }
 
+        public year_month_date_utcMode_true(): boolean {
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            // var xdate = new XDate(YEAR, MONTH, DATE, true);
+            var xdate = new XDate(YEAR, MONTH, DATE);
+            xdate.setUTCMode(true);
+            return xdate.getUTCMode()
+                && xdate.getFullYear() == YEAR
+                && xdate.getMonth() == MONTH
+                && xdate.getDate() == DATE
+                && !xdate.getHours()
+                && !xdate.getMinutes()
+                && !xdate.getSeconds()
+                && !xdate.getMilliseconds();
+        }
 
-    private addWeeks() : boolean {
-        return new XDate(2011, 7, 12).addWeeks(2).getDate() == 26 &&
-        new XDate(2011, 7, 12).addWeeks(-2).getDate() == 29;
-    }
+        public year_month_date_minutes_seconds_milliseconds_utcMode_true(): boolean {
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            var xdate = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS, true);
+            return xdate.getUTCMode()
+                && xdate.getFullYear() == YEAR
+                && xdate.getMonth() == MONTH
+                && xdate.getDate() == DATE
+                && xdate.getHours() == HOURS
+                && xdate.getMinutes() == MINUTES
+                && xdate.getSeconds() == SECONDS
+                && xdate.getMilliseconds() == MILLISECONDS;
+        }
 
-    public constructor()
-    {
-        super();
-        super.assert( this.addYears() );
-        super.assert( this.addMonths_prevent_overflow() );
-        super.assert( this.addMonths_prevent_overflow_backwards_january_bug()  );
-        super.assert( this.addDays() );
-        super.assert( this.addHours_addMinutes_addSeconds_addMilliseconds() );
-        super.assert( this.addWeeks() );
-    }
-
-    }
-
-
-    class constructors extends test_base
-    {
-
-    public no_args() : boolean {
-        var xdate = new XDate();
-        var time = +new Date();
-        return Math.abs(xdate.getTime() - time) < 1000 && !xdate.getUTCMode();
-    }
-
-    public only_utcMode_false(): boolean {
-        var xdate = new XDate(false);
-        var time = +new Date();
-        return Math.abs(xdate.getTime() - time) < 1000 && !xdate.getUTCMode();
-    }
-
-    public only_utcMode_true() : boolean {
-        var xdate = new XDate(true);
-        var time = +new Date();
-        return Math.abs(xdate.getTime() - time) < 1000 && xdate.getUTCMode();
-    }
-
-    public from_XDate_XDate() : boolean {
-        var xdate1 = new XDate();
-        var xdate2 = new XDate(xdate1);
-        return xdate1.getTime() == xdate2.getTime() &&
-        !xdate1.getUTCMode() && !xdate2.getUTCMode();
-    }
-
-    public from_XDate_XDate_with_utcMode_true() : boolean {
-        var xdate1 = new XDate().setUTCMode(true);
-        var xdate2 = new XDate(xdate1);
-        //return xdate1.getTime() == xdate2.getTime() &&
-        //xdate1.getUTCMode() && xdate2.getUTCMode();
-        return true;
-    }
-
-    public from_XDate_XDate_override_with_utcMode_true() : boolean {
-        var xdate1 = new XDate();
-        var xdate2 = new XDate(xdate1, true);
-        return xdate1.getTime() == xdate2.getTime() &&
-        !xdate1.getUTCMode() && xdate2.getUTCMode();
-    }
-
-    public from_XDate_XDate_override_with_utcMode_false() : boolean {
-        var xdate1 = new XDate().setUTCMode(true);
-        var xdate2 = new XDate(xdate1, false);
-        return xdate1.getTime() == xdate2.getTime() &&
-        xdate1.getUTCMode() && !xdate2.getUTCMode();
-    }
-
-    public from_native_Date_utcMode_false() : boolean {
-        var date = new Date();
-        var xdate1 = new XDate(date);
-        var xdate2 = new XDate(date, false);
-        return date.getTime() == xdate1.getTime() &&
-        date.getTime() == xdate2.getTime() &&
-        !xdate1.getUTCMode() && !xdate2.getUTCMode();
-    }
-
-    public from_native_Date_utcMode_true(): boolean {
-        var date = new Date();
-        var xdate = new XDate(date, true);
-        return date.getTime() == xdate.getTime() &&
-        xdate.getUTCMode();
-    }
-
-    public from_milliseconds_time_utcMode_false() : boolean {
-        var MS = 933490800000;
-        var xdate1 = new XDate(MS);
-        var xdate2 = new XDate(MS, false);
-        return !xdate1.getUTCMode() &&
-        !xdate2.getUTCMode() &&
-        xdate1.getTime() == MS &&
-        xdate2.getTime() == MS;
-    }
-
-    public from_milliseconds_time_utcMode_true() : boolean {
-        var MS = 933490800000;
-        var xdate = new XDate(MS, true);
-        return xdate.getUTCMode() && xdate.getTime() == MS;
-    }
-
-    public year_month_date_utcMode_false() : boolean {
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var xdate1 = new XDate(YEAR, MONTH, DATE);
-        //var xdate2 = new XDate(YEAR, MONTH, DATE, false);
-        var xdate2 = new XDate(YEAR, MONTH, DATE);
-        xdate2.setUTCMode(false);
-        return !xdate1.getUTCMode() && !xdate2.getUTCMode() &&
-        xdate1.getTime() == xdate2.getTime() &&
-        xdate1.getFullYear() == YEAR &&
-        xdate1.getMonth() == MONTH &&
-        xdate1.getDate() == DATE &&
-        !xdate1.getHours() &&
-        !xdate1.getMinutes() &&
-        !xdate1.getSeconds() &&
-        !xdate1.getMilliseconds();
-    }
-
-    public toString_utcMode_undefined_true() : boolean {
-        var xdate1 = new XDate('2012-09-21');
-        var xdate2 = new XDate('2012-09-21', true);
-        return xdate1.toString('yyyy-MM-dd HH-mm-ss') == '2012-09-21 00-00-00' &&
-        xdate2.toString('yyyy-MM-dd HH-mm-ss') == '2012-09-21 00-00-00';
-    }
-
-    public year_month_date_minutes_seconds_milliseconds_utcMode_false() : boolean {
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        var xdate1 = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS);
-        var xdate2 = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS, false);
-        return !xdate1.getUTCMode() && !xdate2.getUTCMode() &&
-        xdate1.getTime() == xdate2.getTime() &&
-        xdate1.getFullYear() == YEAR &&
-        xdate1.getMonth() == MONTH &&
-        xdate1.getDate() == DATE &&
-        xdate1.getHours() == HOURS &&
-        xdate1.getMinutes() == MINUTES &&
-        xdate1.getSeconds() == SECONDS &&
-        xdate1.getMilliseconds() == MILLISECONDS;
-    }
-
-    public year_month_date_utcMode_true() : boolean {
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        //var xdate = new XDate(YEAR, MONTH, DATE, true);
-        var xdate = new XDate(YEAR, MONTH, DATE);
-        xdate.setUTCMode(true);
-        return xdate.getUTCMode() &&
-        xdate.getFullYear() == YEAR &&
-        xdate.getMonth() == MONTH &&
-        xdate.getDate() == DATE &&
-        !xdate.getHours() &&
-        !xdate.getMinutes() &&
-        !xdate.getSeconds() &&
-        !xdate.getMilliseconds();
-    }
-
-    public year_month_date_minutes_seconds_milliseconds_utcMode_true() : boolean {
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        var xdate = new XDate(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS, true);
-        return xdate.getUTCMode() &&
-        xdate.getFullYear() == YEAR &&
-        xdate.getMonth() == MONTH &&
-        xdate.getDate() == DATE &&
-        xdate.getHours() == HOURS &&
-        xdate.getMinutes() == MINUTES &&
-        xdate.getSeconds() == SECONDS &&
-        xdate.getMilliseconds() == MILLISECONDS;
-    }
-
-    /*
+        /*
       public without_new_operator() : boolean {
       return XDate("Sun Aug 14 2011 00:28:53 GMT-0700 (PDT)") &&
       !XDate("asdf").valid();
       }
     */
 
+        public constructor() {
+            super();
+            super.assert(this.no_args());
+            super.assert(this.only_utcMode_false());
+            super.assert(this.only_utcMode_true());
+            super.assert(this.from_XDate_XDate());
 
-    public constructor()
-    {
-        super();
-        super.assert( this.no_args() );
-        super.assert( this.only_utcMode_false() );
-        super.assert( this.only_utcMode_true() );
-        super.assert( this.from_XDate_XDate() );
-
-        super.assert(this.from_XDate_XDate_with_utcMode_true());
-        super.assert(this.from_XDate_XDate_override_with_utcMode_true());
-        super.assert(this.from_XDate_XDate_override_with_utcMode_false());
-        super.assert(this.from_native_Date_utcMode_false());
-        super.assert(this.from_native_Date_utcMode_true());
-        super.assert(this.from_milliseconds_time_utcMode_false());
-        super.assert(this.from_milliseconds_time_utcMode_true());
-        super.assert(this.year_month_date_utcMode_false());
-        super.assert(this.toString_utcMode_undefined_true());
-        super.assert(this.year_month_date_minutes_seconds_milliseconds_utcMode_false());
-        super.assert(this.year_month_date_utcMode_true());
-        super.assert(this.year_month_date_minutes_seconds_milliseconds_utcMode_true());
+            super.assert(this.from_XDate_XDate_with_utcMode_true());
+            super.assert(this.from_XDate_XDate_override_with_utcMode_true());
+            super.assert(this.from_XDate_XDate_override_with_utcMode_false());
+            super.assert(this.from_native_Date_utcMode_false());
+            super.assert(this.from_native_Date_utcMode_true());
+            super.assert(this.from_milliseconds_time_utcMode_false());
+            super.assert(this.from_milliseconds_time_utcMode_true());
+            super.assert(this.year_month_date_utcMode_false());
+            super.assert(this.toString_utcMode_undefined_true());
+            super.assert(this.year_month_date_minutes_seconds_milliseconds_utcMode_false());
+            super.assert(this.year_month_date_utcMode_true());
+            super.assert(this.year_month_date_minutes_seconds_milliseconds_utcMode_true());
+        }
     }
-    }
-
 
     // based on xdate/test/diffing.js
-    class diffing extends test_base
-    {
+    class diffing extends test_base {
+        public diffWeeks(): boolean {
+            return Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 26))) == 1
+                // Math.abs(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 26), true) - (1+1/7)) < .001 &&
+                && Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 24))) == 0
+                // Math.abs(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 24), true) - (1-1/7)) < .001 &&
+                && Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate("2011-05-26"))) == 1;
+        }
 
+        public diffYears(): boolean {
+            return new XDate("2011-04-10").diffYears("2013-04-10") == 2
+                && new XDate("2011-01-01T06:06:06").diffYears("2013-07-01T06:06:06") == 2.5;
+        }
 
-    public diffWeeks() : boolean{
-        return Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 26))) == 1 &&
-        //Math.abs(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 26), true) - (1+1/7)) < .001 &&
-        Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 24))) == 0 &&
-        //Math.abs(new XDate(2011, 4, 18).diffWeeks(new XDate(2011, 4, 24), true) - (1-1/7)) < .001 &&
-        Math.floor(new XDate(2011, 4, 18).diffWeeks(new XDate('2011-05-26'))) == 1;
-    }
+        public diffMonths(): boolean {
+            return new XDate("2011-06-05").diffMonths("2012-07-05") == 13
+                && new XDate("2012-07-05").diffMonths("2011-06-05") == -13;
+        }
 
+        public diffDays(): boolean {
+            return new XDate("2012-12-25").diffDays("2012-12-30") == 5;
+        }
 
-    public diffYears() :boolean {
-        return new XDate('2011-04-10').diffYears('2013-04-10') == 2 &&
-        new XDate('2011-01-01T06:06:06').diffYears('2013-07-01T06:06:06') == 2.5;
-    }
+        public diffHours(): boolean {
+            return new XDate("2012-05-05T06:30:00").diffHours("2012-05-05T04:00:00") == -2.5;
+        }
 
+        public diffMinutes(): boolean {
+            return new XDate("2012-05-01T05:50").diffMinutes("2012-05-01T06:10:30") == 20.5;
+        }
 
-    public diffMonths() :boolean {
-        return new XDate('2011-06-05').diffMonths('2012-07-05') == 13 &&
-        new XDate('2012-07-05').diffMonths('2011-06-05') == -13;
-    }
+        public diffSeconds(): boolean {
+            return new XDate("2012-03-01T00:00:45").diffSeconds("2012-03-01T00:01:15") == 30;
+        }
 
+        public diffMilliseconds(): boolean {
+            return new XDate("2011-06-06T05:05:05").diffMilliseconds("2011-06-06T05:05:08.100") == 3100;
+        }
 
-    public diffDays() :boolean {
-        return new XDate('2012-12-25').diffDays('2012-12-30') == 5;
-    }
-
-
-    public diffHours() :boolean {
-        return new XDate('2012-05-05T06:30:00').diffHours('2012-05-05T04:00:00') == -2.5;
-    }
-
-
-    public diffMinutes() :boolean {
-        return new XDate('2012-05-01T05:50').diffMinutes('2012-05-01T06:10:30') == 20.5;
-    }
-
-
-    public diffSeconds() :boolean {
-        return new XDate('2012-03-01T00:00:45').diffSeconds('2012-03-01T00:01:15') == 30;
-    }
-
-
-    public diffMilliseconds() :boolean {
-        return new XDate('2011-06-06T05:05:05').diffMilliseconds('2011-06-06T05:05:08.100') == 3100;
-    }
-
-
-
-    public constructor()
-    {
-        super();
-        super.assert( this.diffWeeks() );
-        super.assert( this.diffYears() );
-        super.assert( this.diffMonths() );
-        super.assert( this.diffDays() );
-        super.assert( this.diffHours() );
-        super.assert( this.diffMinutes() );
-        super.assert( this.diffSeconds() );
-        super.assert( this.diffMilliseconds() );
-    }
-
+        public constructor() {
+            super();
+            super.assert(this.diffWeeks());
+            super.assert(this.diffYears());
+            super.assert(this.diffMonths());
+            super.assert(this.diffDays());
+            super.assert(this.diffHours());
+            super.assert(this.diffMinutes());
+            super.assert(this.diffSeconds());
+            super.assert(this.diffMilliseconds());
+        }
     }
 
     // based on xdate/test/formatting.js
-    class formatting extends test_base
-    {
+    class formatting extends test_base {
+        public numbers_am(): boolean {
+            return new XDate(1986, 5, 8, 4, 3, 2)
+                .toString("MM/dd/yyyy hh:mm:ss tt") == "06/08/1986 04:03:02 am";
+        }
 
-    public numbers_am() : boolean  {
-        return new XDate(1986, 5, 8, 4, 3, 2)
-        .toString('MM/dd/yyyy hh:mm:ss tt') == "06/08/1986 04:03:02 am";
+        public numbers_am_uppercase(): boolean {
+            return new XDate(1986, 5, 8, 4, 3, 2)
+                .toString("MM/dd/yyyy hh:mm:ss TT") == "06/08/1986 04:03:02 AM";
+        }
+
+        public numbers_am_mini(): boolean {
+            return new XDate(1986, 5, 8, 4, 3, 2)
+                .toString("M/d/yy h:m:s t") == "6/8/86 4:3:2 a";
+        }
+
+        public numbers_pm(): boolean {
+            return new XDate(1986, 5, 8, 14, 3, 2)
+                .toString("MM/dd/yyyy hh:mm:ss tt") == "06/08/1986 02:03:02 pm";
+        }
+
+        public numbers_pm_uppercase(): boolean {
+            return new XDate(1986, 5, 8, 14, 3, 2)
+                .toString("MM/dd/yyyy hh:mm:ss TT") == "06/08/1986 02:03:02 PM";
+        }
+
+        public numbers_pm_mini(): boolean {
+            return new XDate(1986, 5, 8, 14, 3, 2)
+                .toString("M/d/yy h:m:s t") == "6/8/86 2:3:2 p";
+        }
+
+        public no_am_pm_confusion(): boolean {
+            return new XDate(2012, 5, 8).toString("tt") == "am"
+                && new XDate(2012, 5, 8, 12).toString("tt") == "pm";
+        }
+
+        public numbers_24_hour_clock(): boolean {
+            return new XDate(1986, 5, 8, 14, 3, 2)
+                .toString("dd/MM/yyyy HH:mm:ss") == "08/06/1986 14:03:02";
+        }
+
+        public short_names(): boolean {
+            return new XDate(2011, 10, 5)
+                .toString("ddd, MMM dd, yyyy") == "Sat, Nov 05, 2011";
+        }
+
+        public long_namesu(): boolean {
+            return new XDate(2011, 10, 5)
+                .toString("dddd, MMMM dd, yyyy") == "Saturday, November 05, 2011";
+        }
+
+        public ordinals(): boolean {
+            return new XDate(2011, 1, 1).toString("dS") == "1st"
+                && new XDate(2011, 1, 2).toString("dS") == "2nd"
+                && new XDate(2011, 1, 3).toString("dS") == "3rd"
+                && new XDate(2011, 1, 4).toString("dS") == "4th"
+                && new XDate(2011, 1, 23).toString("dS") == "23rd"
+                && new XDate(2011, 1, 11).toString("dS") == "11th";
+        }
+
+        public fff_milliseconds(): boolean {
+            var d = new XDate();
+            var s = d.toString("fff");
+            return d.getMilliseconds() === parseInt(s, 10) && s.length == 3;
+        }
+
+        public timezone(): boolean {
+            var d1 = new XDate();
+            d1.getTimezoneOffset = function() {
+                return 7 * 60 + 15;
+            };
+            var d2 = new XDate();
+            d2.getTimezoneOffset = function() {
+                return -(7 * 60 + 15);
+            };
+            return d1.toString("z") == "-7"
+                && d1.toString("zz") == "-07"
+                && d1.toString("zzz") == "-07:15"
+                && d2.toString("z") == "+7"
+                && d2.toString("zz") == "+07"
+                && d2.toString("zzz") == "+07:15";
+        }
+
+        public toString_i(): boolean {
+            var d = new XDate(2011, 5, 8, 14, 35, 21);
+            return d.toString("i") == "2011-06-08T14:35:21";
+        }
+
+        public toString_i_utcMode_true(): boolean {
+            var d = new XDate(2011, 5, 8, 14, 35, 21);
+            d.setUTCMode(true);
+            return d.toString("i") == "2011-06-08T14:35:21";
+        }
+
+        public toString_u(): boolean {
+            var d = new XDate(2011, 5, 8, 14, 35, 21);
+            return d.toString("u").indexOf("2011-06-08T14:35:21") == 0;
+        }
+
+        public toString_u_utcMode_true(): boolean {
+            var d = new XDate(2011, 5, 8, 14, 35, 21);
+            d.setUTCMode(true);
+            return d.toString("u") == "2011-06-08T14:35:21Z";
+        }
+
+        public toUTCString_i(): boolean {
+            var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21));
+            return d.toUTCString("i") == "2011-06-08T14:35:21";
+        }
+
+        public toUTCString_i_utcMode_true(): boolean {
+            var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21), true);
+            return d.toUTCString("i") == "2011-06-08T14:35:21";
+        }
+
+        public toUTCString_u(): boolean {
+            var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21));
+            return d.toUTCString("u") == "2011-06-08T14:35:21Z";
+        }
+
+        public toUTCString_u_utcMode_true(): boolean {
+            var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21), true);
+            return d.toUTCString("u") == "2011-06-08T14:35:21Z";
+        }
+
+        public non_zero_parenthesis(): boolean {
+            var d1 = new XDate(2010, 5, 8, 1);
+            var d2 = new XDate(2010, 5, 8, 14, 30);
+            return d1.toString("M/d/yyyy h(:mm)tt") == "6/8/2010 1am"
+                && d2.toString("M/d/yyyy h(:mm)tt") == "6/8/2010 2:30pm";
+        }
+
+        public non_zero_parenthesis_nested(): boolean {
+            return new XDate(2011, 5, 8).toString("(h(:mm)tt)") == "12am"
+                && new XDate(2011, 5, 8, 6).toString("(h(:mm)tt)") == "6am"
+                && new XDate(2011, 5, 8, 6, 30).toString("(h(:mm)tt)") == "6:30am";
+        }
+
+        public non_zero_parenthesis_crazy_quotes(): boolean {
+            return new XDate(2010, 5, 8, 14, 30)
+                .toString("M/d/yyyy h(:mm')')tt") == "6/8/2010 2:30)pm";
+        }
+
+        public string_literal(): boolean {
+            var d = new XDate(2011, 5, 8);
+            return d.toString("MMM dS 'yyyy!mm'") == "Jun 8th yyyy!mm";
+        }
+
+        public escaped_single_quote(): boolean {
+            var d = new XDate(2011, 5, 8);
+            return d.toString("''MMM dS yyyy''") == "'Jun 8th 2011'";
+        }
+
+        public toString_toUTCString_settings_param(): boolean {
+            var settings = {
+                dayNames: ["Sunday", "Benduday", "Zhellday", "Taungsday", "Centaxday", "Primeday", "Saturday"],
+            };
+            return new XDate(2011, 3, 29).toString("dddd yyyy", settings) == "Primeday 2011"
+                && new XDate(2011, 3, 4, 12).toUTCString("dddd yyyy", settings) == "Benduday 2011";
+        }
+
+        public iso_week_correct_digits(): boolean {
+            return new XDate(2011, 2, 1).toString("w") == "9"
+                && new XDate(2011, 2, 1).toUTCString("w") == "9"
+                && new XDate(2011, 2, 1).toString("ww") == "09"
+                && new XDate(2011, 2, 1).toUTCString("ww") == "09";
+        }
+
+        public toString_toUTCString_different_locale(): boolean {
+            XDate.locales["starwars"] = {
+                dayNames: ["Sunday", "Benduday", "Zhellday", "Taungsday", "Centaxday", "Primeday", "Saturday"],
+            };
+            return new XDate(2011, 3, 29).toString("dddd yyyy", "starwars") == "Primeday 2011"
+                && new XDate(2011, 3, 4, 12).toUTCString("dddd yyyy", "starwars") == "Benduday 2011";
+        }
+
+        public toString_toUTCString_new_default_locale(): boolean {
+            XDate.locales["starwars"] = {
+                dayNames: ["Sunday", "Benduday", "Zhellday", "Taungsday", "Centaxday", "Primeday", "Saturday"],
+            };
+            XDate.defaultLocale = "starwars";
+            var good = new XDate(2011, 3, 29).toString("dddd yyyy") == "Primeday 2011"
+                && new XDate(2011, 3, 4, 12).toUTCString("dddd yyyy") == "Benduday 2011";
+            XDate.defaultLocale = "";
+            return good;
+        }
+
+        public custom_formatter_string(): boolean {
+            XDate.formatters.xxx = "yyyyMMdd";
+            var d = new XDate("2012-11-01");
+            return d.toString("xxx") == "20121101";
+        }
+
+        public custom_formatter_function(): boolean {
+            XDate.formatters.vvv = function(xdate, useUTC) {
+                return "cool/" + useUTC + "/" + xdate.getDate();
+            };
+            var d = new XDate("2012-10-05");
+            return d.toString("vvv") == "cool/false/5"
+                && d.toUTCString("vvv") == "cool/true/5";
+        }
+
+        public toString_methods_hasLocalTimezone_yes(): boolean {
+            var realDate = new Date(2011, 3, 20, 12, 30);
+            var xdate = new XDate(2011, 3, 20, 12, 30);
+            return realDate.toString() == xdate.toString()
+                && realDate.toDateString() == xdate.toDateString()
+                && realDate.toTimeString() == xdate.toTimeString()
+                && realDate.toLocaleString() == xdate.toLocaleString()
+                && realDate.toLocaleDateString() == xdate.toLocaleDateString()
+                && realDate.toLocaleTimeString() == xdate.toLocaleTimeString()
+                && realDate.toUTCString() == xdate.toUTCString();
+            // toGMTString() was abolition
+            // &&
+            // realDate.toGMTString() == xdate.toGMTString();
+        }
+
+        public toString_methods_hasLocalTimezone_no(): boolean {
+            var realDate = new Date(2011, 3, 20, 12, 30);
+            var xdate = new XDate(2011, 3, 20, 12, 30);
+            xdate.setUTCMode(false);
+            return realDate.toString().indexOf(xdate.toString()) == 0
+                && realDate.toTimeString().indexOf(xdate.toTimeString()) == 0
+                && realDate.toLocaleString().indexOf(xdate.toLocaleString()) == 0
+                && realDate.toLocaleDateString().indexOf(xdate.toLocaleDateString()) == 0
+                && realDate.toLocaleTimeString().indexOf(xdate.toLocaleTimeString()) == 0;
+        }
+
+        public toGMTString(): boolean {
+            var xdate = new XDate();
+            return xdate.toUTCString() == xdate.toGMTString();
+        }
     }
 
-
-    public numbers_am_uppercase() : boolean  {
-        return new XDate(1986, 5, 8, 4, 3, 2)
-        .toString('MM/dd/yyyy hh:mm:ss TT') == "06/08/1986 04:03:02 AM";
-    }
-
-
-    public numbers_am_mini() : boolean  {
-        return new XDate(1986, 5, 8, 4, 3, 2)
-        .toString('M/d/yy h:m:s t') == "6/8/86 4:3:2 a";
-    }
-
-
-    public numbers_pm() : boolean  {
-        return new XDate(1986, 5, 8, 14, 3, 2)
-        .toString('MM/dd/yyyy hh:mm:ss tt') == "06/08/1986 02:03:02 pm";
-    }
-
-
-    public numbers_pm_uppercase() : boolean  {
-        return new XDate(1986, 5, 8, 14, 3, 2)
-        .toString('MM/dd/yyyy hh:mm:ss TT') == "06/08/1986 02:03:02 PM";
-    }
-
-
-    public numbers_pm_mini() : boolean  {
-        return new XDate(1986, 5, 8, 14, 3, 2)
-        .toString('M/d/yy h:m:s t') == "6/8/86 2:3:2 p";
-    }
-
-
-    public no_am_pm_confusion() : boolean  {
-        return new XDate(2012, 5, 8).toString('tt') == 'am' &&
-        new XDate(2012, 5, 8, 12).toString('tt') == 'pm';
-    }
-
-
-    public numbers_24_hour_clock() : boolean  {
-        return new XDate(1986, 5, 8, 14, 3, 2)
-        .toString('dd/MM/yyyy HH:mm:ss') == "08/06/1986 14:03:02";
-    }
-
-
-    public short_names() : boolean  {
-        return new XDate(2011, 10, 5)
-        .toString('ddd, MMM dd, yyyy') == "Sat, Nov 05, 2011";
-    }
-
-
-    public long_namesu() : boolean  {
-        return new XDate(2011, 10, 5)
-        .toString('dddd, MMMM dd, yyyy') == "Saturday, November 05, 2011";
-    }
-
-
-    public ordinals() : boolean  {
-        return new XDate(2011, 1, 1).toString('dS') == "1st" &&
-        new XDate(2011, 1, 2).toString('dS') == "2nd" &&
-        new XDate(2011, 1, 3).toString('dS') == "3rd" &&
-        new XDate(2011, 1, 4).toString('dS') == "4th" &&
-        new XDate(2011, 1, 23).toString('dS') == "23rd" &&
-        new XDate(2011, 1, 11).toString('dS') == "11th";
-    }
-
-
-    public fff_milliseconds() : boolean  {
-        var d = new XDate();
-        var s = d.toString('fff');
-        return d.getMilliseconds() === parseInt(s, 10) && s.length==3;
-    }
-
-
-    public timezone() : boolean  {
-        var d1 = new XDate();
-        d1.getTimezoneOffset = function() { return 7 * 60 + 15 };
-        var d2 = new XDate();
-        d2.getTimezoneOffset = function() { return -(7 * 60 + 15) };
-        return d1.toString('z') == '-7' &&
-        d1.toString('zz') == '-07' &&
-        d1.toString('zzz') == '-07:15' &&
-        d2.toString('z') == '+7' &&
-        d2.toString('zz') == '+07' &&
-        d2.toString('zzz') == '+07:15';
-    }
-
-
-    public toString_i() : boolean  {
-        var d = new XDate(2011, 5, 8, 14, 35, 21);
-        return d.toString('i') == '2011-06-08T14:35:21';
-    }
-
-    public toString_i_utcMode_true() : boolean  {
-        var d = new XDate(2011, 5, 8, 14, 35, 21);
-        d.setUTCMode(true);
-        return d.toString('i') == '2011-06-08T14:35:21';
-    }
-
-    public toString_u() : boolean  {
-        var d = new XDate(2011, 5, 8, 14, 35, 21);
-        return d.toString('u').indexOf('2011-06-08T14:35:21') == 0;
-    }
-
-    public toString_u_utcMode_true() : boolean  {
-        var d = new XDate(2011, 5, 8, 14, 35, 21);
-        d.setUTCMode(true);
-        return d.toString('u') == '2011-06-08T14:35:21Z';
-    }
-
-    public toUTCString_i() : boolean  {
-        var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21));
-        return d.toUTCString('i') == '2011-06-08T14:35:21';
-    }
-
-    public toUTCString_i_utcMode_true() : boolean  {
-        var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21), true);
-        return d.toUTCString('i') == '2011-06-08T14:35:21';
-    }
-
-    public toUTCString_u() : boolean  {
-        var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21));
-        return d.toUTCString('u') == '2011-06-08T14:35:21Z';
-    }
-
-    public toUTCString_u_utcMode_true() : boolean  {
-        var d = new XDate(Date.UTC(2011, 5, 8, 14, 35, 21), true);
-        return d.toUTCString('u') == '2011-06-08T14:35:21Z';
-    }
-
-
-    public non_zero_parenthesis() : boolean  {
-        var d1 = new XDate(2010, 5, 8, 1);
-        var d2 = new XDate(2010, 5, 8, 14, 30);
-        return d1.toString('M/d/yyyy h(:mm)tt') == "6/8/2010 1am" &&
-        d2.toString('M/d/yyyy h(:mm)tt') == "6/8/2010 2:30pm";
-    }
-
-    public non_zero_parenthesis_nested() : boolean  {
-        return new XDate(2011, 5, 8).toString("(h(:mm)tt)") == "12am" &&
-        new XDate(2011, 5, 8, 6).toString("(h(:mm)tt)") == "6am" &&
-        new XDate(2011, 5, 8, 6, 30).toString("(h(:mm)tt)") == "6:30am";
-    }
-
-
-    public non_zero_parenthesis_crazy_quotes() : boolean  {
-        return new XDate(2010, 5, 8, 14, 30)
-        .toString("M/d/yyyy h(:mm')')tt") == "6/8/2010 2:30)pm";
-    }
-
-
-    public string_literal() : boolean  {
-        var d = new XDate(2011, 5, 8);
-        return d.toString("MMM dS 'yyyy!mm'") == "Jun 8th yyyy!mm";
-    }
-
-
-    public escaped_single_quote() : boolean  {
-        var d = new XDate(2011, 5, 8);
-        return d.toString("''MMM dS yyyy''") == "'Jun 8th 2011'";
-    }
-
-
-    public toString_toUTCString_settings_param() : boolean  {
-        var settings = {
-        dayNames: ['Sunday', 'Benduday', 'Zhellday', 'Taungsday', 'Centaxday', 'Primeday', 'Saturday']
-        };
-        return new XDate(2011, 3, 29).toString('dddd yyyy', settings) == 'Primeday 2011' &&
-        new XDate(2011, 3, 4, 12).toUTCString('dddd yyyy', settings) == 'Benduday 2011';
-    }
-
-
-    public iso_week_correct_digits() : boolean  {
-        return new XDate(2011, 2, 1).toString('w') == '9' &&
-        new XDate(2011, 2, 1).toUTCString('w') == '9' &&
-        new XDate(2011, 2, 1).toString('ww') == '09' &&
-        new XDate(2011, 2, 1).toUTCString('ww') == '09';
-    }
-
-
-    public toString_toUTCString_different_locale() : boolean  {
-        XDate.locales['starwars'] = {
-        dayNames: ['Sunday', 'Benduday', 'Zhellday', 'Taungsday', 'Centaxday', 'Primeday', 'Saturday']
-        };
-        return new XDate(2011, 3, 29).toString('dddd yyyy', 'starwars') == 'Primeday 2011' &&
-        new XDate(2011, 3, 4, 12).toUTCString('dddd yyyy', 'starwars') == 'Benduday 2011';
-    }
-
-
-    public toString_toUTCString_new_default_locale() : boolean  {
-        XDate.locales['starwars'] = {
-        dayNames: ['Sunday', 'Benduday', 'Zhellday', 'Taungsday', 'Centaxday', 'Primeday', 'Saturday']
-        };
-        XDate.defaultLocale = 'starwars';
-        var good =
-        new XDate(2011, 3, 29).toString('dddd yyyy') == 'Primeday 2011' &&
-        new XDate(2011, 3, 4, 12).toUTCString('dddd yyyy') == 'Benduday 2011';
-        XDate.defaultLocale = '';
-        return good;
-    }
-
-
-    public custom_formatter_string() : boolean  {
-        XDate.formatters.xxx = 'yyyyMMdd';
-        var d = new XDate('2012-11-01');
-        return d.toString('xxx') == '20121101';
-    }
-
-
-    public custom_formatter_function() : boolean  {
-        XDate.formatters.vvv = function(xdate, useUTC) {
-        return "cool/" + useUTC + "/" + xdate.getDate();
-        };
-        var d = new XDate('2012-10-05');
-        return d.toString('vvv') == "cool/false/5" &&
-        d.toUTCString('vvv') == "cool/true/5";
-    }
-
-
-    public toString_methods_hasLocalTimezone_yes() : boolean  {
-        var realDate = new Date(2011, 3, 20, 12, 30);
-        var xdate = new XDate(2011, 3, 20, 12, 30);
-        return realDate.toString() == xdate.toString() &&
-        realDate.toDateString() == xdate.toDateString() &&
-        realDate.toTimeString() == xdate.toTimeString() &&
-        realDate.toLocaleString() == xdate.toLocaleString() &&
-        realDate.toLocaleDateString() == xdate.toLocaleDateString() &&
-        realDate.toLocaleTimeString() == xdate.toLocaleTimeString() &&
-        realDate.toUTCString() == xdate.toUTCString();
-        //toGMTString() was abolition
-        //&&
-        //realDate.toGMTString() == xdate.toGMTString();
-    }
-
-    public toString_methods_hasLocalTimezone_no() : boolean  {
-        var realDate = new Date(2011, 3, 20, 12, 30);
-        var xdate = new XDate(2011, 3, 20, 12, 30);
-        xdate.setUTCMode(false);
-        return realDate.toString().indexOf(xdate.toString()) == 0 &&
-        realDate.toTimeString().indexOf(xdate.toTimeString()) == 0 &&
-        realDate.toLocaleString().indexOf(xdate.toLocaleString()) == 0 &&
-        realDate.toLocaleDateString().indexOf(xdate.toLocaleDateString()) == 0 &&
-        realDate.toLocaleTimeString().indexOf(xdate.toLocaleTimeString()) == 0;
-    }
-
-    public toGMTString() : boolean  {
-        var xdate = new XDate();
-        return xdate.toUTCString() == xdate.toGMTString();
-    }
-
-    }
-
-    //based on xdate/test/getters.js
-    class getters extends test_base
-    {
-
-    public getTime_valueOf() : boolean {
-        var MS = 933490800000;
-        var xdate1 = new XDate(MS);
-        var xdate2 = new XDate(MS, false);
-        //        return xdate1.getTime() == MS && xdate1.valueOf() == MS && +xdate1 == MS &&
-        //    xdate2.getTime() == MS && xdate2.valueOf() == MS && xdate2 == MS;
-
-        return xdate1.getTime() == MS && xdate1.valueOf() == MS &&
-            xdate2.getTime() == MS && xdate2.valueOf() == MS;
-
-    }
-
-    public getUTC() : boolean {
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        var xdate = new XDate(Date.UTC(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS));
-        return xdate.getUTCFullYear() == YEAR &&
-        xdate.getUTCMonth() == MONTH &&
-        xdate.getUTCDate() == DATE &&
-        xdate.getUTCHours() == HOURS &&
-        xdate.getUTCMinutes() == MINUTES &&
-        xdate.getUTCSeconds() == SECONDS &&
-        xdate.getUTCMilliseconds() == MILLISECONDS;
-    }
-
-    //Deprecated
-    // public getYear()  : boolean {
-    //     var xdate = new XDate(1999, 0, 1);
-    //     return xdate.getYear() == 99;
-    // }
-
-    public getWeek() : boolean {
-        return new XDate(2011, 2, 1).getWeek() == 9;
-    }
-
-    public getUTCWeek() : boolean {
-        return new XDate(2011, 2, 1, 12, 30).getUTCWeek() == 9;
-    }
-
-    //Non-standard
-    /*
+    // based on xdate/test/getters.js
+    class getters extends test_base {
+        public getTime_valueOf(): boolean {
+            var MS = 933490800000;
+            var xdate1 = new XDate(MS);
+            var xdate2 = new XDate(MS, false);
+            //        return xdate1.getTime() == MS && xdate1.valueOf() == MS && +xdate1 == MS &&
+            //    xdate2.getTime() == MS && xdate2.valueOf() == MS && xdate2 == MS;
+
+            return xdate1.getTime() == MS && xdate1.valueOf() == MS
+                && xdate2.getTime() == MS && xdate2.valueOf() == MS;
+        }
+
+        public getUTC(): boolean {
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            var xdate = new XDate(Date.UTC(YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS));
+            return xdate.getUTCFullYear() == YEAR
+                && xdate.getUTCMonth() == MONTH
+                && xdate.getUTCDate() == DATE
+                && xdate.getUTCHours() == HOURS
+                && xdate.getUTCMinutes() == MINUTES
+                && xdate.getUTCSeconds() == SECONDS
+                && xdate.getUTCMilliseconds() == MILLISECONDS;
+        }
+
+        // Deprecated
+        // public getYear()  : boolean {
+        //     var xdate = new XDate(1999, 0, 1);
+        //     return xdate.getYear() == 99;
+        // }
+
+        public getWeek(): boolean {
+            return new XDate(2011, 2, 1).getWeek() == 9;
+        }
+
+        public getUTCWeek(): boolean {
+            return new XDate(2011, 2, 1, 12, 30).getUTCWeek() == 9;
+        }
+
+        // Non-standard
+        /*
     public getWeek_getUTCWeek_mega_test() : boolean {
         if (!Date.prototype.toLocaleFormat) {
             return "need Mozilla toLocaleFormat";
@@ -728,596 +657,559 @@ namespace XDate_Test
         return true;
     }
     */
-
     }
 
     // based on xdate/test/parsing.js
-    class parsing extends test_base
-    {
+    class parsing extends test_base {
+        public IETF(): boolean {
+            var s = "Sat Apr 23 2011 13:44:12 GMT";
+            var d = new XDate(s);
+            return d.getUTCFullYear() == 2011
+                && d.getUTCMonth() == 3
+                && d.getUTCDate() == 23
+                && d.getUTCHours() == 13
+                && d.getUTCMinutes() == 44
+                && d.getUTCSeconds() == 12
+                && !d.getUTCMode()
+                && +d == +new Date(s);
+        }
 
-    public IETF() : boolean {
-        var s = "Sat Apr 23 2011 13:44:12 GMT";
-        var d = new XDate(s);
-        return d.getUTCFullYear() == 2011 &&
-        d.getUTCMonth() == 3 &&
-        d.getUTCDate() == 23 &&
-        d.getUTCHours() == 13 &&
-        d.getUTCMinutes() == 44 &&
-        d.getUTCSeconds() == 12 &&
-        !d.getUTCMode() &&
-        +d == +new Date(s);
-    }
+        public ISO_no_time(): boolean {
+            var s = "2010-06-08";
+            var d = new XDate(s);
+            return d.getFullYear() == 2010
+                && d.getMonth() == 5
+                && d.getDate() == 8
+                && !d.getHours()
+                && !d.getMinutes()
+                && !d.getSeconds()
+                && !d.getMilliseconds()
+                && !d.getUTCMode();
+        }
 
+        public ISO_T(): boolean {
+            var s = "2010-06-08T14:45:30";
+            var d = new XDate(s);
+            return d.getFullYear() == 2010
+                && d.getMonth() == 5
+                && d.getDate() == 8
+                && d.getHours() == 14
+                && d.getMinutes() == 45
+                && d.getSeconds() == 30
+                && !d.getMilliseconds()
+                && !d.getUTCMode();
+        }
 
-    public ISO_no_time() : boolean
-    {
-        var s = "2010-06-08";
-        var d = new XDate(s);
-        return d.getFullYear() == 2010 &&
-        d.getMonth() == 5 &&
-        d.getDate() == 8 &&
-        !d.getHours() &&
-        !d.getMinutes() &&
-        !d.getSeconds() &&
-        !d.getMilliseconds() &&
-        !d.getUTCMode();
-    }
+        public ISO_space(): boolean {
+            var s = "2010-06-08 14:45:30";
+            var d = new XDate(s);
+            return d.getFullYear() == 2010
+                && d.getMonth() == 5
+                && d.getDate() == 8
+                && d.getHours() == 14
+                && d.getMinutes() == 45
+                && d.getSeconds() == 30
+                && !d.getMilliseconds()
+                && !d.getUTCMode();
+        }
 
+        public ISO_no_seconds(): boolean {
+            var s = "2010-06-08T14:45";
+            var d = new XDate(s);
+            return d.getFullYear() == 2010
+                && d.getMonth() == 5
+                && d.getDate() == 8
+                && d.getHours() == 14
+                && d.getMinutes() == 45
+                && !d.getSeconds()
+                && !d.getMilliseconds()
+                && !d.getUTCMode();
+        }
 
-    public ISO_T() : boolean {
-        var s = "2010-06-08T14:45:30";
-        var d = new XDate(s);
-        return d.getFullYear() == 2010 &&
-        d.getMonth() == 5 &&
-        d.getDate() == 8 &&
-        d.getHours() == 14 &&
-        d.getMinutes() == 45 &&
-        d.getSeconds() == 30 &&
-        !d.getMilliseconds() &&
-        !d.getUTCMode();
-    }
+        public ISO_milliseconds(): boolean {
+            var s = "2010-06-08T14:45:30.500";
+            var d = new XDate(s);
+            return d.getFullYear() == 2010
+                && d.getMonth() == 5
+                && d.getDate() == 8
+                && d.getHours() == 14
+                && d.getMinutes() == 45
+                && d.getSeconds() == 30
+                && d.getMilliseconds() == 500
+                && !d.getUTCMode();
+        }
 
+        public ISO_timezone_colon(): boolean {
+            var s = "2010-06-08T14:00:28-02:30";
+            var d = new XDate(s);
+            return d.getUTCHours() == 16
+                && d.getUTCMinutes() == 30
+                && d.getUTCSeconds() == 28
+                && !d.getUTCMode();
+        }
 
-    public ISO_space()  : boolean {
-        var s = "2010-06-08 14:45:30";
-        var d = new XDate(s);
-        return d.getFullYear() == 2010 &&
-        d.getMonth() == 5 &&
-        d.getDate() == 8 &&
-        d.getHours() == 14 &&
-        d.getMinutes() == 45 &&
-        d.getSeconds() == 30 &&
-        !d.getMilliseconds() &&
-        !d.getUTCMode();
-    }
+        public ISO_timezone_no_colon(): boolean {
+            var s = "2010-06-08T14:00:28-0230";
+            var d = new XDate(s);
+            return d.getUTCHours() == 16
+                && d.getUTCMinutes() == 30
+                && d.getUTCSeconds() == 28
+                && !d.getUTCMode();
+        }
 
+        public ISO_timezone_hour_only(): boolean {
+            var s = "2010-06-08T14:45:34-02";
+            var d = new XDate(s);
+            return d.getUTCHours() == 16
+                && d.getUTCMinutes() == 45
+                && d.getUTCSeconds() == 34
+                && !d.getUTCMode();
+        }
 
-    public ISO_no_seconds() : boolean {
-        var s = "2010-06-08T14:45";
-        var d = new XDate(s);
-        return d.getFullYear() == 2010 &&
-        d.getMonth() == 5 &&
-        d.getDate() == 8 &&
-        d.getHours() == 14 &&
-        d.getMinutes() == 45 &&
-        !d.getSeconds() &&
-        !d.getMilliseconds() &&
-        !d.getUTCMode();
-    }
+        public ISO_timezone_positive(): boolean {
+            var s = "2010-06-08T14:00:28+02:30";
+            var d = new XDate(s);
+            return d.getUTCHours() == 11
+                && d.getUTCMinutes() == 30
+                && d.getUTCSeconds() == 28
+                && !d.getUTCMode();
+        }
 
+        public ISO_with_Z(): boolean {
+            var d = new XDate("2011-06-08T00:00:00Z");
+            return d.getUTCFullYear() == 2011
+                && d.getUTCMonth() == 5
+                && d.getUTCDate() == 8
+                && !d.getUTCHours() && !d.getUTCMinutes()
+                && !d.getUTCMode();
+        }
 
-    public ISO_milliseconds()  : boolean {
-        var s = "2010-06-08T14:45:30.500";
-        var d = new XDate(s);
-        return d.getFullYear() == 2010 &&
-        d.getMonth() == 5 &&
-        d.getDate() == 8 &&
-        d.getHours() == 14 &&
-        d.getMinutes() == 45 &&
-        d.getSeconds() == 30 &&
-        d.getMilliseconds() == 500 &&
-        !d.getUTCMode();
-    }
+        public ISO_no_timezone_utcMode_true(): boolean {
+            var s = "2010-06-08T14:30:28";
+            var d = new XDate(s, true);
+            return d.getFullYear() == 2010 && d.getUTCFullYear() == 2010
+                && d.getMonth() == 5 && d.getUTCMonth() == 5
+                && d.getDate() == 8 && d.getUTCDate() == 8
+                && d.getHours() == 14 && d.getUTCHours() == 14
+                && d.getMinutes() == 30 && d.getUTCMinutes() == 30
+                && d.getSeconds() == 28 && d.getUTCSeconds() == 28;
+        }
 
-
-    public ISO_timezone_colon()  : boolean {
-        var s = "2010-06-08T14:00:28-02:30";
-        var d = new XDate(s);
-        return d.getUTCHours() == 16 &&
-        d.getUTCMinutes() == 30 &&
-        d.getUTCSeconds() == 28 &&
-        !d.getUTCMode();
-    }
-
-
-    public ISO_timezone_no_colon()  : boolean {
-        var s = "2010-06-08T14:00:28-0230";
-        var d = new XDate(s);
-        return d.getUTCHours() == 16 &&
-        d.getUTCMinutes() == 30 &&
-        d.getUTCSeconds() == 28 &&
-        !d.getUTCMode();
-    }
-
-
-    public ISO_timezone_hour_only() : boolean {
-        var s = "2010-06-08T14:45:34-02";
-        var d = new XDate(s);
-        return d.getUTCHours() == 16 &&
-        d.getUTCMinutes() == 45 &&
-        d.getUTCSeconds() == 34 &&
-        !d.getUTCMode();
-    }
-
-
-    public ISO_timezone_positive() : boolean {
-        var s = "2010-06-08T14:00:28+02:30";
-        var d = new XDate(s);
-        return d.getUTCHours() == 11 &&
-        d.getUTCMinutes() == 30 &&
-        d.getUTCSeconds() == 28 &&
-        !d.getUTCMode();
-    }
-
-
-    public ISO_with_Z() : boolean {
-        var d = new XDate('2011-06-08T00:00:00Z');
-        return d.getUTCFullYear() == 2011 &&
-        d.getUTCMonth() == 5 &&
-        d.getUTCDate() == 8 &&
-        !d.getUTCHours() && !d.getUTCMinutes() &&
-        !d.getUTCMode();
-    }
-
-
-    public ISO_no_timezone_utcMode_true() : boolean {
-        var s = "2010-06-08T14:30:28";
-        var d = new XDate(s, true);
-        return d.getFullYear() == 2010 && d.getUTCFullYear() == 2010 &&
-        d.getMonth() == 5 && d.getUTCMonth() == 5 &&
-        d.getDate() == 8 && d.getUTCDate() == 8 &&
-        d.getHours() == 14 && d.getUTCHours() == 14 &&
-        d.getMinutes() == 30 && d.getUTCMinutes() == 30 &&
-        d.getSeconds() == 28 && d.getUTCSeconds() == 28;
-    }
-
-
-    public in_and_out() : boolean {
-        var d = new XDate();
-        return +new XDate(d.toISOString()) == +d;
-    }
-
+        public in_and_out(): boolean {
+            var d = new XDate();
+            return +new XDate(d.toISOString()) == +d;
+        }
     }
 
     // based on xdate/test/setters.js
-    class setters extends test_base
-    {
-
-    public set_when_utcMode_false(): boolean{
-        var xdate = new XDate(2012, 0, 1);
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        xdate.setFullYear(YEAR)
-        .setMonth(MONTH)
-        .setDate(DATE)
-        .setHours(HOURS)
-        .setMinutes(MINUTES)
-        .setSeconds(SECONDS)
-        .setMilliseconds(MILLISECONDS);
-        return xdate.getFullYear() == YEAR &&
-        xdate.getMonth() == MONTH &&
-        xdate.getDate() == DATE &&
-        xdate.getHours() == HOURS &&
-        xdate.getMinutes() == MINUTES &&
-        xdate.getSeconds() == SECONDS &&
-        xdate.getMilliseconds() == MILLISECONDS;
-    }
-
-    public set_when_utcMode_true() : boolean{
-        var xdate = new XDate(2012, 0, 1, 0,0,0,0, true);
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        xdate.setFullYear(YEAR)
-        .setMonth(MONTH)
-        .setDate(DATE)
-        .setHours(HOURS)
-        .setMinutes(MINUTES)
-        .setSeconds(SECONDS)
-        .setMilliseconds(MILLISECONDS);
-        return xdate.getFullYear() == YEAR &&
-        xdate.getMonth() == MONTH &&
-        xdate.getDate() == DATE &&
-        xdate.getHours() == HOURS &&
-        xdate.getMinutes() == MINUTES &&
-        xdate.getSeconds() == SECONDS &&
-        xdate.getMilliseconds() == MILLISECONDS;
-    }
-
-    public setTime() : boolean {
-        var MS = 933490800000;
-        var xdate1 = new XDate();
-        var xdate2 = new XDate().setUTCMode(true);
-        xdate1.setTime(MS);
-        xdate2.setTime(MS);
-        return xdate1.getTime() == MS && xdate2.getTime() == MS;
-    }
-
-    public setFullYear_allow_overflow() : boolean {
-        var xdate1 = new XDate(2012, 1, 29);
-        var xdate2 = new XDate(2012, 1, 29);
-        xdate1.setFullYear(2013);
-        xdate2.setFullYear(2013, false);
-        return xdate1.getMonth() == 2 && xdate1.getDate() == 1 &&
-        xdate2.getMonth() == 2 && xdate2.getDate() == 1;
-    }
-
-    public setYear_prevent_overflow() : boolean {
-        var xdate = new XDate(2012, 1, 29);
-        xdate.setFullYear(2013, true);
-        return xdate.getMonth() == 1 && xdate.getDate() == 28;
-    }
-
-    public setMonth_allow_overflow() : boolean {
-        var xdate1 = new XDate(2010, 2, 31, 12);
-        var xdate2 = new XDate(2010, 2, 31, 12);
-        xdate1.setMonth(1);
-        xdate2.setMonth(1, false);
-        return xdate1.getMonth() == 2 && xdate1.getDate() == 3 &&
-        xdate2.getMonth() == 2 && xdate2.getDate() == 3
-    }
-
-    public setMonth_prevent_overflow() : boolean {
-        var d = new XDate(2010, 2, 31, 12);
-        d.setMonth(1, true);
-        return d.getMonth() == 1 && d.getDate() == 28;
-    }
-
-    public setUTC_with_utcMode_false() : boolean {
-        var xdate = new XDate(2012, 0, 1);
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        xdate.setUTCFullYear(YEAR)
-        .setUTCMonth(MONTH)
-        .setUTCDate(DATE)
-        .setUTCHours(HOURS)
-        .setUTCMinutes(MINUTES)
-        .setUTCSeconds(SECONDS)
-        .setUTCMilliseconds(MILLISECONDS);
-        return xdate.getUTCFullYear() == YEAR &&
-        xdate.getUTCMonth() == MONTH &&
-        xdate.getUTCDate() == DATE &&
-        xdate.getUTCHours() == HOURS &&
-        xdate.getUTCMinutes() == MINUTES &&
-        xdate.getUTCSeconds() == SECONDS &&
-        xdate.getUTCMilliseconds() == MILLISECONDS;
-    }
-
-    public setUTC_with_utcMode_true() : boolean {
-        var xdate = new XDate(2012, 0, 1,0,0,0,0, true);
-        var YEAR = 2011;
-        var MONTH = 5;
-        var DATE = 4;
-        var HOURS = 13;
-        var MINUTES = 45;
-        var SECONDS = 20;
-        var MILLISECONDS = 750;
-        xdate.setUTCFullYear(YEAR)
-        .setUTCMonth(MONTH)
-        .setUTCDate(DATE)
-        .setUTCHours(HOURS)
-        .setUTCMinutes(MINUTES)
-        .setUTCSeconds(SECONDS)
-        .setUTCMilliseconds(MILLISECONDS);
-        return xdate.getUTCFullYear() == YEAR &&
-        xdate.getUTCMonth() == MONTH &&
-        xdate.getUTCDate() == DATE &&
-        xdate.getUTCHours() == HOURS &&
-        xdate.getUTCMinutes() == MINUTES &&
-        xdate.getUTCSeconds() == SECONDS &&
-        xdate.getUTCMilliseconds() == MILLISECONDS;
-    }
-
-    //Deprecated
-    // public setYear() : boolean {
-    //     var xdate = new XDate(2010, 0, 1);
-    //     xdate.setYear(99);
-    //     return xdate.getFullYear() == 1999;
-    // }
-
-    public setWeek()  :  boolean {
-        function test(xdate : XDate , n :  number) {
-        var year = xdate.getFullYear();
-        xdate.setWeek(n);
-        return xdate.getWeek() == n &&
-            xdate.getFullYear() == year &&
-            xdate.getDay() == 1 && // monday
-            xdate.getHours() == 0 &&
-            xdate.getMinutes() == 0 &&
-            xdate.getSeconds() == 0 &&
-            xdate.getMilliseconds() == 0;
+    class setters extends test_base {
+        public set_when_utcMode_false(): boolean {
+            var xdate = new XDate(2012, 0, 1);
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            xdate.setFullYear(YEAR)
+                .setMonth(MONTH)
+                .setDate(DATE)
+                .setHours(HOURS)
+                .setMinutes(MINUTES)
+                .setSeconds(SECONDS)
+                .setMilliseconds(MILLISECONDS);
+            return xdate.getFullYear() == YEAR
+                && xdate.getMonth() == MONTH
+                && xdate.getDate() == DATE
+                && xdate.getHours() == HOURS
+                && xdate.getMinutes() == MINUTES
+                && xdate.getSeconds() == SECONDS
+                && xdate.getMilliseconds() == MILLISECONDS;
         }
-        return test(new XDate(), 50) &&
-        test(new XDate(), 21) &&
-        test(new XDate(2011, 5, 5), 5) &&
-        test(new XDate(2009, 12, 12), 13);
-    }
 
-    public setWeek_with_year() : boolean {
-        function test(xdate : XDate , n : number , year : number) {
-        xdate.setWeek(n, year);
-        return xdate.getWeek() == n &&
-            xdate.getFullYear() == year &&
-            xdate.getDay() == 1 && // monday
-            xdate.getHours() == 0 &&
-            xdate.getMinutes() == 0 &&
-            xdate.getSeconds() == 0 &&
-            xdate.getMilliseconds() == 0;
+        public set_when_utcMode_true(): boolean {
+            var xdate = new XDate(2012, 0, 1, 0, 0, 0, 0, true);
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            xdate.setFullYear(YEAR)
+                .setMonth(MONTH)
+                .setDate(DATE)
+                .setHours(HOURS)
+                .setMinutes(MINUTES)
+                .setSeconds(SECONDS)
+                .setMilliseconds(MILLISECONDS);
+            return xdate.getFullYear() == YEAR
+                && xdate.getMonth() == MONTH
+                && xdate.getDate() == DATE
+                && xdate.getHours() == HOURS
+                && xdate.getMinutes() == MINUTES
+                && xdate.getSeconds() == SECONDS
+                && xdate.getMilliseconds() == MILLISECONDS;
         }
-        return test(new XDate(), 50, 2013) &&
-        test(new XDate(), 21, 2014) &&
-        test(new XDate(2011, 5, 5), 5, 1999) &&
-        test(new XDate(2009, 12, 12), 13, 1995);
-    }
 
-    public setUTCWeek() : boolean {
-        function test(xdate : XDate , n : number) {
-        var year = xdate.getUTCFullYear();
-        xdate.setUTCWeek(n);
-        return xdate.getUTCWeek() == n &&
-            xdate.getUTCFullYear() == year &&
-            xdate.getUTCDay() == 1 && // monday
-            xdate.getUTCHours() == 0 &&
-            xdate.getUTCMinutes() == 0 &&
-            xdate.getUTCSeconds() == 0 &&
-            xdate.getUTCMilliseconds() == 0;
+        public setTime(): boolean {
+            var MS = 933490800000;
+            var xdate1 = new XDate();
+            var xdate2 = new XDate().setUTCMode(true);
+            xdate1.setTime(MS);
+            xdate2.setTime(MS);
+            return xdate1.getTime() == MS && xdate2.getTime() == MS;
         }
-        return test(new XDate(), 50) &&
-        test(new XDate(), 21) &&
-        test(new XDate(2011, 5, 5), 5) &&
-        test(new XDate(2009, 12, 12), 13);
-    }
 
-    public setUTCWeek_with_year() : boolean{
-        function test(xdate : XDate , n : number , year : number ) {
-        xdate.setUTCWeek(n, year);
-        return xdate.getUTCWeek() == n &&
-            xdate.getUTCFullYear() == year &&
-            xdate.getUTCDay() == 1 && // monday
-            xdate.getUTCHours() == 0 &&
-            xdate.getUTCMinutes() == 0 &&
-            xdate.getUTCSeconds() == 0 &&
-            xdate.getUTCMilliseconds() == 0;
+        public setFullYear_allow_overflow(): boolean {
+            var xdate1 = new XDate(2012, 1, 29);
+            var xdate2 = new XDate(2012, 1, 29);
+            xdate1.setFullYear(2013);
+            xdate2.setFullYear(2013, false);
+            return xdate1.getMonth() == 2 && xdate1.getDate() == 1
+                && xdate2.getMonth() == 2 && xdate2.getDate() == 1;
         }
-        return test(new XDate(), 50, 2013) &&
-        test(new XDate(), 21, 2014) &&
-        test(new XDate(2011, 5, 5), 5, 1999) &&
-        test(new XDate(2009, 12, 12), 13, 1995);
-    }
 
-    public setWeek_overflow() : boolean {
-        var xdate = new XDate(2012, 0, 3);
-        xdate.setWeek(54);
-        return xdate.getFullYear() == 2013 &&
-        xdate.getWeek() == 2 &&
-        xdate.getMonth() == 0 &&
-        xdate.getDate() == 7;
-    }
+        public setYear_prevent_overflow(): boolean {
+            var xdate = new XDate(2012, 1, 29);
+            xdate.setFullYear(2013, true);
+            return xdate.getMonth() == 1 && xdate.getDate() == 28;
+        }
 
-    public setWeek_underflow() : boolean {
-        var xdate = new XDate(2012, 0, 2); // a monday
-        return +xdate.clone().setWeek(0) == +xdate.clone().addWeeks(-1) &&
-        +xdate.clone().setWeek(-1) == +xdate.clone().addWeeks(-2);
-    }
+        public setMonth_allow_overflow(): boolean {
+            var xdate1 = new XDate(2010, 2, 31, 12);
+            var xdate2 = new XDate(2010, 2, 31, 12);
+            xdate1.setMonth(1);
+            xdate2.setMonth(1, false);
+            return xdate1.getMonth() == 2 && xdate1.getDate() == 3
+                && xdate2.getMonth() == 2 && xdate2.getDate() == 3;
+        }
 
-    public setUTCWeek_correctly_handles_UTC_week_numbering_edge_case() : boolean{
-        var date = new XDate(Date.UTC(2010, 0, 3));
+        public setMonth_prevent_overflow(): boolean {
+            var d = new XDate(2010, 2, 31, 12);
+            d.setMonth(1, true);
+            return d.getMonth() == 1 && d.getDate() == 28;
+        }
 
-        var wasWeek53 = date.getUTCWeek() === 53;
-        date.setUTCWeek(53);
+        public setUTC_with_utcMode_false(): boolean {
+            var xdate = new XDate(2012, 0, 1);
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            xdate.setUTCFullYear(YEAR)
+                .setUTCMonth(MONTH)
+                .setUTCDate(DATE)
+                .setUTCHours(HOURS)
+                .setUTCMinutes(MINUTES)
+                .setUTCSeconds(SECONDS)
+                .setUTCMilliseconds(MILLISECONDS);
+            return xdate.getUTCFullYear() == YEAR
+                && xdate.getUTCMonth() == MONTH
+                && xdate.getUTCDate() == DATE
+                && xdate.getUTCHours() == HOURS
+                && xdate.getUTCMinutes() == MINUTES
+                && xdate.getUTCSeconds() == SECONDS
+                && xdate.getUTCMilliseconds() == MILLISECONDS;
+        }
 
-        return wasWeek53 && "Mon, 28 Dec 2009 00:00:00 GMT" === date.toUTCString();
-    }
+        public setUTC_with_utcMode_true(): boolean {
+            var xdate = new XDate(2012, 0, 1, 0, 0, 0, 0, true);
+            var YEAR = 2011;
+            var MONTH = 5;
+            var DATE = 4;
+            var HOURS = 13;
+            var MINUTES = 45;
+            var SECONDS = 20;
+            var MILLISECONDS = 750;
+            xdate.setUTCFullYear(YEAR)
+                .setUTCMonth(MONTH)
+                .setUTCDate(DATE)
+                .setUTCHours(HOURS)
+                .setUTCMinutes(MINUTES)
+                .setUTCSeconds(SECONDS)
+                .setUTCMilliseconds(MILLISECONDS);
+            return xdate.getUTCFullYear() == YEAR
+                && xdate.getUTCMonth() == MONTH
+                && xdate.getUTCDate() == DATE
+                && xdate.getUTCHours() == HOURS
+                && xdate.getUTCMinutes() == MINUTES
+                && xdate.getUTCSeconds() == SECONDS
+                && xdate.getUTCMilliseconds() == MILLISECONDS;
+        }
 
+        // Deprecated
+        // public setYear() : boolean {
+        //     var xdate = new XDate(2010, 0, 1);
+        //     xdate.setYear(99);
+        //     return xdate.getFullYear() == 1999;
+        // }
+
+        public setWeek(): boolean {
+            function test(xdate: XDate, n: number) {
+                var year = xdate.getFullYear();
+                xdate.setWeek(n);
+                return xdate.getWeek() == n
+                    && xdate.getFullYear() == year
+                    && xdate.getDay() == 1 // monday
+                    && xdate.getHours() == 0
+                    && xdate.getMinutes() == 0
+                    && xdate.getSeconds() == 0
+                    && xdate.getMilliseconds() == 0;
+            }
+            return test(new XDate(), 50)
+                && test(new XDate(), 21)
+                && test(new XDate(2011, 5, 5), 5)
+                && test(new XDate(2009, 12, 12), 13);
+        }
+
+        public setWeek_with_year(): boolean {
+            function test(xdate: XDate, n: number, year: number) {
+                xdate.setWeek(n, year);
+                return xdate.getWeek() == n
+                    && xdate.getFullYear() == year
+                    && xdate.getDay() == 1 // monday
+                    && xdate.getHours() == 0
+                    && xdate.getMinutes() == 0
+                    && xdate.getSeconds() == 0
+                    && xdate.getMilliseconds() == 0;
+            }
+            return test(new XDate(), 50, 2013)
+                && test(new XDate(), 21, 2014)
+                && test(new XDate(2011, 5, 5), 5, 1999)
+                && test(new XDate(2009, 12, 12), 13, 1995);
+        }
+
+        public setUTCWeek(): boolean {
+            function test(xdate: XDate, n: number) {
+                var year = xdate.getUTCFullYear();
+                xdate.setUTCWeek(n);
+                return xdate.getUTCWeek() == n
+                    && xdate.getUTCFullYear() == year
+                    && xdate.getUTCDay() == 1 // monday
+                    && xdate.getUTCHours() == 0
+                    && xdate.getUTCMinutes() == 0
+                    && xdate.getUTCSeconds() == 0
+                    && xdate.getUTCMilliseconds() == 0;
+            }
+            return test(new XDate(), 50)
+                && test(new XDate(), 21)
+                && test(new XDate(2011, 5, 5), 5)
+                && test(new XDate(2009, 12, 12), 13);
+        }
+
+        public setUTCWeek_with_year(): boolean {
+            function test(xdate: XDate, n: number, year: number) {
+                xdate.setUTCWeek(n, year);
+                return xdate.getUTCWeek() == n
+                    && xdate.getUTCFullYear() == year
+                    && xdate.getUTCDay() == 1 // monday
+                    && xdate.getUTCHours() == 0
+                    && xdate.getUTCMinutes() == 0
+                    && xdate.getUTCSeconds() == 0
+                    && xdate.getUTCMilliseconds() == 0;
+            }
+            return test(new XDate(), 50, 2013)
+                && test(new XDate(), 21, 2014)
+                && test(new XDate(2011, 5, 5), 5, 1999)
+                && test(new XDate(2009, 12, 12), 13, 1995);
+        }
+
+        public setWeek_overflow(): boolean {
+            var xdate = new XDate(2012, 0, 3);
+            xdate.setWeek(54);
+            return xdate.getFullYear() == 2013
+                && xdate.getWeek() == 2
+                && xdate.getMonth() == 0
+                && xdate.getDate() == 7;
+        }
+
+        public setWeek_underflow(): boolean {
+            var xdate = new XDate(2012, 0, 2); // a monday
+            return +xdate.clone().setWeek(0) == +xdate.clone().addWeeks(-1)
+                && +xdate.clone().setWeek(-1) == +xdate.clone().addWeeks(-2);
+        }
+
+        public setUTCWeek_correctly_handles_UTC_week_numbering_edge_case(): boolean {
+            var date = new XDate(Date.UTC(2010, 0, 3));
+
+            var wasWeek53 = date.getUTCWeek() === 53;
+            date.setUTCWeek(53);
+
+            return wasWeek53 && "Mon, 28 Dec 2009 00:00:00 GMT" === date.toUTCString();
+        }
     }
 
     // based on xdate/test/utc-mode.js
-    class utc_mode extends test_base
-    {
+    class utc_mode extends test_base {
+        public identical_methods(): boolean {
+            var xdate = new XDate(true);
+            return xdate.getFullYear() == xdate.getUTCFullYear()
+                && xdate.getMonth() == xdate.getUTCMonth()
+                && xdate.getDate() == xdate.getUTCDate()
+                && xdate.getHours() == xdate.getUTCHours()
+                && xdate.getMinutes() == xdate.getUTCMinutes()
+                && xdate.getSeconds() == xdate.getUTCSeconds()
+                && xdate.getMilliseconds() == xdate.getUTCMilliseconds();
+        }
 
-    public identical_methods() : boolean {
-        var xdate = new XDate(true);
-        return xdate.getFullYear() == xdate.getUTCFullYear() &&
-        xdate.getMonth() == xdate.getUTCMonth() &&
-        xdate.getDate() == xdate.getUTCDate() &&
-        xdate.getHours() == xdate.getUTCHours() &&
-        xdate.getMinutes() == xdate.getUTCMinutes() &&
-        xdate.getSeconds() == xdate.getUTCSeconds() &&
-        xdate.getMilliseconds() == xdate.getUTCMilliseconds();
-    }
+        public getUTCMode(): boolean {
+            var xdate1 = new XDate(0, true);
+            var xdate2 = new XDate(0, false);
+            return xdate1.getUTCMode() && !xdate2.getUTCMode();
+        }
 
-    public getUTCMode() : boolean {
-        var xdate1 = new XDate(0, true);
-        var xdate2 = new XDate(0, false);
-        return xdate1.getUTCMode() && !xdate2.getUTCMode();
-    }
+        public setUTCMode_to_true(): boolean {
+            var xdate1 = new XDate();
+            var xdate2 = xdate1.clone().setUTCMode(true);
+            return !xdate1.getUTCMode() && xdate2.getUTCMode() && +xdate1 == +xdate2;
+        }
 
-    public setUTCMode_to_true() : boolean {
-        var xdate1 = new XDate();
-        var xdate2 = xdate1.clone().setUTCMode(true);
-        return !xdate1.getUTCMode() && xdate2.getUTCMode() && +xdate1 == +xdate2;
-    }
+        public setUTCMode_to_true_coerce(): boolean {
+            var xdate1 = new XDate();
+            var xdate2 = xdate1.clone().setUTCMode(true, true);
+            return !xdate1.getUTCMode()
+                && xdate2.getUTCMode()
+                && (!xdate1.getTimezoneOffset() || xdate1.getTime() != xdate2.getTime())
+                && xdate1.getDate() == xdate2.getDate()
+                && xdate2.getDate() == xdate2.getUTCDate()
+                && xdate1.getHours() == xdate2.getHours()
+                && xdate2.getHours() == xdate2.getUTCHours();
+        }
 
-    public setUTCMode_to_true_coerce() : boolean {
-        var xdate1 = new XDate();
-        var xdate2 = xdate1.clone().setUTCMode(true, true);
-        return !xdate1.getUTCMode() &&
-            xdate2.getUTCMode() &&
-            (!xdate1.getTimezoneOffset() || xdate1.getTime() != xdate2.getTime()) &&
-            xdate1.getDate() == xdate2.getDate() &&
-            xdate2.getDate() == xdate2.getUTCDate() &&
-            xdate1.getHours() == xdate2.getHours() &&
-            xdate2.getHours() == xdate2.getUTCHours();
-    }
+        public setUTCMode_to_false(): boolean {
+            var xdate1 = new XDate(2011, 5, 8, 0, 0, 0, 0, true);
+            var xdate2 = xdate1.clone().setUTCMode(false);
+            return xdate1.getUTCMode() && !xdate2.getUTCMode() && +xdate1 == +xdate2;
+        }
 
-    public setUTCMode_to_false() : boolean {
-        var xdate1 = new XDate(2011, 5, 8, 0,0,0,0, true);
-        var xdate2 = xdate1.clone().setUTCMode(false);
-        return xdate1.getUTCMode() && !xdate2.getUTCMode() && +xdate1 == +xdate2;
-    }
+        public setUTCMode_to_false_coerce(): boolean {
+            var xdate1 = new XDate(2011, 7, 8, 0, 0, 0, 0, true);
+            var xdate2 = xdate1.clone().setUTCMode(false, true);
+            return xdate1.getUTCMode() && !xdate2.getUTCMode()
+                && (!xdate1.getTimezoneOffset() || xdate1.getTime() != xdate2.getTime())
+                && xdate1.getDate() == xdate2.getDate()
+                && xdate1.getHours() == xdate1.getHours();
+        }
 
-    public setUTCMode_to_false_coerce() : boolean {
-        var xdate1 = new XDate(2011, 7, 8, 0,0,0,0, true);
-        var xdate2 = xdate1.clone().setUTCMode(false, true);
-        return xdate1.getUTCMode() && !xdate2.getUTCMode() &&
-        (!xdate1.getTimezoneOffset() || xdate1.getTime() != xdate2.getTime()) &&
-        xdate1.getDate() == xdate2.getDate() &&
-        xdate1.getHours() == xdate1.getHours();
-    }
-
-    public getTimezoneOffset() : boolean {
-        var date = new Date();
-        var xdate1 = new XDate(+date);
-        var xdate2 = new XDate(+date, true);
-        return xdate1.getTimezoneOffset() == date.getTimezoneOffset() &&
-        !xdate2.getTimezoneOffset();
-    }
+        public getTimezoneOffset(): boolean {
+            var date = new Date();
+            var xdate1 = new XDate(+date);
+            var xdate2 = new XDate(+date, true);
+            return xdate1.getTimezoneOffset() == date.getTimezoneOffset()
+                && !xdate2.getTimezoneOffset();
+        }
     }
 
     // bases on xdate/test/utilities.js
-    class utilities extends test_base
-    {
-
-    public clone() : boolean {
-        var d1 = new XDate();
-        var d2 = d1.clone();
-        d2.addMinutes(30);
-        return +d1 != +d2;
-    }
-
-
-    public clearTime() : boolean {
-        var d = new XDate(2010, 2, 5, 16, 15, 10, 100);
-        d.clearTime();
-        return !d.getHours() && !d.getMinutes() && !d.getSeconds() && !d.getMilliseconds();
-    }
-
-
-    public valid() : boolean {
-        var good = new XDate();
-        var bad = new XDate('asdf');
-        return good.valid() && !bad.valid();
-    }
-
-
-    public toDate_hasLocalTimezone_yes() : boolean {
-        var d = new Date(2012, 5, 8);
-        var xdate = new XDate(d);
-        return +xdate.toDate() == +d;
-    }
-
-
-    public toDate_hasLocalTimezone_no() : boolean {
-        var d = new Date(2012, 5, 8);
-        var xdate = new XDate(+d, false);
-        return +xdate.toDate() == +d;
-    }
-
-
-    public getDaysInMonth() : boolean {
-        return XDate.getDaysInMonth(2011, 1) == 28 && // feb
-        XDate.getDaysInMonth(2012, 1) == 29 && // feb, leap year
-        XDate.getDaysInMonth(2012, 8) == 30 && // sep
-        XDate.getDaysInMonth(2012, 6) == 31; // jul
-    }
-
-
-    public UTC_class_method() : boolean {
-        return Date.UTC(2011, 3, 20, 12, 30) == XDate.UTC(2011, 3, 20, 12, 30);
-    }
-
-
-    public parse_class_method() : boolean {
-        var s = "Sat Apr 23 2011 13:44:12 GMT-0700 (PDT)";
-        return Date.parse(s) == XDate.parse(s);
-        //&&
-        //isNaN(Date.parse()) && isNaN(XDate.parse());
-    }
-
-
-    public now_class_method() : boolean {
-        return Math.abs(+new Date() - XDate.now()) < 1000;
-    }
-
-
-    public today_class_method() : boolean {
-        var xdate = XDate.today();
-        var d = new Date();
-        return xdate.getFullYear() == d.getFullYear() &&
-        xdate.getMonth() == d.getMonth() &&
-        xdate.getDate() == d.getDate() &&
-        !xdate.getHours() &&
-        !xdate.getSeconds() &&
-        !xdate.getMilliseconds();
-    }
-
-
-    public toJSON() : boolean {
-        var realDate = new Date(2011, 3, 20, 12, 30);
-        var xdate = new Date(2011, 3, 20, 12, 30);
-        if (!realDate.toJSON) {
-        return false;
+    class utilities extends test_base {
+        public clone(): boolean {
+            var d1 = new XDate();
+            var d2 = d1.clone();
+            d2.addMinutes(30);
+            return +d1 != +d2;
         }
-        return realDate.toJSON() == xdate.toJSON();
+
+        public clearTime(): boolean {
+            var d = new XDate(2010, 2, 5, 16, 15, 10, 100);
+            d.clearTime();
+            return !d.getHours() && !d.getMinutes() && !d.getSeconds() && !d.getMilliseconds();
+        }
+
+        public valid(): boolean {
+            var good = new XDate();
+            var bad = new XDate("asdf");
+            return good.valid() && !bad.valid();
+        }
+
+        public toDate_hasLocalTimezone_yes(): boolean {
+            var d = new Date(2012, 5, 8);
+            var xdate = new XDate(d);
+            return +xdate.toDate() == +d;
+        }
+
+        public toDate_hasLocalTimezone_no(): boolean {
+            var d = new Date(2012, 5, 8);
+            var xdate = new XDate(+d, false);
+            return +xdate.toDate() == +d;
+        }
+
+        public getDaysInMonth(): boolean {
+            return XDate.getDaysInMonth(2011, 1) == 28 // feb
+                && XDate.getDaysInMonth(2012, 1) == 29 // feb, leap year
+                && XDate.getDaysInMonth(2012, 8) == 30 // sep
+                && XDate.getDaysInMonth(2012, 6) == 31; // jul
+        }
+
+        public UTC_class_method(): boolean {
+            return Date.UTC(2011, 3, 20, 12, 30) == XDate.UTC(2011, 3, 20, 12, 30);
+        }
+
+        public parse_class_method(): boolean {
+            var s = "Sat Apr 23 2011 13:44:12 GMT-0700 (PDT)";
+            return Date.parse(s) == XDate.parse(s);
+            // &&
+            // isNaN(Date.parse()) && isNaN(XDate.parse());
+        }
+
+        public now_class_method(): boolean {
+            return Math.abs(+new Date() - XDate.now()) < 1000;
+        }
+
+        public today_class_method(): boolean {
+            var xdate = XDate.today();
+            var d = new Date();
+            return xdate.getFullYear() == d.getFullYear()
+                && xdate.getMonth() == d.getMonth()
+                && xdate.getDate() == d.getDate()
+                && !xdate.getHours()
+                && !xdate.getSeconds()
+                && !xdate.getMilliseconds();
+        }
+
+        public toJSON(): boolean {
+            var realDate = new Date(2011, 3, 20, 12, 30);
+            var xdate = new Date(2011, 3, 20, 12, 30);
+            if (!realDate.toJSON) {
+                return false;
+            }
+            return realDate.toJSON() == xdate.toJSON();
+        }
+
+        public chaining(): boolean {
+            var d = new XDate()
+                //        .setYear(99)
+                .setFullYear(2011)
+                .setWeek(50)
+                .setMonth(1)
+                .setDate(5)
+                .setHours(12)
+                .setMinutes(50)
+                .setSeconds(20)
+                .setMilliseconds(500)
+                .setTime(0)
+                .addYears(1)
+                .addMonths(1)
+                .addDays(1)
+                .addMinutes(1)
+                .addSeconds(1)
+                .addMilliseconds(1)
+                .clone()
+                .clearTime()
+                .setUTCFullYear(2010)
+                .setUTCMonth(6)
+                .setUTCWeek(5)
+                .setUTCDate(4)
+                .setUTCHours(12)
+                .setUTCMinutes(30)
+                .setUTCSeconds(30)
+                .setUTCMilliseconds(10)
+                .setUTCMode(true);
+            return d instanceof XDate;
+        }
     }
-
-
-    public chaining() : boolean {
-        var d = new XDate()
-//        .setYear(99)
-        .setFullYear(2011)
-        .setWeek(50)
-        .setMonth(1)
-        .setDate(5)
-        .setHours(12)
-        .setMinutes(50)
-        .setSeconds(20)
-        .setMilliseconds(500)
-        .setTime(0)
-        .addYears(1)
-        .addMonths(1)
-        .addDays(1)
-        .addMinutes(1)
-        .addSeconds(1)
-        .addMilliseconds(1)
-        .clone()
-        .clearTime()
-        .setUTCFullYear(2010)
-        .setUTCMonth(6)
-        .setUTCWeek(5)
-        .setUTCDate(4)
-        .setUTCHours(12)
-        .setUTCMinutes(30)
-        .setUTCSeconds(30)
-        .setUTCMilliseconds(10)
-        .setUTCMode(true);
-        return d instanceof XDate;
-    }
-
-    }
-
 }

--- a/types/xdomain/index.d.ts
+++ b/types/xdomain/index.d.ts
@@ -3,50 +3,49 @@
 // Definitions by: Dan Chao <http://dchao.co/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 declare interface XDomainCookies {
-  master: string;
-  slave: string;
+    master: string;
+    slave: string;
 }
 
 declare interface IXDomain {
-  /**
-   * Will initialize as a master
-   *
-   * Each of the slaves must be defined as: origin: proxy file
-   *
-   * The slaves object is used as a list slaves to force one proxy file per origin.
-   * @param slaveObj
-   */
-  slaves (slaveObj: Object): void;
-  /**
-   * Will initialize as a slave
-   *
-   * Each of the masters must be defined as: origin: path
-   *
-   * origin and path are converted to a regular expression by escaping all non-alphanumeric chars, then converting * into .* and finally wrapping it with ^ and $. path can also be a RegExp literal.
-   *
-   * Requests that do not match both the origin and the path regular expressions will be blocked.
-   * @param masterObj
-   */
-  masters (masterObj: Object): void;
-  origin: string;
-  /**
-   * When true, XDomain will log actions to console
-   */
-  debug: boolean;
-  /**
-   * event may be log, warn or timeout. When listening for log and warn events, handler with contain the message as
-   * the first parameter. The timeout event fires when an iframe exeeds the xdomain.timeout time limit.
-   * @param event
-   * @param handler
-   */
-  on (event: "log"|"warn"|"timeout", handler: (message?: string) => any): void;
-  cookies: XDomainCookies;
+    /**
+     * Will initialize as a master
+     *
+     * Each of the slaves must be defined as: origin: proxy file
+     *
+     * The slaves object is used as a list slaves to force one proxy file per origin.
+     * @param slaveObj
+     */
+    slaves(slaveObj: Object): void;
+    /**
+     * Will initialize as a slave
+     *
+     * Each of the masters must be defined as: origin: path
+     *
+     * origin and path are converted to a regular expression by escaping all non-alphanumeric chars, then converting * into .* and finally wrapping it with ^ and $. path can also be a RegExp literal.
+     *
+     * Requests that do not match both the origin and the path regular expressions will be blocked.
+     * @param masterObj
+     */
+    masters(masterObj: Object): void;
+    origin: string;
+    /**
+     * When true, XDomain will log actions to console
+     */
+    debug: boolean;
+    /**
+     * event may be log, warn or timeout. When listening for log and warn events, handler with contain the message as
+     * the first parameter. The timeout event fires when an iframe exeeds the xdomain.timeout time limit.
+     * @param event
+     * @param handler
+     */
+    on(event: "log" | "warn" | "timeout", handler: (message?: string) => any): void;
+    cookies: XDomainCookies;
 }
 
 declare var xdomain: IXDomain;
 
 declare module "xdomain" {
-  export const xdomain: IXDomain;
+    export const xdomain: IXDomain;
 }

--- a/types/xdomain/xdomain-tests.ts
+++ b/types/xdomain/xdomain-tests.ts
@@ -1,11 +1,9 @@
-
-
 xdomain.masters({
-  'http://abc.example.com': '/api/*'
+    "http://abc.example.com": "/api/*",
 });
 
 xdomain.slaves({
-  "http://xyz.example.com": "/proxy.html"
+    "http://xyz.example.com": "/proxy.html",
 });
 
 xdomain.debug = true;

--- a/types/xelib/index.d.ts
+++ b/types/xelib/index.d.ts
@@ -335,7 +335,8 @@ export type I<T> = T;
  * API for xelib wrapper
  */
 export interface XELib
-    extends I<typeof LoaderState>,
+    extends
+        I<typeof LoaderState>,
         I<typeof GameMode>,
         I<typeof ArchiveType>,
         I<typeof ElementType>,
@@ -343,7 +344,8 @@ export interface XELib
         I<typeof SmashType>,
         I<typeof ValueType>,
         I<typeof ConflictThis>,
-        I<typeof ConflictAll> {
+        I<typeof ConflictAll>
+{
     /**
      * Meta functions
      * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FMeta}

--- a/types/xelib/xelib-tests.ts
+++ b/types/xelib/xelib-tests.ts
@@ -1,8 +1,8 @@
-import { wrapper as xelib, Handle, ElementHandle, RecordHandle, ConflictAll, ConflictThis } from 'xelib';
+import { ConflictAll, ConflictThis, ElementHandle, Handle, RecordHandle, wrapper as xelib } from "xelib";
 
-xelib.GetGlobal('foo');
+xelib.GetGlobal("foo");
 
-xelib.SetSortMode('None', false);
+xelib.SetSortMode("None", false);
 
 xelib.BuildReferences(0, false);
 
@@ -18,11 +18,11 @@ const [ca, ct]: [keyof typeof ConflictAll, keyof typeof ConflictThis] = xelib.Ge
 xelib.GetConflictData(0, elHandle); // $ExpectType [ConflictAll, ConflictThis]
 
 // $ExpectType { [k: string]: RecordHandle; }
-xelib.BuildReferenceMap(handle, '');
+xelib.BuildReferenceMap(handle, "");
 // $ExpectType { [k: string]: number; }
-xelib.BuildReferenceMap(handle, '', undefined, (_: RecordHandle) => 1);
+xelib.BuildReferenceMap(handle, "", undefined, (_: RecordHandle) => 1);
 
 // $ExpectType { a: Zeroable<ElementHandle>; b: Zeroable<ElementHandle>; }
-xelib.ResolveElements(handle, { a: 'foo', b: 'bar' });
+xelib.ResolveElements(handle, { a: "foo", b: "bar" });
 // $ExpectType { a: ElementHandle; b: ElementHandle; }
-xelib.ResolveElementsEx(handle, { a: 'foo', b: 'bar' });
+xelib.ResolveElementsEx(handle, { a: "foo", b: "bar" });

--- a/types/xhook/xhook-tests.ts
+++ b/types/xhook/xhook-tests.ts
@@ -1,4 +1,4 @@
-import xhook = require('xhook');
+import xhook = require("xhook");
 
 xhook.disable();
 xhook.enable();
@@ -17,8 +17,8 @@ xhook.before((request, callback) => {
         status: 200,
         data: new Document(),
         headers: {},
-        statusText: '',
-        text: '',
+        statusText: "",
+        text: "",
         xml: new XMLDocument(),
     });
 });

--- a/types/xk6-sql-browser/index.d.ts
+++ b/types/xk6-sql-browser/index.d.ts
@@ -7,7 +7,7 @@
  * xk6-sql: k6 extension that allows connection to RDBMSs: mysql, postgres, sqlite3, sqlserver
  * https://github.com/grafana/xk6-sql
  */
-declare module 'k6/x/sql' {
+declare module "k6/x/sql" {
     namespace sql {
         /**
          * Opens a database connection.
@@ -18,7 +18,7 @@ declare module 'k6/x/sql' {
          * const db = sql.open("sqlserver", "Server=127.0.0.1;Database=myDB;User Id=myUser;Password=myPassword;")
          */
         function open(
-            type: 'mysql' | 'postgres' | 'sqlite3' | 'sqlserver',
+            type: "mysql" | "postgres" | "sqlite3" | "sqlserver",
             connectionString: string,
         ): DatabaseConnection;
 
@@ -57,7 +57,7 @@ declare module 'k6/x/sql' {
     export default sql;
 }
 
-declare module 'xk6-sql' {
+declare module "xk6-sql" {
     namespace sql {
         /**
          * Opens a database connection.
@@ -68,7 +68,7 @@ declare module 'xk6-sql' {
          * const db = sql.open("sqlserver", "Server=127.0.0.1;Database=myDB;User Id=myUser;Password=myPassword;")
          */
         function open(
-            type: 'mysql' | 'postgres' | 'sqlite3' | 'sqlserver',
+            type: "mysql" | "postgres" | "sqlite3" | "sqlserver",
             connectionString: string,
         ): DatabaseConnection;
 

--- a/types/xk6-sql-browser/xk6-sql-browser-tests.ts
+++ b/types/xk6-sql-browser/xk6-sql-browser-tests.ts
@@ -1,21 +1,21 @@
-import sql from 'k6/x/sql';
+import sql from "k6/x/sql";
 
 // @ts-expect-error
 sql.open();
 // @ts-expect-error
-sql.open('not-supported', '123');
+sql.open("not-supported", "123");
 // @ts-expect-error
-sql.open('sqlite3');
+sql.open("sqlite3");
 
 // $ExpectType DatabaseConnection
-sql.open('sqlite3', 'my.db');
+sql.open("sqlite3", "my.db");
 
-const db = sql.open('sqlite3', 'my.db');
+const db = sql.open("sqlite3", "my.db");
 
 // @ts-expect-error
 db.exec();
 
-db.exec('some statements');
+db.exec("some statements");
 
 // @ts-expect-error
 db.close(1);
@@ -25,11 +25,11 @@ db.close();
 // @ts-expect-error
 sql.query();
 // @ts-expect-error
-sql.query('not-connection-object', 'select statement');
+sql.query("not-connection-object", "select statement");
 // @ts-expect-error
 sql.query(db);
 
-sql.query(db, 'select statement');
-sql.query(db, 'select statement', 'param1');
-sql.query(db, 'select statement', 'param1', 'param2');
-sql.query(db, 'select statement', 'param1', 'param2', 'param3');
+sql.query(db, "select statement");
+sql.query(db, "select statement", "param1");
+sql.query(db, "select statement", "param1", "param2");
+sql.query(db, "select statement", "param1", "param2", "param3");

--- a/types/xml-c14n/xml-c14n-tests.ts
+++ b/types/xml-c14n/xml-c14n-tests.ts
@@ -1,5 +1,5 @@
-import c14n from 'xml-c14n';
+import c14n from "xml-c14n";
 
 const canonizer = c14n().createCanonicaliser(
-  'http://www.w3.org/2001/10/xml-exc-c14n#',
+    "http://www.w3.org/2001/10/xml-exc-c14n#",
 );

--- a/types/xml-crypto/index.d.ts
+++ b/types/xml-crypto/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-import { SelectedValue } from 'xpath';
+import { SelectedValue } from "xpath";
 
 export class HashAlgorithm {
     getAlgorithmName(): string;
@@ -34,9 +34,9 @@ export class TransformationAlgorithm {
 }
 
 export class SignedXml {
-    static CanonicalizationAlgorithms: {[uri: string]: new () => TransformationAlgorithm };
-    static HashAlgorithms: {[uri: string]: new () => HashAlgorithm};
-    static SignatureAlgorithms: {[uri: string]: new () => SignatureAlgorithm};
+    static CanonicalizationAlgorithms: { [uri: string]: new() => TransformationAlgorithm };
+    static HashAlgorithms: { [uri: string]: new() => HashAlgorithm };
+    static SignatureAlgorithms: { [uri: string]: new() => SignatureAlgorithm };
     canonicalizationAlgorithm: string;
     keyInfoProvider: FileKeyInfo;
     references: Reference[];
@@ -44,11 +44,11 @@ export class SignedXml {
     signingKey: Buffer | string;
     validationErrors: string[];
     constructor(idMode?: string | null, options?: {
-        canonicalizationAlgorithm?: string | undefined
-        idAttribute?: string | undefined
-        implicitTransforms?: ReadonlyArray<string> | undefined
-        signatureAlgorithm?: string | undefined
-    })
+        canonicalizationAlgorithm?: string | undefined;
+        idAttribute?: string | undefined;
+        implicitTransforms?: ReadonlyArray<string> | undefined;
+        signatureAlgorithm?: string | undefined;
+    });
     addReference(
         xpath: string,
         transforms?: ReadonlyArray<string>,
@@ -56,20 +56,20 @@ export class SignedXml {
         uri?: string,
         digestValue?: string,
         inclusiveNamespacesPrefixList?: string,
-        isEmptyUri?: boolean
+        isEmptyUri?: boolean,
     ): void;
     checkSignature(xml: string): boolean;
     computeSignature(
         xml: string,
         opts?: {
-            prefix?: string | undefined,
-            attrs?: {[key: string]: any} | undefined,
+            prefix?: string | undefined;
+            attrs?: { [key: string]: any } | undefined;
             location?: {
-                reference: string,
-                action: 'append' | 'prepend' | 'before' |  'after'
-            } | undefined,
-            existingPrefixes?: {[prefix: string]: string} | undefined
-        }
+                reference: string;
+                action: "append" | "prepend" | "before" | "after";
+            } | undefined;
+            existingPrefixes?: { [prefix: string]: string } | undefined;
+        },
     ): void;
     getOriginalXmlWithIds(): string;
     getSignatureXml(): string;

--- a/types/xml-crypto/xml-crypto-tests.ts
+++ b/types/xml-crypto/xml-crypto-tests.ts
@@ -1,11 +1,11 @@
 import {
-  FileKeyInfo,
-  HashAlgorithm,
-  SignatureAlgorithm,
-  SignedXml,
-  TransformationAlgorithm,
-  xpath as select,
-} from 'xml-crypto';
+    FileKeyInfo,
+    HashAlgorithm,
+    SignatureAlgorithm,
+    SignedXml,
+    TransformationAlgorithm,
+    xpath as select,
+} from "xml-crypto";
 
 // Modified from https://github.com/yaronn/xml-crypto#signing-xml-documents
 const xml = `
@@ -17,94 +17,94 @@ const xml = `
 `;
 const sig1 = new SignedXml();
 sig1.addReference("//*[local-name(.)='book']");
-sig1.signingKey = 'not a real key';
+sig1.signingKey = "not a real key";
 sig1.computeSignature(xml);
 const signed: string = sig1.getSignedXml();
 
 // Modified from https://github.com/yaronn/xml-crypto#hashing-algorithms
 const doc = new Document();
 const signature = select(
-  doc,
-  "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
+    doc,
+    "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
 )[0] as Node;
 const sig2 = new SignedXml();
-sig2.keyInfoProvider = new FileKeyInfo('client_public.pem');
+sig2.keyInfoProvider = new FileKeyInfo("client_public.pem");
 sig2.loadSignature(signature);
 const res2: boolean = sig2.checkSignature(xml);
 const errs: string[] = sig2.validationErrors;
 
 // Modified from https://github.com/yaronn/xml-crypto#caring-for-implicit-transform
 const option = {
-  implicitTransforms: ['http://www.w3.org/TR/2001/REC-xml-c14n-20010315'],
+    implicitTransforms: ["http://www.w3.org/TR/2001/REC-xml-c14n-20010315"],
 };
 const sig3 = new SignedXml(null, option);
-sig3.keyInfoProvider = new FileKeyInfo('client_public.pem');
+sig3.keyInfoProvider = new FileKeyInfo("client_public.pem");
 sig3.loadSignature(signature);
 const res3: boolean = sig3.checkSignature(xml);
 
 // Modified from https://github.com/yaronn/xml-crypto#customizing-algorithms
 class MyKeyInfo extends FileKeyInfo {
-  getKeyInfo(key?: string, prefix?: string) {
-    prefix = prefix || '';
-    prefix = prefix ? prefix + ':' : prefix;
-    return `<${prefix}X509Data></${prefix}X509Data>`;
-  }
-  getKey(keyInfo?: Node) {
-    return Buffer.from('not a real key');
-  }
+    getKeyInfo(key?: string, prefix?: string) {
+        prefix = prefix || "";
+        prefix = prefix ? prefix + ":" : prefix;
+        return `<${prefix}X509Data></${prefix}X509Data>`;
+    }
+    getKey(keyInfo?: Node) {
+        return Buffer.from("not a real key");
+    }
 }
 class MyDigest extends HashAlgorithm {
-  getHash(xml: string) {
-    return 'the base64 hash representation of the given xml string';
-  }
-  getAlgorithmName() {
-    return 'http://myDigestAlgorithm';
-  }
+    getHash(xml: string) {
+        return "the base64 hash representation of the given xml string";
+    }
+    getAlgorithmName() {
+        return "http://myDigestAlgorithm";
+    }
 }
 class MySignatureAlgorithm extends SignatureAlgorithm {
-  getSignature(signedInfo: Node, signingKey: Buffer) {
-    return 'signature of signedInfo as base64...';
-  }
-  getAlgorithmName() {
-    return 'http://mySigningAlgorithm';
-  }
+    getSignature(signedInfo: Node, signingKey: Buffer) {
+        return "signature of signedInfo as base64...";
+    }
+    getAlgorithmName() {
+        return "http://mySigningAlgorithm";
+    }
 }
 class MyTransformation extends TransformationAlgorithm {
-  process(node: Node) {
-    return node.toString();
-  }
-  getAlgorithmName() {
-    return 'http://myTransformation';
-  }
+    process(node: Node) {
+        return node.toString();
+    }
+    getAlgorithmName() {
+        return "http://myTransformation";
+    }
 }
 class MyCanonicalization extends TransformationAlgorithm {
-  process(node: Node) {
-    return '< x/>';
-  }
-  getAlgorithmName() {
-    return 'http://myCanonicalization';
-  }
+    process(node: Node) {
+        return "< x/>";
+    }
+    getAlgorithmName() {
+        return "http://myCanonicalization";
+    }
 }
 SignedXml.CanonicalizationAlgorithms[
-  'http://MyTransformation'
+    "http://MyTransformation"
 ] = MyTransformation;
 SignedXml.CanonicalizationAlgorithms[
-  'http://MyCanonicalization'
+    "http://MyCanonicalization"
 ] = MyCanonicalization;
-SignedXml.HashAlgorithms['http://myDigestAlgorithm'] = MyDigest;
+SignedXml.HashAlgorithms["http://myDigestAlgorithm"] = MyDigest;
 SignedXml.SignatureAlgorithms[
-  'http://mySigningAlgorithm'
+    "http://mySigningAlgorithm"
 ] = MySignatureAlgorithm;
 const sig4 = new SignedXml();
-sig4.signatureAlgorithm = 'http://mySignatureAlgorithm';
+sig4.signatureAlgorithm = "http://mySignatureAlgorithm";
 sig4.keyInfoProvider = new MyKeyInfo();
-sig4.canonicalizationAlgorithm = 'http://MyCanonicalization';
+sig4.canonicalizationAlgorithm = "http://MyCanonicalization";
 sig4.addReference(
-  "//*[local-name(.)='x']",
-  ['http://MyTransformation'],
-  'http://myDigestAlgorithm',
+    "//*[local-name(.)='x']",
+    ["http://MyTransformation"],
+    "http://myDigestAlgorithm",
 );
-sig4.signingKey = Buffer.from('not a real key');
+sig4.signingKey = Buffer.from("not a real key");
 sig4.addReference("//*[local-name(.)='book']");
 sig4.computeSignature(xml);
 const res4: string = sig4.getSignedXml();
@@ -112,13 +112,13 @@ const res4: string = sig4.getSignedXml();
 // Modified from https://github.com/yaronn/xml-crypto#examples
 const sig5 = new SignedXml();
 sig5.addReference("//*[local-name(.)='book']");
-sig5.signingKey = Buffer.from('not a real key');
+sig5.signingKey = Buffer.from("not a real key");
 sig5.computeSignature(xml, {
-  prefix: 'ds',
+    prefix: "ds",
 });
 const sig6 = new SignedXml();
 sig6.addReference("//*[local-name(.)='book']");
-sig6.signingKey = Buffer.from('not a real key');
+sig6.signingKey = Buffer.from("not a real key");
 sig6.computeSignature(xml, {
-  location: { reference: "//*[local-name(.)='book']", action: 'after' },
+    location: { reference: "//*[local-name(.)='book']", action: "after" },
 });

--- a/types/xml-encryption/index.d.ts
+++ b/types/xml-encryption/index.d.ts
@@ -7,15 +7,15 @@
 export type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
 
 export type KeyEncryptionAlgorithm =
-    | 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    | 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
+    | "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
+    | "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
 
 export type EncryptionAlgorithm =
-    | 'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
-    | 'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
-    | 'http://www.w3.org/2009/xmlenc11#aes128-gcm'
-    | 'http://www.w3.org/2009/xmlenc11#aes256-gcm'
-    | 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc';
+    | "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+    | "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+    | "http://www.w3.org/2009/xmlenc11#aes128-gcm"
+    | "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+    | "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
 
 export interface EncryptOptions extends EncryptKeyOptions {
     encryptionAlgorithm: EncryptionAlgorithm;

--- a/types/xml-encryption/xml-encryption-tests.ts
+++ b/types/xml-encryption/xml-encryption-tests.ts
@@ -1,42 +1,42 @@
-import { decrypt, encrypt, decryptKeyInfo, encryptKeyInfo, EncryptOptions } from 'xml-encryption';
+import { decrypt, decryptKeyInfo, encrypt, encryptKeyInfo, EncryptOptions } from "xml-encryption";
 
 // no key
 // @ts-expect-error
-decrypt('enc', {}, (err, res) => {});
+decrypt("enc", {}, (err, res) => {});
 // @ts-expect-error
-decryptKeyInfo('enc', {});
+decryptKeyInfo("enc", {});
 
 decrypt(
-    'enc',
-    { key: 'mykey', disallowDecryptionWithInsecureAlgorithm: false, warnInsecureAlgorithm: false },
+    "enc",
+    { key: "mykey", disallowDecryptionWithInsecureAlgorithm: false, warnInsecureAlgorithm: false },
     (err, res) => {
         // $ExpectType string
         const result = res;
     },
 );
 // $ExpectType Buffer
-const decrypted = decryptKeyInfo('enc', { key: 'mykey' });
+const decrypted = decryptKeyInfo("enc", { key: "mykey" });
 
 // @ts-expect-error
-encrypt('dec', {}, (err, res) => {});
+encrypt("dec", {}, (err, res) => {});
 // @ts-expect-error
-encryptKeyInfo(Buffer.from('dec'), {}, (err, res) => {});
+encryptKeyInfo(Buffer.from("dec"), {}, (err, res) => {});
 
 const encryptOptions: EncryptOptions = {
-    rsa_pub: 'pub',
-    pem: 'pem',
-    encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+    rsa_pub: "pub",
+    pem: "pem",
+    encryptionAlgorithm: "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+    keyEncryptionAlgorithm: "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p",
     disallowEncryptionWithInsecureAlgorithm: true,
     warnInsecureAlgorithm: true,
-    input_encoding: 'utf8',
+    input_encoding: "utf8",
 };
 
-encrypt('dec', encryptOptions, (err, res) => {
+encrypt("dec", encryptOptions, (err, res) => {
     // $ExpectType string
     const result = res;
 });
-encryptKeyInfo(Buffer.from('dec'), encryptOptions, (err, res) => {
+encryptKeyInfo(Buffer.from("dec"), encryptOptions, (err, res) => {
     // $ExpectType string
     const result = res;
 });

--- a/types/xml-escape/xml-escape-tests.ts
+++ b/types/xml-escape/xml-escape-tests.ts
@@ -16,5 +16,5 @@ const preservingApostrophe = xmlEscape(xml, "&"); // $ExpectType string
 
 console.info({
     fullEscaped,
-    preservingApostrophe
+    preservingApostrophe,
 });

--- a/types/xml-flow/index.d.ts
+++ b/types/xml-flow/index.d.ts
@@ -6,8 +6,8 @@
 
 /// <reference types="node" />
 
-import { Readable } from "stream";
 import { EventEmitter } from "events";
+import { Readable } from "stream";
 
 declare function flow(infile: Readable, options?: flow.parserOptions): EventEmitter;
 

--- a/types/xml-flow/xml-flow-tests.ts
+++ b/types/xml-flow/xml-flow-tests.ts
@@ -19,7 +19,7 @@ const myOptions = {
     trim: false,
     normalize: true,
     cdataAsText: true,
-    strict: true
+    strict: true,
 };
 
 // $ExpectType EventEmitter
@@ -29,8 +29,8 @@ const myFlowWithOptions = flow(readStreamTwo, myOptions);
 const xmlTarget = {
     head: {
         childOne: "text",
-        childTwo: "text"
-    }
+        childTwo: "text",
+    },
 };
 
 // $ExpectType string
@@ -39,7 +39,7 @@ const xmlString = flow.toXml(xmlTarget);
 const xmlOptions = {
     indent: "\t",
     selfClosing: true,
-    escape: (s: string) => s
+    escape: (s: string) => s,
 };
 
 // $ExpectType string

--- a/types/xml-name-validator/xml-name-validator-tests.ts
+++ b/types/xml-name-validator/xml-name-validator-tests.ts
@@ -1,4 +1,4 @@
-import { name, qname } from 'xml-name-validator';
+import { name, qname } from "xml-name-validator";
 
-name(''); // $ExpectType boolean
-qname(''); // $ExpectType boolean
+name(""); // $ExpectType boolean
+qname(""); // $ExpectType boolean

--- a/types/xml-parser/index.d.ts
+++ b/types/xml-parser/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Matt Frantz <https://github.com/mhfrantz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-
 declare function parse(xml: string): parse.Document;
 
 declare namespace parse {

--- a/types/xml-parser/xml-parser-tests.ts
+++ b/types/xml-parser/xml-parser-tests.ts
@@ -1,17 +1,18 @@
-import parse = require('xml-parser');
+import parse = require("xml-parser");
 declare var assert: { equal<T>(a: T, b: T): void };
 
 var doc: parse.Document = parse(
-  '<?xml version="1.0" encoding="utf-8"?>' +
-    '<mydoc><child a="1">foo</child><child/></mydoc>');
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<mydoc><child a=\"1\">foo</child><child/></mydoc>",
+);
 var declaration: parse.Declaration = doc.declaration;
-assert.equal(declaration.attributes['version'], '1.0');
-assert.equal(declaration.attributes['encoding'], 'utf-8');
+assert.equal(declaration.attributes["version"], "1.0");
+assert.equal(declaration.attributes["encoding"], "utf-8");
 var root: parse.Node = doc.root;
-assert.equal(root.name, 'mydoc');
+assert.equal(root.name, "mydoc");
 var children: parse.Node[] = root.children;
 assert.equal(children.length, 2);
 var child1: parse.Node = children[0];
-assert.equal(child1.name, 'child');
-assert.equal(child1.attributes['a'], '1');
-assert.equal(child1.content, 'foo');
+assert.equal(child1.name, "child");
+assert.equal(child1.attributes["a"], "1");
+assert.equal(child1.content, "foo");

--- a/types/xml-zero-lexer/index.d.ts
+++ b/types/xml-zero-lexer/index.d.ts
@@ -88,7 +88,7 @@ export const NodeTypeKeys: [
     "NOTATION_NODE",
     "CLOSE_ELEMENT",
     "JSX_ATTRIBUTE",
-    "JSX"
+    "JSX",
 ];
 
 declare namespace Lexx {
@@ -128,4 +128,9 @@ export function onElement(xml: string, i: number, inElement: boolean): [number, 
 export function onExclamation(xml: string, i: number, inElement: boolean): [number, boolean, Lexx.Token];
 export function onShorthandCDATA(xml: string, i: number, inElement: boolean): [number, boolean, Lexx.Token];
 export function onText(xml: string, i: number, jsx?: boolean): [number, boolean, Lexx.Token];
-export function onBlackhole(xml: string, i: number, inElement: boolean, untilToken: Lexx.Token): [number, boolean, Lexx.Token];
+export function onBlackhole(
+    xml: string,
+    i: number,
+    inElement: boolean,
+    untilToken: Lexx.Token,
+): [number, boolean, Lexx.Token];

--- a/types/xml-zero-lexer/xml-zero-lexer-tests.ts
+++ b/types/xml-zero-lexer/xml-zero-lexer-tests.ts
@@ -1,6 +1,6 @@
-import Lexx, { NodeTypes, NodeTypeKeys } from 'xml-zero-lexer';
+import Lexx, { NodeTypeKeys, NodeTypes } from "xml-zero-lexer";
 
-const xml = '<p>his divine shadow</p>';
+const xml = "<p>his divine shadow</p>";
 
 const options: Lexx.Options = { jsx: true, html: true, blackholes: ["script"] };
 

--- a/types/xml/index.d.ts
+++ b/types/xml/index.d.ts
@@ -22,9 +22,10 @@ declare namespace xml {
         declaration?:
             | boolean
             | {
-                  encoding?: string | undefined;
-                  standalone?: string | undefined;
-              } | undefined;
+                encoding?: string | undefined;
+                standalone?: string | undefined;
+            }
+            | undefined;
     }
 
     interface XmlAttrs {

--- a/types/xml/xml-tests.ts
+++ b/types/xml/xml-tests.ts
@@ -3,184 +3,227 @@
 import xml = require("xml");
 
 interface Tester {
-  is(a: any, b: any): void;
-  same(a: any, b: any): void;
-  plan(id: number): void;
-  ok(a: any): void;
+    is(a: any, b: any): void;
+    same(a: any, b: any): void;
+    plan(id: number): void;
+    ok(a: any): void;
 }
 
 function test(c: string, f: (t: Tester) => void) {
-  return;
+    return;
 }
 
-test('no elements', t => {
-    t.is(xml(), '');
-    t.is(xml([]), '');
-    t.is(xml('test'), 'test');
-    t.is(xml('scotch & whisky'), 'scotch &amp; whisky');
-    t.is(xml('bob\'s escape character'), 'bob&apos;s escape character');
+test("no elements", t => {
+    t.is(xml(), "");
+    t.is(xml([]), "");
+    t.is(xml("test"), "test");
+    t.is(xml("scotch & whisky"), "scotch &amp; whisky");
+    t.is(xml("bob's escape character"), "bob&apos;s escape character");
 });
 
-test('simple options', t => {
-    t.is(xml([{a: {}}]), '<a/>');
-    t.is(xml([{a: null}]), '<a/>');
-    t.is(xml([{a: []}]), '<a></a>');
-    t.is(xml([{a: -1}]), '<a>-1</a>');
-    t.is(xml([{a: false}]), '<a>false</a>');
-    t.is(xml([{a: 'test'}]), '<a>test</a>');
-    t.is(xml({a: {}}), '<a/>');
-    t.is(xml({a: null}), '<a/>');
-    t.is(xml({a: []}), '<a></a>');
-    t.is(xml({a: -1}), '<a>-1</a>');
-    t.is(xml({a: false}), '<a>false</a>');
-    t.is(xml({a: 'test'}), '<a>test</a>');
-    t.is(xml([{a: 'test'}, {b: 123}, {c: -0.5}]), '<a>test</a><b>123</b><c>-0.5</c>');
+test("simple options", t => {
+    t.is(xml([{ a: {} }]), "<a/>");
+    t.is(xml([{ a: null }]), "<a/>");
+    t.is(xml([{ a: [] }]), "<a></a>");
+    t.is(xml([{ a: -1 }]), "<a>-1</a>");
+    t.is(xml([{ a: false }]), "<a>false</a>");
+    t.is(xml([{ a: "test" }]), "<a>test</a>");
+    t.is(xml({ a: {} }), "<a/>");
+    t.is(xml({ a: null }), "<a/>");
+    t.is(xml({ a: [] }), "<a></a>");
+    t.is(xml({ a: -1 }), "<a>-1</a>");
+    t.is(xml({ a: false }), "<a>false</a>");
+    t.is(xml({ a: "test" }), "<a>test</a>");
+    t.is(xml([{ a: "test" }, { b: 123 }, { c: -0.5 }]), "<a>test</a><b>123</b><c>-0.5</c>");
 });
 
-test('deeply nested objects', t => {
-    t.is(xml([{a: [{b: [{c: 1}, {c: 2}, {c: 3}]}]}]), '<a><b><c>1</c><c>2</c><c>3</c></b></a>');
+test("deeply nested objects", t => {
+    t.is(xml([{ a: [{ b: [{ c: 1 }, { c: 2 }, { c: 3 }] }] }]), "<a><b><c>1</c><c>2</c><c>3</c></b></a>");
 });
 
-test('indents property', t => {
-    t.is(xml([{a: [{b: [{c: 1}, {c: 2}, {c: 3}]}]}], true), '<a>\n    <b>\n        <c>1</c>\n        <c>2</c>\n        <c>3</c>\n    </b>\n</a>');
-    t.is(xml([{a: [{b: [{c: 1}, {c: 2}, {c: 3}]}]}], '  '), '<a>\n  <b>\n    <c>1</c>\n    <c>2</c>\n    <c>3</c>\n  </b>\n</a>');
-    t.is(xml([{a: [{b: [{c: 1}, {c: 2}, {c: 3}]}]}], '\t'), '<a>\n\t<b>\n\t\t<c>1</c>\n\t\t<c>2</c>\n\t\t<c>3</c>\n\t</b>\n</a>');
-    t.is(xml({guid: [{_attr: {premalink: true}}, 'content']}, true), '<guid premalink="true">content</guid>');
-});
-
-test('supports xml attributes', t => {
-    t.is(xml([{b: {_attr: {}}}]), '<b/>');
-    t.is(xml([{
-        a: {
-            _attr: {
-                attribute1: 'some value',
-                attribute2: 12345
-            }
-        }
-    }]), '<a attribute1="some value" attribute2="12345"/>');
-    t.is(xml([{
-        a: [{
-            _attr: {
-                attribute1: 'some value',
-                attribute2: 12345
-            }
-        }]
-    }]), '<a attribute1="some value" attribute2="12345"></a>');
-    t.is(xml([{
-        a: [{
-            _attr: {
-                attribute1: 'some value',
-                attribute2: 12345
-            }
-        }, 'content']
-    }]), '<a attribute1="some value" attribute2="12345">content</a>');
-});
-
-test('supports cdata', t => {
-    t.is(xml([{a: {_cdata: 'This is some <strong>CDATA</strong>'}}]), '<a><![CDATA[This is some <strong>CDATA</strong>]]></a>');
-    t.is(xml([{
-        a: {
-            _attr: {attribute1: 'some value', attribute2: 12345},
-            _cdata: 'This is some <strong>CDATA</strong>'
-        }
-    }]), '<a attribute1="some value" attribute2="12345"><![CDATA[This is some <strong>CDATA</strong>]]></a>');
+test("indents property", t => {
     t.is(
-        xml([{a: {_cdata: 'This is some <strong>CDATA</strong> with ]]> and then again ]]>'}}]),
-        '<a><![CDATA[This is some <strong>CDATA</strong> with ]]]]><![CDATA[> and then again ]]]]><![CDATA[>]]></a>');
+        xml([{ a: [{ b: [{ c: 1 }, { c: 2 }, { c: 3 }] }] }], true),
+        "<a>\n    <b>\n        <c>1</c>\n        <c>2</c>\n        <c>3</c>\n    </b>\n</a>",
+    );
+    t.is(
+        xml([{ a: [{ b: [{ c: 1 }, { c: 2 }, { c: 3 }] }] }], "  "),
+        "<a>\n  <b>\n    <c>1</c>\n    <c>2</c>\n    <c>3</c>\n  </b>\n</a>",
+    );
+    t.is(
+        xml([{ a: [{ b: [{ c: 1 }, { c: 2 }, { c: 3 }] }] }], "\t"),
+        "<a>\n\t<b>\n\t\t<c>1</c>\n\t\t<c>2</c>\n\t\t<c>3</c>\n\t</b>\n</a>",
+    );
+    t.is(xml({ guid: [{ _attr: { premalink: true } }, "content"] }, true), "<guid premalink=\"true\">content</guid>");
 });
 
-test('supports encoding', t => {
-    t.is(xml([{
-        a: [{
-            _attr: {
-                anglebrackets: 'this is <strong>strong</strong>',
-                url: 'http://google.com?s=opower&y=fun'
-            }
-        }, 'text']
-    }]), '<a anglebrackets="this is &lt;strong&gt;strong&lt;/strong&gt;" url="http://google.com?s=opower&amp;y=fun">text</a>');
+test("supports xml attributes", t => {
+    t.is(xml([{ b: { _attr: {} } }]), "<b/>");
+    t.is(
+        xml([{
+            a: {
+                _attr: {
+                    attribute1: "some value",
+                    attribute2: 12345,
+                },
+            },
+        }]),
+        "<a attribute1=\"some value\" attribute2=\"12345\"/>",
+    );
+    t.is(
+        xml([{
+            a: [{
+                _attr: {
+                    attribute1: "some value",
+                    attribute2: 12345,
+                },
+            }],
+        }]),
+        "<a attribute1=\"some value\" attribute2=\"12345\"></a>",
+    );
+    t.is(
+        xml([{
+            a: [{
+                _attr: {
+                    attribute1: "some value",
+                    attribute2: 12345,
+                },
+            }, "content"],
+        }]),
+        "<a attribute1=\"some value\" attribute2=\"12345\">content</a>",
+    );
 });
 
-test('supports stream interface', t => {
-    const elem = xml.element({_attr: {decade: '80s', locale: 'US'}});
-    const xmlStream = xml({toys: elem}, {stream: true});
-    const results = ['<toys decade="80s" locale="US">', '<toy>Transformers</toy>', '<toy><name>He-man</name></toy>', '<toy>GI Joe</toy>', '</toys>'];
+test("supports cdata", t => {
+    t.is(
+        xml([{ a: { _cdata: "This is some <strong>CDATA</strong>" } }]),
+        "<a><![CDATA[This is some <strong>CDATA</strong>]]></a>",
+    );
+    t.is(
+        xml([{
+            a: {
+                _attr: { attribute1: "some value", attribute2: 12345 },
+                _cdata: "This is some <strong>CDATA</strong>",
+            },
+        }]),
+        "<a attribute1=\"some value\" attribute2=\"12345\"><![CDATA[This is some <strong>CDATA</strong>]]></a>",
+    );
+    t.is(
+        xml([{ a: { _cdata: "This is some <strong>CDATA</strong> with ]]> and then again ]]>" } }]),
+        "<a><![CDATA[This is some <strong>CDATA</strong> with ]]]]><![CDATA[> and then again ]]]]><![CDATA[>]]></a>",
+    );
+});
 
-    elem.push({toy: 'Transformers'});
-    elem.push({toy: [{name: 'He-man'}]});
-    elem.push({toy: 'GI Joe'});
+test("supports encoding", t => {
+    t.is(
+        xml([{
+            a: [{
+                _attr: {
+                    anglebrackets: "this is <strong>strong</strong>",
+                    url: "http://google.com?s=opower&y=fun",
+                },
+            }, "text"],
+        }]),
+        "<a anglebrackets=\"this is &lt;strong&gt;strong&lt;/strong&gt;\" url=\"http://google.com?s=opower&amp;y=fun\">text</a>",
+    );
+});
+
+test("supports stream interface", t => {
+    const elem = xml.element({ _attr: { decade: "80s", locale: "US" } });
+    const xmlStream = xml({ toys: elem }, { stream: true });
+    const results = [
+        "<toys decade=\"80s\" locale=\"US\">",
+        "<toy>Transformers</toy>",
+        "<toy><name>He-man</name></toy>",
+        "<toy>GI Joe</toy>",
+        "</toys>",
+    ];
+
+    elem.push({ toy: "Transformers" });
+    elem.push({ toy: [{ name: "He-man" }] });
+    elem.push({ toy: "GI Joe" });
     elem.close();
 
-    xmlStream.on('data', (stanza: any[]) => {
+    xmlStream.on("data", (stanza: any[]) => {
         t.is(stanza, results.shift());
     });
 
     return new Promise<void>((resolve, reject) => {
-        xmlStream.on('close', () => {
+        xmlStream.on("close", () => {
             t.same(results, []);
             resolve();
         });
-        xmlStream.on('error', reject);
+        xmlStream.on("error", reject);
     });
 });
 
-test('streams end properly', t => {
-    const elem = xml.element({ _attr: { decade: '80s', locale: 'US'} });
+test("streams end properly", t => {
+    const elem = xml.element({ _attr: { decade: "80s", locale: "US" } });
     const xmlStream = xml({ toys: elem }, { stream: true });
 
     let gotData = false;
 
     t.plan(7);
 
-    elem.push({ toy: 'Transformers' });
-    elem.push({ toy: 'GI Joe' });
-    elem.push({ toy: [{name: 'He-man'}] });
+    elem.push({ toy: "Transformers" });
+    elem.push({ toy: "GI Joe" });
+    elem.push({ toy: [{ name: "He-man" }] });
     elem.close();
 
-    xmlStream.on('data',  (data: any) => {
+    xmlStream.on("data", (data: any) => {
         t.ok(data);
         gotData = true;
     });
 
-    xmlStream.on('end',  () => {
+    xmlStream.on("end", () => {
         t.ok(gotData);
     });
 
     return new Promise<void>((resolve, reject) => {
-        xmlStream.on('close',  () => {
+        xmlStream.on("close", () => {
             t.ok(gotData);
             resolve();
         });
-        xmlStream.on('error', reject);
+        xmlStream.on("error", reject);
     });
 });
 
-test('xml declaration options', t => {
-    t.is(xml([{a: 'test'}], {declaration: true}), '<?xml version="1.0" encoding="UTF-8"?><a>test</a>');
-    t.is(xml([{a: 'test'}], {declaration: {encoding: 'foo'}}), '<?xml version="1.0" encoding="foo"?><a>test</a>');
-    t.is(xml([{a: 'test'}], {declaration: {standalone: 'yes'}}), '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><a>test</a>');
-    t.is(xml([{a: 'test'}], {declaration: false}), '<a>test</a>');
-    t.is(xml([{a: 'test'}], {declaration: true, indent: '\n'}), '<?xml version="1.0" encoding="UTF-8"?>\n<a>test</a>');
-    t.is(xml([{a: 'test'}], {}), '<a>test</a>');
+test("xml declaration options", t => {
+    t.is(xml([{ a: "test" }], { declaration: true }), "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>test</a>");
+    t.is(
+        xml([{ a: "test" }], { declaration: { encoding: "foo" } }),
+        "<?xml version=\"1.0\" encoding=\"foo\"?><a>test</a>",
+    );
+    t.is(
+        xml([{ a: "test" }], { declaration: { standalone: "yes" } }),
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><a>test</a>",
+    );
+    t.is(xml([{ a: "test" }], { declaration: false }), "<a>test</a>");
+    t.is(
+        xml([{ a: "test" }], { declaration: true, indent: "\n" }),
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<a>test</a>",
+    );
+    t.is(xml([{ a: "test" }], {}), "<a>test</a>");
 });
 
-const xmlElement = xml.element({_attr: {xmlns: 'http://www.w3.org/1999/xhtml'}});
+const xmlElement = xml.element({ _attr: { xmlns: "http://www.w3.org/1999/xhtml" } });
 
 // $ExpectType ReadableStream
 xml(
-    { 'd:foo': xmlElement },
+    { "d:foo": xmlElement },
     {
         stream: true,
-        indent: '\t',
+        indent: "\t",
         declaration: true,
     },
 );
 
 // $ExpectType string
 const xmlStream = xml(
-    { 'd:foo': xmlElement },
+    { "d:foo": xmlElement },
     {
         stream: false,
-        indent: '\t',
+        indent: "\t",
         declaration: true,
     },
 );

--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -11,8 +11,8 @@
 // Minimum TypeScript Version: 3.5
 
 /// <reference types="node"/>
-import { EventEmitter } from 'events';
-import * as processors from './lib/processors';
+import { EventEmitter } from "events";
+import * as processors from "./lib/processors";
 
 export function parseString(str: convertableToString, callback: (err: Error | null, result: any) => void): void;
 export function parseString(
@@ -23,8 +23,8 @@ export function parseString(
 export function parseStringPromise(str: convertableToString, options?: ParserOptions): Promise<any>;
 
 export const defaults: {
-    '0.1': Options;
-    '0.2': OptionsV2;
+    "0.1": Options;
+    "0.2": OptionsV2;
 };
 
 export interface XmlDeclarationAttributes {

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -1,30 +1,30 @@
-import xml2js = require('xml2js');
-import * as processors from 'xml2js/lib/processors';
-import fs = require('fs');
+import xml2js = require("xml2js");
+import * as processors from "xml2js/lib/processors";
+import fs = require("fs");
 
-xml2js.parseString('<root>Hello xml2js!</root>', (err: Error | null, result: any) => { });
+xml2js.parseString("<root>Hello xml2js!</root>", (err: Error | null, result: any) => {});
 
-xml2js.parseStringPromise('<root>Hello xml2js!</root>');
+xml2js.parseStringPromise("<root>Hello xml2js!</root>");
 
-xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: Error | null, result: any) => { });
+xml2js.parseString("<root>Hello xml2js!</root>", { trim: true }, (err: Error | null, result: any) => {});
 
-xml2js.parseStringPromise('<root>Hello xml2js!</root>', {trim: true});
+xml2js.parseStringPromise("<root>Hello xml2js!</root>", { trim: true });
 
-xml2js.parseString('<root>Hello xml2js!</root>', {
-    attrkey: '$',
-    charkey: '_',
+xml2js.parseString("<root>Hello xml2js!</root>", {
+    attrkey: "$",
+    charkey: "_",
     explicitCharkey: false,
     trim: false,
     normalizeTags: false,
     explicitRoot: true,
-    emptyTag: '',
+    emptyTag: "",
     explicitArray: true,
     ignoreAttrs: false,
     mergeAttrs: false,
     validator: undefined,
     xmlns: false,
     explicitChildren: false,
-    childkey: '$$',
+    childkey: "$$",
     preserveChildrenOrder: false,
     charsAsChildren: false,
     includeWhiteChars: false,
@@ -33,80 +33,80 @@ xml2js.parseString('<root>Hello xml2js!</root>', {
     attrNameProcessors: undefined,
     attrValueProcessors: undefined,
     tagNameProcessors: undefined,
-    valueProcessors: undefined
-}, (err: Error | null, result: any) => { });
+    valueProcessors: undefined,
+}, (err: Error | null, result: any) => {});
 
-xml2js.parseString('<root>Hello xml2js!</root>', {
+xml2js.parseString("<root>Hello xml2js!</root>", {
     attrNameProcessors: [processors.firstCharLowerCase, xml2js.processors.normalize],
     attrValueProcessors: [processors.normalize],
     tagNameProcessors: [processors.stripPrefix],
-    valueProcessors: [processors.parseBooleans, processors.parseNumbers]
-}, (err: Error | null, result: any) => { });
+    valueProcessors: [processors.parseBooleans, processors.parseNumbers],
+}, (err: Error | null, result: any) => {});
 
 let builder = new xml2js.Builder({
     renderOpts: {
-        pretty: false
-    }
+        pretty: false,
+    },
 });
 
 builder = new xml2js.Builder({
-    rootName: 'root',
+    rootName: "root",
     renderOpts: {
         pretty: true,
-        indent: ' ',
-        newline: '\n'
+        indent: " ",
+        newline: "\n",
     },
     xmldec: {
-        version: '1.0',
-        encoding: 'UTF-8',
-        standalone: true
+        version: "1.0",
+        encoding: "UTF-8",
+        standalone: true,
     },
-    doctype: { ext: 'hello.dtd' },
+    doctype: { ext: "hello.dtd" },
     headless: false,
-    cdata: false
+    cdata: false,
 });
 
 const outString = builder.buildObject({
-    hello: 'xml2js!'
+    hello: "xml2js!",
 });
 
 const parser = new xml2js.Parser();
 
-parser.on('end', (result: any) => {
+parser.on("end", (result: any) => {
     console.log("Parser Finished");
     return;
 });
 
-const v1Defaults = xml2js.defaults['0.1'];
+const v1Defaults = xml2js.defaults["0.1"];
 v1Defaults.async = true;
 new xml2js.Parser(v1Defaults);
 new xml2js.Builder(v1Defaults);
-xml2js.parseString('', v1Defaults, () => undefined);
-xml2js.parseStringPromise('', v1Defaults);
+xml2js.parseString("", v1Defaults, () => undefined);
+xml2js.parseStringPromise("", v1Defaults);
 
-const v2Defaults = xml2js.defaults['0.2'];
+const v2Defaults = xml2js.defaults["0.2"];
 v2Defaults.async = false;
 v2Defaults.chunkSize = 20000;
 v2Defaults.emptyTag = () => ({});
 new xml2js.Parser(v2Defaults);
 new xml2js.Builder(v2Defaults);
-xml2js.parseString('', v2Defaults, () => undefined);
-xml2js.parseStringPromise('', v2Defaults);
+xml2js.parseString("", v2Defaults, () => undefined);
+xml2js.parseStringPromise("", v2Defaults);
 
-fs.readFile(__dirname + '/foo.xml', (err, data) => {
+fs.readFile(__dirname + "/foo.xml", (err, data) => {
     parser.parseString(data, (err: Error | null, result: any) => {
         console.dir(result);
-        console.log('Done parseString');
+        console.log("Done parseString");
     });
 
     parser.parseStringPromise(data).then(result => {
         console.dir(result);
-        console.log('Done parseStringPromise');
+        console.log("Done parseStringPromise");
     });
 });
 
-xml2js.parseString('<root>Hello xml2js!</root>', {
+xml2js.parseString("<root>Hello xml2js!</root>", {
     validator: (xpath: string, previousValue: any, newValue: any) => {
-        throw new xml2js.ValidationError('validation error');
-    }
-}, (err: Error | null, result: any) => { });
+        throw new xml2js.ValidationError("validation error");
+    },
+}, (err: Error | null, result: any) => {});

--- a/types/xml2json/xml2json-tests.ts
+++ b/types/xml2json/xml2json-tests.ts
@@ -1,6 +1,6 @@
-import * as parser from 'xml2json';
+import * as parser from "xml2json";
 
-let xml = '<foo attr="value">bar</foo>';
+let xml = "<foo attr=\"value\">bar</foo>";
 
 // xml to json
 const jsonString: string = parser.toJson(xml);
@@ -28,4 +28,4 @@ xml = parser.toXml(jsonObject, {
 
 // Test `alternateTextNode`.
 parser.toJson(xml, { alternateTextNode: true });
-parser.toJson(xml, { alternateTextNode: 'value' });
+parser.toJson(xml, { alternateTextNode: "value" });

--- a/types/xmldoc/index.d.ts
+++ b/types/xmldoc/index.d.ts
@@ -17,7 +17,7 @@ export type XmlNode = XmlElement | XmlTextNode | XmlCDataNode | XmlCommentNode;
 export class XmlElement {
     constructor(tag: XmlTag);
 
-    type: 'element';
+    type: "element";
     name: string;
     attr: XmlAttributes;
     val: string;
@@ -43,7 +43,7 @@ export class XmlElement {
 export class XmlTextNode {
     constructor(text: string);
 
-    type: 'text';
+    type: "text";
     text: string;
 
     toString(opts?: XmlOptions): string;
@@ -53,7 +53,7 @@ export class XmlTextNode {
 export class XmlCDataNode {
     constructor(cdata: string);
 
-    type: 'cdata';
+    type: "cdata";
     cdata: string;
 
     toString(opts?: XmlOptions): string;
@@ -63,7 +63,7 @@ export class XmlCDataNode {
 export class XmlCommentNode {
     constructor(comment: string);
 
-    type: 'comment';
+    type: "comment";
     comment: string;
 
     toString(opts?: XmlOptions): string;

--- a/types/xmldoc/xmldoc-tests.ts
+++ b/types/xmldoc/xmldoc-tests.ts
@@ -22,15 +22,15 @@ const nameNode = bookNode.descendantWithPath("author.name"); // return <name> no
 //
 // https://github.com/nfarina/xmldoc#valuewithpathpath
 //
-const authorName = bookNode.valueWithPath("author.name");               // return "George R. R. Martin"
-const authorIsProper = bookNode.valueWithPath("author.name@isProper");  // return "true"
+const authorName = bookNode.valueWithPath("author.name"); // return "George R. R. Martin"
+const authorIsProper = bookNode.valueWithPath("author.name@isProper"); // return "true"
 
 //
 // https://github.com/nfarina/xmldoc#tostringoptions
 //
-document.toString({ compressed: true });            // strips indents and linebreaks
-document.toString({ trimmed: true });               // trims long strings for easier debugging
-document.toString({ preserveWhitespace: true });    // prevents whitespace being removed from around element values
+document.toString({ compressed: true }); // strips indents and linebreaks
+document.toString({ trimmed: true }); // trims long strings for easier debugging
+document.toString({ preserveWhitespace: true }); // prevents whitespace being removed from around element values
 
 const xml = "<author><name>looooooong value</name></author>";
 console.log("My document: \n" + new xmldoc.XmlDocument(xml).toString({ trimmed: true }));

--- a/types/xmldom/index.d.ts
+++ b/types/xmldom/index.d.ts
@@ -15,12 +15,12 @@ declare namespace xmldom {
     }
 
     interface DOMParserStatic {
-        new (): DOMParser;
-        new (options: Options): DOMParser;
+        new(): DOMParser;
+        new(options: Options): DOMParser;
     }
 
     interface XMLSerializerStatic {
-        new (): XMLSerializer;
+        new(): XMLSerializer;
     }
 
     interface DOMParser {

--- a/types/xmldom/xmldom-tests.ts
+++ b/types/xmldom/xmldom-tests.ts
@@ -1,38 +1,42 @@
-
-import * as xmldom from 'xmldom';
+import * as xmldom from "xmldom";
 
 var doc = new xmldom.DOMParser().parseFromString(
-  '<xml xmlns="a" xmlns:c="./lite">\n'+
-  '\t<child>test</child>\n'+
-  '\t<child></child>\n'+
-  '\t<child/>\n'+
-  '</xml>'
-  ,'text/xml');
-doc.documentElement.setAttribute('x','y');
-doc.documentElement.setAttributeNS('./lite','c:x','y2');
-var nsAttr = doc.documentElement.getAttributeNS('./lite','x');
+    "<xml xmlns=\"a\" xmlns:c=\"./lite\">\n"
+        + "\t<child>test</child>\n"
+        + "\t<child></child>\n"
+        + "\t<child/>\n"
+        + "</xml>",
+    "text/xml",
+);
+doc.documentElement.setAttribute("x", "y");
+doc.documentElement.setAttributeNS("./lite", "c:x", "y2");
+var nsAttr = doc.documentElement.getAttributeNS("./lite", "x");
 console.info(nsAttr);
 console.info(doc);
 
 function callback(w: any) {
-
 }
 
-//errorHandler is supported
+// errorHandler is supported
 new xmldom.DOMParser({
-  /**
-   * locator is always need for error position info
-   */
-  locator:{},
-  /**
-   * you can override the errorHandler for xml parser
-   * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
-   */
-  errorHandler:{warning:function(w: any){console.warn(w)},error:callback,fatalError:callback}
-  //only callback model
-  //errorHandler:function(level,msg){console.log(level,msg)}
+    /**
+     * locator is always need for error position info
+     */
+    locator: {},
+    /**
+     * you can override the errorHandler for xml parser
+     * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+     */
+    errorHandler: {
+        warning: function(w: any) {
+            console.warn(w);
+        },
+        error: callback,
+        fatalError: callback,
+    },
+    // only callback model
+    // errorHandler:function(level,msg){console.log(level,msg)}
 });
-
 
 // XMLSerializer provides serializeToString method
 new xmldom.XMLSerializer().serializeToString(doc) == "string";

--- a/types/xmlhttprequest/xmlhttprequest-tests.ts
+++ b/types/xmlhttprequest/xmlhttprequest-tests.ts
@@ -1,6 +1,6 @@
-import { XMLHttpRequest } from 'xmlhttprequest';
+import { XMLHttpRequest } from "xmlhttprequest";
 
 const { OPENED, HEADERS_RECEIVED, LOADING, DONE } = XMLHttpRequest;
 
 const x = new XMLHttpRequest();
-x.open('GET', 'https://example.com');
+x.open("GET", "https://example.com");

--- a/types/xmljs/xmljs-tests.ts
+++ b/types/xmljs/xmljs-tests.ts
@@ -21,7 +21,7 @@ p.parseString(xml, (err, xmlNode) => {
     }
     const nodes = xmlNode.path(
         ["Envelope", "Body", "GetstockpriceResponse", "Price"],
-        true
+        true,
     );
     const arr = nodes.map(n => n.text);
 

--- a/types/xmlpoke/index.d.ts
+++ b/types/xmlpoke/index.d.ts
@@ -12,7 +12,7 @@ declare namespace XmlPoke { // ghost module
     type Value = string | boolean | number | XmlValue | CDataValue | PathToValueMap | Transform;
     type PathToValueMap = {
         [xpath: string]: Value;
-    }
+    };
     interface API {
         add(xpath: string, value: Value): API;
         add(map: PathToValueMap): API;
@@ -35,11 +35,11 @@ declare namespace XmlPoke { // ghost module
     }
 }
 
-declare module 'xmlpoke' {
+declare module "xmlpoke" {
     const xmlpoke: {
         (xml: string, modify: (api: XmlPoke.API) => void): string;
-        CDataValue: new (value: string) => XmlPoke.CDataValue;
-        XmlString: new (value: string) => XmlPoke.XmlValue;
+        CDataValue: new(value: string) => XmlPoke.CDataValue;
+        XmlString: new(value: string) => XmlPoke.XmlValue;
     };
     namespace xmlpoke {}
     export = xmlpoke;

--- a/types/xmlpoke/xmlpoke-tests.ts
+++ b/types/xmlpoke/xmlpoke-tests.ts
@@ -1,82 +1,85 @@
-import xmlpoke = require('xmlpoke');
-import assert = require('assert');
+import xmlpoke = require("xmlpoke");
+import assert = require("assert");
 
 let result: string;
 
 // add with xpath, value
-result = xmlpoke('<a/>', xml => xml.add('/a/b', 'c'));
-assert.equal(result, '<a><b>c</b></a>');
+result = xmlpoke("<a/>", xml => xml.add("/a/b", "c"));
+assert.equal(result, "<a><b>c</b></a>");
 
 // add with xpath, Transform
-const addfn: XmlPoke.Transform = (node, value) => 'c';
-result = xmlpoke('<a/>', xml => xml.add('/a/b', addfn));
-assert.equal(result, '<a><b>c</b></a>');
+const addfn: XmlPoke.Transform = (node, value) => "c";
+result = xmlpoke("<a/>", xml => xml.add("/a/b", addfn));
+assert.equal(result, "<a><b>c</b></a>");
 
 // add with xpath, CDataValue
-const cdataval: XmlPoke.CDataValue = new xmlpoke.CDataValue('c');
-result = xmlpoke('<a/>', xml => xml.add('/a/b', cdataval));
-assert.equal(result, '<a><b><![CDATA[c]]></b></a>');
+const cdataval: XmlPoke.CDataValue = new xmlpoke.CDataValue("c");
+result = xmlpoke("<a/>", xml => xml.add("/a/b", cdataval));
+assert.equal(result, "<a><b><![CDATA[c]]></b></a>");
 
 // add with xpath, XMLVal
-const xmlval = new xmlpoke.XmlString('<c/>');
-result = xmlpoke('<a/>', xml => xml.add('/a/b', xmlval));
-assert.equal(result, '<a><b><c/></b></a>');
+const xmlval = new xmlpoke.XmlString("<c/>");
+result = xmlpoke("<a/>", xml => xml.add("/a/b", xmlval));
+assert.equal(result, "<a><b><c/></b></a>");
 
 // add with map
-result = xmlpoke('<a/>', xml => xml.add({
-    '/a/b': 'c'
-}));
-assert.equal(result, '<a><b>c</b></a>');
+result = xmlpoke("<a/>", xml =>
+    xml.add({
+        "/a/b": "c",
+    }));
+assert.equal(result, "<a><b>c</b></a>");
 
 // set with xpath, value
-result = xmlpoke('<a>b</a>', xml => xml.set('/a', 'c'));
-assert.equal(result, '<a>c</a>');
+result = xmlpoke("<a>b</a>", xml => xml.set("/a", "c"));
+assert.equal(result, "<a>c</a>");
 
 // set with map
-result = xmlpoke('<a>b</a>', xml => xml.set({
-    '/a': 'c'
-}));
-assert.equal(result, '<a>c</a>');
+result = xmlpoke("<a>b</a>", xml =>
+    xml.set({
+        "/a": "c",
+    }));
+assert.equal(result, "<a>c</a>");
 
 // set with xpath that doesn't exist (no-op)
-result = xmlpoke('<a><b>bval</b></a>', xml => xml.set('/a/c', 'cval'));
-assert.equal(result, '<a><b>bval</b></a>');
+result = xmlpoke("<a><b>bval</b></a>", xml => xml.set("/a/c", "cval"));
+assert.equal(result, "<a><b>bval</b></a>");
 
 // setOrAdd with xpath, value
-result = xmlpoke('<a/>', xml => xml.setOrAdd('/a/b', 'c'));
-assert.equal(result, '<a><b>c</b></a>');
+result = xmlpoke("<a/>", xml => xml.setOrAdd("/a/b", "c"));
+assert.equal(result, "<a><b>c</b></a>");
 
 // setOrAdd with map
-result = xmlpoke('<a/>', xml => xml.setOrAdd({
-    '/a/b': 'c'
-}));
-assert.equal(result, '<a><b>c</b></a>');
+result = xmlpoke("<a/>", xml =>
+    xml.setOrAdd({
+        "/a/b": "c",
+    }));
+assert.equal(result, "<a><b>c</b></a>");
 
 // setOrAdd with xpath that doesn't exist: add
-result = xmlpoke('<a><b>bval</b></a>', xml => xml.setOrAdd('/a/c', 'cval'));
-assert.equal(result, '<a><b>bval</b><c>cval</c></a>');
+result = xmlpoke("<a><b>bval</b></a>", xml => xml.setOrAdd("/a/c", "cval"));
+assert.equal(result, "<a><b>bval</b><c>cval</c></a>");
 
 // remove
-result = xmlpoke('<a><b/></a>', xml => xml.remove('//b'));
-assert.equal(result, '<a/>');
+result = xmlpoke("<a><b/></a>", xml => xml.remove("//b"));
+assert.equal(result, "<a/>");
 
 // clear
-result = xmlpoke('<a><b/></a>', xml => xml.clear('/a'));
-assert.equal(result, '<a/>');
+result = xmlpoke("<a><b/></a>", xml => xml.clear("/a"));
+assert.equal(result, "<a/>");
 
 // withBasePath, addNamespace, errorOnNoMatches
-result = xmlpoke('<test><x><![CDATA[hello]]></x></test>', xml =>
-    xml.withBasePath('/test')
-       .addNamespace('x', 'http://example.com/x')
-       .errorOnNoMatches()
-       .set('/x', (node, value) => {
-            assert.equal(typeof node, 'object');
-            assert.equal((node.constructor as any).name, 'Element');
-            assert.equal(value, 'hello');
-            return 'y';
-       }));
-assert.equal(result, '<test><x>y</x></test>');
+result = xmlpoke("<test><x><![CDATA[hello]]></x></test>", xml =>
+    xml.withBasePath("/test")
+        .addNamespace("x", "http://example.com/x")
+        .errorOnNoMatches()
+        .set("/x", (node, value) => {
+            assert.equal(typeof node, "object");
+            assert.equal((node.constructor as any).name, "Element");
+            assert.equal(value, "hello");
+            return "y";
+        }));
+assert.equal(result, "<test><x>y</x></test>");
 
 // ensure
-result = xmlpoke('</a>', xml => xml.ensure('a/b'));
-assert.equal(result, '<a><b/></a>');
+result = xmlpoke("</a>", xml => xml.ensure("a/b"));
+assert.equal(result, "<a><b/></a>");

--- a/types/xmlrpc/index.d.ts
+++ b/types/xmlrpc/index.d.ts
@@ -5,11 +5,11 @@
 
 /// <reference types="node" />
 
-declare module 'xmlrpc' {
-    import { EventEmitter } from 'events';
-    import { Server as HttpServer } from 'http';
-    import { Server as HttpsServer } from 'https';
-    import { TlsOptions } from 'tls';
+declare module "xmlrpc" {
+    import { EventEmitter } from "events";
+    import { Server as HttpServer } from "http";
+    import { Server as HttpsServer } from "https";
+    import { TlsOptions } from "tls";
 
     interface ClientOptions {
         host?: string | undefined;
@@ -18,7 +18,7 @@ declare module 'xmlrpc' {
         url?: string | undefined;
         cookies?: boolean | undefined;
         headers?: { [header: string]: string } | undefined;
-        basic_auth?: { user: string, pass: string } | undefined;
+        basic_auth?: { user: string; pass: string } | undefined;
         method?: string | undefined;
     }
 
@@ -38,7 +38,7 @@ declare module 'xmlrpc' {
 
     class Cookies {
         get(name: string): string;
-        set(name: string, value: string, options?: { secure: boolean, expires: Date }): void;
+        set(name: string, value: string, options?: { secure: boolean; expires: Date }): void;
         toString(): string;
     }
 
@@ -67,7 +67,7 @@ declare module 'xmlrpc' {
         interface Server extends EventEmitter {
             httpServer: HttpServer | HttpsServer;
 
-            on(eventName: 'NotFound', callback: ServerNotFoundFunction): this;
+            on(eventName: "NotFound", callback: ServerNotFoundFunction): this;
             on(eventName: string, callback: ServerFunction): this;
         }
 
@@ -83,7 +83,7 @@ declare module 'xmlrpc' {
 
             decodeIso8601(time: string): Date;
             encodeIso8601(date: Date): string;
-        }
+        };
 
         export class CustomType {
             tagName: string;

--- a/types/xmlrpc/xmlrpc-tests.ts
+++ b/types/xmlrpc/xmlrpc-tests.ts
@@ -1,38 +1,38 @@
-import * as xmlrpc from 'xmlrpc';
+import * as xmlrpc from "xmlrpc";
 
 const serverOpts = {
-    host: 'localhost',
-    port: 9000
+    host: "localhost",
+    port: 9000,
 };
 
 const serverWithOutCallback = xmlrpc.createServer(serverOpts);
 
 const serverWithCallback = xmlrpc.createServer(serverOpts, () => {
-    serverWithCallback.on('NotFound', method => {
+    serverWithCallback.on("NotFound", method => {
         console.log(`Method ${method} not found`);
-    })
+    });
 
-    serverWithCallback.on('hello', (err, params, cb) => {
+    serverWithCallback.on("hello", (err, params, cb) => {
         cb(null, `Hello, ${params[0]}!`);
     });
 
     var client = xmlrpc.createClient({
-        host: 'localhost',
+        host: "localhost",
         port: 9000,
-        path: '/'
+        path: "/",
     });
 
-    client.methodCall('hello', ['world'], (err, val) => {
+    client.methodCall("hello", ["world"], (err, val) => {
         console.log(val);
     });
 
     class Value extends xmlrpc.CustomType {
         constructor(value: any) {
             super(value);
-            this.tagName = 'Value';
+            this.tagName = "Value";
         }
     }
-    client.methodCall('hello', [new Value('custom_string_value')], (err, val) => {
+    client.methodCall("hello", [new Value("custom_string_value")], (err, val) => {
         console.log(val);
     });
 });

--- a/types/xmlserializer/index.d.ts
+++ b/types/xmlserializer/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import * as parse5 from 'parse5';
+import * as parse5 from "parse5";
 
 export as namespace xmlserializer;
 

--- a/types/xmlserializer/xmlserializer-tests.ts
+++ b/types/xmlserializer/xmlserializer-tests.ts
@@ -1,7 +1,7 @@
-import * as xmlserializer from 'xmlserializer';
-import * as parse5 from 'parse5';
+import * as parse5 from "parse5";
+import * as xmlserializer from "xmlserializer";
 
-const htmlString = '<br>';
+const htmlString = "<br>";
 const dom = parse5.parse(htmlString);
 
 // $ExpectType string

--- a/types/xmltojson/index.d.ts
+++ b/types/xmltojson/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Travis Crowe <https://github.com/traviscrowe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-
 export = xmltojson;
 
 declare namespace xmltojson {
@@ -15,19 +13,19 @@ declare namespace xmltojson {
     function stringToXml(xmlString: string): Document;
 
     interface Options {
-        mergeCDATA?: boolean | undefined,
-        grokAttr?: boolean | undefined,
-        grokText?: boolean | undefined,
-        normalize?: boolean | undefined,
-        xmlns?: boolean | undefined,
-        namespaceKey?: string | undefined,
-        textKey?: string | undefined,
-        valueKey?: string | undefined,
-        attrKey?: string | undefined,
-        cdataKey?: string | undefined,
-        attrsAsObject?: boolean | undefined,
-        stripAttrPrefix?: boolean | undefined,
-        stripElemPrefix?: boolean | undefined,
-        childrenAsArray?: boolean | undefined
+        mergeCDATA?: boolean | undefined;
+        grokAttr?: boolean | undefined;
+        grokText?: boolean | undefined;
+        normalize?: boolean | undefined;
+        xmlns?: boolean | undefined;
+        namespaceKey?: string | undefined;
+        textKey?: string | undefined;
+        valueKey?: string | undefined;
+        attrKey?: string | undefined;
+        cdataKey?: string | undefined;
+        attrsAsObject?: boolean | undefined;
+        stripAttrPrefix?: boolean | undefined;
+        stripElemPrefix?: boolean | undefined;
+        childrenAsArray?: boolean | undefined;
     }
 }

--- a/types/xmltojson/xmltojson-tests.ts
+++ b/types/xmltojson/xmltojson-tests.ts
@@ -1,34 +1,33 @@
+import * as xmltojson from "xmltojson";
 
-import * as xmltojson from 'xmltojson';
-
-//Set options
+// Set options
 var options: xmltojson.Options = {
     mergeCDATA: true,
     grokAttr: true,
     grokText: true,
     normalize: true,
     xmlns: true,
-    namespaceKey: '_ns',
-    textKey: '_text',
-    valueKey: '_value',
-    attrKey: '_attr',
-    cdataKey: '_cdata',
+    namespaceKey: "_ns",
+    textKey: "_text",
+    valueKey: "_value",
+    attrKey: "_attr",
+    cdataKey: "_cdata",
     attrsAsObject: true,
     stripAttrPrefix: true,
     stripElemPrefix: true,
-    childrenAsArray: true
-}
+    childrenAsArray: true,
+};
 
-//Validate parseString(xmlString, opt)
-var xmlString: string = '<xml><a>It Works!</a></xml>';
+// Validate parseString(xmlString, opt)
+var xmlString: string = "<xml><a>It Works!</a></xml>";
 var parsedXmlString: Object = xmltojson.parseString(xmlString, options);
 
 console.log(JSON.stringify(parsedXmlString));
 
-//Validate stringToXml(xmlString) and parseXml(oXMLParent, opt)
+// Validate stringToXml(xmlString) and parseXml(oXMLParent, opt)
 var oXMLParent: Document = xmltojson.stringToXml(xmlString);
 
-console.log(oXMLParent.getElementsByName('a').item(0).textContent);
+console.log(oXMLParent.getElementsByName("a").item(0).textContent);
 
 var parsedXmlString2: Object = xmltojson.parseXml(oXMLParent, options);
 

--- a/types/xmpp__base64/xmpp__base64-tests.ts
+++ b/types/xmpp__base64/xmpp__base64-tests.ts
@@ -1,4 +1,4 @@
-import { encode, decode } from '@xmpp/base64';
+import { decode, encode } from "@xmpp/base64";
 
-encode('foo'); // $ExpectType string
-decode('foo'); // $ExpectType string
+encode("foo"); // $ExpectType string
+decode("foo"); // $ExpectType string

--- a/types/xmpp__client-core/index.d.ts
+++ b/types/xmpp__client-core/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import ClientCls = require('./lib/Client');
-import xmppXml = require('@xmpp/xml');
-import xmppJid = require('@xmpp/jid');
+import ClientCls = require("./lib/Client");
+import xmppXml = require("@xmpp/xml");
+import xmppJid = require("@xmpp/jid");
 
 export const Client: typeof ClientCls;
 export type Client = ClientCls;

--- a/types/xmpp__client-core/lib/Client.d.ts
+++ b/types/xmpp__client-core/lib/Client.d.ts
@@ -1,5 +1,5 @@
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
 
 export = Client;
 

--- a/types/xmpp__client-core/xmpp__client-core-tests.ts
+++ b/types/xmpp__client-core/xmpp__client-core-tests.ts
@@ -1,31 +1,31 @@
-import { Client, xml, jid } from '@xmpp/client-core';
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
+import { Client, jid, xml } from "@xmpp/client-core";
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type C = Client;
 
-const client = new Client({ service: 'foo', domain: 'foo.bar' });
+const client = new Client({ service: "foo", domain: "foo.bar" });
 const conn: Connection = client;
 client.transports; // $ExpectType (typeof Connection)[]
 
 client.Transport; // $ExpectType typeof Connection | undefined
-client.send(new Element('foo')); // $ExpectType Promise<void>
-client.send(new Element('foo'), 'bar', 1); // $ExpectType Promise<void>
-client.sendMany([new Element('foo')]); // $ExpectType Promise<void>
-client.sendMany(new Set([new Element('foo')])); // $ExpectType Promise<void>
-client.sendMany([new Element('foo')], 'bar', 1); // $ExpectType Promise<void>
-client.sendMany(new Set([new Element('foo')]), 'bar', 1); // $ExpectType Promise<void>
-client.header(new Element('foo')); // $ExpectType string
-client.header(new Element('foo'), 'bar', 1); // $ExpectType string
+client.send(new Element("foo")); // $ExpectType Promise<void>
+client.send(new Element("foo"), "bar", 1); // $ExpectType Promise<void>
+client.sendMany([new Element("foo")]); // $ExpectType Promise<void>
+client.sendMany(new Set([new Element("foo")])); // $ExpectType Promise<void>
+client.sendMany([new Element("foo")], "bar", 1); // $ExpectType Promise<void>
+client.sendMany(new Set([new Element("foo")]), "bar", 1); // $ExpectType Promise<void>
+client.header(new Element("foo")); // $ExpectType string
+client.header(new Element("foo"), "bar", 1); // $ExpectType string
 client.headerElement(); // $ExpectType Element
-client.headerElement('bar', 1); // $ExpectType Element
-client.footer(new Element('foo')); // $ExpectType string
-client.footer(new Element('foo'), 'bar', 1); // $ExpectType string
+client.headerElement("bar", 1); // $ExpectType Element
+client.footer(new Element("foo")); // $ExpectType string
+client.footer(new Element("foo"), "bar", 1); // $ExpectType string
 client.footerElement(); // $ExpectType Element
-client.footerElement('bar', 1); // $ExpectType Element
-client.socketParameters('foo'); // $ExpectType unknown
-client.socketParameters('foo', 'bar', 1); // $ExpectType unknown
+client.footerElement("bar", 1); // $ExpectType Element
+client.socketParameters("foo"); // $ExpectType unknown
+client.socketParameters("foo", "bar", 1); // $ExpectType unknown
 
-xml('foo');
-jid('foo@bar.baz');
+xml("foo");
+jid("foo@bar.baz");

--- a/types/xmpp__client/browser.d.ts
+++ b/types/xmpp__client/browser.d.ts
@@ -1,1 +1,1 @@
-export * from './react-native';
+export * from "./react-native";

--- a/types/xmpp__client/dist/xmpp.d.ts
+++ b/types/xmpp__client/dist/xmpp.d.ts
@@ -1,3 +1,3 @@
-export * from '../browser';
+export * from "../browser";
 
 export as namespace XMPP;

--- a/types/xmpp__client/dist/xmpp.min.d.ts
+++ b/types/xmpp__client/dist/xmpp.min.d.ts
@@ -1,3 +1,3 @@
-export * from './xmpp';
+export * from "./xmpp";
 
 export as namespace XMPP;

--- a/types/xmpp__client/index.d.ts
+++ b/types/xmpp__client/index.d.ts
@@ -3,17 +3,17 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Client as ClientCore, jid as xmppJid, xml as xmppXml } from '@xmpp/client-core';
-import { Options as ConnectionOptions } from '@xmpp/connection';
-import { IQCallee } from '@xmpp/iq/callee';
-import { IQCaller } from '@xmpp/iq/caller';
-import { IncomingContext, Middleware } from '@xmpp/middleware';
-import { StreamFeatures } from '@xmpp/stream-features';
-import { Reconnect } from '@xmpp/reconnect';
-import { Resource } from '@xmpp/resource-binding';
-import { Credentials, SASL } from '@xmpp/sasl';
-import { StreamManagement } from '@xmpp/stream-management';
-import * as koaCompose from 'koa-compose';
+import { Client as ClientCore, jid as xmppJid, xml as xmppXml } from "@xmpp/client-core";
+import { Options as ConnectionOptions } from "@xmpp/connection";
+import { IQCallee } from "@xmpp/iq/callee";
+import { IQCaller } from "@xmpp/iq/caller";
+import { IncomingContext, Middleware } from "@xmpp/middleware";
+import { Reconnect } from "@xmpp/reconnect";
+import { Resource } from "@xmpp/resource-binding";
+import { Credentials, SASL } from "@xmpp/sasl";
+import { StreamFeatures } from "@xmpp/stream-features";
+import { StreamManagement } from "@xmpp/stream-management";
+import * as koaCompose from "koa-compose";
 
 /**
  * An XMPP client is an entity that connects to an XMPP server.

--- a/types/xmpp__client/react-native.d.ts
+++ b/types/xmpp__client/react-native.d.ts
@@ -1,4 +1,4 @@
-import * as fullClient from './index';
+import * as fullClient from "./index";
 
 export function client(...args: Parameters<typeof fullClient.client>): Client;
 export type Options = fullClient.Options;

--- a/types/xmpp__client/test/xmpp__client-bundle.ts
+++ b/types/xmpp__client/test/xmpp__client-bundle.ts
@@ -3,17 +3,17 @@ type Opts = XMPP.Options;
 type Cl = XMPP.Client;
 
 const c = XMPP.client(); // $ExpectType Client
-XMPP.client({ resource: 'foo' }); // $ExpectType Client
-XMPP.client({ resource: XMPP.xml('foo') }); // $ExpectType Client
+XMPP.client({ resource: "foo" }); // $ExpectType Client
+XMPP.client({ resource: XMPP.xml("foo") }); // $ExpectType Client
 XMPP.client({ resource: async cb => {} }); // $ExpectType Client
-XMPP.client({ credentials: { username: 'foo' } }); // $ExpectType Client
-XMPP.client({ credentials: { password: 'foo' } }); // $ExpectType Client
+XMPP.client({ credentials: { username: "foo" } }); // $ExpectType Client
+XMPP.client({ credentials: { password: "foo" } }); // $ExpectType Client
 XMPP.client({ credentials: async (cb, mech) => {} }); // $ExpectType Client
-XMPP.client({ username: 'foo' }); // $ExpectType Client
-XMPP.client({ password: 'foo' }); // $ExpectType Client
-XMPP.client({ domain: 'foo' }); // $ExpectType Client
-XMPP.client({ service: 'foo.bar' }); // $ExpectType Client
-XMPP.client({ lang: 'en' }); // $ExpectType Client
+XMPP.client({ username: "foo" }); // $ExpectType Client
+XMPP.client({ password: "foo" }); // $ExpectType Client
+XMPP.client({ domain: "foo" }); // $ExpectType Client
+XMPP.client({ service: "foo.bar" }); // $ExpectType Client
+XMPP.client({ lang: "en" }); // $ExpectType Client
 
 c.entity; // $ExpectType Client
 c.reconnect; // $ExpectType Reconnect<Client>
@@ -26,8 +26,8 @@ c.sasl; // $ExpectType SASL
 c.streamManagement; // $ExpectType StreamManagement
 c.mechanisms; // $ExpectType ({ plain: undefined; } | { anonymous: undefined; })[]
 
-XMPP.jid('foo');
-XMPP.jid(null, 'foo', 'bar');
+XMPP.jid("foo");
+XMPP.jid(null, "foo", "bar");
 
-XMPP.xml('foo');
-XMPP.xml('foo', { foo: 'bar' }, 'bar');
+XMPP.xml("foo");
+XMPP.xml("foo", { foo: "bar" }, "bar");

--- a/types/xmpp__client/test/xmpp__client.ts
+++ b/types/xmpp__client/test/xmpp__client.ts
@@ -1,11 +1,11 @@
-import { Client, client, jid, Options, xml } from '@xmpp/client';
-import * as rn from '@xmpp/client/react-native';
-import * as browser from '@xmpp/client/browser';
-import * as browserBundle from '@xmpp/client/dist/xmpp';
-import * as browserBundleMin from '@xmpp/client/dist/xmpp.min';
-import getDomain = require('@xmpp/client/lib/getDomain');
-import { Client as ClientCore } from '@xmpp/client-core';
-import { Element } from '@xmpp/xml';
+import { Client, client, jid, Options, xml } from "@xmpp/client";
+import * as browser from "@xmpp/client/browser";
+import * as browserBundle from "@xmpp/client/dist/xmpp";
+import * as browserBundleMin from "@xmpp/client/dist/xmpp.min";
+import * as rn from "@xmpp/client/react-native";
+import getDomain = require("@xmpp/client/lib/getDomain");
+import { Client as ClientCore } from "@xmpp/client-core";
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type Opts = Options;
@@ -20,17 +20,17 @@ type Opts5 = browserBundleMin.Options;
 type Cl5 = browserBundleMin.Client;
 
 const c = client(); // $ExpectType Client
-client({ resource: 'foo' }); // $ExpectType Client
-client({ resource: new Element('foo') }); // $ExpectType Client
+client({ resource: "foo" }); // $ExpectType Client
+client({ resource: new Element("foo") }); // $ExpectType Client
 client({ resource: async cb => {} }); // $ExpectType Client
-client({ credentials: { username: 'foo' } }); // $ExpectType Client
-client({ credentials: { password: 'foo' } }); // $ExpectType Client
+client({ credentials: { username: "foo" } }); // $ExpectType Client
+client({ credentials: { password: "foo" } }); // $ExpectType Client
 client({ credentials: async (cb, mech) => {} }); // $ExpectType Client
-client({ username: 'foo' }); // $ExpectType Client
-client({ password: 'foo' }); // $ExpectType Client
-client({ domain: 'foo' }); // $ExpectType Client
-client({ service: 'foo.bar' }); // $ExpectType Client
-client({ lang: 'en' }); // $ExpectType Client
+client({ username: "foo" }); // $ExpectType Client
+client({ password: "foo" }); // $ExpectType Client
+client({ domain: "foo" }); // $ExpectType Client
+client({ service: "foo.bar" }); // $ExpectType Client
+client({ lang: "en" }); // $ExpectType Client
 
 const rnC = rn.client(); // $ExpectType Client
 const browserC = browser.client(); // $ExpectType Client
@@ -54,26 +54,26 @@ browserC.mechanisms; // $ExpectType ({ plain: undefined; } | { anonymous: undefi
 browserBundleC.mechanisms; // $ExpectType ({ plain: undefined; } | { anonymous: undefined; })[]
 browserBundleMinC.mechanisms; // $ExpectType ({ plain: undefined; } | { anonymous: undefined; })[]
 
-getDomain('foo.bar'); // $ExpectType string
+getDomain("foo.bar"); // $ExpectType string
 
-jid('foo');
-jid(null, 'foo', 'bar');
-rn.jid('foo');
-rn.jid(null, 'foo', 'bar');
-browser.jid('foo');
-browser.jid(null, 'foo', 'bar');
-browserBundle.jid('foo');
-browserBundle.jid(null, 'foo', 'bar');
-browserBundleMin.jid('foo');
-browserBundleMin.jid(null, 'foo', 'bar');
+jid("foo");
+jid(null, "foo", "bar");
+rn.jid("foo");
+rn.jid(null, "foo", "bar");
+browser.jid("foo");
+browser.jid(null, "foo", "bar");
+browserBundle.jid("foo");
+browserBundle.jid(null, "foo", "bar");
+browserBundleMin.jid("foo");
+browserBundleMin.jid(null, "foo", "bar");
 
-xml('foo');
-xml('foo', { foo: 'bar' }, 'bar');
-rn.xml('foo');
-rn.xml('foo', { foo: 'bar' }, 'bar');
-browser.xml('foo');
-browser.xml('foo', { foo: 'bar' }, 'bar');
-browserBundle.xml('foo');
-browserBundle.xml('foo', { foo: 'bar' }, 'bar');
-browserBundleMin.xml('foo');
-browserBundleMin.xml('foo', { foo: 'bar' }, 'bar');
+xml("foo");
+xml("foo", { foo: "bar" }, "bar");
+rn.xml("foo");
+rn.xml("foo", { foo: "bar" }, "bar");
+browser.xml("foo");
+browser.xml("foo", { foo: "bar" }, "bar");
+browserBundle.xml("foo");
+browserBundle.xml("foo", { foo: "bar" }, "bar");
+browserBundleMin.xml("foo");
+browserBundleMin.xml("foo", { foo: "bar" }, "bar");

--- a/types/xmpp__component-core/index.d.ts
+++ b/types/xmpp__component-core/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import ComponentCls = require('./lib/Component');
-import xmppXml = require('@xmpp/xml');
-import xmppJid = require('@xmpp/jid');
+import ComponentCls = require("./lib/Component");
+import xmppXml = require("@xmpp/xml");
+import xmppJid = require("@xmpp/jid");
 
 export const Component: typeof ComponentCls;
 export type Component = ComponentCls;

--- a/types/xmpp__component-core/lib/Component.d.ts
+++ b/types/xmpp__component-core/lib/Component.d.ts
@@ -1,9 +1,9 @@
-import ConnectionTCP = require('@xmpp/connection-tcp');
+import ConnectionTCP = require("@xmpp/connection-tcp");
 
 export = Component;
 
 declare class Component extends ConnectionTCP {
-    static readonly NS: 'jabber:component:accept';
+    static readonly NS: "jabber:component:accept";
 
     socketParameters(service: string): Component.SocketParameters;
     authenticate(id: string, password: string): Promise<void>;

--- a/types/xmpp__component-core/xmpp__component-core-tests.ts
+++ b/types/xmpp__component-core/xmpp__component-core-tests.ts
@@ -1,16 +1,16 @@
-import { Component, SocketParameters, jid, xml } from '@xmpp/component-core';
-import ConnectionTCP = require('@xmpp/connection-tcp');
+import { Component, jid, SocketParameters, xml } from "@xmpp/component-core";
+import ConnectionTCP = require("@xmpp/connection-tcp");
 
 // test type exports
 type Comp = Component;
 type SockParams = SocketParameters;
 
-const comp = new Component({ service: 'foo', domain: 'foo.bar' });
+const comp = new Component({ service: "foo", domain: "foo.bar" });
 const connTcp: ConnectionTCP = comp;
-const params = comp.socketParameters('foo'); // $ExpectType SocketParameters
+const params = comp.socketParameters("foo"); // $ExpectType SocketParameters
 params.port; // $ExpectType number
 params.host; // $ExpectType string
-comp.authenticate('foo', 'bar'); // $ExpectType Promise<void>
+comp.authenticate("foo", "bar"); // $ExpectType Promise<void>
 
-xml('foo');
-jid('foo@bar.baz');
+xml("foo");
+jid("foo@bar.baz");

--- a/types/xmpp__component/index.d.ts
+++ b/types/xmpp__component/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Component as ComponentCore, jid as xmppJid, xml as xmppXml } from '@xmpp/component-core';
-import { IQCallee } from '@xmpp/iq/callee';
-import { IQCaller } from '@xmpp/iq/caller';
-import { Middleware } from '@xmpp/middleware';
-import { Reconnect } from '@xmpp/reconnect';
+import { Component as ComponentCore, jid as xmppJid, xml as xmppXml } from "@xmpp/component-core";
+import { IQCallee } from "@xmpp/iq/callee";
+import { IQCaller } from "@xmpp/iq/caller";
+import { Middleware } from "@xmpp/middleware";
+import { Reconnect } from "@xmpp/reconnect";
 
 export function component(options: Options): Component;
 

--- a/types/xmpp__component/xmpp__component-tests.ts
+++ b/types/xmpp__component/xmpp__component-tests.ts
@@ -1,21 +1,21 @@
-import { Component, component, jid, Options, xml } from '@xmpp/component';
-import { Component as ComponentCore } from '@xmpp/component-core';
+import { Component, component, jid, Options, xml } from "@xmpp/component";
+import { Component as ComponentCore } from "@xmpp/component-core";
 
 // test type exports
 type Opts = Options;
 type Cl = Component;
 
 const c = component({}); // $ExpectType Component
-component({ password: 'foo' }); // $ExpectType Component
+component({ password: "foo" }); // $ExpectType Component
 // $ExpectType Component
 component({
     password: async auth => {
         auth; // $ExpectType (password: string) => Promise<void>
-        await auth('foo');
+        await auth("foo");
     },
 });
-component({ domain: 'foo' }); // $ExpectType Component
-component({ service: 'foo.bar' }); // $ExpectType Component
+component({ domain: "foo" }); // $ExpectType Component
+component({ service: "foo.bar" }); // $ExpectType Component
 
 const cc: ComponentCore = c;
 c.entity; // $ExpectType Component
@@ -24,8 +24,8 @@ c.middleware; // $ExpectType Middleware<Component>
 c.iqCaller; // $ExpectType IQCaller<Component>
 c.iqCallee; // $ExpectType IQCallee<Component>
 
-jid('foo');
-jid(null, 'foo', 'bar');
+jid("foo");
+jid(null, "foo", "bar");
 
-xml('foo');
-xml('foo', { foo: 'bar' }, 'bar');
+xml("foo");
+xml("foo", { foo: "bar" }, "bar");

--- a/types/xmpp__connection-tcp/index.d.ts
+++ b/types/xmpp__connection-tcp/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
-import { Socket } from 'net';
-import { URL } from 'url';
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
+import { Socket } from "net";
+import { URL } from "url";
 
 export = ConnectionTCP;
 
@@ -25,6 +25,6 @@ declare namespace ConnectionTCP {
     }
 
     interface SocketConstructor extends Connection.SocketConstructor {
-        new (): Socket;
+        new(): Socket;
     }
 }

--- a/types/xmpp__connection-tcp/xmpp__connection-tcp-tests.ts
+++ b/types/xmpp__connection-tcp/xmpp__connection-tcp-tests.ts
@@ -1,16 +1,16 @@
-import Connection = require('@xmpp/connection');
-import ConnectionTCP = require('@xmpp/connection-tcp');
-import { Element } from '@xmpp/xml';
-import { URL } from 'url';
+import Connection = require("@xmpp/connection");
+import ConnectionTCP = require("@xmpp/connection-tcp");
+import { Element } from "@xmpp/xml";
+import { URL } from "url";
 
 // test type exports
 type SocketParams = ConnectionTCP.SocketParameters;
 type SocketCtor = ConnectionTCP.SocketConstructor;
 
-const cTcp = new ConnectionTCP({ domain: 'foo', service: 'bar' });
+const cTcp = new ConnectionTCP({ domain: "foo", service: "bar" });
 const c: Connection = cTcp;
-cTcp.sendMany([new Element('foo')]); // $ExpectType Promise<void>
-cTcp.sendMany(new Set([new Element('foo')])); // $ExpectType Promise<void>
-cTcp.socketParameters('foo'); // $ExpectType SocketParameters | undefined
-cTcp.socketParameters(new URL('foo')); // $ExpectType SocketParameters | undefined
+cTcp.sendMany([new Element("foo")]); // $ExpectType Promise<void>
+cTcp.sendMany(new Set([new Element("foo")])); // $ExpectType Promise<void>
+cTcp.socketParameters("foo"); // $ExpectType SocketParameters | undefined
+cTcp.socketParameters(new URL("foo")); // $ExpectType SocketParameters | undefined
 cTcp.headerElement(); // $ExpectType Element

--- a/types/xmpp__connection/index.d.ts
+++ b/types/xmpp__connection/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter } from '@xmpp/events';
-import { JID } from '@xmpp/jid';
-import { Element, Parser } from '@xmpp/xml';
+import { EventEmitter } from "@xmpp/events";
+import { JID } from "@xmpp/jid";
+import { Element, Parser } from "@xmpp/xml";
 
 export = Connection;
 
@@ -142,7 +142,7 @@ declare abstract class Connection extends EventEmitter {
     off(event: string | symbol, listener: (...args: any[]) => void): this;
 
     emit<TStatus extends keyof Connection.StatusEvents>(
-        event: 'status',
+        event: "status",
         status: TStatus,
         ...args: Parameters<Connection.StatusEvents[TStatus]>
     ): boolean;
@@ -207,7 +207,7 @@ declare namespace Connection {
     }
 
     interface SocketConstructor {
-        new (): SocketBase;
+        new(): SocketBase;
     }
 
     interface SocketBase extends EventEmitter {

--- a/types/xmpp__connection/lib/StreamError.d.ts
+++ b/types/xmpp__connection/lib/StreamError.d.ts
@@ -1,5 +1,5 @@
-import XMPPError = require('@xmpp/error');
+import XMPPError = require("@xmpp/error");
 
 export = StreamError;
 
-declare class StreamError extends XMPPError<'StreamError'> {}
+declare class StreamError extends XMPPError<"StreamError"> {}

--- a/types/xmpp__connection/lib/util.d.ts
+++ b/types/xmpp__connection/lib/util.d.ts
@@ -1,4 +1,4 @@
-import { URL } from 'url';
+import { URL } from "url";
 
 export function parseURI(URI: string | URL): ParsedURI;
 export function parseHost(host: string): ParsedHost;

--- a/types/xmpp__connection/xmpp__connection-tests.ts
+++ b/types/xmpp__connection/xmpp__connection-tests.ts
@@ -1,11 +1,11 @@
-import Connection = require('@xmpp/connection');
-import StreamError = require('@xmpp/connection/lib/StreamError');
-import * as util from '@xmpp/connection/lib/util';
-import XMPPError = require('@xmpp/error');
-import { JID } from '@xmpp/jid';
-import { Element } from '@xmpp/xml';
-import { SocketConnectOpts } from 'net';
-import { URL } from 'url';
+import Connection = require("@xmpp/connection");
+import StreamError = require("@xmpp/connection/lib/StreamError");
+import * as util from "@xmpp/connection/lib/util";
+import XMPPError = require("@xmpp/error");
+import { JID } from "@xmpp/jid";
+import { Element } from "@xmpp/xml";
+import { SocketConnectOpts } from "net";
+import { URL } from "url";
 
 // test type exports
 type ParsedHost = util.ParsedHost;
@@ -20,43 +20,43 @@ type SocketConstructor = Connection.SocketConstructor;
 type SocketBase = Connection.SocketBase;
 type SocketEvents = Connection.SocketEvents;
 
-const streamErr = new StreamError('foo');
-const xmppErr: XMPPError<'StreamError'> = streamErr;
+const streamErr = new StreamError("foo");
+const xmppErr: XMPPError<"StreamError"> = streamErr;
 class MyStreamErr extends StreamError {}
 
-const uri = util.parseURI('https://foo.bar'); // $ExpectType ParsedURI
-util.parseURI(new URL('https://foo.bar')); // $ExpectType ParsedURI
+const uri = util.parseURI("https://foo.bar"); // $ExpectType ParsedURI
+util.parseURI(new URL("https://foo.bar")); // $ExpectType ParsedURI
 uri.hostname; // $ExpectType string
 uri.port; // $ExpectType string
 uri.protocol; // $ExpectType string
-const host = util.parseHost('foo.bar'); // $ExpectType ParsedHost
+const host = util.parseHost("foo.bar"); // $ExpectType ParsedHost
 host.hostname; // $ExpectType string
 host.port; // $ExpectType string
-const service = util.parseService('foo.bar'); // $ExpectType ParsedService
+const service = util.parseService("foo.bar"); // $ExpectType ParsedService
 service.hostname; // $ExpectType string
 service.port; // $ExpectType string
 service.protocol; // $ExpectType string | undefined
 
 class MyConn extends Connection {
     headerElement(): Element {
-        return new Element('foo');
+        return new Element("foo");
     }
     footerElement(): Element {
-        return new Element('foo');
+        return new Element("foo");
     }
     socketParameters(service: string) {
         return {
-            foo: 'bar' as const,
+            foo: "bar" as const,
         };
     }
 }
 
 class MyConn2 extends Connection {
     headerElement(): Element {
-        return new Element('foo');
+        return new Element("foo");
     }
     footerElement(): Element {
-        return new Element('foo');
+        return new Element("foo");
     }
     socketParameters(service: string) {
         return null as any as SocketConnectOpts;
@@ -64,9 +64,9 @@ class MyConn2 extends Connection {
 }
 
 const conn = new MyConn({});
-new MyConn({ service: 'foo' });
-new MyConn({ service: 'foo', domain: 'bar.baz' });
-new MyConn({ service: 'foo', domain: 'bar.baz', lang: 'en' });
+new MyConn({ service: "foo" });
+new MyConn({ service: "foo", domain: "bar.baz" });
+new MyConn({ service: "foo", domain: "bar.baz", lang: "en" });
 
 conn.jid; // $ExpectType JID | null
 conn.timeout; // $ExpectType number
@@ -88,350 +88,350 @@ conn.Socket; // $ExpectType SocketConstructor | null
 conn.Parser; // $ExpectType typeof Parser | null
 
 conn.start(); // $ExpectType Promise<JID>
-conn.connect('foo'); // $ExpectType Promise<void>
+conn.connect("foo"); // $ExpectType Promise<void>
 conn.disconnect(); // $ExpectType Promise<void>
 conn.disconnect(100); // $ExpectType Promise<void>
-conn.open('foo'); // $ExpectType Promise<Element>
-conn.open({ domain: 'foo' }); // $ExpectType Promise<Element>
-conn.open({ domain: 'foo', lang: 'en' }); // $ExpectType Promise<Element>
-conn.open({ domain: 'foo', timeout: 100 }); // $ExpectType Promise<Element>
+conn.open("foo"); // $ExpectType Promise<Element>
+conn.open({ domain: "foo" }); // $ExpectType Promise<Element>
+conn.open({ domain: "foo", lang: "en" }); // $ExpectType Promise<Element>
+conn.open({ domain: "foo", timeout: 100 }); // $ExpectType Promise<Element>
 conn.stop(); // $ExpectType Promise<Element>
 conn.close(); // $ExpectType Promise<Element>
 conn.close(100); // $ExpectType Promise<Element>
 conn.restart(); // $ExpectType Promise<Element>
-conn.send(new Element('foo')); // $ExpectType Promise<void>
-conn.sendReceive(new Element('foo')); // $ExpectType Promise<Element>
-conn.sendReceive(new Element('foo'), 100); // $ExpectType Promise<Element>
-conn.write('foo'); // $ExpectType Promise<void>
-conn.isStanza(new Element('foo')); // $ExpectType boolean
-conn.isNonza(new Element('foo')); // $ExpectType boolean
+conn.send(new Element("foo")); // $ExpectType Promise<void>
+conn.sendReceive(new Element("foo")); // $ExpectType Promise<Element>
+conn.sendReceive(new Element("foo"), 100); // $ExpectType Promise<Element>
+conn.write("foo"); // $ExpectType Promise<void>
+conn.isStanza(new Element("foo")); // $ExpectType boolean
+conn.isNonza(new Element("foo")); // $ExpectType boolean
 
-conn.addListener('input', input => {
+conn.addListener("input", input => {
     input; // $ExpectType string
 });
-conn.addListener('send', el => {
+conn.addListener("send", el => {
     el; // $ExpectType Element
 });
-conn.addListener('error', (error: Error) => {});
-conn.addListener('element', el => {
+conn.addListener("error", (error: Error) => {});
+conn.addListener("element", el => {
     el; // $ExpectType Element
 });
-conn.addListener('stanza', el => {
+conn.addListener("stanza", el => {
     el; // $ExpectType Element
 });
-conn.addListener('nonza', el => {
+conn.addListener("nonza", el => {
     el; // $ExpectType Element
 });
-conn.addListener('status', (status, ...args) => {
+conn.addListener("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.addListener('online', jid => {
+conn.addListener("online", jid => {
     jid; // $ExpectType JID
 });
-conn.addListener('offline', el => {
+conn.addListener("offline", el => {
     el; // $ExpectType Element
 });
-conn.addListener('connect', () => {});
-conn.addListener('connecting', service => {
+conn.addListener("connect", () => {});
+conn.addListener("connecting", service => {
     service; // $ExpectType string
 });
-conn.addListener('disconnect', result => {
+conn.addListener("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.addListener('disconnecting', () => {});
-conn.addListener('open', el => {
+conn.addListener("disconnecting", () => {});
+conn.addListener("open", el => {
     el; // $ExpectType Element
 });
-conn.addListener('opening', () => {});
-conn.addListener('close', el => {
+conn.addListener("opening", () => {});
+conn.addListener("close", el => {
     el; // $ExpectType Element
 });
-conn.addListener('closing', () => {});
+conn.addListener("closing", () => {});
 
-conn.on('input', input => {
+conn.on("input", input => {
     input; // $ExpectType string
 });
-conn.on('send', el => {
+conn.on("send", el => {
     el; // $ExpectType Element
 });
-conn.on('error', (error: Error) => {});
-conn.on('element', el => {
+conn.on("error", (error: Error) => {});
+conn.on("element", el => {
     el; // $ExpectType Element
 });
-conn.on('stanza', el => {
+conn.on("stanza", el => {
     el; // $ExpectType Element
 });
-conn.on('nonza', el => {
+conn.on("nonza", el => {
     el; // $ExpectType Element
 });
-conn.on('status', (status, ...args) => {
+conn.on("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.on('online', el => {
+conn.on("online", el => {
     el; // $ExpectType JID
 });
-conn.on('offline', el => {
+conn.on("offline", el => {
     el; // $ExpectType Element
 });
-conn.on('connect', () => {});
-conn.on('connecting', service => {
+conn.on("connect", () => {});
+conn.on("connecting", service => {
     service; // $ExpectType string
 });
-conn.on('disconnect', result => {
+conn.on("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.on('disconnecting', () => {});
-conn.on('open', el => {
+conn.on("disconnecting", () => {});
+conn.on("open", el => {
     el; // $ExpectType Element
 });
-conn.on('opening', () => {});
-conn.on('close', el => {
+conn.on("opening", () => {});
+conn.on("close", el => {
     el; // $ExpectType Element
 });
-conn.on('closing', () => {});
+conn.on("closing", () => {});
 
-conn.once('input', input => {
+conn.once("input", input => {
     input; // $ExpectType string
 });
-conn.once('send', el => {
+conn.once("send", el => {
     el; // $ExpectType Element
 });
-conn.once('error', (error: Error) => {});
-conn.once('element', el => {
+conn.once("error", (error: Error) => {});
+conn.once("element", el => {
     el; // $ExpectType Element
 });
-conn.once('stanza', el => {
+conn.once("stanza", el => {
     el; // $ExpectType Element
 });
-conn.once('nonza', el => {
+conn.once("nonza", el => {
     el; // $ExpectType Element
 });
-conn.once('status', (status, ...args) => {
+conn.once("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
-    if (status === 'disconnect') {
+    if (status === "disconnect") {
         const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
     }
 });
-conn.once('online', el => {
+conn.once("online", el => {
     el; // $ExpectType JID
 });
-conn.once('offline', el => {
+conn.once("offline", el => {
     el; // $ExpectType Element
 });
-conn.once('connect', () => {});
-conn.once('connecting', service => {
+conn.once("connect", () => {});
+conn.once("connecting", service => {
     service; // $ExpectType string
 });
-conn.once('disconnect', result => {
+conn.once("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.once('disconnecting', () => {});
-conn.once('open', el => {
+conn.once("disconnecting", () => {});
+conn.once("open", el => {
     el; // $ExpectType Element
 });
-conn.once('opening', () => {});
-conn.once('close', el => {
+conn.once("opening", () => {});
+conn.once("close", el => {
     el; // $ExpectType Element
 });
-conn.once('closing', () => {});
+conn.once("closing", () => {});
 
-conn.prependListener('input', input => {
+conn.prependListener("input", input => {
     input; // $ExpectType string
 });
-conn.prependListener('send', el => {
+conn.prependListener("send", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('error', (error: Error) => {});
-conn.prependListener('element', el => {
+conn.prependListener("error", (error: Error) => {});
+conn.prependListener("element", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('stanza', el => {
+conn.prependListener("stanza", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('nonza', el => {
+conn.prependListener("nonza", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('status', (status, ...args) => {
+conn.prependListener("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.prependListener('online', el => {
+conn.prependListener("online", el => {
     el; // $ExpectType JID
 });
-conn.prependListener('offline', el => {
+conn.prependListener("offline", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('connect', () => {});
-conn.prependListener('connecting', service => {
+conn.prependListener("connect", () => {});
+conn.prependListener("connecting", service => {
     service; // $ExpectType string
 });
-conn.prependListener('disconnect', result => {
+conn.prependListener("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.prependListener('disconnecting', () => {});
-conn.prependListener('open', el => {
+conn.prependListener("disconnecting", () => {});
+conn.prependListener("open", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('opening', () => {});
-conn.prependListener('close', el => {
+conn.prependListener("opening", () => {});
+conn.prependListener("close", el => {
     el; // $ExpectType Element
 });
-conn.prependListener('closing', () => {});
+conn.prependListener("closing", () => {});
 
-conn.prependOnceListener('input', input => {
+conn.prependOnceListener("input", input => {
     input; // $ExpectType string
 });
-conn.prependOnceListener('send', el => {
+conn.prependOnceListener("send", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('error', (error: Error) => {});
-conn.prependOnceListener('element', el => {
+conn.prependOnceListener("error", (error: Error) => {});
+conn.prependOnceListener("element", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('stanza', el => {
+conn.prependOnceListener("stanza", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('nonza', el => {
+conn.prependOnceListener("nonza", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('status', (status, ...args) => {
+conn.prependOnceListener("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.prependOnceListener('online', el => {
+conn.prependOnceListener("online", el => {
     el; // $ExpectType JID
 });
-conn.prependOnceListener('offline', el => {
+conn.prependOnceListener("offline", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('connect', () => {});
-conn.prependOnceListener('connecting', service => {
+conn.prependOnceListener("connect", () => {});
+conn.prependOnceListener("connecting", service => {
     service; // $ExpectType string
 });
-conn.prependOnceListener('disconnect', result => {
+conn.prependOnceListener("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.prependOnceListener('disconnecting', () => {});
-conn.prependOnceListener('open', el => {
+conn.prependOnceListener("disconnecting", () => {});
+conn.prependOnceListener("open", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('opening', () => {});
-conn.prependOnceListener('close', el => {
+conn.prependOnceListener("opening", () => {});
+conn.prependOnceListener("close", el => {
     el; // $ExpectType Element
 });
-conn.prependOnceListener('closing', () => {});
+conn.prependOnceListener("closing", () => {});
 
-conn.removeListener('input', input => {
+conn.removeListener("input", input => {
     input; // $ExpectType string
 });
-conn.removeListener('send', el => {
+conn.removeListener("send", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('error', (error: Error) => {});
-conn.removeListener('element', el => {
+conn.removeListener("error", (error: Error) => {});
+conn.removeListener("element", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('stanza', el => {
+conn.removeListener("stanza", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('nonza', el => {
+conn.removeListener("nonza", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('status', (status, ...args) => {
+conn.removeListener("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.removeListener('online', el => {
+conn.removeListener("online", el => {
     el; // $ExpectType JID
 });
-conn.removeListener('offline', el => {
+conn.removeListener("offline", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('connect', () => {});
-conn.removeListener('connecting', service => {
+conn.removeListener("connect", () => {});
+conn.removeListener("connecting", service => {
     service; // $ExpectType string
 });
-conn.removeListener('disconnect', result => {
+conn.removeListener("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.removeListener('disconnecting', () => {});
-conn.removeListener('open', el => {
+conn.removeListener("disconnecting", () => {});
+conn.removeListener("open", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('opening', () => {});
-conn.removeListener('close', el => {
+conn.removeListener("opening", () => {});
+conn.removeListener("close", el => {
     el; // $ExpectType Element
 });
-conn.removeListener('closing', () => {});
+conn.removeListener("closing", () => {});
 
-conn.off('input', input => {
+conn.off("input", input => {
     input; // $ExpectType string
 });
-conn.off('send', el => {
+conn.off("send", el => {
     el; // $ExpectType Element
 });
-conn.off('error', (error: Error) => {});
-conn.off('element', el => {
+conn.off("error", (error: Error) => {});
+conn.off("element", el => {
     el; // $ExpectType Element
 });
-conn.off('stanza', el => {
+conn.off("stanza", el => {
     el; // $ExpectType Element
 });
-conn.off('nonza', el => {
+conn.off("nonza", el => {
     el; // $ExpectType Element
 });
-conn.off('status', (status, ...args) => {
+conn.off("status", (status, ...args) => {
     const s: keyof StatusEvents = status;
     const a = args[0]; // $ExpectType string | JID | Element | { clean: boolean; event: unknown; } | undefined
 });
-conn.off('online', el => {
+conn.off("online", el => {
     el; // $ExpectType JID
 });
-conn.off('offline', el => {
+conn.off("offline", el => {
     el; // $ExpectType Element
 });
-conn.off('connect', () => {});
-conn.off('connecting', service => {
+conn.off("connect", () => {});
+conn.off("connecting", service => {
     service; // $ExpectType string
 });
-conn.off('disconnect', result => {
+conn.off("disconnect", result => {
     result; // $ExpectType { clean: boolean; event: unknown; }
 });
-conn.off('disconnecting', () => {});
-conn.off('open', el => {
+conn.off("disconnecting", () => {});
+conn.off("open", el => {
     el; // $ExpectType Element
 });
-conn.off('opening', () => {});
-conn.off('close', el => {
+conn.off("opening", () => {});
+conn.off("close", el => {
     el; // $ExpectType Element
 });
-conn.off('closing', () => {});
+conn.off("closing", () => {});
 
-conn.emit<'input'>('input', 'foo');
-conn.emit<'send'>('send', new Element('foo'));
-conn.emit<'error'>('error', new Error('foo'));
-conn.emit<'element'>('element', new Element('foo'));
-conn.emit<'stanza'>('stanza', new Element('foo'));
-conn.emit<'nonza'>('nonza', new Element('foo'));
-conn.emit<'online'>('status', 'online', new JID('foo', 'bar'));
-conn.emit<'offline'>('status', 'offline', new Element('foo'));
-conn.emit<'connect'>('status', 'connect');
-conn.emit<'connecting'>('status', 'connecting', 'foo');
-conn.emit<'disconnect'>('status', 'disconnect', { clean: true, event: 'foo' });
-conn.emit<'disconnecting'>('status', 'disconnecting');
-conn.emit<'open'>('status', 'open', new Element('foo'));
-conn.emit<'opening'>('status', 'opening');
-conn.emit<'close'>('status', 'close', new Element('foo'));
-conn.emit<'closing'>('status', 'closing');
-conn.emit<'online'>('online', new JID('foo', 'bar'));
-conn.emit<'offline'>('offline', new Element('foo'));
-conn.emit<'connect'>('connect');
-conn.emit<'connecting'>('connecting', 'foo');
-conn.emit<'disconnect'>('disconnect', { clean: true, event: 'foo' });
-conn.emit<'disconnecting'>('disconnecting');
-conn.emit<'open'>('open', new Element('foo'));
-conn.emit<'opening'>('opening');
-conn.emit<'close'>('close', new Element('foo'));
-conn.emit<'closing'>('closing');
+conn.emit<"input">("input", "foo");
+conn.emit<"send">("send", new Element("foo"));
+conn.emit<"error">("error", new Error("foo"));
+conn.emit<"element">("element", new Element("foo"));
+conn.emit<"stanza">("stanza", new Element("foo"));
+conn.emit<"nonza">("nonza", new Element("foo"));
+conn.emit<"online">("status", "online", new JID("foo", "bar"));
+conn.emit<"offline">("status", "offline", new Element("foo"));
+conn.emit<"connect">("status", "connect");
+conn.emit<"connecting">("status", "connecting", "foo");
+conn.emit<"disconnect">("status", "disconnect", { clean: true, event: "foo" });
+conn.emit<"disconnecting">("status", "disconnecting");
+conn.emit<"open">("status", "open", new Element("foo"));
+conn.emit<"opening">("status", "opening");
+conn.emit<"close">("status", "close", new Element("foo"));
+conn.emit<"closing">("status", "closing");
+conn.emit<"online">("online", new JID("foo", "bar"));
+conn.emit<"offline">("offline", new Element("foo"));
+conn.emit<"connect">("connect");
+conn.emit<"connecting">("connecting", "foo");
+conn.emit<"disconnect">("disconnect", { clean: true, event: "foo" });
+conn.emit<"disconnecting">("disconnecting");
+conn.emit<"open">("open", new Element("foo"));
+conn.emit<"opening">("opening");
+conn.emit<"close">("close", new Element("foo"));
+conn.emit<"closing">("closing");

--- a/types/xmpp__debug/index.d.ts
+++ b/types/xmpp__debug/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
 
 export = debug;
 

--- a/types/xmpp__debug/xmpp__debug-tests.ts
+++ b/types/xmpp__debug/xmpp__debug-tests.ts
@@ -1,10 +1,10 @@
-import Connection = require('@xmpp/connection');
-import debug = require('@xmpp/debug');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import debug = require("@xmpp/debug");
+import { Element } from "@xmpp/xml";
 
 debug(null as any as Connection); // $ExpectType void
 debug(null as any as Connection, true); // $ExpectType void
-debug.hideSensitive(new Element('foo')); // $ExpectType Element
+debug.hideSensitive(new Element("foo")); // $ExpectType Element
 debug.hideSensitive = el => {
     el; // $ExpectType Element
     return el;

--- a/types/xmpp__error/index.d.ts
+++ b/types/xmpp__error/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Element } from '@xmpp/xml';
+import { Element } from "@xmpp/xml";
 
 export = XMPPError;
 
-declare class XMPPError<TName extends string = 'XMPPError'> extends Error {
+declare class XMPPError<TName extends string = "XMPPError"> extends Error {
     readonly name: TName;
     readonly condition: string;
     readonly text: string | undefined;

--- a/types/xmpp__error/xmpp__error-tests.ts
+++ b/types/xmpp__error/xmpp__error-tests.ts
@@ -1,24 +1,24 @@
-import XMPPError = require('@xmpp/error');
-import { Element } from '@xmpp/xml';
+import XMPPError = require("@xmpp/error");
+import { Element } from "@xmpp/xml";
 
-const err = new XMPPError('foo');
-const err2: Error = new XMPPError('foo');
-new XMPPError('foo', 'text');
-new XMPPError('foo', 'text', new Element('foo'));
+const err = new XMPPError("foo");
+const err2: Error = new XMPPError("foo");
+new XMPPError("foo", "text");
+new XMPPError("foo", "text", new Element("foo"));
 
 err.name; // $ExpectType "XMPPError"
 // @ts-expect-error
-err.name = 'XMPPError';
+err.name = "XMPPError";
 err.condition; // $ExpectType string
 // @ts-expect-error
-err.condition = 'foo';
+err.condition = "foo";
 err.text; // $ExpectType string | undefined
 // @ts-expect-error
-err.text = 'foo';
+err.text = "foo";
 err.application; // $ExpectType Element | undefined
 // @ts-expect-error
-err.application = 'foo';
+err.application = "foo";
 err.element; // $ExpectType Element | undefined
-err.element = new Element('foo');
+err.element = new Element("foo");
 
-XMPPError.fromElement(new Element('foo')); // $ExpectType XMPPError<"XMPPError">
+XMPPError.fromElement(new Element("foo")); // $ExpectType XMPPError<"XMPPError">

--- a/types/xmpp__events/index.d.ts
+++ b/types/xmpp__events/index.d.ts
@@ -5,13 +5,13 @@
 
 /// <reference types="node" />
 
-import * as events from 'events';
+import * as events from "events";
 
 export const EventEmitter: typeof events.EventEmitter;
 export type EventEmitter = events.EventEmitter;
 
 export class TimeoutError extends Error {
-    readonly name: 'TimeoutError';
+    readonly name: "TimeoutError";
 }
 
 export function delay(ms: number): Promise<void> & { timeout: NodeJS.Timeout | number };

--- a/types/xmpp__events/xmpp__events-tests.ts
+++ b/types/xmpp__events/xmpp__events-tests.ts
@@ -1,4 +1,4 @@
-import * as events from '@xmpp/events';
+import * as events from "@xmpp/events";
 
 // test type exports
 type EventEmitter = events.EventEmitter;
@@ -8,30 +8,30 @@ type Deferred<T> = events.Deferred<T>;
 new events.EventEmitter();
 class MyEmitter extends events.EventEmitter {}
 
-const ttErr = new events.TimeoutError('foo');
+const ttErr = new events.TimeoutError("foo");
 const err: Error = ttErr;
 ttErr.name; // $ExpectType "TimeoutError"
 
 events.delay(100); // $ExpectType Promise<void> & { timeout: number | Timeout; }
 events.timeout(Promise.resolve(10), 10); // $ExpectType Promise<number>
-events.timeout(Promise.resolve('foo'), 10); // $ExpectType Promise<string>
-events.promise(new events.EventEmitter(), 'foo'); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), Symbol('foo')); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), 'foo', 'err'); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), 'foo', Symbol('err')); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), 'foo', null); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), 'foo', 'err', 10); // $ExpectType Promise<unknown>
-events.promise(new events.EventEmitter(), 'foo', 'err', null); // $ExpectType Promise<unknown>
+events.timeout(Promise.resolve("foo"), 10); // $ExpectType Promise<string>
+events.promise(new events.EventEmitter(), "foo"); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), Symbol("foo")); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), "foo", "err"); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), "foo", Symbol("err")); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), "foo", null); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), "foo", "err", 10); // $ExpectType Promise<unknown>
+events.promise(new events.EventEmitter(), "foo", "err", null); // $ExpectType Promise<unknown>
 
 const deferred = new events.Deferred();
 deferred.promise; // $ExpectType Promise<unknown>
-deferred.resolve('foo'); // $ExpectType void
-deferred.resolve(Promise.resolve('foo')); // $ExpectType void
+deferred.resolve("foo"); // $ExpectType void
+deferred.resolve(Promise.resolve("foo")); // $ExpectType void
 deferred.reject(); // $ExpectType void
-deferred.reject('err'); // $ExpectType void
+deferred.reject("err"); // $ExpectType void
 const deferred2 = new events.Deferred<string>();
 deferred2.promise; // $ExpectType Promise<string>
-deferred2.resolve('foo'); // $ExpectType void
+deferred2.resolve("foo"); // $ExpectType void
 // @ts-expect-error
 deferred2.resolve(10);
 

--- a/types/xmpp__id/xmpp__id-tests.ts
+++ b/types/xmpp__id/xmpp__id-tests.ts
@@ -1,3 +1,3 @@
-import id = require('@xmpp/id');
+import id = require("@xmpp/id");
 
 id(); // $ExpectType string

--- a/types/xmpp__iq/callee.d.ts
+++ b/types/xmpp__iq/callee.d.ts
@@ -1,5 +1,5 @@
-import { Entity, IncomingContext, Middleware } from '@xmpp/middleware';
-import * as koaCompose from 'koa-compose';
+import { Entity, IncomingContext, Middleware } from "@xmpp/middleware";
+import * as koaCompose from "koa-compose";
 
 export = iqCallee;
 

--- a/types/xmpp__iq/caller.d.ts
+++ b/types/xmpp__iq/caller.d.ts
@@ -1,6 +1,6 @@
-import { Deferred } from '@xmpp/events';
-import { Entity, Middleware } from '@xmpp/middleware';
-import { Element } from '@xmpp/xml';
+import { Deferred } from "@xmpp/events";
+import { Entity, Middleware } from "@xmpp/middleware";
+import { Element } from "@xmpp/xml";
 
 export = iqCaller;
 

--- a/types/xmpp__iq/xmpp__iq-tests.ts
+++ b/types/xmpp__iq/xmpp__iq-tests.ts
@@ -1,8 +1,8 @@
-import Connection = require('@xmpp/connection');
-import iqCallee = require('@xmpp/iq/callee');
-import iqCaller = require('@xmpp/iq/caller');
-import middleware = require('@xmpp/middleware');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import iqCallee = require("@xmpp/iq/callee");
+import iqCaller = require("@xmpp/iq/caller");
+import middleware = require("@xmpp/middleware");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type IQCallee<TEntity extends middleware.Entity> = iqCallee.IQCallee<TEntity>;
@@ -13,7 +13,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -21,16 +21,16 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const ent = new Foo({ service: 'foo', domain: 'foo.bar' });
+const ent = new Foo({ service: "foo", domain: "foo.bar" });
 const mw = middleware({ entity: ent });
 
 const callee = iqCallee({ middleware: mw, entity: ent }); // $ExpectType IQCallee<Foo>
-callee.get('foo', 'bar', (ctx, next) => {
+callee.get("foo", "bar", (ctx, next) => {
     ctx; // $ExpectType IncomingContext<Foo>
     next; // $ExpectType Next
     return next();
 });
-callee.set('foo', 'bar', (ctx, next) => {
+callee.set("foo", "bar", (ctx, next) => {
     ctx; // $ExpectType IncomingContext<Foo>
     next; // $ExpectType Next
     return next();
@@ -40,12 +40,12 @@ const caller = iqCaller({ middleware: mw, entity: ent }); // $ExpectType IQCalle
 caller.entity; // $ExpectType Foo
 caller.handlers; // $ExpectType Map<string, Deferred<Element>>
 caller.middleware; // $ExpectType Middleware<Foo>
-caller.get(new Element('foo')); // $ExpectType Promise<Element | undefined>
-caller.get(new Element('foo'), 'bar'); // $ExpectType Promise<Element | undefined>
-caller.get(new Element('foo'), 'bar', 10); // $ExpectType Promise<Element | undefined>
-caller.set(new Element('foo')); // $ExpectType Promise<Element | undefined>
-caller.set(new Element('foo'), 'bar'); // $ExpectType Promise<Element | undefined>
-caller.set(new Element('foo'), 'bar', 10); // $ExpectType Promise<Element | undefined>
-caller.request(new Element('foo')); // $ExpectType Promise<Element>
-caller.request(new Element('foo'), 10); // $ExpectType Promise<Element>
+caller.get(new Element("foo")); // $ExpectType Promise<Element | undefined>
+caller.get(new Element("foo"), "bar"); // $ExpectType Promise<Element | undefined>
+caller.get(new Element("foo"), "bar", 10); // $ExpectType Promise<Element | undefined>
+caller.set(new Element("foo")); // $ExpectType Promise<Element | undefined>
+caller.set(new Element("foo"), "bar"); // $ExpectType Promise<Element | undefined>
+caller.set(new Element("foo"), "bar", 10); // $ExpectType Promise<Element | undefined>
+caller.request(new Element("foo")); // $ExpectType Promise<Element>
+caller.request(new Element("foo"), 10); // $ExpectType Promise<Element>
 caller.start(); // $ExpectType void

--- a/types/xmpp__jid/xmpp__jid-tests.ts
+++ b/types/xmpp__jid/xmpp__jid-tests.ts
@@ -1,38 +1,38 @@
-import jid = require('@xmpp/jid');
+import jid = require("@xmpp/jid");
 
 // test type exports
 type JID = jid.JID;
 
-const addr = jid('alice@wonderland.net/rabbithole'); // $ExpectType JID
-jid('alice', 'wonderland.net'); // $ExpectType JID
-jid(null, 'wonderland.net'); // $ExpectType JID
-jid(undefined, 'wonderland.net'); // $ExpectType JID
-jid('alice', 'wonderland.net', 'rabbithole'); // $ExpectType JID
-jid('alice', 'wonderland.net', null); // $ExpectType JID
-jid('alice', 'wonderland.net', undefined); // $ExpectType JID
+const addr = jid("alice@wonderland.net/rabbithole"); // $ExpectType JID
+jid("alice", "wonderland.net"); // $ExpectType JID
+jid(null, "wonderland.net"); // $ExpectType JID
+jid(undefined, "wonderland.net"); // $ExpectType JID
+jid("alice", "wonderland.net", "rabbithole"); // $ExpectType JID
+jid("alice", "wonderland.net", null); // $ExpectType JID
+jid("alice", "wonderland.net", undefined); // $ExpectType JID
 
-jid.jid('alice@wonderland.net/rabbithole'); // $ExpectType JID
-jid.jid('alice', 'wonderland.net'); // $ExpectType JID
-jid.jid(null, 'wonderland.net'); // $ExpectType JID
-jid.jid(undefined, 'wonderland.net'); // $ExpectType JID
-jid.jid('alice', 'wonderland.net', 'rabbithole'); // $ExpectType JID
-jid.jid('alice', 'wonderland.net', null); // $ExpectType JID
-jid.jid('alice', 'wonderland.net', undefined); // $ExpectType JID
+jid.jid("alice@wonderland.net/rabbithole"); // $ExpectType JID
+jid.jid("alice", "wonderland.net"); // $ExpectType JID
+jid.jid(null, "wonderland.net"); // $ExpectType JID
+jid.jid(undefined, "wonderland.net"); // $ExpectType JID
+jid.jid("alice", "wonderland.net", "rabbithole"); // $ExpectType JID
+jid.jid("alice", "wonderland.net", null); // $ExpectType JID
+jid.jid("alice", "wonderland.net", undefined); // $ExpectType JID
 
-addr.local = 'alice';
+addr.local = "alice";
 addr.local; // $ExpectType string
-addr.setLocal('alice'); // $ExpectType void
-addr.setLocal('alice', true); // $ExpectType void
+addr.setLocal("alice"); // $ExpectType void
+addr.setLocal("alice", true); // $ExpectType void
 addr.getLocal(); // $ExpectType string
 
-addr.domain = 'wonderland.net';
+addr.domain = "wonderland.net";
 addr.domain; // $ExpectType string
-addr.setDomain('wonderland.net'); // $ExpectType void
+addr.setDomain("wonderland.net"); // $ExpectType void
 addr.getDomain(); // $ExpectType string
 
-addr.resource = 'rabbithole';
+addr.resource = "rabbithole";
 addr.resource; // $ExpectType string
-addr.setResource('rabbithole'); // $ExpectType void
+addr.setResource("rabbithole"); // $ExpectType void
 addr.getResource(); // $ExpectType string
 
 addr.toString(); // $ExpectType string
@@ -44,9 +44,9 @@ addr.equals(addr); // $ExpectType boolean
 jid.equal(addr, addr); // $ExpectType boolean
 
 jid.equal(addr, addr); // $ExpectType boolean
-jid.detectEscape('homies'); // $ExpectType boolean
-jid.escapeLocal('homies'); // $ExpectType string
-jid.unescapeLocal('homies'); // $ExpectType string
-jid.parse('homies'); // $ExpectType JID
+jid.detectEscape("homies"); // $ExpectType boolean
+jid.escapeLocal("homies"); // $ExpectType string
+jid.unescapeLocal("homies"); // $ExpectType string
+jid.parse("homies"); // $ExpectType JID
 
 class MyJID extends jid.JID {}

--- a/types/xmpp__middleware/index.d.ts
+++ b/types/xmpp__middleware/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as koaCompose from 'koa-compose';
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
-import IncomingCtx = require('./lib/IncomingContext');
-import OutgoingCtx = require('./lib/OutgoingContext');
+import * as koaCompose from "koa-compose";
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
+import IncomingCtx = require("./lib/IncomingContext");
+import OutgoingCtx = require("./lib/OutgoingContext");
 
 export = middleware;
 

--- a/types/xmpp__middleware/lib/Context.d.ts
+++ b/types/xmpp__middleware/lib/Context.d.ts
@@ -1,6 +1,6 @@
-import { JID } from '@xmpp/jid';
-import { Element } from '@xmpp/xml';
-import { Entity } from '../index';
+import { JID } from "@xmpp/jid";
+import { Element } from "@xmpp/xml";
+import { Entity } from "../index";
 
 export = Context;
 

--- a/types/xmpp__middleware/lib/IncomingContext.d.ts
+++ b/types/xmpp__middleware/lib/IncomingContext.d.ts
@@ -1,5 +1,5 @@
-import { Entity } from '../index';
-import Context = require('./Context');
+import { Entity } from "../index";
+import Context = require("./Context");
 
 export = IncomingContext;
 

--- a/types/xmpp__middleware/lib/OutgoingContext.d.ts
+++ b/types/xmpp__middleware/lib/OutgoingContext.d.ts
@@ -1,5 +1,5 @@
-import { Entity } from '../index';
-import Context = require('./Context');
+import { Entity } from "../index";
+import Context = require("./Context");
 
 export = OutgoingContext;
 

--- a/types/xmpp__middleware/lib/StanzaError.d.ts
+++ b/types/xmpp__middleware/lib/StanzaError.d.ts
@@ -1,9 +1,9 @@
-import XMPPError = require('@xmpp/error');
-import { Element } from '@xmpp/xml';
+import XMPPError = require("@xmpp/error");
+import { Element } from "@xmpp/xml";
 
 export = StanzaError;
 
-declare class StanzaError extends XMPPError<'StanzaError'> {
+declare class StanzaError extends XMPPError<"StanzaError"> {
     type?: string | undefined;
 
     constructor(condition: string, text?: string, application?: Element, type?: string);

--- a/types/xmpp__middleware/xmpp__middleware-tests.ts
+++ b/types/xmpp__middleware/xmpp__middleware-tests.ts
@@ -1,10 +1,10 @@
-import Connection = require('@xmpp/connection');
-import middleware = require('@xmpp/middleware');
-import Context = require('@xmpp/middleware/lib/Context');
-import IncomingContext = require('@xmpp/middleware/lib/IncomingContext');
-import OutgoingContext = require('@xmpp/middleware/lib/OutgoingContext');
-import StanzaError = require('@xmpp/middleware/lib/StanzaError');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import middleware = require("@xmpp/middleware");
+import Context = require("@xmpp/middleware/lib/Context");
+import IncomingContext = require("@xmpp/middleware/lib/IncomingContext");
+import OutgoingContext = require("@xmpp/middleware/lib/OutgoingContext");
+import StanzaError = require("@xmpp/middleware/lib/StanzaError");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type E = middleware.Entity;
@@ -18,7 +18,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -26,7 +26,7 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const entity = new Foo({ service: 'foo', domain: 'foo.bar' });
+const entity = new Foo({ service: "foo", domain: "foo.bar" });
 
 const res = middleware({ entity }); // $ExpectType Middleware<Foo>
 // $ExpectType (ctx: IncomingContext<Foo>, next: Next) => Promise<void>
@@ -64,15 +64,15 @@ res.filter(async (ctx, next) => {
     ctx.resource; // $ExpectType string
 });
 
-const err = new StanzaError('foo');
-new StanzaError('foo', 'bar');
-new StanzaError('foo', 'bar', new Element('el'));
-new StanzaError('foo', 'bar', new Element('el'), 'baz');
+const err = new StanzaError("foo");
+new StanzaError("foo", "bar");
+new StanzaError("foo", "bar", new Element("el"));
+new StanzaError("foo", "bar", new Element("el"), "baz");
 
 err.name; // $ExpectType "StanzaError"
 err.type; // $ExpectType string | undefined
 
-let ctx = new Context<Foo>(entity, new Element('foo'));
+let ctx = new Context<Foo>(entity, new Element("foo"));
 ctx.stanza; // $ExpectType Element
 ctx.entity; // $ExpectType Foo
 ctx.name; // $ExpectType string
@@ -84,7 +84,7 @@ ctx.local; // $ExpectType string
 ctx.domain; // $ExpectType string
 ctx.resource; // $ExpectType string
 
-const oCtx = new OutgoingContext<Foo>(entity, new Element('foo'));
+const oCtx = new OutgoingContext<Foo>(entity, new Element("foo"));
 ctx = oCtx;
-const iCtx = new IncomingContext<Foo>(entity, new Element('foo'));
+const iCtx = new IncomingContext<Foo>(entity, new Element("foo"));
 ctx = iCtx;

--- a/types/xmpp__reconnect/index.d.ts
+++ b/types/xmpp__reconnect/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter } from '@xmpp/events';
-import Connection = require('@xmpp/connection');
+import { EventEmitter } from "@xmpp/events";
+import Connection = require("@xmpp/connection");
 
 export = reconnect;
 

--- a/types/xmpp__reconnect/xmpp__reconnect-tests.ts
+++ b/types/xmpp__reconnect/xmpp__reconnect-tests.ts
@@ -1,7 +1,7 @@
-import Connection = require('@xmpp/connection');
-import { EventEmitter } from '@xmpp/events';
-import reconnect = require('@xmpp/reconnect');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import { EventEmitter } from "@xmpp/events";
+import reconnect = require("@xmpp/reconnect");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type R<T extends Connection> = reconnect.Reconnect<T>;
@@ -12,7 +12,7 @@ class Foo extends Connection {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -20,7 +20,7 @@ class Foo extends Connection {
     }
 }
 
-const entity = new Foo({ service: 'foo', domain: 'foo.bar' });
+const entity = new Foo({ service: "foo", domain: "foo.bar" });
 
 const rec = reconnect({ entity }); // $ExpectType Reconnect<Foo>
 const e: EventEmitter = rec;
@@ -33,26 +33,26 @@ rec.stop(); // $ExpectType void
 
 new rec.constructor(entity); // $ExpectType ReconnectCls<Foo>
 
-rec.addListener('reconnected', () => {});
-rec.addListener('reconnecting', () => {});
+rec.addListener("reconnected", () => {});
+rec.addListener("reconnecting", () => {});
 
-rec.on('reconnected', () => {});
-rec.on('reconnecting', () => {});
+rec.on("reconnected", () => {});
+rec.on("reconnecting", () => {});
 
-rec.once('reconnected', () => {});
-rec.once('reconnecting', () => {});
+rec.once("reconnected", () => {});
+rec.once("reconnecting", () => {});
 
-rec.prependListener('reconnected', () => {});
-rec.prependListener('reconnecting', () => {});
+rec.prependListener("reconnected", () => {});
+rec.prependListener("reconnecting", () => {});
 
-rec.prependOnceListener('reconnected', () => {});
-rec.prependOnceListener('reconnecting', () => {});
+rec.prependOnceListener("reconnected", () => {});
+rec.prependOnceListener("reconnecting", () => {});
 
-rec.removeListener('reconnected', () => {});
-rec.removeListener('reconnecting', () => {});
+rec.removeListener("reconnected", () => {});
+rec.removeListener("reconnecting", () => {});
 
-rec.off('reconnected', () => {});
-rec.off('reconnecting', () => {});
+rec.off("reconnected", () => {});
+rec.off("reconnecting", () => {});
 
-rec.emit('reconnected');
-rec.emit('reconnecting');
+rec.emit("reconnected");
+rec.emit("reconnecting");

--- a/types/xmpp__resolve/index.d.ts
+++ b/types/xmpp__resolve/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
+import Connection = require("@xmpp/connection");
 
 export = resolve;
 

--- a/types/xmpp__resolve/lib/alt-connections.d.ts
+++ b/types/xmpp__resolve/lib/alt-connections.d.ts
@@ -1,5 +1,5 @@
-import { ResolvedTxtRecord } from './dns';
-import { ResolvedEndpoint } from './http';
+import { ResolvedTxtRecord } from "./dns";
+import { ResolvedEndpoint } from "./http";
 
 export function compare(
     a: ResolvedEndpoint | ResolvedTxtRecord,

--- a/types/xmpp__resolve/lib/dns.d.ts
+++ b/types/xmpp__resolve/lib/dns.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="node" />
-import { LookupOptions as DnsLookupOptions, SrvRecord } from 'dns';
+import { LookupOptions as DnsLookupOptions, SrvRecord } from "dns";
 
 export function lookup(domain: string, options?: LookupOptions): Promise<ResolvedAddress[]>;
 
-export type LookupOptions = Omit<DnsLookupOptions, 'all'>;
+export type LookupOptions = Omit<DnsLookupOptions, "all">;
 
 export interface ResolvedAddress {
     family: 4 | 6;

--- a/types/xmpp__resolve/resolve.d.ts
+++ b/types/xmpp__resolve/resolve.d.ts
@@ -1,5 +1,5 @@
-import * as dnsResolver from './lib/dns';
-import * as httpResolver from './lib/http';
+import * as dnsResolver from "./lib/dns";
+import * as httpResolver from "./lib/http";
 
 export = resolve;
 

--- a/types/xmpp__resolve/xmpp__resolve-tests.ts
+++ b/types/xmpp__resolve/xmpp__resolve-tests.ts
@@ -1,8 +1,8 @@
-import Connection = require('@xmpp/connection');
-import registerResolve = require('@xmpp/resolve');
-import resolve = require('@xmpp/resolve/resolve');
-import { compare } from '@xmpp/resolve/lib/alt-connections';
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import registerResolve = require("@xmpp/resolve");
+import resolve = require("@xmpp/resolve/resolve");
+import { compare } from "@xmpp/resolve/lib/alt-connections";
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type LookupOptions = resolve.LookupOptions;
@@ -15,34 +15,34 @@ type ResolvedRecord = resolve.ResolvedRecord;
 type ResolvedEndpoint = resolve.ResolvedEndpoint;
 
 // need to test via assignments because of TS4.1 ...
-let res: Promise<Array<ResolvedEndpoint | ResolvedRecord>> = resolve('foo');
-res = resolve('foo', { family: 1 });
-res = resolve('foo', { hints: 1 });
-res = resolve('foo', { owner: 'foo' });
-res = resolve('foo', { srv: [{ service: 'foo', protocol: 'bar' }] });
-res = resolve('foo', { verbatim: true });
+let res: Promise<Array<ResolvedEndpoint | ResolvedRecord>> = resolve("foo");
+res = resolve("foo", { family: 1 });
+res = resolve("foo", { hints: 1 });
+res = resolve("foo", { owner: "foo" });
+res = resolve("foo", { srv: [{ service: "foo", protocol: "bar" }] });
+res = resolve("foo", { verbatim: true });
 
-resolve.dns!.resolve('foo'); // $ExpectType Promise<ResolvedRecord[]>
-resolve.dns!.resolve('foo', { family: 2 }); // $ExpectType Promise<ResolvedRecord[]>
-resolve.dns!.resolve('foo', { hints: 2 }); // $ExpectType Promise<ResolvedRecord[]>
-resolve.dns!.resolve('foo', { owner: 'foo' }); // $ExpectType Promise<ResolvedRecord[]>
-resolve.dns!.resolve('foo', { srv: [{ service: 'foo', protocol: 'bar' }] }); // $ExpectType Promise<ResolvedRecord[]>
-resolve.dns!.resolve('foo', { verbatim: true }); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo"); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo", { family: 2 }); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo", { hints: 2 }); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo", { owner: "foo" }); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo", { srv: [{ service: "foo", protocol: "bar" }] }); // $ExpectType Promise<ResolvedRecord[]>
+resolve.dns!.resolve("foo", { verbatim: true }); // $ExpectType Promise<ResolvedRecord[]>
 
-resolve('foo').then(([record]) => {
-    if ('rel' in record) {
+resolve("foo").then(([record]) => {
+    if ("rel" in record) {
         record; // $ExpectType ResolvedEndpoint
         record.href; // $ExpectType string
         record.method; // $ExpectType string
         record.rel; // $ExpectType string
         record.uri; // $ExpectType string
-    } else if ('attribute' in record) {
+    } else if ("attribute" in record) {
         record; // $ExpectType ResolvedTxtRecord
         record.attribute; // $ExpectType string
         record.method; // $ExpectType string
         record.uri; // $ExpectType string
         record.value; // $ExpectType string
-    } else if ('service' in record) {
+    } else if ("service" in record) {
         record; // $ExpectType LookedUpSrvRecord
         record.address; // $ExpectType string
         record.family; // $ExpectType 4 | 6
@@ -61,11 +61,11 @@ resolve('foo').then(([record]) => {
     }
 });
 
-resolve.dns!.lookup('foo'); // $ExpectType Promise<ResolvedAddress[]>
-resolve.dns!.lookup('foo', { family: 1 }); // $ExpectType Promise<ResolvedAddress[]>
-resolve.dns!.lookup('foo', { hints: 1 }); // $ExpectType Promise<ResolvedAddress[]>
-resolve.dns!.lookup('foo', { verbatim: true }); // $ExpectType Promise<ResolvedAddress[]>
-resolve.dns!.lookup('foo').then(([addr]) => {
+resolve.dns!.lookup("foo"); // $ExpectType Promise<ResolvedAddress[]>
+resolve.dns!.lookup("foo", { family: 1 }); // $ExpectType Promise<ResolvedAddress[]>
+resolve.dns!.lookup("foo", { hints: 1 }); // $ExpectType Promise<ResolvedAddress[]>
+resolve.dns!.lookup("foo", { verbatim: true }); // $ExpectType Promise<ResolvedAddress[]>
+resolve.dns!.lookup("foo").then(([addr]) => {
     addr; // $ExpectType ResolvedAddress
     addr.address; // $ExpectType string
     addr.family; // $ExpectType 4 | 6
@@ -90,8 +90,8 @@ resolve.dns!.lookupSrvs(resolvedSrvRecords).then(([rec]) => {
     rec.weight; // $ExpectType number
 });
 
-resolve.dns!.resolveSrv('foo', { service: 'foo', protocol: 'tcp' }); // $ExpectType Promise<ResolvedSrvRecord[]>
-resolve.dns!.resolveSrv('foo', { service: 'foo', protocol: 'tcp' }).then(([rec]) => {
+resolve.dns!.resolveSrv("foo", { service: "foo", protocol: "tcp" }); // $ExpectType Promise<ResolvedSrvRecord[]>
+resolve.dns!.resolveSrv("foo", { service: "foo", protocol: "tcp" }).then(([rec]) => {
     rec; // $ExpectType ResolvedSrvRecord
     rec.name; // $ExpectType string
     rec.port; // $ExpectType number
@@ -103,8 +103,8 @@ resolve.dns!.resolveSrv('foo', { service: 'foo', protocol: 'tcp' }).then(([rec])
 
 resolve.dns!.sortSrv(resolvedSrvRecords); // $ExpectType ResolvedSrvRecord[]
 
-resolve.http.resolve('foo'); // $ExpectType Promise<ResolvedEndpoint[]>
-resolve.http.resolve('foo').then(([rec]) => {
+resolve.http.resolve("foo"); // $ExpectType Promise<ResolvedEndpoint[]>
+resolve.http.resolve("foo").then(([rec]) => {
     rec; // $ExpectType ResolvedEndpoint
     rec.href; // $ExpectType string
     rec.method; // $ExpectType string
@@ -117,7 +117,7 @@ class Foo extends Connection {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -125,12 +125,12 @@ class Foo extends Connection {
     }
 }
 
-registerResolve({ entity: new Foo({ domain: 'foo.bar', service: 'foo' }) }); // $ExpectType void
+registerResolve({ entity: new Foo({ domain: "foo.bar", service: "foo" }) }); // $ExpectType void
 
-resolve('foo').then(([record]) => {
-    if ('rel' in record) {
+resolve("foo").then(([record]) => {
+    if ("rel" in record) {
         compare(record, record); // $ExpectType 0 | 1 | -1
-    } else if ('attribute' in record) {
+    } else if ("attribute" in record) {
         compare(record, record); // $ExpectType 0 | 1 | -1
     }
 });

--- a/types/xmpp__resource-binding/index.d.ts
+++ b/types/xmpp__resource-binding/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { IQCaller } from '@xmpp/iq/caller';
-import { Entity } from '@xmpp/middleware';
-import { StreamFeatures } from '@xmpp/stream-features';
-import { Node } from '@xmpp/xml';
+import { IQCaller } from "@xmpp/iq/caller";
+import { Entity } from "@xmpp/middleware";
+import { StreamFeatures } from "@xmpp/stream-features";
+import { Node } from "@xmpp/xml";
 
 export = resourceBinding;
 

--- a/types/xmpp__resource-binding/xmpp__resource-binding-tests.ts
+++ b/types/xmpp__resource-binding/xmpp__resource-binding-tests.ts
@@ -1,9 +1,9 @@
-import Connection = require('@xmpp/connection');
-import iqCaller = require('@xmpp/iq/caller');
-import middleware = require('@xmpp/middleware');
-import resourceBinding = require('@xmpp/resource-binding');
-import streamFeatures = require('@xmpp/stream-features');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import iqCaller = require("@xmpp/iq/caller");
+import middleware = require("@xmpp/middleware");
+import resourceBinding = require("@xmpp/resource-binding");
+import streamFeatures = require("@xmpp/stream-features");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type Resource = resourceBinding.Resource;
@@ -14,7 +14,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -22,15 +22,15 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const ent = new Foo({ service: 'foo', domain: 'foo.bar' });
+const ent = new Foo({ service: "foo", domain: "foo.bar" });
 const mw = middleware({ entity: ent });
 const sf = streamFeatures({ middleware: mw }); // $ExpectType StreamFeatures<Foo>
 const caller = iqCaller({ middleware: mw, entity: ent }); // $ExpectType IQCaller<Foo>
 
 resourceBinding({ streamFeatures: sf, iqCaller: caller }); // $ExpectType void
-resourceBinding({ streamFeatures: sf, iqCaller: caller }, new Element('foo')); // $ExpectType void
+resourceBinding({ streamFeatures: sf, iqCaller: caller }, new Element("foo")); // $ExpectType void
 // $ExpectType void
 resourceBinding({ streamFeatures: sf, iqCaller: caller }, async bind => {
     bind; // $ExpectType (resource: Node) => Promise<string>
-    const jid = await bind(new Element('foo')); // $ExpectType string
+    const jid = await bind(new Element("foo")); // $ExpectType string
 });

--- a/types/xmpp__sasl-anonymous/index.d.ts
+++ b/types/xmpp__sasl-anonymous/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { SASL } from '@xmpp/sasl';
+import { SASL } from "@xmpp/sasl";
 
 export = saslAnonymous;
 

--- a/types/xmpp__sasl-anonymous/xmpp__sasl-anonymous-tests.ts
+++ b/types/xmpp__sasl-anonymous/xmpp__sasl-anonymous-tests.ts
@@ -1,4 +1,4 @@
-import { SASL } from '@xmpp/sasl';
-import saslAnonymous = require('@xmpp/sasl-anonymous');
+import { SASL } from "@xmpp/sasl";
+import saslAnonymous = require("@xmpp/sasl-anonymous");
 
 saslAnonymous(null as any as SASL); // $ExpectType void

--- a/types/xmpp__sasl-plain/index.d.ts
+++ b/types/xmpp__sasl-plain/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { SASL } from '@xmpp/sasl';
+import { SASL } from "@xmpp/sasl";
 
 export = saslPlain;
 

--- a/types/xmpp__sasl-plain/xmpp__sasl-plain-tests.ts
+++ b/types/xmpp__sasl-plain/xmpp__sasl-plain-tests.ts
@@ -1,4 +1,4 @@
-import { SASL } from '@xmpp/sasl';
-import saslPlain = require('@xmpp/sasl-plain');
+import { SASL } from "@xmpp/sasl";
+import saslPlain = require("@xmpp/sasl-plain");
 
 saslPlain(null as any as SASL); // $ExpectType void

--- a/types/xmpp__sasl-scram-sha-1/index.d.ts
+++ b/types/xmpp__sasl-scram-sha-1/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { SASL } from '@xmpp/sasl';
+import { SASL } from "@xmpp/sasl";
 
 export = saslScramSha1;
 

--- a/types/xmpp__sasl-scram-sha-1/xmpp__sasl-scram-sha-1-tests.ts
+++ b/types/xmpp__sasl-scram-sha-1/xmpp__sasl-scram-sha-1-tests.ts
@@ -1,4 +1,4 @@
-import { SASL } from '@xmpp/sasl';
-import saslScramSha1 = require('@xmpp/sasl-scram-sha-1');
+import { SASL } from "@xmpp/sasl";
+import saslScramSha1 = require("@xmpp/sasl-scram-sha-1");
 
 saslScramSha1(null as any as SASL); // $ExpectType void

--- a/types/xmpp__sasl/index.d.ts
+++ b/types/xmpp__sasl/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Entity } from '@xmpp/middleware';
-import streamFeatures = require('@xmpp/stream-features');
-import SASLFactory = require('saslmechanisms');
+import { Entity } from "@xmpp/middleware";
+import streamFeatures = require("@xmpp/stream-features");
+import SASLFactory = require("saslmechanisms");
 
 export = sasl;
 

--- a/types/xmpp__sasl/lib/SASLError.d.ts
+++ b/types/xmpp__sasl/lib/SASLError.d.ts
@@ -1,5 +1,5 @@
-import XMPPError = require('@xmpp/error');
+import XMPPError = require("@xmpp/error");
 
 export = SASLError;
 
-declare class SASLError extends XMPPError<'SASLError'> {}
+declare class SASLError extends XMPPError<"SASLError"> {}

--- a/types/xmpp__sasl/xmpp__sasl-tests.ts
+++ b/types/xmpp__sasl/xmpp__sasl-tests.ts
@@ -1,14 +1,14 @@
-import Connection = require('@xmpp/connection');
-import XMPPError = require('@xmpp/error');
-import middleware = require('@xmpp/middleware');
-import sasl = require('@xmpp/sasl');
-import SASLError = require('@xmpp/sasl/lib/SASLError');
-import streamFeatures = require('@xmpp/stream-features');
-import { Element } from '@xmpp/xml';
-import SASLFactory = require('saslmechanisms');
-import SASLAnonymous = require('sasl-anonymous');
-import SASLPlain = require('sasl-plain');
-import SASLScramSha1 = require('sasl-scram-sha-1');
+import Connection = require("@xmpp/connection");
+import XMPPError = require("@xmpp/error");
+import middleware = require("@xmpp/middleware");
+import sasl = require("@xmpp/sasl");
+import SASLError = require("@xmpp/sasl/lib/SASLError");
+import streamFeatures = require("@xmpp/stream-features");
+import { Element } from "@xmpp/xml";
+import SASLFactory = require("saslmechanisms");
+import SASLAnonymous = require("sasl-anonymous");
+import SASLPlain = require("sasl-plain");
+import SASLScramSha1 = require("sasl-scram-sha-1");
 
 // test type exports
 type Credentials = sasl.Credentials;
@@ -22,7 +22,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -30,36 +30,36 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const mw = middleware({ entity: new Foo({ service: 'foo', domain: 'foo.bar' }) });
+const mw = middleware({ entity: new Foo({ service: "foo", domain: "foo.bar" }) });
 const sf = streamFeatures({ middleware: mw });
 
 const saslMw = sasl({ streamFeatures: sf }, {}); // $ExpectType SASL
-sasl({ streamFeatures: sf }, { username: 'foo' }); // $ExpectType SASL
-sasl({ streamFeatures: sf }, { password: 'foo' }); // $ExpectType SASL
+sasl({ streamFeatures: sf }, { username: "foo" }); // $ExpectType SASL
+sasl({ streamFeatures: sf }, { password: "foo" }); // $ExpectType SASL
 // $ExpectType SASL
 sasl({ streamFeatures: sf }, async (cb, mech) => {
     cb; // $ExpectType (credentials: CredentialsObj) => Promise<void>
     mech; // $ExpectType string
 
-    await cb({ username: 'foo', password: 'bar' });
+    await cb({ username: "foo", password: "bar" });
 });
 
 class MyMechanism implements SASLFactory.Mechanism {
-    name = 'foo';
+    name = "foo";
 
     response(cred: { [key: string]: any }) {
-        return 'bar';
+        return "bar";
     }
 
     challenge(chal: string) {}
 }
 
-saslMw.use('foo', MyMechanism); // $ExpectType Factory
+saslMw.use("foo", MyMechanism); // $ExpectType Factory
 saslMw.use(MyMechanism); // $ExpectType Factory
 saslMw.use(SASLAnonymous); // $ExpectType Factory
 saslMw.use(SASLPlain); // $ExpectType Factory
 saslMw.use(SASLScramSha1); // $ExpectType Factory
 
-const err = new SASLError('foo', 'bar', new Element('foo'));
-const xmppErr: XMPPError<'SASLError'> = err;
+const err = new SASLError("foo", "bar", new Element("foo"));
+const xmppErr: XMPPError<"SASLError"> = err;
 err.name; // $ExpectType "SASLError"

--- a/types/xmpp__session-establishment/index.d.ts
+++ b/types/xmpp__session-establishment/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { IQCaller } from '@xmpp/iq/caller';
-import { Entity } from '@xmpp/middleware';
-import { StreamFeatures } from '@xmpp/stream-features';
+import { IQCaller } from "@xmpp/iq/caller";
+import { Entity } from "@xmpp/middleware";
+import { StreamFeatures } from "@xmpp/stream-features";
 
 export = sessionEstablishment;
 

--- a/types/xmpp__session-establishment/xmpp__session-establishment-tests.ts
+++ b/types/xmpp__session-establishment/xmpp__session-establishment-tests.ts
@@ -1,16 +1,16 @@
-import Connection = require('@xmpp/connection');
-import iqCaller = require('@xmpp/iq/caller');
-import middleware = require('@xmpp/middleware');
-import sessionEstablishment = require('@xmpp/session-establishment');
-import streamFeatures = require('@xmpp/stream-features');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import iqCaller = require("@xmpp/iq/caller");
+import middleware = require("@xmpp/middleware");
+import sessionEstablishment = require("@xmpp/session-establishment");
+import streamFeatures = require("@xmpp/stream-features");
+import { Element } from "@xmpp/xml";
 
 class Foo extends Connection implements middleware.Entity {
     domain?: string;
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -18,7 +18,7 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const ent = new Foo({ service: 'foo', domain: 'foo.bar' });
+const ent = new Foo({ service: "foo", domain: "foo.bar" });
 const mw = middleware({ entity: ent });
 const sf = streamFeatures({ middleware: mw }); // $ExpectType StreamFeatures<Foo>
 const caller = iqCaller({ middleware: mw, entity: ent }); // $ExpectType IQCaller<Foo>

--- a/types/xmpp__starttls/client.d.ts
+++ b/types/xmpp__starttls/client.d.ts
@@ -1,6 +1,6 @@
-import { Entity, IncomingContext } from '@xmpp/middleware';
-import { StreamFeatures } from '@xmpp/stream-features';
-import { Middleware } from 'koa-compose';
+import { Entity, IncomingContext } from "@xmpp/middleware";
+import { StreamFeatures } from "@xmpp/stream-features";
+import { Middleware } from "koa-compose";
 
 export = starttls;
 

--- a/types/xmpp__starttls/starttls.d.ts
+++ b/types/xmpp__starttls/starttls.d.ts
@@ -1,5 +1,5 @@
-import { Socket } from 'net';
-import { ConnectionOptions, TLSSocket } from 'tls';
+import { Socket } from "net";
+import { ConnectionOptions, TLSSocket } from "tls";
 
 export function canUpgrade(socket: Socket): boolean;
 export function upgrade(socket: Socket, options?: ConnectionOptions): TLSSocket;

--- a/types/xmpp__starttls/xmpp__starttls-tests.ts
+++ b/types/xmpp__starttls/xmpp__starttls-tests.ts
@@ -1,17 +1,17 @@
-import Connection = require('@xmpp/connection');
-import middleware = require('@xmpp/middleware');
-import starttls = require('@xmpp/starttls/client');
-import { canUpgrade, upgrade } from '@xmpp/starttls/starttls';
-import streamFeatures = require('@xmpp/stream-features');
-import { Element } from '@xmpp/xml';
-import * as net from 'net';
+import Connection = require("@xmpp/connection");
+import middleware = require("@xmpp/middleware");
+import starttls = require("@xmpp/starttls/client");
+import { canUpgrade, upgrade } from "@xmpp/starttls/starttls";
+import streamFeatures = require("@xmpp/stream-features");
+import { Element } from "@xmpp/xml";
+import * as net from "net";
 
 class Foo extends Connection implements middleware.Entity {
     domain?: string;
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -19,7 +19,7 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const mw = middleware({ entity: new Foo({ service: 'foo', domain: 'foo.bar' }) });
+const mw = middleware({ entity: new Foo({ service: "foo", domain: "foo.bar" }) });
 const sf = streamFeatures({ middleware: mw }); // $ExpectType StreamFeatures<Foo>
 
 starttls({ streamFeatures: sf }); // $ExpectType Middleware<IncomingContext<Foo>>

--- a/types/xmpp__stream-features/index.d.ts
+++ b/types/xmpp__stream-features/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Entity, Middleware, IncomingContext } from '@xmpp/middleware';
-import { Element } from '@xmpp/xml';
-import * as Koa from 'koa';
-import * as koaCompose from 'koa-compose';
+import { Entity, IncomingContext, Middleware } from "@xmpp/middleware";
+import { Element } from "@xmpp/xml";
+import * as Koa from "koa";
+import * as koaCompose from "koa-compose";
 
 export = streamFeatures;
 

--- a/types/xmpp__stream-features/route.d.ts
+++ b/types/xmpp__stream-features/route.d.ts
@@ -1,5 +1,5 @@
-import { Entity, IncomingContext } from '@xmpp/middleware';
-import * as Koa from 'koa';
+import { Entity, IncomingContext } from "@xmpp/middleware";
+import * as Koa from "koa";
 
 export = route;
 

--- a/types/xmpp__stream-features/xmpp__stream-features-tests.ts
+++ b/types/xmpp__stream-features/xmpp__stream-features-tests.ts
@@ -1,8 +1,8 @@
-import Connection = require('@xmpp/connection');
-import middleware = require('@xmpp/middleware');
-import streamFeatures = require('@xmpp/stream-features');
-import route = require('@xmpp/stream-features/route');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import middleware = require("@xmpp/middleware");
+import streamFeatures = require("@xmpp/stream-features");
+import route = require("@xmpp/stream-features/route");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type StreamFeatures<TEntity extends middleware.Entity> = streamFeatures.StreamFeatures<TEntity>;
@@ -12,7 +12,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -20,10 +20,10 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const mw = middleware({ entity: new Foo({ service: 'foo', domain: 'foo.bar' }) });
+const mw = middleware({ entity: new Foo({ service: "foo", domain: "foo.bar" }) });
 const sf = streamFeatures({ middleware: mw }); // $ExpectType StreamFeatures<Foo>
 // $ExpectType Middleware<IncomingContext<Foo>>
-sf.use('foo', 'ns', (ctx, next, features) => {
+sf.use("foo", "ns", (ctx, next, features) => {
     ctx; // $ExpectType IncomingContext<Foo>
     next; // $ExpectType Next
     features; // $ExpectType Element
@@ -31,7 +31,7 @@ sf.use('foo', 'ns', (ctx, next, features) => {
     return Promise.resolve();
 });
 // $ExpectType Middleware<IncomingContext<Foo>>
-sf.use('foo', undefined, (ctx, next, features) => {
+sf.use("foo", undefined, (ctx, next, features) => {
     ctx; // $ExpectType IncomingContext<Foo>
     next; // $ExpectType Next
     features; // $ExpectType Element

--- a/types/xmpp__stream-management/index.d.ts
+++ b/types/xmpp__stream-management/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { StreamFeatures } from '@xmpp/stream-features';
-import { Entity, Middleware } from '@xmpp/middleware';
+import { Entity, Middleware } from "@xmpp/middleware";
+import { StreamFeatures } from "@xmpp/stream-features";
 
 export = streamManagement;
 

--- a/types/xmpp__stream-management/xmpp__stream-management-tests.ts
+++ b/types/xmpp__stream-management/xmpp__stream-management-tests.ts
@@ -1,8 +1,8 @@
-import Connection = require('@xmpp/connection');
-import middleware = require('@xmpp/middleware');
-import streamFeatures = require('@xmpp/stream-features');
-import streamManagement = require('@xmpp/stream-management');
-import { Element } from '@xmpp/xml';
+import Connection = require("@xmpp/connection");
+import middleware = require("@xmpp/middleware");
+import streamFeatures = require("@xmpp/stream-features");
+import streamManagement = require("@xmpp/stream-management");
+import { Element } from "@xmpp/xml";
 
 // test type exports
 type StreamManagement = streamManagement.StreamManagement;
@@ -12,7 +12,7 @@ class Foo extends Connection implements middleware.Entity {
     hookOutgoing?: (stanza: Element) => Promise<void>;
 
     headerElement() {
-        return new Element('foo');
+        return new Element("foo");
     }
 
     socketParameters(service: string) {
@@ -20,7 +20,7 @@ class Foo extends Connection implements middleware.Entity {
     }
 }
 
-const entity = new Foo({ service: 'foo', domain: 'foo.bar' });
+const entity = new Foo({ service: "foo", domain: "foo.bar" });
 const mw = middleware({ entity });
 const sf = streamFeatures({ middleware: mw });
 

--- a/types/xmpp__tcp/index.d.ts
+++ b/types/xmpp__tcp/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
+import Connection = require("@xmpp/connection");
 
 export = tcp;
 

--- a/types/xmpp__tcp/lib/Connection.d.ts
+++ b/types/xmpp__tcp/lib/Connection.d.ts
@@ -1,4 +1,4 @@
-import Connection = require('@xmpp/connection-tcp');
+import Connection = require("@xmpp/connection-tcp");
 
 export = ConnectionTCP;
 

--- a/types/xmpp__tcp/xmpp__tcp-tests.ts
+++ b/types/xmpp__tcp/xmpp__tcp-tests.ts
@@ -1,13 +1,13 @@
-import Connection = require('@xmpp/connection');
-import ConnectionConnTCP = require('@xmpp/connection-tcp');
-import tcp = require('@xmpp/tcp');
-import ConnectionTCP = require('@xmpp/tcp/lib/Connection');
+import Connection = require("@xmpp/connection");
+import ConnectionConnTCP = require("@xmpp/connection-tcp");
+import tcp = require("@xmpp/tcp");
+import ConnectionTCP = require("@xmpp/tcp/lib/Connection");
 
 // test type exports
 type Entity = tcp.Entity;
 type Conn = ConnectionTCP;
 
-const conn = new ConnectionTCP({ domain: 'foo', service: 'bar' });
+const conn = new ConnectionTCP({ domain: "foo", service: "bar" });
 const connTcp: ConnectionConnTCP = conn;
 
 const entity = {

--- a/types/xmpp__time/xmpp__time-tests.ts
+++ b/types/xmpp__time/xmpp__time-tests.ts
@@ -1,17 +1,17 @@
-import { time, date, datetime, offset } from '@xmpp/time';
+import { date, datetime, offset, time } from "@xmpp/time";
 
 date(); // $ExpectType string
-date('05 October 2011 14:48 UTC'); // $ExpectType string
-date(new Date('05 October 2011 14:48 UTC')); // $ExpectType string
+date("05 October 2011 14:48 UTC"); // $ExpectType string
+date(new Date("05 October 2011 14:48 UTC")); // $ExpectType string
 
 time(); // $ExpectType string
-time('05 October 2011 14:48 UTC'); // $ExpectType string
-time(new Date('05 October 2011 14:48 UTC')); // $ExpectType string
+time("05 October 2011 14:48 UTC"); // $ExpectType string
+time(new Date("05 October 2011 14:48 UTC")); // $ExpectType string
 
 datetime(); // $ExpectType string
-datetime('05 October 2011 14:48 UTC'); // $ExpectType string
-datetime(new Date('05 October 2011 14:48 UTC')); // $ExpectType string
+datetime("05 October 2011 14:48 UTC"); // $ExpectType string
+datetime(new Date("05 October 2011 14:48 UTC")); // $ExpectType string
 
 offset(); // $ExpectType string
-offset('05 October 2011 14:48 UTC'); // $ExpectType string
-offset(new Date('05 October 2011 14:48 UTC')); // $ExpectType string
+offset("05 October 2011 14:48 UTC"); // $ExpectType string
+offset(new Date("05 October 2011 14:48 UTC")); // $ExpectType string

--- a/types/xmpp__tls/index.d.ts
+++ b/types/xmpp__tls/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
+import Connection = require("@xmpp/connection");
 
 export = tls;
 

--- a/types/xmpp__tls/lib/Connection.d.ts
+++ b/types/xmpp__tls/lib/Connection.d.ts
@@ -1,6 +1,6 @@
-import Connection = require('@xmpp/connection');
-import ConnectionTCP = require('@xmpp/connection-tcp');
-import Socket = require('./Socket');
+import Connection = require("@xmpp/connection");
+import ConnectionTCP = require("@xmpp/connection-tcp");
+import Socket = require("./Socket");
 
 export = ConnectionTLS;
 
@@ -16,6 +16,6 @@ declare namespace ConnectionTLS {
     }
 
     interface SocketConstructor extends Connection.SocketConstructor {
-        new (): Socket;
+        new(): Socket;
     }
 }

--- a/types/xmpp__tls/lib/Socket.d.ts
+++ b/types/xmpp__tls/lib/Socket.d.ts
@@ -1,6 +1,6 @@
-import { SocketBase } from '@xmpp/connection';
-import { ConnectionOptions, TLSSocket } from 'tls';
-import { EventEmitter } from 'events';
+import { SocketBase } from "@xmpp/connection";
+import { EventEmitter } from "events";
+import { ConnectionOptions, TLSSocket } from "tls";
 
 export = Socket;
 

--- a/types/xmpp__tls/xmpp__tls-tests.ts
+++ b/types/xmpp__tls/xmpp__tls-tests.ts
@@ -1,8 +1,8 @@
-import Connection = require('@xmpp/connection');
-import ConnectionTCP = require('@xmpp/connection-tcp');
-import tls = require('@xmpp/tls');
-import ConnectionTLS = require('@xmpp/tls/lib/Connection');
-import Socket = require('@xmpp/tls/lib/Socket');
+import Connection = require("@xmpp/connection");
+import ConnectionTCP = require("@xmpp/connection-tcp");
+import tls = require("@xmpp/tls");
+import ConnectionTLS = require("@xmpp/tls/lib/Connection");
+import Socket = require("@xmpp/tls/lib/Socket");
 
 // test type exports
 type Entity = tls.Entity;
@@ -15,71 +15,71 @@ type SockEvents = Socket.Events;
 const sock = new Socket();
 sock.timeout; // $ExpectType Timeout | null
 sock.socket; // $ExpectType TLSSocket | undefined
-sock.connect({ host: 'foo' }); // $ExpectType void
+sock.connect({ host: "foo" }); // $ExpectType void
 sock.end(); // $ExpectType void
 sock.write(new Uint8Array(10));
-sock.write('foo');
+sock.write("foo");
 sock.write(new Uint8Array(10), err => {
     err; // $ExpectType Error | undefined
 });
-sock.write('foo', err => {
+sock.write("foo", err => {
     err; // $ExpectType Error | undefined
 });
 
-sock.addListener('connect', () => {});
-sock.addListener('data', data => {
+sock.addListener("connect", () => {});
+sock.addListener("data", data => {
     data; // $ExpectType Buffer
 });
-sock.addListener('close', () => {});
-sock.addListener('error', err => {
+sock.addListener("close", () => {});
+sock.addListener("error", err => {
     err; // $ExpectType Error
 });
 
-sock.on('connect', () => {});
-sock.on('data', data => {
+sock.on("connect", () => {});
+sock.on("data", data => {
     data; // $ExpectType Buffer
 });
-sock.on('close', () => {});
-sock.on('error', err => {
+sock.on("close", () => {});
+sock.on("error", err => {
     err; // $ExpectType Error
 });
 
-sock.once('connect', () => {});
-sock.once('data', data => {
+sock.once("connect", () => {});
+sock.once("data", data => {
     data; // $ExpectType Buffer
 });
-sock.once('close', () => {});
-sock.once('error', err => {
+sock.once("close", () => {});
+sock.once("error", err => {
     err; // $ExpectType Error
 });
 
-sock.prependListener('connect', () => {});
-sock.prependListener('data', data => {
+sock.prependListener("connect", () => {});
+sock.prependListener("data", data => {
     data; // $ExpectType Buffer
 });
-sock.prependListener('close', () => {});
-sock.prependListener('error', err => {
+sock.prependListener("close", () => {});
+sock.prependListener("error", err => {
     err; // $ExpectType Error
 });
 
-sock.prependOnceListener('connect', () => {});
-sock.prependOnceListener('data', data => {
+sock.prependOnceListener("connect", () => {});
+sock.prependOnceListener("data", data => {
     data; // $ExpectType Buffer
 });
-sock.prependOnceListener('close', () => {});
-sock.prependOnceListener('error', err => {
+sock.prependOnceListener("close", () => {});
+sock.prependOnceListener("error", err => {
     err; // $ExpectType Error
 });
 
-sock.emit<'connect'>('connect');
-sock.emit<'data'>('data', Buffer.from('foo'));
-sock.emit<'close'>('close');
-sock.emit<'error'>('error', new Error('foo'));
+sock.emit<"connect">("connect");
+sock.emit<"data">("data", Buffer.from("foo"));
+sock.emit<"close">("close");
+sock.emit<"error">("error", new Error("foo"));
 
-const conn = new ConnectionTLS({ domain: 'foo', service: 'bar' });
+const conn = new ConnectionTLS({ domain: "foo", service: "bar" });
 const connTcp: ConnectionTCP = conn;
 conn.Socket; // $ExpectType SocketConstructor
-const sockParams = conn.socketParameters('foo'); // $ExpectType SocketParameters | undefined
+const sockParams = conn.socketParameters("foo"); // $ExpectType SocketParameters | undefined
 sockParams!.host; // $ExpectType string
 sockParams!.port; // $ExpectType number
 

--- a/types/xmpp__uri/index.d.ts
+++ b/types/xmpp__uri/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { JID } from '@xmpp/jid';
-import { ParsedUrlQuery } from 'querystring';
+import { JID } from "@xmpp/jid";
+import { ParsedUrlQuery } from "querystring";
 
 /**
  * Parse XMPP URIs.

--- a/types/xmpp__uri/xmpp__uri-tests.ts
+++ b/types/xmpp__uri/xmpp__uri-tests.ts
@@ -1,10 +1,10 @@
-import { parse, XMPPURI, XMPPURIQuery } from '@xmpp/uri';
+import { parse, XMPPURI, XMPPURIQuery } from "@xmpp/uri";
 
 // test type exports
 type XU = XMPPURI;
 type XUQ = XMPPURIQuery;
 
-const uri = parse('foo'); // $ExpectType XMPPURI
+const uri = parse("foo"); // $ExpectType XMPPURI
 
 uri.path; // $ExpectType JID
 uri.authority; // $ExpectType JID | undefined

--- a/types/xmpp__websocket/index.d.ts
+++ b/types/xmpp__websocket/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Connection = require('@xmpp/connection');
+import Connection = require("@xmpp/connection");
 
 export = websocket;
 

--- a/types/xmpp__websocket/lib/Connection.d.ts
+++ b/types/xmpp__websocket/lib/Connection.d.ts
@@ -1,7 +1,7 @@
-import Connection = require('@xmpp/connection');
-import { Element } from '@xmpp/xml';
-import FramedParser = require('./FramedParser');
-import Socket = require('./Socket');
+import Connection = require("@xmpp/connection");
+import { Element } from "@xmpp/xml";
+import FramedParser = require("./FramedParser");
+import Socket = require("./Socket");
 
 export = ConnectionWebSocket;
 

--- a/types/xmpp__websocket/lib/FramedParser.d.ts
+++ b/types/xmpp__websocket/lib/FramedParser.d.ts
@@ -1,4 +1,4 @@
-import { Parser } from '@xmpp/xml';
+import { Parser } from "@xmpp/xml";
 
 export = FramedParser;
 

--- a/types/xmpp__websocket/lib/Socket.d.ts
+++ b/types/xmpp__websocket/lib/Socket.d.ts
@@ -1,7 +1,7 @@
-import { SocketBase } from '@xmpp/connection';
-import { EventEmitter } from 'events';
-import { URL } from 'url';
-import WebSocket = require('ws');
+import { SocketBase } from "@xmpp/connection";
+import { EventEmitter } from "events";
+import { URL } from "url";
+import WebSocket = require("ws");
 
 export = Socket;
 
@@ -43,8 +43,8 @@ declare namespace Socket {
     }
 
     interface WebSocketError extends Error {
-        readonly errno?: 'ECONNERROR';
-        readonly code?: 'ECONNERROR';
+        readonly errno?: "ECONNERROR";
+        readonly code?: "ECONNERROR";
         readonly event: WebSocket.ErrorEvent;
         readonly url: string | URL;
     }

--- a/types/xmpp__websocket/xmpp__websocket-tests.ts
+++ b/types/xmpp__websocket/xmpp__websocket-tests.ts
@@ -1,11 +1,11 @@
-import Connection = require('@xmpp/connection');
-import websocket = require('@xmpp/websocket');
-import ConnectionWebSocket = require('@xmpp/websocket/lib/Connection');
-import FramedParser = require('@xmpp/websocket/lib/FramedParser');
-import Socket = require('@xmpp/websocket/lib/Socket');
-import { Element, Parser } from '@xmpp/xml';
-import { URL } from 'url';
-import { CloseEvent } from 'ws';
+import Connection = require("@xmpp/connection");
+import websocket = require("@xmpp/websocket");
+import ConnectionWebSocket = require("@xmpp/websocket/lib/Connection");
+import FramedParser = require("@xmpp/websocket/lib/FramedParser");
+import Socket = require("@xmpp/websocket/lib/Socket");
+import { Element, Parser } from "@xmpp/xml";
+import { URL } from "url";
+import { CloseEvent } from "ws";
 
 // test type exports
 type Entity = websocket.Entity;
@@ -17,22 +17,22 @@ type Err = Socket.WebSocketError;
 const sock = new Socket();
 sock.url; // $ExpectType string | URL | undefined
 sock.socket; // $ExpectType WebSocket | undefined
-sock.connect('foo'); // $ExpectType void
-sock.connect(new URL('foo')); // $ExpectType void
+sock.connect("foo"); // $ExpectType void
+sock.connect(new URL("foo")); // $ExpectType void
 sock.end(); // $ExpectType void
 sock.write(new Uint8Array(10), err => {
     err; // $ExpectType Error | undefined
 });
-sock.write('foo', err => {
+sock.write("foo", err => {
     err; // $ExpectType Error | undefined
 });
 
-sock.addListener('connect', () => {});
-sock.addListener('data', data => {
+sock.addListener("connect", () => {});
+sock.addListener("data", data => {
     data; // $ExpectType Data
 });
-sock.addListener('close', () => {});
-sock.addListener('error', err => {
+sock.addListener("close", () => {});
+sock.addListener("error", err => {
     err; // $ExpectType WebSocketError
     err.url; // $ExpectType string | URL
     err.event; // $ExpectType ErrorEvent
@@ -40,57 +40,57 @@ sock.addListener('error', err => {
     err.errno; // $ExpectType "ECONNERROR" | undefined
 });
 
-sock.on('connect', () => {});
-sock.on('data', data => {
+sock.on("connect", () => {});
+sock.on("data", data => {
     data; // $ExpectType Data
 });
-sock.on('close', () => {});
-sock.on('error', err => {
+sock.on("close", () => {});
+sock.on("error", err => {
     err; // $ExpectType WebSocketError
 });
 
-sock.once('connect', () => {});
-sock.once('data', data => {
+sock.once("connect", () => {});
+sock.once("data", data => {
     data; // $ExpectType Data
 });
-sock.once('close', () => {});
-sock.once('error', err => {
+sock.once("close", () => {});
+sock.once("error", err => {
     err; // $ExpectType WebSocketError
 });
 
-sock.prependListener('connect', () => {});
-sock.prependListener('data', data => {
+sock.prependListener("connect", () => {});
+sock.prependListener("data", data => {
     data; // $ExpectType Data
 });
-sock.prependListener('close', () => {});
-sock.prependListener('error', err => {
+sock.prependListener("close", () => {});
+sock.prependListener("error", err => {
     err; // $ExpectType WebSocketError
 });
 
-sock.prependOnceListener('connect', () => {});
-sock.prependOnceListener('data', data => {
+sock.prependOnceListener("connect", () => {});
+sock.prependOnceListener("data", data => {
     data; // $ExpectType Data
 });
-sock.prependOnceListener('close', () => {});
-sock.prependOnceListener('error', err => {
+sock.prependOnceListener("close", () => {});
+sock.prependOnceListener("error", err => {
     err; // $ExpectType WebSocketError
 });
 
-sock.emit<'connect'>('connect');
-sock.emit<'data'>('data', Buffer.from('foo'));
-sock.emit<'close'>('close', true, null as any as CloseEvent);
-sock.emit<'error'>('error', null as any as Socket.WebSocketError);
+sock.emit<"connect">("connect");
+sock.emit<"data">("data", Buffer.from("foo"));
+sock.emit<"close">("close", true, null as any as CloseEvent);
+sock.emit<"error">("error", null as any as Socket.WebSocketError);
 
 const fprsr = new FramedParser();
 const prsr: Parser = fprsr;
 
-const connWs = new ConnectionWebSocket({ domain: 'foo', service: 'bar' });
+const connWs = new ConnectionWebSocket({ domain: "foo", service: "bar" });
 const conn: Connection = connWs;
 connWs.Socket; // $ExpectType typeof Socket
 connWs.Parser; // $ExpectType typeof FramedParser
-connWs.sendMany([new Element('foo')]); // $ExpectType Promise<void>
-connWs.sendMany(new Set([new Element('foo')])); // $ExpectType Promise<void>
-connWs.socketParameters('foo'); // $ExpectType string | undefined
+connWs.sendMany([new Element("foo")]); // $ExpectType Promise<void>
+connWs.sendMany(new Set([new Element("foo")])); // $ExpectType Promise<void>
+connWs.socketParameters("foo"); // $ExpectType string | undefined
 
 const entity = {
     transports: [] as Array<typeof Connection>,

--- a/types/xmpp__xml/index.d.ts
+++ b/types/xmpp__xml/index.d.ts
@@ -5,9 +5,9 @@
 
 export = xml;
 
-import * as ltx from 'ltx';
-import * as escape from 'ltx/lib/escape';
-import LtxParser = require('ltx/lib/parsers/ltx');
+import * as ltx from "ltx";
+import * as escape from "ltx/lib/escape";
+import LtxParser = require("ltx/lib/parsers/ltx");
 
 declare function xml(...args: Parameters<typeof ltx.createElement>): ReturnType<typeof ltx.createElement>;
 
@@ -35,7 +35,7 @@ declare namespace xml {
     }
 
     class XMLError extends Error {
-        readonly name: 'XMLError';
+        readonly name: "XMLError";
     }
 }
 

--- a/types/xmpp__xml/xmpp__xml-tests.ts
+++ b/types/xmpp__xml/xmpp__xml-tests.ts
@@ -1,15 +1,15 @@
-import xml = require('@xmpp/xml');
-import { Parser as LtxParser } from 'ltx';
+import xml = require("@xmpp/xml");
+import { Parser as LtxParser } from "ltx";
 
 // test type exports
 type Element = xml.Element;
 type Node = xml.Node;
 type XMLError = xml.XMLError;
 
-xml.escapeXML(''); // $ExpectType string
-xml.unescapeXML(''); // $ExpectType string
-xml.escapeXMLText(''); // $ExpectType string
-xml.unescapeXMLText(''); // $ExpectType string
+xml.escapeXML(""); // $ExpectType string
+xml.unescapeXML(""); // $ExpectType string
+xml.escapeXMLText(""); // $ExpectType string
+xml.unescapeXMLText(""); // $ExpectType string
 
 xml.Parser.XMLError; // $ExpectType typeof XMLError
 const parser = new xml.Parser();
@@ -17,40 +17,40 @@ const ltxParser: LtxParser = parser;
 parser.parser; // $ExpectType SaxLtx
 parser.root; // $ExpectType Element | null
 parser.cursor; // $ExpectType Element | null
-parser.onStartElement('el'); // $ExpectType void
-parser.onEndElement('el'); // $ExpectType void
-parser.onText('text'); // $ExpectType void
-parser.write('foo'); // $ExpectType void
-parser.end('foo'); // $ExpectType void
+parser.onStartElement("el"); // $ExpectType void
+parser.onEndElement("el"); // $ExpectType void
+parser.onText("text"); // $ExpectType void
+parser.write("foo"); // $ExpectType void
+parser.end("foo"); // $ExpectType void
 
-const recipient = 'user@example.com';
-const days = ['Monday', 'Tuesday'];
+const recipient = "user@example.com";
+const days = ["Monday", "Tuesday"];
 // $ExpectType Element
 const message = xml(
-    'message',
+    "message",
     { to: recipient },
-    xml('body', {}, 'foo'),
-    xml('days', undefined, ...days.map(day => xml('day', {}, day))),
+    xml("body", {}, "foo"),
+    xml("days", undefined, ...days.map(day => xml("day", {}, day))),
 );
 
 message.attrs; // $ExpectType { [attrName: string]: any; }
-message.getChild('body')!.text(); // $ExpectType string
-message.getChild('body')!.toString(); // $ExpectType string
-message.getChild('days')!.getChildren('day'); // $ExpectType Element[]
-message.getChildText('body'); // $ExpectType string | null
+message.getChild("body")!.text(); // $ExpectType string
+message.getChild("body")!.toString(); // $ExpectType string
+message.getChild("days")!.getChildren("day"); // $ExpectType Element[]
+message.getChildText("body"); // $ExpectType string | null
 
-message.attrs.type = 'chat';
-Object.assign(message.attrs, { type: 'chat' });
-message.getChild('body')!.text('Hello world'); // $ExpectType Element
-message.append(xml('foo')); // $ExpectType void
-message.append('bar'); // $ExpectType void
-message.append(...days.map(day => xml('day', {}, day))); // $ExpectType void
-message.prepend(xml('foo')); // $ExpectType void
-message.prepend('bar'); // $ExpectType void
-message.prepend(...days.map(day => xml('day', {}, day))); // $ExpectType void
-const body = message.getChild('body');
+message.attrs.type = "chat";
+Object.assign(message.attrs, { type: "chat" });
+message.getChild("body")!.text("Hello world"); // $ExpectType Element
+message.append(xml("foo")); // $ExpectType void
+message.append("bar"); // $ExpectType void
+message.append(...days.map(day => xml("day", {}, day))); // $ExpectType void
+message.prepend(xml("foo")); // $ExpectType void
+message.prepend("bar"); // $ExpectType void
+message.prepend(...days.map(day => xml("day", {}, day))); // $ExpectType void
+const body = message.getChild("body");
 message.remove(body!); // $ExpectType Element
 
-const xmlError = new xml.XMLError('foo');
+const xmlError = new xml.XMLError("foo");
 const error: Error = xmlError;
 xmlError.name; // $ExpectType "XMLError"

--- a/types/xmpp__xml/xmpp__xml-tests.tsx
+++ b/types/xmpp__xml/xmpp__xml-tests.tsx
@@ -1,16 +1,14 @@
 /** @jsx xml */
 
-import xml = require('@xmpp/xml');
+import xml = require("@xmpp/xml");
 
-const recipient = 'user@example.com';
-const days = ['Monday', 'Tuesday'];
+const recipient = "user@example.com";
+const days = ["Monday", "Tuesday"];
 const message = (
     <message to={recipient}>
         <body>{1 + 2}</body>
         <days>
-            {days.map(day => (
-                <day>${day}</day>
-            ))}
+            {days.map(day => <day>${day}</day>)}
         </days>
     </message>
 );
@@ -19,8 +17,8 @@ const message = (
 message.append(
     <myevent xmlns="xmpp:example.org">
         <json xmlns="urn:xmpp:json:0">{JSON.stringify(days)}</json>
-    </myevent>
+    </myevent>,
 );
 
 // read
-JSON.parse(message.getChild('myevent', 'xmpp:example.org')!.getChildText('json', 'urn:xmpp:json:0')!);
+JSON.parse(message.getChild("myevent", "xmpp:example.org")!.getChildText("json", "urn:xmpp:json:0")!);

--- a/types/xo/index.d.ts
+++ b/types/xo/index.d.ts
@@ -4,7 +4,7 @@
 //                 Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import eslint = require('eslint');
+import eslint = require("eslint");
 
 // eslint.CLIEngine.getErrorResults without modification
 // eslint.CLIEngine.getFormatter without modification
@@ -30,45 +30,47 @@ export function outputFixes(report: ResultReport): void;
 
 export function getConfig(
     options: CLIEngineOptions & { filePath: string },
-): ReturnType<eslint.ESLint['calculateConfigForFile']>;
+): ReturnType<eslint.ESLint["calculateConfigForFile"]>;
 export function lintText(text: string, options?: Options): ResultReport;
 export function lintFiles(patterns: string | string[], options?: Options): ResultReport | Promise<ResultReport>;
 
-export type CLIEngineOptions = Pick<eslint.ESLint.Options, 'baseConfig' | 'cwd' | 'extensions' | 'fix' | 'ignore'> & {
+export type CLIEngineOptions = Pick<eslint.ESLint.Options, "baseConfig" | "cwd" | "extensions" | "fix" | "ignore"> & {
     envs?: string[] | undefined;
     globals?: string[] | undefined;
     parser?: string | undefined;
     plugins?: string[];
     rules?: { [name: string]: eslint.Linter.RuleLevel | eslint.Linter.RuleLevelAndOptions } | undefined;
 };
-export type ESLintOptions = Pick<eslint.Linter.LintOptions, 'filename'>;
-export type ESLintConfig = Pick<eslint.Linter.Config, 'extends' | 'settings'>;
+export type ESLintOptions = Pick<eslint.Linter.LintOptions, "filename">;
+export type ESLintConfig = Pick<eslint.Linter.Config, "extends" | "settings">;
 
-export type Options = {
-    /** Some paths are ignored by default, including paths in .gitignore and .eslintignore. Additional ignores can be added here */
-    ignores?: string[] | undefined;
-    /** Enable rules specific to the Node.js versions within the configured range */
-    nodeVersion?: string | boolean | undefined;
-    /** Format code with Prettier */
-    prettier?: boolean | undefined;
-    /**
-     *  Print the ESLint configuration for the given file
-     */
-    printConfig?: string | undefined;
-    /** Set it to false to enforce no-semicolon style. */
-    semicolon?: boolean | undefined;
-    /** Set it to true to get 2-space indentation or specify the number of spaces. */
-    space?: boolean | number | undefined;
-    /**
-     * Use {@link https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack}
-     * to resolve import search paths. This is enabled automatically if a `webpack.config.js` file is found.
-     * Set this to a boolean to explicitly enable or disable the resolver.
-     * @default false
-     */
-    webpack?: boolean | object | undefined;
-} & CLIEngineOptions &
-    ESLintConfig &
-    ESLintOptions;
+export type Options =
+    & {
+        /** Some paths are ignored by default, including paths in .gitignore and .eslintignore. Additional ignores can be added here */
+        ignores?: string[] | undefined;
+        /** Enable rules specific to the Node.js versions within the configured range */
+        nodeVersion?: string | boolean | undefined;
+        /** Format code with Prettier */
+        prettier?: boolean | undefined;
+        /**
+         *  Print the ESLint configuration for the given file
+         */
+        printConfig?: string | undefined;
+        /** Set it to false to enforce no-semicolon style. */
+        semicolon?: boolean | undefined;
+        /** Set it to true to get 2-space indentation or specify the number of spaces. */
+        space?: boolean | number | undefined;
+        /**
+         * Use {@link https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack}
+         * to resolve import search paths. This is enabled automatically if a `webpack.config.js` file is found.
+         * Set this to a boolean to explicitly enable or disable the resolver.
+         * @default false
+         */
+        webpack?: boolean | object | undefined;
+    }
+    & CLIEngineOptions
+    & ESLintConfig
+    & ESLintOptions;
 
 export interface ResultReport {
     readonly errorCount: number;

--- a/types/xo/xo-tests.ts
+++ b/types/xo/xo-tests.ts
@@ -1,19 +1,19 @@
-import xo = require('xo');
-import { Options } from 'xo';
+import xo = require("xo");
+import { Options } from "xo";
 
-const glob = 'some/path';
+const glob = "some/path";
 const options: Options = {};
 
 options.space = 2;
 options.space = true;
 options.space = false;
-options.printConfig = 'index.js';
+options.printConfig = "index.js";
 
 options.webpack = {
     config: {
         resolve: {
             alias: {
-                file2alias: './file2.js',
+                file2alias: "./file2.js",
             },
         },
     },
@@ -23,60 +23,60 @@ options.webpack = false;
 
 if (options.semicolon === false && !options.prettier) {
     if (options.rules) {
-        options.rules.semi = ['error', 'never'];
-        options.rules['semi-spacing'] = [
-            'error',
+        options.rules.semi = ["error", "never"];
+        options.rules["semi-spacing"] = [
+            "error",
             {
                 before: false,
                 after: true,
             },
         ];
-        options.rules['node/no-unsupported-features/es-builtins'] = ['error', { version: options.nodeVersion }];
-        options.rules['node/no-unsupported-features/es-syntax'] = [
-            'error',
-            { version: options.nodeVersion, ignores: ['modules'] },
+        options.rules["node/no-unsupported-features/es-builtins"] = ["error", { version: options.nodeVersion }];
+        options.rules["node/no-unsupported-features/es-syntax"] = [
+            "error",
+            { version: options.nodeVersion, ignores: ["modules"] },
         ];
-        options.rules['node/no-unsupported-features/node-builtins'] = ['error', { version: options.nodeVersion }];
+        options.rules["node/no-unsupported-features/node-builtins"] = ["error", { version: options.nodeVersion }];
     }
     if (options.plugins) {
-        options.plugins = options.plugins.concat('react');
+        options.plugins = options.plugins.concat("react");
     }
     if (options.prettier && options.plugins) {
-        options.plugins = options.plugins.concat('prettier');
+        options.plugins = options.plugins.concat("prettier");
         if (options.baseConfig && options.baseConfig.extends) {
-            options.baseConfig.extends = options.baseConfig.extends.concat('prettier');
-            options.baseConfig.extends = options.baseConfig.extends.concat('prettier/unicorn');
+            options.baseConfig.extends = options.baseConfig.extends.concat("prettier");
+            options.baseConfig.extends = options.baseConfig.extends.concat("prettier/unicorn");
         }
     }
 }
 let result = xo.lintText("'use strict'\nconsole.log('unicorn');\n");
 result = xo.lintText("'use strict'\nconsole.log('unicorn');\n", {
-    filename: 'ignored/index.js',
-    ignores: ['ignored/**/*.js'],
+    filename: "ignored/index.js",
+    ignores: ["ignored/**/*.js"],
 });
 xo.lintText("'use strict'\nconsole.log('unicorn');\n", {
-    filename: 'node_modules/ignored/index.js',
+    filename: "node_modules/ignored/index.js",
 });
 result.errorCount; // $ExpectType number
 result.warningCount; // $ExpectType number
 result.results; // LintResult[]
 
 (async () => {
-    const moreExtensionsResults = await xo.lintFiles(glob, { extensions: ['md'] });
-    const { errorCount, results, warningCount } = await xo.lintFiles('**/*', { cwd: 'fixtures/cwd' });
-    const report = await xo.lintFiles('**/*', { cwd: 'fixtures/cwd' });
+    const moreExtensionsResults = await xo.lintFiles(glob, { extensions: ["md"] });
+    const { errorCount, results, warningCount } = await xo.lintFiles("**/*", { cwd: "fixtures/cwd" });
+    const report = await xo.lintFiles("**/*", { cwd: "fixtures/cwd" });
     // only get the error messages
     const errorReport = xo.getErrorResults(result.results);
     // output fixes to disk
     xo.outputFixes(report);
     // tests for the formatter
     let formatter = xo.getFormatter();
-    formatter = xo.getFormatter('compact');
-    formatter = xo.getFormatter('./my/formatter.js');
-    xo.getFormatter('compact')(report.results);
+    formatter = xo.getFormatter("compact");
+    formatter = xo.getFormatter("./my/formatter.js");
+    xo.getFormatter("compact")(report.results);
     formatter(report.results); // $ExpectType string
     // tests getConfig
-    const config = await xo.getConfig({ filePath: './xo-tests.ts' }); // $ExpectType any
+    const config = await xo.getConfig({ filePath: "./xo-tests.ts" }); // $ExpectType any
     // @ts-expect-error
     await xo.getConfig({});
 })();

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -534,7 +534,7 @@ declare namespace Xrm {
         entityId?: string | undefined;
         /**
          * The parent record that provides default values based on mapped attribute values.
-         **/
+         */
         createFromEntity?: LookupValue | undefined;
         /**
          * ID of the currently displayed form.
@@ -822,12 +822,12 @@ declare namespace Xrm {
         }
 
         /**
-        * Form Data OnLoad event context.
-        * In the API documentation, this is sometimes referred to as the executionContext.
-        * Subscribe to this event with {@link Data.addOnLoad()}
-        * Not to be confused with {@link LoadEventContext}, registered in the designer.
-        * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/execution-context External Link: Execution context (Client API reference)}
-        */
+         * Form Data OnLoad event context.
+         * In the API documentation, this is sometimes referred to as the executionContext.
+         * Subscribe to this event with {@link Data.addOnLoad()}
+         * Not to be confused with {@link LoadEventContext}, registered in the designer.
+         * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/execution-context External Link: Execution context (Client API reference)}
+         */
         interface DataLoadEventContext extends EventContext {
             /**
              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/executioncontext/geteventargs#return-value External Link: getEventArgs (Client API reference)}
@@ -974,23 +974,23 @@ declare namespace Xrm {
 
         namespace Attribute {
             type ChangeEventHandler = (context: ChangeEventContext) => void;
-            interface ChangeEventContext extends EventContext { }
+            interface ChangeEventContext extends EventContext {}
         }
 
         namespace GridControl {
             type LoadEventHandler = (context: LoadEventContext) => void;
-            interface LoadEventContext extends EventContext { }
+            interface LoadEventContext extends EventContext {}
         }
 
         namespace KbSearchControl {
             type PostSearchEventHandler = (context: PostSearchEventContext) => void;
-            interface PostSearchEventContext extends EventContext { }
+            interface PostSearchEventContext extends EventContext {}
 
             type ResultOpenedEventHandler = (context: ResultOpenedEventContext) => void;
-            interface ResultOpenedEventContext extends EventContext { }
+            interface ResultOpenedEventContext extends EventContext {}
 
             type SelectionEventHandler = (context: SelectionEventContext) => void;
-            interface SelectionEventContext extends EventContext { }
+            interface SelectionEventContext extends EventContext {}
         }
     }
 
@@ -1905,31 +1905,31 @@ declare namespace Xrm {
         /**
          * @deprecated Use {@link Xrm.Controls.AddControlNotificationOptions} instead.
          */
-        interface AddControlNotificationOptions extends Controls.AddControlNotificationOptions { }
+        interface AddControlNotificationOptions extends Controls.AddControlNotificationOptions {}
 
         /**
          * Interface to define the actions on a control notification
          * @deprecated Use {@link Xrm.Controls.ControlNotificationAction} instead.
          */
-        interface ControlNotificationAction extends Controls.ControlNotificationAction { }
+        interface ControlNotificationAction extends Controls.ControlNotificationAction {}
 
         /**
          * Interface for an entity's form selector item.
          * @deprecated Use {@link Xrm.Controls.FormItem} instead.
          */
-        interface FormItem extends Controls.FormItem { }
+        interface FormItem extends Controls.FormItem {}
 
         /**
          * Interface for the form selector API.
          * @deprecated Use {@link Xrm.Controls.FormSelector} instead.
          */
-        interface FormSelector extends Controls.FormSelector { }
+        interface FormSelector extends Controls.FormSelector {}
 
         /**
          * Interface for Xrm.Page.ui.navigation.
          * @deprecated Use {@link Xrm.Controls.Navigation} instead.
          */
-        interface Navigation extends Controls.Navigation { }
+        interface Navigation extends Controls.Navigation {}
 
         /**
          * Interface for a navigation item.
@@ -1937,7 +1937,7 @@ declare namespace Xrm {
          * @see {@link UiFocusable}
          * @deprecated Use {@link Xrm.Controls.NavigationItem} instead.
          */
-        interface NavigationItem extends Controls.NavigationItem { }
+        interface NavigationItem extends Controls.NavigationItem {}
 
         /**
          * Constants to use with the addNotification method of form controls
@@ -1977,7 +1977,6 @@ declare namespace Xrm {
         /**
          * Control type for Xrm.Page.ui.QuickForm.getControlType().
          * @deprecated Use {@link Xrm.Controls.ControlQuickFormType} instead.
-         *
          */
         type ControlQuickFormType = Controls.ControlQuickFormType;
 
@@ -2033,43 +2032,43 @@ declare namespace Xrm {
          * Interface for a CRM Business Process Flow instance.
          * @deprecated Use {@link Xrm.ProcessFlow.Process} instead.
          */
-        interface Process extends ProcessFlow.Process { }
+        interface Process extends ProcessFlow.Process {}
 
         /**
          * Interface for CRM Business Process Flow stages.
          * @deprecated Use {@link Xrm.ProcessFlow.Stage} instead.
          */
-        interface Stage extends ProcessFlow.Stage { }
+        interface Stage extends ProcessFlow.Stage {}
 
         /**
          * Interface for CRM Business Process Flow steps.
          * @deprecated Use {@link Xrm.ProcessFlow.Step} instead.
          */
-        interface Step extends ProcessFlow.Step { }
+        interface Step extends ProcessFlow.Step {}
 
         /**
          * Interface for the event context.
          * @deprecated Use {@link Xrm.Events.EventContext} instead.
          */
-        interface EventContext extends Events.EventContext { }
+        interface EventContext extends Events.EventContext {}
 
         /**
          * Interface for a save event context
          * @deprecated Use {@link Xrm.Events.SaveEventContext} instead.
          */
-        interface SaveEventContext extends Events.SaveEventContext { }
+        interface SaveEventContext extends Events.SaveEventContext {}
 
         /**
          * Interface for a process stage change event context
          * @deprecated Use {@link Xrm.Events.StageChangeEventContext} instead.
          */
-        interface StageChangeEventContext extends Events.StageChangeEventContext { }
+        interface StageChangeEventContext extends Events.StageChangeEventContext {}
 
         /**
          * Interface for a process stage select event context
          * @deprecated  Use {@link Xrm.Events.StageSelectedEventContext} instead.
          */
-        interface StageSelectedEventContext extends Events.StageSelectedEventContext { }
+        interface StageSelectedEventContext extends Events.StageSelectedEventContext {}
 
         /**
          * Type for a context-sensitive handler.
@@ -2089,167 +2088,167 @@ declare namespace Xrm {
          * Interface for UI elements with labels.
          * @deprecated Use {@link Xrm.Controls.UiLabelElement} instead.
          */
-        interface UiLabelElement extends Controls.UiLabelElement { }
+        interface UiLabelElement extends Controls.UiLabelElement {}
 
         /**
          * Interface for UI elements which can have the visibility value read.
          * @deprecated Use {@link Xrm.Controls.UiCanGetVisibleElement} instead.
          */
-        interface UiCanGetVisibleElement extends Controls.UiCanGetVisibleElement { }
+        interface UiCanGetVisibleElement extends Controls.UiCanGetVisibleElement {}
 
         /**
          * Interface for UI elements which can have the visibility value updated.
          * @deprecated Use {@link Xrm.Controls.UiCanSetVisibleElement} instead.
          */
-        interface UiCanSetVisibleElement extends Controls.UiCanSetVisibleElement { }
+        interface UiCanSetVisibleElement extends Controls.UiCanSetVisibleElement {}
 
         /**
          * Base interface for standard UI elements.
          * @deprecated Use {@link Xrm.Controls.UiStandardElement} instead.
          */
-        interface UiStandardElement extends Controls.UiStandardElement { }
+        interface UiStandardElement extends Controls.UiStandardElement {}
 
         /**
          * Interface for focusable UI elements.
          * @deprecated Use {@link Xrm.Controls.UiFocusable} instead.
          */
-        interface UiFocusable extends Controls.UiFocusable { }
+        interface UiFocusable extends Controls.UiFocusable {}
 
         /**
          * Interface for controls which methods provide immediate feedback or take actions as user types in a control.
          * Contains methods which can be used to perform data validations in a control even before the user commits (saves) the value in a form.
          * @deprecated Use {@link Xrm.Controls.UiKeyPressable} instead.
          */
-        interface UiKeyPressable extends Controls.UiKeyPressable { }
+        interface UiKeyPressable extends Controls.UiKeyPressable {}
 
         /**
          * Interface for Result value of AutoCompleteResultSet
          * @deprecated Use {@link Xrm.Controls.AutoCompleteResult} instead.
          */
-        interface AutoCompleteResult extends Controls.AutoCompleteResult { }
+        interface AutoCompleteResult extends Controls.AutoCompleteResult {}
 
         /**
          * Interface for command of AutoCompleteResultSet.  This is displayed at the bottom of the auto complete view
          * @deprecated Use {@link Xrm.Controls.AutoCompleteCommand} instead.
          */
-        interface AutoCompleteCommand extends Controls.AutoCompleteCommand { }
+        interface AutoCompleteCommand extends Controls.AutoCompleteCommand {}
 
         /**
          * Interface for showAutoComplete argument
          * @deprecated Use {@link Xrm.Controls.AutoCompleteResultSet} instead.
          */
-        interface AutoCompleteResultSet extends Controls.AutoCompleteResultSet { }
+        interface AutoCompleteResultSet extends Controls.AutoCompleteResultSet {}
 
         /**
          * Interface for a Lookup value.
          * @deprecated Use {@link Xrm.LookupValue} instead.
          */
-        interface LookupValue extends Xrm.LookupValue { }
+        interface LookupValue extends Xrm.LookupValue {}
 
         /**
          * Interface for an OptionSet value.
          * @deprecated Use {@link Xrm.OptionSetValue} instead.
          */
-        interface OptionSetValue extends Xrm.OptionSetValue { }
+        interface OptionSetValue extends Xrm.OptionSetValue {}
 
         /**
          * Interface for a privilege.
          * @deprecated Use {@link Xrm.Privilege} instead.
          */
-        interface Privilege extends Xrm.Privilege { }
+        interface Privilege extends Xrm.Privilege {}
 
         /**
          * Interface for an Entity attribute.
          * @deprecated Use {@link Xrm.Attributes.Attribute} instead.
          */
-        interface Attribute extends Attributes.Attribute { }
+        interface Attribute extends Attributes.Attribute {}
 
         /**
          * Interface for a Number attribute.
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.NumberAttribute} instead.
          */
-        interface NumberAttribute extends Attributes.NumberAttribute { }
+        interface NumberAttribute extends Attributes.NumberAttribute {}
 
         /**
          * Interface for a String attribute.
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.StringAttribute} instead.
          */
-        interface StringAttribute extends Attributes.StringAttribute { }
+        interface StringAttribute extends Attributes.StringAttribute {}
 
         /**
          * Common interface for enumeration attributes (OptionSet and Boolean).
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.EnumAttribute} instead.
          */
-        interface EnumAttribute extends Attributes.EnumAttribute<number | boolean> { }
+        interface EnumAttribute extends Attributes.EnumAttribute<number | boolean> {}
 
         /**
          * Interface for a Boolean attribute.
          * @see {@link EnumAttribute}
          * @deprecated Use {@link Xrm.Attributes.BooleanAttribute} instead.
          */
-        interface BooleanAttribute extends Attributes.BooleanAttribute { }
+        interface BooleanAttribute extends Attributes.BooleanAttribute {}
 
         /**
          * Interface for a Date attribute.
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.DateAttribute} instead.
          */
-        interface DateAttribute extends Attributes.DateAttribute { }
+        interface DateAttribute extends Attributes.DateAttribute {}
 
         /**
          * Interface an OptionSet attribute.
          * @see {@link EnumAttribute}
          * @deprecated Use {@link Xrm.Attributes.OptionSetAttribute} instead.
          */
-        interface OptionSetAttribute extends Attributes.OptionSetAttribute { }
+        interface OptionSetAttribute extends Attributes.OptionSetAttribute {}
 
         /**
          * Interface a Lookup attribute.
          * @see {@link Attribute}
          * @deprecated Use {@link Xrm.Attributes.LookupAttribute} instead.
          */
-        interface LookupAttribute extends Attributes.LookupAttribute { }
+        interface LookupAttribute extends Attributes.LookupAttribute {}
 
         /**
          * Interface for the form's record context, Xrm.Page.data.entity
          * @deprecated Use {@link Xrm.Entity} instead.
          */
-        interface Entity extends Xrm.Entity { }
+        interface Entity extends Xrm.Entity {}
 
         /**
          * Interface for save event arguments.
          * @deprecated Use {@link Xrm.Events.SaveEventContext} instead.
          */
-        interface SaveEventArguments extends Events.SaveEventContext { }
+        interface SaveEventArguments extends Events.SaveEventContext {}
 
         /**
          * Interface for process stage change event arguments.
          * @deprecated Use {@link Xrm.Events.StageChangeEventArguments} instead.
          */
-        interface StageChangeEventArguments extends Events.StageChangeEventArguments { }
+        interface StageChangeEventArguments extends Events.StageChangeEventArguments {}
 
         /**
          * Interface for process stage selected event arguments.
          * @deprecated Use {@link Xrm.Events.StageSelectedEventArguments} instead.
          */
-        interface StageSelectedEventArguments extends Events.StageSelectedEventArguments { }
+        interface StageSelectedEventArguments extends Events.StageSelectedEventArguments {}
 
         /**
          * Interface for Xrm.Page.ui controls.
          * @see {@link UiElement}
          * @deprecated Use {@link Xrm.Controls.Control} instead.
          */
-        interface Control extends Controls.Control { }
+        interface Control extends Controls.Control {}
 
         /**
          * Interface for a standard control.
          * @see {@link Control}
          * @deprecated Use {@link Xrm.Controls.StandardControl} instead.
          */
-        interface StandardControl extends Controls.StandardControl { }
+        interface StandardControl extends Controls.StandardControl {}
 
         /**
          * Interface for Auto Lookup Control.
@@ -2258,42 +2257,42 @@ declare namespace Xrm {
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.AutoLookupControl} instead.
          */
-        interface AutoLookupControl extends Controls.AutoLookupControl { }
+        interface AutoLookupControl extends Controls.AutoLookupControl {}
 
         /**
          * Interface for a String control.
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.StringControl} instead.
          */
-        interface StringControl extends Controls.StringControl { }
+        interface StringControl extends Controls.StringControl {}
 
         /**
          * Interface for a Number control.
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.NumberControl} instead.
          */
-        interface NumberControl extends AutoLookupControl { }
+        interface NumberControl extends AutoLookupControl {}
 
         /**
          * Interface for a Date control.
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.DateControl} instead.
          */
-        interface DateControl extends StandardControl { }
+        interface DateControl extends StandardControl {}
 
         /**
          * Interface for a Lookup control.
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.LookupControl} instead.
          */
-        interface LookupControl extends Controls.LookupControl { }
+        interface LookupControl extends Controls.LookupControl {}
 
         /**
          * Interface for an OptionSet control.
          * @see {@link StandardControl}
          * @deprecated Use {@link Xrm.Controls.OptionSetControl} instead.
          */
-        interface OptionSetControl extends Controls.OptionSetControl { }
+        interface OptionSetControl extends Controls.OptionSetControl {}
 
         /**
          * Interface for a CRM grid control.
@@ -2301,7 +2300,7 @@ declare namespace Xrm {
          * @see {@link Control}
          * @deprecated  Use {@link Xrm.Controls.GridControl} instead.
          */
-        interface GridControl extends Controls.GridControl { }
+        interface GridControl extends Controls.GridControl {}
 
         /**
          * Interface for a framed control, which is either a Web Resource or an Iframe.
@@ -2310,28 +2309,28 @@ declare namespace Xrm {
          *              appropriate.  Silverlight controls should use {@link SilverlightControl}.
          * @deprecated  Use {@link Xrm.Controls.FramedControl} instead.
          */
-        interface FramedControl extends Controls.FramedControl { }
+        interface FramedControl extends Controls.FramedControl {}
 
         /**
          * Interface for an Iframe control.
          * @see {@link FramedControl}
          * @deprecated  Use {@link Xrm.Controls.IframeControl} instead.
          */
-        interface IframeControl extends Controls.IframeControl { }
+        interface IframeControl extends Controls.IframeControl {}
 
         /**
          * Interface for a Silverlight control.
          * @see {@link Control}
          * @deprecated Use {@link Xrm.Controls.SilverlightControl} instead.
          */
-        interface SilverlightControl extends Controls.SilverlightControl { }
+        interface SilverlightControl extends Controls.SilverlightControl {}
 
         /**
          * Interface for a Timeline control.
          * @see {@link Control}
          * @deprecated Use {@link Xrm.Controls.TimelineWall} instead.
          */
-        interface TimelineWall extends Controls.TimelineWall { }
+        interface TimelineWall extends Controls.TimelineWall {}
 
         /**
          * Interface for a form tab.
@@ -2339,14 +2338,14 @@ declare namespace Xrm {
          * @see {@link UiFocusable}
          * @deprecated Use {@link Xrm.Controls.Tab} instead.
          */
-        interface Tab extends Controls.Tab { }
+        interface Tab extends Controls.Tab {}
 
         /**
          * Interface for a form section.
          * @see {@link UiElement}
          * @deprecated Use {@link Xrm.Controls.Section} instead.
          */
-        interface Section extends Controls.Section { }
+        interface Section extends Controls.Section {}
 
         /**
          * Module for the Xrm.Page.data API.
@@ -2357,7 +2356,7 @@ declare namespace Xrm {
              * Interface for the Xrm.Page.data.process API.
              * @deprecated Use {@link Xrm.ProcessFlow.ProcessManager} instead.
              */
-            interface ProcessManager extends ProcessFlow.ProcessManager { }
+            interface ProcessManager extends ProcessFlow.ProcessManager {}
 
             /**
              * Called when method to get active processes is complete
@@ -2411,7 +2410,7 @@ declare namespace Xrm {
              * Represents a key-value pair, where the key is the Process Flow's ID, and the value is the name thereof.
              * @deprecated Use {@link Xrm.ProcessFlow.ProcessDictionary} instead.
              */
-            interface ProcessDictionary extends ProcessFlow.ProcessDictionary { }
+            interface ProcessDictionary extends ProcessFlow.ProcessDictionary {}
         }
 
         /**
@@ -2435,14 +2434,14 @@ declare namespace Xrm {
              * Interface for Xrm.Page.ui.process API
              * @deprecated Use {@link Xrm.Controls.ProcessControl} instead.
              */
-            interface ProcessManager extends Controls.ProcessControl { }
+            interface ProcessManager extends Controls.ProcessControl {}
 
             /**
              * Interface for a grid.  Use Grid methods to access information about data in the grid. Grid is returned by the
              * GridControl.getGrid method.
              * @deprecated Use {@link Xrm.Controls.Grid} instead.
              */
-            interface Grid extends Controls.Grid { }
+            interface Grid extends Controls.Grid {}
 
             /**
              * Interface for a grid row.  Use the GridRow.getData method to access the GridRowData. A collection of GridRow is
@@ -2450,42 +2449,42 @@ declare namespace Xrm {
              * In V9 - this is essentailly a form context.
              * @deprecated Use {@link Xrm.Controls.Grid.GridRow} instead.
              */
-            interface GridRow extends Controls.Grid.GridRow { }
+            interface GridRow extends Controls.Grid.GridRow {}
 
             /**
              * Interface for grid row data.  Use the GridRowData.getEntity method to access the GridEntity. GridRowData is
              * returned by the GridRow.getData method.
              * @deprecated Use {@link Xrm.Controls.Grid.GridRowData} instead.
              */
-            interface GridRowData extends Controls.Grid.GridRowData { }
+            interface GridRowData extends Controls.Grid.GridRowData {}
 
             /**
              * Interface for a grid entity.  Use the GridEntity methods to access data about the specific records in the rows.
              * GridEntity is returned by the GridRowData.getEntity method.
              * @deprecated Use {@link Xrm.Controls.Grid.GridRowData} instead.v
              */
-            interface GridEntity extends Controls.Grid.GridEntity { }
+            interface GridEntity extends Controls.Grid.GridEntity {}
 
             /**
              * Interface for the view selector.  Use the ViewSelector methods to get or set information about the view selector
              * of the grid control.
              * @deprecated Use {@link Xrm.Controls.ViewSelector} instead.
              */
-            interface ViewSelector extends Controls.ViewSelector { }
+            interface ViewSelector extends Controls.ViewSelector {}
 
             /**
              * Interface for a view selector item. This object contains data that identifies a view. Use this as a parameter to
              * the ViewSelector.setCurrentView method.
              * @deprecated Use {@link Xrm.Controls.ViewSelectorItem} instead.
              */
-            interface ViewSelectorItem extends Controls.ViewSelectorItem { }
+            interface ViewSelectorItem extends Controls.ViewSelectorItem {}
 
             /**
              * Interface for a quick view control instance on a form.
              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/formcontext-ui-quickforms External Link: formContext.ui.quickForms (client-side reference)}
              * @deprecated Use {@link Xrm.Controls.ViewSelectorItem} instead.
              */
-            interface QuickForm extends Controls.QuickFormControl { }
+            interface QuickForm extends Controls.QuickFormControl {}
         }
     }
 
@@ -2846,7 +2845,7 @@ declare namespace Xrm {
             /**
              * Gets the attribute format.
              * @returns the string "boolean"
-             **/
+             */
             getAttributeType(): "boolean";
         }
 
@@ -2932,11 +2931,11 @@ declare namespace Xrm {
             controls: Collection.ItemCollection<Controls.OptionSetControl>;
         }
 
-         /**
+        /**
          * Interface an OptionSet attribute.
          * @see {@link EnumAttribute}
          */
-         interface MultiSelectOptionSetAttribute extends EnumAttribute<number[]> {
+        interface MultiSelectOptionSetAttribute extends EnumAttribute<number[]> {
             /**
              * Gets the attribute format.
              * @returns The format of the attribute.
@@ -3304,11 +3303,8 @@ declare namespace Xrm {
          * @see {@link Control}
          */
         interface StandardControl
-            extends Control,
-            UiStandardElement,
-            UiFocusable,
-            UiCanGetDisabledElement,
-            UiCanSetDisabledElement {
+            extends Control, UiStandardElement, UiFocusable, UiCanGetDisabledElement, UiCanSetDisabledElement
+        {
             /**
              * Clears the notification identified by uniqueId.
              * @param uniqueId (Optional) Unique identifier.
@@ -3400,9 +3396,9 @@ declare namespace Xrm {
         }
 
         /**
-        * Interface for a Boolean (yes/no) control.
-        * @see {@link StandardControl}
-        */
+         * Interface for a Boolean (yes/no) control.
+         * @see {@link StandardControl}
+         */
         interface BooleanControl extends StandardControl {
             /**
              * Gets the control's bound attribute.
@@ -3594,7 +3590,7 @@ declare namespace Xrm {
         }
 
         interface MultiSelectOptionSetControl extends StandardControl {
-             /**
+            /**
              * Adds an option.
              *
              * @param option The option.
@@ -3603,26 +3599,26 @@ declare namespace Xrm {
              * @remarks This method does not check that the values within the options you add are valid.
              *          If index is not provided, the new option will be added to the end of the list.
              */
-             addOption(option: OptionSetValue, index?: number): void;
+            addOption(option: OptionSetValue, index?: number): void;
 
-             /**
-              * Clears all options.
-              */
-             clearOptions(): void;
+            /**
+             * Clears all options.
+             */
+            clearOptions(): void;
 
-             /**
-              * Gets the control's bound attribute.
-              *
-              * @returns The attribute.
-              */
-             getAttribute(): Attributes.MultiSelectOptionSetAttribute;
+            /**
+             * Gets the control's bound attribute.
+             *
+             * @returns The attribute.
+             */
+            getAttribute(): Attributes.MultiSelectOptionSetAttribute;
 
-             /**
-              * Removes the option matching the value.
-              *
-              * @param value The value.
-              */
-             removeOption(value: number): void;
+            /**
+             * Removes the option matching the value.
+             *
+             * @param value The value.
+             */
+            removeOption(value: number): void;
         }
 
         /**
@@ -3732,8 +3728,8 @@ declare namespace Xrm {
         }
 
         /**
-             * Object containing information about the relationship used to filter the subgrid.
-             */
+         * Object containing information about the relationship used to filter the subgrid.
+         */
         interface GridRelationship {
             /**
              * Name of the column
@@ -3887,19 +3883,19 @@ declare namespace Xrm {
         }
 
         /**
-          * Interface for a knowledge base search control
-          */
+         * Interface for a knowledge base search control
+         */
         interface KbSearchControl extends Control {
             /**
-              * Adds an event handler to the PostSearch event.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/addonpostsearch External Link: addOnPostSearch (Client API reference)}
-              */
+             * Adds an event handler to the PostSearch event.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/addonpostsearch External Link: addOnPostSearch (Client API reference)}
+             */
             addOnPostSearch(handler: Events.KbSearchControl.PostSearchEventHandler): void;
 
             /**
-              * Adds an event handler to the OnResultOpened event.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/addonresultopened External Link: addOnResultOpened (Client API reference)}
-              */
+             * Adds an event handler to the OnResultOpened event.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/addonresultopened External Link: addOnResultOpened (Client API reference)}
+             */
             addOnResultOpened(handler: Events.KbSearchControl.ResultOpenedEventHandler): void;
 
             /**
@@ -3909,59 +3905,59 @@ declare namespace Xrm {
             addOnSelection(handler: Events.KbSearchControl.SelectionEventHandler): void;
 
             /**
-              * Gets the text used as the search criteria for the knowledge base management control.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getsearchquery External Link: getSearchQuery (Client API reference)}
-              */
+             * Gets the text used as the search criteria for the knowledge base management control.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getsearchquery External Link: getSearchQuery (Client API reference)}
+             */
             getSearchQuery(): string;
 
             /**
-              * Gets the currently selected result of the search control. The currently selected result also represents the result that is currently open.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getselectedresults External Link: getSelectedResults (Client API Reference)}
-              */
+             * Gets the currently selected result of the search control. The currently selected result also represents the result that is currently open.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getselectedresults External Link: getSelectedResults (Client API Reference)}
+             */
             getSelectedResults(): KbSearchResult;
 
             /**
-              * Gets the count of results found in the search control.
-              * @returns The count of the search result.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/gettotalresultcount External Link: getTotalResultCount (Client API reference)}
-              */
+             * Gets the count of results found in the search control.
+             * @returns The count of the search result.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/gettotalresultcount External Link: getTotalResultCount (Client API reference)}
+             */
             getTotalResultCount(): number;
 
             /**
-              * Opens a search result in the search control by specifying the result number.
-              * @param resultNumber Numerical value specifying the result number to be opened. Result number starts from 1.
-              * @param mode Specify "Inline" or "Popout". "Inline" mode opens the result inline either in the reading pane of the control or in a reference panel tab in case of reference panel. "Popout" mode opens the result in a pop-out window.
-              * @returns Status of opening the specified search result. Returns 1 if successful; 0 if unsuccessful. The method will return -1 if the specified resultNumber value is not present, or if the specified mode value is invalid.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/opensearchresult External Link: openSearchResult (Client API reference)}
-              */
+             * Opens a search result in the search control by specifying the result number.
+             * @param resultNumber Numerical value specifying the result number to be opened. Result number starts from 1.
+             * @param mode Specify "Inline" or "Popout". "Inline" mode opens the result inline either in the reading pane of the control or in a reference panel tab in case of reference panel. "Popout" mode opens the result in a pop-out window.
+             * @returns Status of opening the specified search result. Returns 1 if successful; 0 if unsuccessful. The method will return -1 if the specified resultNumber value is not present, or if the specified mode value is invalid.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/opensearchresult External Link: openSearchResult (Client API reference)}
+             */
             openSearchResult(resultNumber: number, mode?: XrmEnum.OpenSearchResultMode): boolean;
 
             /**
-              * Removes an event handler from the PostSearch event.
-              * @param handler The function to remove from the PostSearch event.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonpostsearch External Link: removeOnPostSearch (Client API reference)}
-              */
+             * Removes an event handler from the PostSearch event.
+             * @param handler The function to remove from the PostSearch event.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonpostsearch External Link: removeOnPostSearch (Client API reference)}
+             */
             removeOnPostSearch(handler: Events.KbSearchControl.PostSearchEventHandler): void;
 
             /**
-              * Removes an event handler from the OnResultOpened event.
-              * @param handler The function to remove from the OnResultOpened event.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonresultopened External Link: removeOnResultOpened (Client API reference)}
-              */
+             * Removes an event handler from the OnResultOpened event.
+             * @param handler The function to remove from the OnResultOpened event.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonresultopened External Link: removeOnResultOpened (Client API reference)}
+             */
             removeOnResultOpened(handler: Events.KbSearchControl.ResultOpenedEventHandler): void;
 
             /**
-              * Removes an event handler from the OnResultSelection event.
-              * @param handler The function to remove from the OnSelection event.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonselection External Link: removeOnSelection (Client API reference)}
-              */
+             * Removes an event handler from the OnResultSelection event.
+             * @param handler The function to remove from the OnSelection event.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/removeonselection External Link: removeOnSelection (Client API reference)}
+             */
             removeOnSelection(handler: Events.KbSearchControl.SelectionEventHandler): void;
 
             /**
-              * Sets the text used as the search criteria for the knowledge base search control.
-              * @param searchString The text for the search query.
-              * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/setsearchquery External Link: setSearchQuery (Client API reference)}
-              */
+             * Sets the text used as the search criteria for the knowledge base search control.
+             * @param searchString The text for the search query.
+             * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/setsearchquery External Link: setSearchQuery (Client API reference)}
+             */
             setSearchQuery(searchString: string): void;
         }
 
@@ -4062,13 +4058,15 @@ declare namespace Xrm {
          * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/formcontext-ui-quickforms External Link: formContext.ui.quickForms (Client API reference)}
          */
         interface QuickFormControl
-            extends Control,
-            UiLabelElement,
-            UiFocusable,
-            UiCanGetDisabledElement,
-            UiCanSetDisabledElement,
-            UiCanGetVisibleElement,
-            UiCanSetVisibleElement {
+            extends
+                Control,
+                UiLabelElement,
+                UiFocusable,
+                UiCanGetDisabledElement,
+                UiCanSetDisabledElement,
+                UiCanGetVisibleElement,
+                UiCanSetVisibleElement
+        {
             /**
              * Gets the constituent controls in a quick view control.
              * @returns An array of controls.
@@ -5417,11 +5415,11 @@ declare namespace Xrm {
             pageType: "entityrecord";
             /**
              * Logical name of the entity to display the form for.
-             * */
+             */
             entityName: string;
             /**
              * ID of the entity record to display the form for. If you don't specify this value, the form will be opened in create mode.
-             * */
+             */
             entityId?: string | undefined;
             /**
              * Designates a record that will provide default values based on mapped attribute values. The lookup object has the following String properties: entityType, id, and name (optional).
@@ -5469,15 +5467,15 @@ declare namespace Xrm {
             pageType: "entitylist";
             /**
              * The logical name of the entity to load in the list control.
-             * */
+             */
             entityName: string;
             /**
              * The ID of the view to load. If you don't specify it, navigates to the default main view for the entity.
-             * */
+             */
             viewId?: string | undefined;
             /**
              * Type of view to load. Specify "savedquery" or "userquery".
-             * */
+             */
             viewType?: "savedquery" | "userquery" | undefined;
         }
 
@@ -5489,11 +5487,11 @@ declare namespace Xrm {
             name: string;
             /**
              * The logical name of the table to be made available in the custom page via Param("entityName").
-             * */
+             */
             entityName?: string | undefined;
             /**
              * ID of the table record to be made available in the custom page via Param("recordId").
-             * */
+             */
             recordId?: string | undefined;
         }
 
@@ -5501,11 +5499,11 @@ declare namespace Xrm {
             pageType: "webresource";
             /**
              * The name of the web resource to load.
-             * */
+             */
             webresourceName: string;
             /**
              * The data to pass to the web resource.
-             * */
+             */
             data?: string | undefined;
         }
 
@@ -5519,24 +5517,24 @@ declare namespace Xrm {
 
         /**
          * Options for navigating to a page: whether to open inline or in a dialog. If you don't specify this parameter, page is opened inline by default.
-         * */
+         */
         interface NavigationOptions {
             /**
              * Specify 1 to open the page inline; 2 to open the page in a dialog.
              * Entity lists can only be opened inline; web resources can be opened either inline or in a dialog.
-             * */
+             */
             target: 1 | 2;
             /**
              * The width of dialog. To specify the width in pixels, just type a numeric value. To specify the width in percentage, specify an object of type
-             * */
+             */
             width?: number | NavigationOptions.SizeValue | undefined;
             /**
              * The width of dialog. To specify the width in pixels, just type a numeric value. To specify the width in percentage, specify an object of type
-             * */
+             */
             height?: number | NavigationOptions.SizeValue | undefined;
             /**
              * Specify 1 to open the dialog in center; 2 to open the dialog on the side. Default is 1 (center).
-             * */
+             */
             position?: 1 | 2 | undefined;
             /*
              * The dialog title on top of the center or side dialog.
@@ -5548,11 +5546,11 @@ declare namespace Xrm {
             interface SizeValue {
                 /**
                  * The numerical value
-                 * */
+                 */
                 value: number;
                 /**
                  * The unit of measurement. Specify "%" or "px". Default value is "px"
-                 * */
+                 */
                 unit: "%" | "px";
             }
         }
@@ -6292,7 +6290,7 @@ declare namespace Xrm {
     /**
      * Interface for the WebAPI Execute request response
      */
-    interface ExecuteResponse extends Response { }
+    interface ExecuteResponse extends Response {}
 }
 
 declare namespace XrmEnum {
@@ -6372,7 +6370,7 @@ declare namespace XrmEnum {
      */
     const enum GridClient {
         Browser = 0,
-        MobileApplication = 1
+        MobileApplication = 1,
     }
 
     /**
@@ -6515,10 +6513,10 @@ declare namespace XrmEnum {
      * @see {@link Xrm.AppNotificationLevel}
      */
     const enum AppNotificationLevel {
-      Success = 1,
-      Error = 2,
-      Warning = 3,
-      Information = 4,
+        Success = 1,
+        Error = 2,
+        Warning = 3,
+        Information = 4,
     }
 
     /**
@@ -6705,6 +6703,6 @@ declare namespace XrmEnum {
 
     const enum OpenSearchResultMode {
         Inline = "Inline",
-        Popup = "Popup"
+        Popup = "Popup",
     }
 }

--- a/types/xrm/v6/index.d.ts
+++ b/types/xrm/v6/index.d.ts
@@ -3,13 +3,11 @@
 // Definitions by: David Berry <https://github.com/6ix4our/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Xrm
-{
+declare namespace Xrm {
     /**
      * Interface for the client context.
      */
-    export interface ClientContext
-    {
+    export interface ClientContext {
         /**
          * Returns a value to indicate which client the script is executing in.
          *
@@ -28,8 +26,7 @@ declare namespace Xrm
     /**
      * Interface for the xRM application context.
      */
-    export interface Context
-    {
+    export interface Context {
         /**
          * The client's context instance.
          */
@@ -122,19 +119,17 @@ declare namespace Xrm
          *
          * @remarks Format: "/"+ OrgName + sPath
          */
-        prependOrgName( sPath: string ): string;
+        prependOrgName(sPath: string): string;
     }
 
     /**
      *  A definition module for asynchronous interface declarations.
      */
-    export namespace Async
-    {
+    export namespace Async {
         /**
          * Interface for success callbacks.
          */
-        export interface SuccessCallbackDelegate
-        {
+        export interface SuccessCallbackDelegate {
             /**
              * Called when the operation is successful.
              */
@@ -144,44 +139,40 @@ declare namespace Xrm
         /**
          * Interface for error callbacks.
          */
-        export interface ErrorCallbackDelegate
-        {
+        export interface ErrorCallbackDelegate {
             /**
              * Called when the operation fails.
              *
              * @param   {number}    errorCode   The error code.
              * @param   {string}    message     The message.
              */
-            ( errorCode: number, message: string ): void;
+            (errorCode: number, message: string): void;
         }
 
         /**
          * Interface for Xrm.Page.data promises.
          */
-        export interface XrmPromise
-        {
+        export interface XrmPromise {
             /**
              * A basic 'then' promise.
              *
              * @param   {SuccessCallbackDelegate}   successCallback   The success callback.
              * @param   {ErrorCallbackDelegate}     errorCallback     The error callback.
              */
-            then( successCallback: SuccessCallbackDelegate, errorCallback: ErrorCallbackDelegate ): void;
+            then(successCallback: SuccessCallbackDelegate, errorCallback: ErrorCallbackDelegate): void;
         }
     }
 
     /**
      * A definition module for collection interface declarations.
      */
-    export namespace Collection
-    {
+    export namespace Collection {
         /**
          * Interface for a matching delegate.
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface MatchingDelegate<T>
-        {
+        export interface MatchingDelegate<T> {
             /**
              * Called for each item in an array
              *
@@ -190,7 +181,7 @@ declare namespace Xrm
              *
              * @return  true if the item matches, false if it does not.
              */
-            ( item: T, index?: number ): boolean;
+            (item: T, index?: number): boolean;
         }
 
         /**
@@ -198,15 +189,14 @@ declare namespace Xrm
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface IterativeDelegate<T>
-        {
+        export interface IterativeDelegate<T> {
             /**
              * Called for each item in an array
              *
              * @param   {T} item            The item.
              * @param   {number}    index   Zero-based index of the item array.
              */
-            ( item: T, index?: number ): void;
+            (item: T, index?: number): void;
         }
 
         /**
@@ -214,14 +204,13 @@ declare namespace Xrm
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface ItemCollection<T>
-        {
+        export interface ItemCollection<T> {
             /**
              * Applies an operation to all items in this collection.
              *
              * @param   {IterativeDelegate{T}}  delegate    An iterative delegate function
              */
-            forEach( delegate: IterativeDelegate<T> ): void;
+            forEach(delegate: IterativeDelegate<T>): void;
 
             /**
              * Gets.
@@ -230,7 +219,7 @@ declare namespace Xrm
              *
              * @return  A T[] whose members have been validated by delegate.
              */
-            get( delegate: MatchingDelegate<T> ): T[];
+            get(delegate: MatchingDelegate<T>): T[];
 
             /**
              * Gets the item given by the index.
@@ -239,7 +228,7 @@ declare namespace Xrm
              *
              * @return  The T in the itemNumber-th place.
              */
-            get( itemNumber: number ): T;
+            get(itemNumber: number): T;
 
             /**
              * Gets the item given by the key.
@@ -250,7 +239,7 @@ declare namespace Xrm
              *
              * @see {@link Xrm.Page.Control.getName()} for Control-naming schemes.
              */
-            get( itemName: string ): T;
+            get(itemName: string): T;
 
             /**
              * Gets the entire array of T.
@@ -273,26 +262,23 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328255.aspx|Documentation} for details.
      */
-    export namespace Page
-    {
+    export namespace Page {
         /**
          * Enumeration of entity form states/types.
          */
-        export const enum FormType
-        {
+        export const enum FormType {
             Undefined = 0,
             Create = 1,
             Update = 2,
             ReadOnly = 3,
             Disabled = 4,
-            BulkEdit = 6
+            BulkEdit = 6,
         }
 
         /**
          * Enumeration of entity form save modes.
          */
-        export const enum SaveMode
-        {
+        export const enum SaveMode {
             Save = 1,
             SaveAndClose = 2,
             SaveAndNew = 59,
@@ -303,14 +289,13 @@ declare namespace Xrm
             Assign = 47,
             Send = 7,
             Qualify = 16,
-            Disqualify = 15
+            Disqualify = 15,
         }
 
         /**
          * Interface for the event context.
          */
-        export interface EventContext
-        {
+        export interface EventContext {
             /**
              * Gets the Xrm context.
              *
@@ -351,7 +336,7 @@ declare namespace Xrm
              *
              * @remarks Used to pass values between handlers of an event.
              */
-            getSharedVariable<T>( key: string ): T;
+            getSharedVariable<T>(key: string): T;
 
             /**
              * Sets a shared variable.
@@ -362,25 +347,23 @@ declare namespace Xrm
              *
              * @remarks Used to pass values between handlers of an event.
              */
-            setSharedVariable<T>( key: string, value: T ): void;
+            setSharedVariable<T>(key: string, value: T): void;
         }
 
         /**
          * Interface for a context-sensitive handler.
          */
-        export interface ContextSensitiveHandler
-        {
+        export interface ContextSensitiveHandler {
             /**
              * @param   {EventContext}  context The context.
              */
-            ( context?: EventContext ): void;
+            (context?: EventContext): void;
         }
 
         /**
          * Base interface for UI elements.
          */
-        export interface UiElement
-        {
+        export interface UiElement {
             /**
              * Gets the label.
              *
@@ -400,21 +383,20 @@ declare namespace Xrm
              *
              * @param   {string}    label   The label.
              */
-            setLabel( label: string ): void;
+            setLabel(label: string): void;
 
             /**
              * Sets the visibility state.
              *
              * @param   {boolean}   visible true to show, false to hide.
              */
-            setVisible( visible: boolean ): void;
+            setVisible(visible: boolean): void;
         }
 
         /**
          * Interface for focusable UI elements.
          */
-        export interface UiFocusable
-        {
+        export interface UiFocusable {
             /**
              * Sets focus on the element.
              */
@@ -424,8 +406,7 @@ declare namespace Xrm
         /**
          * Interface for a Lookup value.
          */
-        export interface LookupValue
-        {
+        export interface LookupValue {
             /**
              * The identifier.
              */
@@ -445,8 +426,7 @@ declare namespace Xrm
         /**
          * Interface for an OptionSet value.
          */
-        export interface OptionSetValue
-        {
+        export interface OptionSetValue {
             /**
              * The label text.
              */
@@ -464,8 +444,7 @@ declare namespace Xrm
         /**
          * Interface for a privilege.
          */
-        export interface Privilege
-        {
+        export interface Privilege {
             /**
              * true if the user can read.
              */
@@ -485,8 +464,7 @@ declare namespace Xrm
         /**
          * Interface for an Entity attribute.
          */
-        export interface Attribute
-        {
+        export interface Attribute {
             /**
              * A collection of all the controls on the form that interface with this attribute.
              */
@@ -497,7 +475,7 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}  handler The function reference.
              */
-            addOnChange( handler: ContextSensitiveHandler ): void;
+            addOnChange(handler: ContextSensitiveHandler): void;
 
             /**
              * Fire all "on change" event handlers.
@@ -593,56 +571,56 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            removeOnChange( handler: ContextSensitiveHandler ): void;
+            removeOnChange(handler: ContextSensitiveHandler): void;
 
             /**
              * Sets required level.
              *
              * @param   {"none"}    requirementLevel    Not required.
              */
-            setRequiredLevel( requirementLevel: "none" ): void;
+            setRequiredLevel(requirementLevel: "none"): void;
 
             /**
              * Sets required level.
              *
              * @param   {"required"}    requirementLevel    Required.
              */
-            setRequiredLevel( requirementLevel: "required" ): void;
+            setRequiredLevel(requirementLevel: "required"): void;
 
             /**
              * Sets required level.
              *
              * @param   {"recommended"}    requirementLevel    Recommended.
              */
-            setRequiredLevel( requirementLevel: "recommended" ): void;
+            setRequiredLevel(requirementLevel: "recommended"): void;
 
             /**
              * Sets the required level.
              *
              * @param   {string}    requirementLevel    The requirement level, as either "none", "required", or "recommended"
              */
-            setRequiredLevel( requirementLevel: string ): void;
+            setRequiredLevel(requirementLevel: string): void;
 
             /**
              * Sets submit mode.
              *
              * @param   {"always"}    submitMode  Always submit this attribute.
              */
-            setSubmitMode( submitMode: "always" ): void;
+            setSubmitMode(submitMode: "always"): void;
 
             /**
              * Sets submit mode.
              *
              * @param   {"never"}    submitMode  Never submit this attribute.
              */
-            setSubmitMode( submitMode: "never" ): void;
+            setSubmitMode(submitMode: "never"): void;
 
             /**
              * Sets submit mode.
              *
              * @param   {"dirty"}    submitMode  Submit this attribute when changed.
              */
-            setSubmitMode( submitMode: "dirty" ): void;
+            setSubmitMode(submitMode: "dirty"): void;
 
             /**
              * Sets the submit mode.
@@ -651,14 +629,13 @@ declare namespace Xrm
              *
              * @remarks The default value is "dirty"
              */
-            setSubmitMode( submitMode: string ): void;
+            setSubmitMode(submitMode: string): void;
         }
 
         /**
          * Interface for a Number attribute.
          */
-        export interface NumberAttribute extends Attribute
-        {
+        export interface NumberAttribute extends Attribute {
             /**
              * Gets the maximum value allowed.
              *
@@ -694,14 +671,13 @@ declare namespace Xrm
              *
              * @remarks Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: number ): void;
+            setValue(value: number): void;
         }
 
         /**
          * Interface for a String attribute.
          */
-        export interface StringAttribute extends Attribute
-        {
+        export interface StringAttribute extends Attribute {
             /**
              * Gets maximum length allowed.
              *
@@ -727,14 +703,13 @@ declare namespace Xrm
              *              address formatting. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue( value: string ): void;
+            setValue(value: string): void;
         }
 
         /**
          * Common interface for enumeration attributes (OptionSet and Boolean).
          */
-        export interface EnumAttribute extends Attribute
-        {
+        export interface EnumAttribute extends Attribute {
             /**
              * Gets the initial value of the attribute.
              *
@@ -747,8 +722,7 @@ declare namespace Xrm
         /**
          * Interface for a Boolean attribute.
          */
-        export interface BooleanAttribute extends EnumAttribute
-        {
+        export interface BooleanAttribute extends EnumAttribute {
             /**
              * Gets the value.
              *
@@ -763,14 +737,13 @@ declare namespace Xrm
              *
              * @remarks  Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: boolean ): void;
+            setValue(value: boolean): void;
         }
 
         /**
          * Interface for a Date attribute.
          */
-        export interface DateAttribute extends Attribute
-        {
+        export interface DateAttribute extends Attribute {
             /**
              * Gets the value.
              *
@@ -785,14 +758,13 @@ declare namespace Xrm
              *
              * @remarks  Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: Date ): void;
+            setValue(value: Date): void;
         }
 
         /**
          * Interface an OptionSet attribute.
          */
-        export interface OptionSetAttribute extends EnumAttribute
-        {
+        export interface OptionSetAttribute extends EnumAttribute {
             /**
              * Gets the option matching a value.
              *
@@ -800,7 +772,7 @@ declare namespace Xrm
              *
              * @return  The option.
              */
-            getOption( value: number ): OptionSetValue;
+            getOption(value: number): OptionSetValue;
 
             /**
              * Gets the option matching a label.
@@ -809,7 +781,7 @@ declare namespace Xrm
              *
              * @return  The option.
              */
-            getOption( label: string ): OptionSetValue;
+            getOption(label: string): OptionSetValue;
 
             /**
              * Gets all of the options.
@@ -849,14 +821,13 @@ declare namespace Xrm
              *              OptionSet attribute. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue( value: number ): void;
+            setValue(value: number): void;
         }
 
         /**
          * Interface a Lookup attribute.
          */
-        export interface LookupAttribute extends Attribute
-        {
+        export interface LookupAttribute extends Attribute {
             /**
              * Gets a boolean value indicating whether the Lookup is a multi-value PartyList.
              *
@@ -878,14 +849,13 @@ declare namespace Xrm
              *
              * @remarks Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: LookupValue[] ): void;
+            setValue(value: LookupValue[]): void;
         }
 
         /**
          * Interface for the form's record context, Xrm.Page.data.entity
          */
-        export interface Entity
-        {
+        export interface Entity {
             /**
              * The collection of attributes for the record.
              */
@@ -896,7 +866,7 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            addOnSave( handler: ContextSensitiveHandler ): void;
+            addOnSave(handler: ContextSensitiveHandler): void;
 
             /**
              * Gets an serialized-XML string representing data that will be passed to the server upon saving
@@ -947,7 +917,7 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            removeOnSave( handler: ContextSensitiveHandler ): void;
+            removeOnSave(handler: ContextSensitiveHandler): void;
 
             /**
              * Saves the record.
@@ -963,14 +933,14 @@ declare namespace Xrm
              *
              * @param   {"saveandclose"}    saveMode    Saves the record, and closes the form.
              */
-            save( saveMode: "saveandclose" ): void;
+            save(saveMode: "saveandclose"): void;
 
             /**
              * Saves the record with the given save mode.
              *
              * @param   {"saveandnew"}  saveMode    Saves the record, and opens a blank form.
              */
-            save( saveMode: "saveandnew" ): void;
+            save(saveMode: "saveandnew"): void;
 
             /**
              * Saves the record with the given save mode.
@@ -978,14 +948,13 @@ declare namespace Xrm
              * @param   {string}    saveMode    (Optional) the save mode to save, as either "saveandclose" or
              *                                  "saveandnew".
              */
-            save( saveMode: string ): void;
+            save(saveMode: string): void;
         }
 
         /**
          * Interface for save event arguments.
          */
-        export interface SaveEventArguments
-        {
+        export interface SaveEventArguments {
             /**
              * Gets save mode, as an integer.
              *
@@ -1022,8 +991,7 @@ declare namespace Xrm
         /**
          * Interface for the Xrm.Page.data API.
          */
-        export interface Data
-        {
+        export interface Data {
             /**
              * The record context of the form.
              */
@@ -1036,7 +1004,7 @@ declare namespace Xrm
              *
              * @return  An Async.XrmPromise.
              */
-            refresh( save: boolean ): Async.XrmPromise;
+            refresh(save: boolean): Async.XrmPromise;
 
             /**
              * Asynchronously saves the record.
@@ -1049,8 +1017,7 @@ declare namespace Xrm
         /**
          * Interface for Xrm.Page.ui controls.
          */
-        export interface Control extends UiElement
-        {
+        export interface Control extends UiElement {
             /**
              * Clears the notification identified by uniqueId.
              *
@@ -1060,7 +1027,7 @@ declare namespace Xrm
              *
              * @remarks If the uniqueId parameter is not used, the current notification shown will be removed.
              */
-            clearNotification( uniqueId?: string ): boolean;
+            clearNotification(uniqueId?: string): boolean;
 
             /**
              * Gets the control's type.
@@ -1114,7 +1081,7 @@ declare namespace Xrm
              *
              * @param   {boolean}   disabled    true to disable, false to enable.
              */
-            setDisabled( disabled: boolean ): void;
+            setDisabled(disabled: boolean): void;
 
             /**
              * Sets a control-local notification message.
@@ -1127,14 +1094,13 @@ declare namespace Xrm
              * @remarks     When this method is used on Microsoft Dynamics CRM for tablets a red "X" icon
              *              appears next to the control. Tapping on the icon will display the message.
              */
-            setNotification( message: string, uniqueId: string ): boolean;
+            setNotification(message: string, uniqueId: string): boolean;
         }
 
         /**
          * Interface for a standard control.
          */
-        export interface StandardControl extends Control
-        {
+        export interface StandardControl extends Control {
             /**
              * Gets the control's bound attribute.
              *
@@ -1155,8 +1121,7 @@ declare namespace Xrm
         /**
          * Interface for a Date control.
          */
-        export interface DateControl extends StandardControl
-        {
+        export interface DateControl extends StandardControl {
             /**
              * Gets the control's bound attribute.
              *
@@ -1169,20 +1134,19 @@ declare namespace Xrm
              *
              * @param   {boolean}   showTimeValue   true to show, false to hide the time value.
              */
-            setShowTime( showTimeValue: boolean ): void;
+            setShowTime(showTimeValue: boolean): void;
         }
 
         /**
          * Interface for a Lookup control.
          */
-        export interface LookupControl extends StandardControl
-        {
+        export interface LookupControl extends StandardControl {
             /**
              * Adds a handler to the "pre search" event of the Lookup control.
              *
              * @param   {Function}  handler The handler.
              */
-            addPreSearch( handler: () => void ): void;
+            addPreSearch(handler: () => void): void;
 
             /**
              * Adds an additional custom filter to the lookup, with the "AND" filter operator.
@@ -1198,7 +1162,7 @@ declare namespace Xrm
              *                              <condition attribute="address1_city" operator="eq" value="Redmond" />
              *                              </filter>
              */
-            addCustomFilter( filter: string, entityLogicalName?: string ): void;
+            addCustomFilter(filter: string, entityLogicalName?: string): void;
 
             /**
              * Adds a custom view for the Lookup dialog.
@@ -1216,7 +1180,14 @@ declare namespace Xrm
              *          Example viewId value: "{00000000-0000-0000-0000-000000000001}"
              *          Layout XML Reference: {@link http://msdn.microsoft.com/en-us/library/gg334522.aspx}
              */
-            addCustomView( viewId: string, entityName: string, viewDisplayName: string, fetchXml: string, layoutXml: string, isDefault: boolean ): void;
+            addCustomView(
+                viewId: string,
+                entityName: string,
+                viewDisplayName: string,
+                fetchXml: string,
+                layoutXml: string,
+                isDefault: boolean,
+            ): void;
 
             /**
              * Gets the control's bound attribute.
@@ -1239,7 +1210,7 @@ declare namespace Xrm
              *
              * @param   {Function}  handler The handler.
              */
-            removePreSearch( handler: () => void ): void;
+            removePreSearch(handler: () => void): void;
 
             /**
              * Sets the Lookup's default view.
@@ -1248,14 +1219,13 @@ declare namespace Xrm
              *
              * @remarks Example viewGuid value: "{00000000-0000-0000-0000-000000000000}"
              */
-            setDefaultView( viewGuid: string ): void;
+            setDefaultView(viewGuid: string): void;
         }
 
         /**
          * Interface for an OptionSet control.
          */
-        export interface OptionSetControl extends StandardControl
-        {
+        export interface OptionSetControl extends StandardControl {
             /**
              * Adds an option.
              *
@@ -1265,7 +1235,7 @@ declare namespace Xrm
              * @remarks This method does not check that the values within the options you add are valid.
              *          If index is not provided, the new option will be added to the end of the list.
              */
-            addOption( option: OptionSetValue, index?: number ): void;
+            addOption(option: OptionSetValue, index?: number): void;
 
             /**
              * Clears all options.
@@ -1284,14 +1254,13 @@ declare namespace Xrm
              *
              * @param   {number}    value   The value.
              */
-            removeOption( value: number ): void;
+            removeOption(value: number): void;
         }
 
         /**
          * Interface for a CRM grid control.
          */
-        export interface GridControl extends Control
-        {
+        export interface GridControl extends Control {
             /**
              * Refreshes the sub grid.
              *
@@ -1306,8 +1275,7 @@ declare namespace Xrm
          * @remarks     An Iframe control provides additional methods, so use {@link IframeControl} where
          *              appropriate.  Silverlight controls should use {@link SilverlightControl}.
          */
-        export interface FramedControl extends Control
-        {
+        export interface FramedControl extends Control {
             /**
              * Gets the DOM element containing the control.
              *
@@ -1333,14 +1301,13 @@ declare namespace Xrm
              *
              * @remarks Unavailable for Microsoft Dynamics CRM for tablets.
              */
-            setSrc( src: string ): void;
+            setSrc(src: string): void;
         }
 
         /**
          * Interface for an Iframe control.
          */
-        export interface IframeControl extends FramedControl
-        {
+        export interface IframeControl extends FramedControl {
             /**
              * Gets initial URL defined for the Iframe.
              *
@@ -1354,8 +1321,7 @@ declare namespace Xrm
         /**
          * Interface for a Silverlight control.
          */
-        export interface SilverlightControl extends Control
-        {
+        export interface SilverlightControl extends Control {
             /**
              * Gets the query string value passed to Silverlight.
              *
@@ -1372,7 +1338,7 @@ declare namespace Xrm
              *
              * @remarks Unavailable for Microsoft Dynamics CRM for tablets.
              */
-            setData( data: string ): void;
+            setData(data: string): void;
 
             /**
              * Gets the DOM element containing the control.
@@ -1387,8 +1353,7 @@ declare namespace Xrm
         /**
          * Interface for a form tab.
          */
-        export interface Tab extends UiElement, UiFocusable
-        {
+        export interface Tab extends UiElement, UiFocusable {
             /**
              * A reference to the collection of form sections within this tab.
              */
@@ -1420,28 +1385,27 @@ declare namespace Xrm
              *
              * @param   {"collapsed"}   displayState    Collapsed tab.
              */
-            setDisplayState( displayState: "collapsed" ): void;
+            setDisplayState(displayState: "collapsed"): void;
 
             /**
              * Sets display state of the tab.
              *
              * @param   {"expanded"}    displayState    Expanded tab.
              */
-            setDisplayState( displayState: "expanded" ): void;
+            setDisplayState(displayState: "expanded"): void;
 
             /**
              * Sets display state of the tab.
              *
              * @param   {string}    displayState   Display state of the tab, as either "expanded" or "collapsed"
              */
-            setDisplayState( displayState: string ): void;
+            setDisplayState(displayState: string): void;
         }
 
         /**
          * Interface for a form section.
          */
-        export interface Section extends UiElement
-        {
+        export interface Section extends UiElement {
             /**
              * A reference to the collection of controls within this tab.
              */
@@ -1465,8 +1429,7 @@ declare namespace Xrm
         /**
          * Interface for Xrm.Page.ui API.
          */
-        export interface Ui
-        {
+        export interface Ui {
             /**
              * A reference to the collection of controls on the form.
              */
@@ -1498,7 +1461,7 @@ declare namespace Xrm
              *
              * @return  true if it succeeds, otherwise false.
              */
-            clearFormNotification( uniqueId: string ): boolean;
+            clearFormNotification(uniqueId: string): boolean;
 
             /**
              * Closes the form.
@@ -1554,7 +1517,7 @@ declare namespace Xrm
              *
              * @return  true if it succeeds, false if it fails.
              */
-            setFormNotification( message: string, level: "ERROR", uniqueId: string ): boolean;
+            setFormNotification(message: string, level: "ERROR", uniqueId: string): boolean;
 
             /**
              * Sets a form-level notification.
@@ -1565,7 +1528,7 @@ declare namespace Xrm
              *
              * @return  true if it succeeds, false if it fails.
              */
-            setFormNotification( message: string, level: "WARNING", uniqueId: string ): boolean;
+            setFormNotification(message: string, level: "WARNING", uniqueId: string): boolean;
 
             /**
              * Sets a form-level notification.
@@ -1576,7 +1539,7 @@ declare namespace Xrm
              *
              * @return  true if it succeeds, false if it fails.
              */
-            setFormNotification( message: string, level: "INFO", uniqueId: string ): boolean;
+            setFormNotification(message: string, level: "INFO", uniqueId: string): boolean;
 
             /**
              * Sets a form-level notification.
@@ -1587,14 +1550,13 @@ declare namespace Xrm
              *
              * @return  true if it succeeds, otherwise false.
              */
-            setFormNotification( message: string, level: string, uniqueId: string ): boolean;
+            setFormNotification(message: string, level: string, uniqueId: string): boolean;
         }
 
         /**
          * Interface for a navigation item.
          */
-        export interface NavigationItem extends UiElement, UiFocusable
-        {
+        export interface NavigationItem extends UiElement, UiFocusable {
             /**
              * Gets the name of the item.
              *
@@ -1606,8 +1568,7 @@ declare namespace Xrm
         /**
          * Interface for Xrm.Page.ui.navigation.
          */
-        export interface Navigation
-        {
+        export interface Navigation {
             /**
              * A reference to the collection of available navigation items.
              */
@@ -1617,8 +1578,7 @@ declare namespace Xrm
         /**
          * Interface for an entity's form selector item.
          */
-        export interface FormItem
-        {
+        export interface FormItem {
             /**
              * Gets the unique identifier of the form.
              *
@@ -1642,8 +1602,7 @@ declare namespace Xrm
         /**
          * Interface for the form selector API.
          */
-        export interface FormSelector
-        {
+        export interface FormSelector {
             /**
              * Gets current form.
              *
@@ -1689,7 +1648,7 @@ declare namespace Xrm
          *
          * @return  The attribute.
          */
-        export function getAttribute<T extends Attribute>( attributeName: string ): T;
+        export function getAttribute<T extends Attribute>(attributeName: string): T;
 
         /**
          * Gets an attribute matching attributeName.
@@ -1698,7 +1657,7 @@ declare namespace Xrm
          *
          * @return  The attribute.
          */
-        export function getAttribute( attributeName: string ): Attribute;
+        export function getAttribute(attributeName: string): Attribute;
 
         /**
          * Gets an attribute by index.
@@ -1707,7 +1666,7 @@ declare namespace Xrm
          *
          * @return  The attribute.
          */
-        export function getAttribute( index: number ): Attribute;
+        export function getAttribute(index: number): Attribute;
 
         /**
          * Gets an attribute.
@@ -1716,7 +1675,7 @@ declare namespace Xrm
          *
          * @return  An array of attribute.
          */
-        export function getAttribute( delegateFunction: Collection.MatchingDelegate<Attribute> ): Attribute[];
+        export function getAttribute(delegateFunction: Collection.MatchingDelegate<Attribute>): Attribute[];
 
         /**
          * Gets all controls.
@@ -1733,7 +1692,7 @@ declare namespace Xrm
          *
          * @return  The control.
          */
-        export function getControl<T extends Control>( controlName: string ): T;
+        export function getControl<T extends Control>(controlName: string): T;
 
         /**
          * Gets a control matching controlName.
@@ -1742,7 +1701,7 @@ declare namespace Xrm
          *
          * @return  The control.
          */
-        export function getControl( controlName: string ): Control;
+        export function getControl(controlName: string): Control;
 
         /**
          * Gets a control by index.
@@ -1751,7 +1710,7 @@ declare namespace Xrm
          *
          * @return  The control.
          */
-        export function getControl( index: number ): Control;
+        export function getControl(index: number): Control;
 
         /**
          * Gets a control.
@@ -1760,7 +1719,7 @@ declare namespace Xrm
          *
          * @return  An array of control.
          */
-        export function getControl( delegateFunction: Collection.MatchingDelegate<Control> ): Control[];
+        export function getControl(delegateFunction: Collection.MatchingDelegate<Control>): Control[];
     }
 
     /**
@@ -1768,15 +1727,13 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
      */
-    export namespace Url
-    {
+    export namespace Url {
         /**
          * An enumeration for view types.
          */
-        export const enum ViewType
-        {
+        export const enum ViewType {
             SystemView = 1039,
-            UserView = 4230
+            UserView = 4230,
         }
 
         /**
@@ -1789,8 +1746,7 @@ declare namespace Xrm
          * @remarks  A member for "pagetype" is not provided.  The value "entityrecord" is required in
          *           the URL, for forms. Example:  "pagetype=entityrecord"
          */
-        export interface FormOpenParameters
-        {
+        export interface FormOpenParameters {
             /**
              * The logical name of the entity.
              */
@@ -1832,8 +1788,7 @@ declare namespace Xrm
          * @remarks  A member for "pagetype" is not provided.  The value "entitylist" is required in
          *           the URL, for views. Example:  "pagetype=entitylist"
          */
-        export interface ViewOpenParameters
-        {
+        export interface ViewOpenParameters {
             /**
              * The logical name of the entity.
              */
@@ -1877,8 +1832,7 @@ declare namespace Xrm
          *
          * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
          */
-        export interface DialogOpenParameters
-        {
+        export interface DialogOpenParameters {
             /**
              * The unique identifier of the dialog, in Guid format, which is valid for the entity described
              * by: {@link EntityName}
@@ -1903,8 +1857,7 @@ declare namespace Xrm
          *
          * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
          */
-        export interface ReportOpenParameters
-        {
+        export interface ReportOpenParameters {
             /**
              * The action to perform, as either "run" or "filter".
              *
@@ -1931,13 +1884,11 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328255.aspx|Documentation} for details.
      */
-    export namespace Utility
-    {
+    export namespace Utility {
         /**
          * Interface for defining parameters on a Xrm.Utility.openEntityForm() request.
          */
-        export interface FormOpenParameters
-        {
+        export interface FormOpenParameters {
             /**
              * The identifier of the form to use, when several are available.
              */
@@ -1974,7 +1925,7 @@ declare namespace Xrm
          * @param   {string}        message         The message.
          * @param   {function()}    onCloseCallback The "OK" callback.
          */
-        export function alertDialog( message: string, onCloseCallback: () => void ): void;
+        export function alertDialog(message: string, onCloseCallback: () => void): void;
 
         /**
          * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
@@ -1983,7 +1934,7 @@ declare namespace Xrm
          * @param   {function()}    yesCloseCallback    The "OK" callback.
          * @param   {function()}    noCloseCallback     The "Cancel" callback.
          */
-        export function confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
+        export function confirmDialog(message: string, yesCloseCallback: () => void, noCloseCallback: () => void): void;
 
         /**
          * Query if 'entityType' is an Activity entity.
@@ -1992,7 +1943,7 @@ declare namespace Xrm
          *
          * @return  true if the entity is an Activity, false if not.
          */
-        export function isActivityType( entityType: string ): boolean;
+        export function isActivityType(entityType: string): boolean;
 
         /**
          * Opens an entity form.
@@ -2001,7 +1952,7 @@ declare namespace Xrm
          * @param   {string}    id                  (Optional) The unique identifier for the record.
          * @param   {FormParameters}    parameters  (Optional) Options for controlling the operation.
          */
-        export function openEntityForm( name: string, id?: string, parameters?: FormOpenParameters ): void;
+        export function openEntityForm(name: string, id?: string, parameters?: FormOpenParameters): void;
 
         /**
          * Opens an HTML Web Resource in a new browser window.
@@ -2024,7 +1975,12 @@ declare namespace Xrm
          *                                              data (identical to this method's webResourceData parameter)
          *                                              formid
          */
-        export function openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
+        export function openWebResource(
+            webResourceName: string,
+            webResourceData?: string,
+            width?: number,
+            height?: number,
+        ): Window;
     }
 }
 

--- a/types/xrm/v6/xrm-tests.ts
+++ b/types/xrm/v6/xrm-tests.ts
@@ -1,67 +1,70 @@
-
-function _getContext()
-{
+function _getContext() {
     const errorMessage = "Context is not available.";
-    if ( typeof GetGlobalContext !== "undefined" )
-    { return GetGlobalContext(); }
-    else
-    {
-        if ( typeof Xrm !== "undefined" )
-        {
+    if (typeof GetGlobalContext !== "undefined") {
+        return GetGlobalContext();
+    } else {
+        if (typeof Xrm !== "undefined") {
             return Xrm.Page.context;
-        }
-        else { throw new Error( errorMessage ); }
+        } else throw new Error(errorMessage);
     }
 }
 
 const crmContext = _getContext();
 
-const grids = Xrm.Page.getControl(( control ) =>
-{
+const grids = Xrm.Page.getControl((control) => {
     return control.getControlType() === "subgrid";
 });
 
 const selectedGridReferences: Xrm.Page.LookupValue[] = [];
 
-grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
-{
+grids.forEach((gridControl: Xrm.Page.GridControl) => {
     gridControl.refresh();
 });
 
-const lookupAttribute = Xrm.Page.getControl<Xrm.Page.LookupControl>( "customerid" );
+const lookupAttribute = Xrm.Page.getControl<Xrm.Page.LookupControl>("customerid");
 
-lookupAttribute.addCustomFilter( `<filter type="and">
+lookupAttribute.addCustomFilter(
+    `<filter type="and">
     <condition attribute="address1_city" operator="eq" value="Redmond" />
-</filter>`, "account" );
+</filter>`,
+    "account",
+);
 
-lookupAttribute.addPreSearch(() => { alert( "A search was performed." ); });
+lookupAttribute.addPreSearch(() => {
+    alert("A search was performed.");
+});
 
 const lookupValues = lookupAttribute.getAttribute().getValue();
 
-if ( lookupValues !== null )
-    if ( !lookupValues[0].id || !lookupValues[0].entityType )
+if (lookupValues !== null) {
+    if (!lookupValues[0].id || !lookupValues[0].entityType) {
         throw new Error("Invalid value in Lookup control.");
+    }
+}
 
-Xrm.Page.ui.controls.forEach(( control ) => { control.setVisible( true ); });
+Xrm.Page.ui.controls.forEach((control) => {
+    control.setVisible(true);
+});
 
-Xrm.Page.ui.tabs.forEach(( tab ) =>
-{
-    tab.setVisible( true );
+Xrm.Page.ui.tabs.forEach((tab) => {
+    tab.setVisible(true);
 
-    tab.sections.forEach(( section ) =>
-    {
-        section.setVisible( true );
+    tab.sections.forEach((section) => {
+        section.setVisible(true);
     });
 });
 
-Xrm.Page.data.entity.addOnSave(( context ) =>
-{
+Xrm.Page.data.entity.addOnSave((context) => {
     const eventArgs = context.getEventArgs();
 
-    if ( eventArgs.getSaveMode() === Xrm.Page.SaveMode.AutoSave || eventArgs.getSaveMode() === Xrm.Page.SaveMode.SaveAndClose )
+    if (
+        eventArgs.getSaveMode() === Xrm.Page.SaveMode.AutoSave
+        || eventArgs.getSaveMode() === Xrm.Page.SaveMode.SaveAndClose
+    ) {
         eventArgs.preventDefault();
+    }
 });
 
-alert( `The current form type is: ${Xrm.Page.ui.getFormType() }` );
+alert(`The current form type is: ${Xrm.Page.ui.getFormType()}`);
 
-alert( `The current entity type is: ${Xrm.Page.data.entity.getEntityName() }` );
+alert(`The current entity type is: ${Xrm.Page.data.entity.getEntityName()}`);

--- a/types/xrm/v7/index.d.ts
+++ b/types/xrm/v7/index.d.ts
@@ -6,19 +6,16 @@
 declare var Xrm: Xrm.XrmStatic;
 declare function GetGlobalContext(): Xrm.Context;
 
-interface Window
-{
+interface Window {
     Xrm: Xrm.XrmStatic;
     GetGlobalContext(): Xrm.Context;
 }
 
-declare namespace Xrm
-{
+declare namespace Xrm {
     /**
      * Static xRM object.
      */
-    export interface XrmStatic
-    {
+    export interface XrmStatic {
         /**
          * Provides a namespace container for the context, data and ui objects.
          */
@@ -53,7 +50,7 @@ declare namespace Xrm
              *
              * @return  The attribute.
              */
-            getAttribute<T extends Page.Attribute>( attributeName: string ): T;
+            getAttribute<T extends Page.Attribute>(attributeName: string): T;
 
             /**
              * Gets an attribute matching attributeName.
@@ -62,7 +59,7 @@ declare namespace Xrm
              *
              * @return  The attribute.
              */
-            getAttribute( attributeName: string ): Page.Attribute;
+            getAttribute(attributeName: string): Page.Attribute;
 
             /**
              * Gets an attribute by index.
@@ -71,7 +68,7 @@ declare namespace Xrm
              *
              * @return  The attribute.
              */
-            getAttribute( index: number ): Page.Attribute;
+            getAttribute(index: number): Page.Attribute;
 
             /**
              * Gets an attribute.
@@ -80,7 +77,7 @@ declare namespace Xrm
              *
              * @return  An array of attribute.
              */
-            getAttribute( delegateFunction: Collection.MatchingDelegate<Page.Attribute> ): Page.Attribute[];
+            getAttribute(delegateFunction: Collection.MatchingDelegate<Page.Attribute>): Page.Attribute[];
 
             /**
              * Gets all controls.
@@ -97,7 +94,7 @@ declare namespace Xrm
              *
              * @return  The control.
              */
-            getControl<T extends Page.Control>( controlName: string ): T;
+            getControl<T extends Page.Control>(controlName: string): T;
 
             /**
              * Gets a control matching controlName.
@@ -106,7 +103,7 @@ declare namespace Xrm
              *
              * @return  The control.
              */
-            getControl( controlName: string ): Page.Control;
+            getControl(controlName: string): Page.Control;
 
             /**
              * Gets a control by index.
@@ -115,7 +112,7 @@ declare namespace Xrm
              *
              * @return  The control.
              */
-            getControl( index: number ): Page.Control;
+            getControl(index: number): Page.Control;
 
             /**
              * Gets a control.
@@ -124,7 +121,7 @@ declare namespace Xrm
              *
              * @return  An array of control.
              */
-            getControl( delegateFunction: Collection.MatchingDelegate<Page.Control> ): Page.Control[];
+            getControl(delegateFunction: Collection.MatchingDelegate<Page.Control>): Page.Control[];
         };
 
         /**
@@ -137,7 +134,7 @@ declare namespace Xrm
              * @param   {string}        message         The message.
              * @param   {function()}    onCloseCallback The "OK" callback.
              */
-            alertDialog( message: string, onCloseCallback: () => void ): void;
+            alertDialog(message: string, onCloseCallback: () => void): void;
 
             /**
              * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
@@ -146,7 +143,7 @@ declare namespace Xrm
              * @param   {function()}    yesCloseCallback    The "OK" callback.
              * @param   {function()}    noCloseCallback     The "Cancel" callback.
              */
-            confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
+            confirmDialog(message: string, yesCloseCallback: () => void, noCloseCallback: () => void): void;
 
             /**
              * Query if 'entityType' is an Activity entity.
@@ -155,7 +152,7 @@ declare namespace Xrm
              *
              * @return  true if the entity is an Activity, false if not.
              */
-            isActivityType( entityType: string ): boolean;
+            isActivityType(entityType: string): boolean;
 
             /**
              * Opens quick create.
@@ -170,10 +167,11 @@ declare namespace Xrm
              *                                                  error.
              */
             openQuickCreate(
-                callback: ( recordReference: Page.LookupValue ) => void,
+                callback: (recordReference: Page.LookupValue) => void,
                 entityLogicalName: string,
                 createFromEntity?: Page.LookupValue,
-                parameters?: Utility.OpenParameters ): void;
+                parameters?: Utility.OpenParameters,
+            ): void;
 
             /**
              * Opens an entity form.
@@ -183,7 +181,12 @@ declare namespace Xrm
              * @param   {FormParameters}    parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
              * @param   {WindowOptions} windowOptions   (Optional) Options for controlling the window.
              */
-            openEntityForm( name: string, id?: string, parameters?: Utility.FormOpenParameters, windowOptions?: Utility.WindowOptions ): void;
+            openEntityForm(
+                name: string,
+                id?: string,
+                parameters?: Utility.FormOpenParameters,
+                windowOptions?: Utility.WindowOptions,
+            ): void;
 
             /**
              * Opens an HTML Web Resource in a new browser window.
@@ -206,7 +209,7 @@ declare namespace Xrm
              *                                              data (identical to this method's webResourceData parameter)
              *                                              formid
              */
-            openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
+            openWebResource(webResourceName: string, webResourceData?: string, width?: number, height?: number): Window;
         };
     }
 
@@ -226,8 +229,7 @@ declare namespace Xrm
     /**
      * Interface for the client context.
      */
-    export interface ClientContext
-    {
+    export interface ClientContext {
         /**
          * Returns a value to indicate which client the script is executing in.
          *
@@ -246,8 +248,7 @@ declare namespace Xrm
     /**
      * Interface for the xRM application context.
      */
-    interface Context
-    {
+    interface Context {
         /**
          * The client's context instance.
          */
@@ -354,14 +355,13 @@ declare namespace Xrm
          *
          * @remarks Format: "/"+ OrgName + sPath
          */
-        prependOrgName( sPath: string ): string;
+        prependOrgName(sPath: string): string;
     }
 
     /**
      * Interface for the Xrm.Page.data object.
      */
-    export interface Data
-    {
+    export interface Data {
         /**
          * Asynchronously refreshes data on the form, without reloading the page.
          *
@@ -369,7 +369,7 @@ declare namespace Xrm
          *
          * @return  An Async.XrmPromise.
          */
-        refresh( save: boolean ): Async.XrmPromise;
+        refresh(save: boolean): Async.XrmPromise;
 
         /**
          * Asynchronously saves the record.
@@ -394,8 +394,7 @@ declare namespace Xrm
     /**
      * Interface for the Xrm.Page.ui object.
      */
-    export interface Ui
-    {
+    export interface Ui {
         /**
          * Clears the form notification described by uniqueId.
          *
@@ -403,7 +402,7 @@ declare namespace Xrm
          *
          * @return  true if it succeeds, otherwise false.
          */
-        clearFormNotification( uniqueId: string ): boolean;
+        clearFormNotification(uniqueId: string): boolean;
 
         /**
          * Closes the form.
@@ -450,7 +449,7 @@ declare namespace Xrm
          */
         refreshRibbon(): void;
 
-        setFormNotification(message: string, level: Page.ui.FormNotificationLevel | string, uniqueId: string ): boolean;
+        setFormNotification(message: string, level: Page.ui.FormNotificationLevel | string, uniqueId: string): boolean;
 
         process: Page.ui.ProcessManager;
 
@@ -482,8 +481,7 @@ declare namespace Xrm
     /**
      *  A definition module for asynchronous interface declarations.
      */
-    export namespace Async
-    {
+    export namespace Async {
         /**
          * Called when the operation is successful.
          */
@@ -495,35 +493,32 @@ declare namespace Xrm
          * @param   {number}    errorCode   The error code.
          * @param   {string}    message     The message.
          */
-        export type ErrorCallbackDelegate = ( errorCode: number, message: string ) => void;
+        export type ErrorCallbackDelegate = (errorCode: number, message: string) => void;
 
         /**
          * Interface for Xrm.Page.data promises.
          */
-        export interface XrmPromise
-        {
+        export interface XrmPromise {
             /**
              * A basic 'then' promise.
              *
              * @param   {SuccessCallbackDelegate}   successCallback   The success callback.
              * @param   {ErrorCallbackDelegate}     errorCallback     The error callback.
              */
-            then( successCallback: SuccessCallbackDelegate, errorCallback: ErrorCallbackDelegate ): void;
+            then(successCallback: SuccessCallbackDelegate, errorCallback: ErrorCallbackDelegate): void;
         }
     }
 
     /**
      * A definition module for collection interface declarations.
      */
-    export namespace Collection
-    {
+    export namespace Collection {
         /**
          * Interface for a matching delegate.
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface MatchingDelegate<T>
-        {
+        export interface MatchingDelegate<T> {
             /**
              * Called for each item in an array
              *
@@ -532,7 +527,7 @@ declare namespace Xrm
              *
              * @return  true if the item matches, false if it does not.
              */
-            ( item: T, index?: number ): boolean;
+            (item: T, index?: number): boolean;
         }
 
         /**
@@ -540,15 +535,14 @@ declare namespace Xrm
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface IterativeDelegate<T>
-        {
+        export interface IterativeDelegate<T> {
             /**
              * Called for each item in an array
              *
              * @param   {T} item            The item.
              * @param   {number}    index   Zero-based index of the item array.
              */
-            ( item: T, index?: number ): void;
+            (item: T, index?: number): void;
         }
 
         /**
@@ -556,14 +550,13 @@ declare namespace Xrm
          *
          * @typeParam  T   Generic type parameter.
          */
-        export interface ItemCollection<T>
-        {
+        export interface ItemCollection<T> {
             /**
              * Applies an operation to all items in this collection.
              *
              * @param   {IterativeDelegate{T}}  delegate    An iterative delegate function
              */
-            forEach( delegate: IterativeDelegate<T> ): void;
+            forEach(delegate: IterativeDelegate<T>): void;
 
             /**
              * Gets.
@@ -572,7 +565,7 @@ declare namespace Xrm
              *
              * @return  A T[] whose members have been validated by delegate.
              */
-            get( delegate: MatchingDelegate<T> ): T[];
+            get(delegate: MatchingDelegate<T>): T[];
 
             /**
              * Gets the item given by the index.
@@ -581,7 +574,7 @@ declare namespace Xrm
              *
              * @return  The T in the itemNumber-th place.
              */
-            get( itemNumber: number ): T;
+            get(itemNumber: number): T;
 
             /**
              * Gets the item given by the key.
@@ -592,7 +585,7 @@ declare namespace Xrm
              *
              * @see {@link Xrm.Page.Control.getName()} for Control-naming schemes.
              */
-            get( itemName: string ): T;
+            get(itemName: string): T;
 
             /**
              * Gets the entire array of T.
@@ -615,8 +608,7 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328255.aspx|Documentation} for details.
      */
-    export namespace Page
-    {
+    export namespace Page {
         /**
          * Requirement Level for Xrm.Page.Attribute.getRequiredLevel() and Xrm.Page.Attribute.setRequiredLevel().
          */
@@ -637,8 +629,7 @@ declare namespace Xrm
         /**
          * Interface for a CRM Business Process Flow instance.
          */
-        export interface Process
-        {
+        export interface Process {
             /**
              * Returns the unique identifier of the process.
              *
@@ -673,8 +664,7 @@ declare namespace Xrm
         /**
          * Interface for CRM Business Process Flow stages.
          */
-        export interface Stage
-        {
+        export interface Stage {
             /**
              * Returns an object with a getValue method which will return the integer value of the business process flow
              * category.
@@ -723,8 +713,7 @@ declare namespace Xrm
             getSteps(): Step[];
         }
 
-        export interface Step
-        {
+        export interface Step {
             /**
              * Returns the logical name of the attribute associated to the step.
              *
@@ -756,8 +745,7 @@ declare namespace Xrm
         /**
          * Interface for the event context.
          */
-        export interface EventContext
-        {
+        export interface EventContext {
             /**
              * Gets the Xrm context.
              *
@@ -798,7 +786,7 @@ declare namespace Xrm
              *
              * @remarks Used to pass values between handlers of an event.
              */
-            getSharedVariable<T>( key: string ): T;
+            getSharedVariable<T>(key: string): T;
 
             /**
              * Sets a shared variable.
@@ -809,25 +797,23 @@ declare namespace Xrm
              *
              * @remarks Used to pass values between handlers of an event.
              */
-            setSharedVariable<T>( key: string, value: T ): void;
+            setSharedVariable<T>(key: string, value: T): void;
         }
 
         /**
          * Interface for a context-sensitive handler.
          */
-        export interface ContextSensitiveHandler
-        {
+        export interface ContextSensitiveHandler {
             /**
              * @param   {EventContext}  context The context.
              */
-            ( context?: EventContext ): void;
+            (context?: EventContext): void;
         }
 
         /**
          * Base interface for UI elements.
          */
-        export interface UiElement
-        {
+        export interface UiElement {
             /**
              * Gets the label.
              *
@@ -847,21 +833,20 @@ declare namespace Xrm
              *
              * @param   {string}    label   The label.
              */
-            setLabel( label: string ): void;
+            setLabel(label: string): void;
 
             /**
              * Sets the visibility state.
              *
              * @param   {boolean}   visible true to show, false to hide.
              */
-            setVisible( visible: boolean ): void;
+            setVisible(visible: boolean): void;
         }
 
         /**
          * Interface for focusable UI elements.
          */
-        export interface UiFocusable
-        {
+        export interface UiFocusable {
             /**
              * Sets focus on the element.
              */
@@ -871,8 +856,7 @@ declare namespace Xrm
         /**
          * Interface for a Lookup value.
          */
-        export interface LookupValue
-        {
+        export interface LookupValue {
             /**
              * The identifier.
              */
@@ -892,8 +876,7 @@ declare namespace Xrm
         /**
          * Interface for an OptionSet value.
          */
-        export interface OptionSetValue
-        {
+        export interface OptionSetValue {
             /**
              * The label text.
              */
@@ -908,8 +891,7 @@ declare namespace Xrm
         /**
          * Interface for a privilege.
          */
-        export interface Privilege
-        {
+        export interface Privilege {
             /**
              * true if the user can read.
              */
@@ -929,14 +911,13 @@ declare namespace Xrm
         /**
          * Interface for an Entity attribute.
          */
-        export interface Attribute
-        {
+        export interface Attribute {
             /**
              * Adds a handler to be called when the attribute's value is changed.
              *
              * @param   {ContextSensitiveHandler}  handler The function reference.
              */
-            addOnChange( handler: ContextSensitiveHandler ): void;
+            addOnChange(handler: ContextSensitiveHandler): void;
 
             /**
              * Fire all "on change" event handlers.
@@ -1032,7 +1013,7 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            removeOnChange( handler: ContextSensitiveHandler ): void;
+            removeOnChange(handler: ContextSensitiveHandler): void;
 
             /**
              * Sets the required level.
@@ -1063,7 +1044,6 @@ declare namespace Xrm
             getValue(): any;
 
             /**
-             *
              * @param       value   The value.
              */
             setValue(value: any): void;
@@ -1072,8 +1052,7 @@ declare namespace Xrm
         /**
          * Interface for a Number attribute.
          */
-        export interface NumberAttribute extends Attribute
-        {
+        export interface NumberAttribute extends Attribute {
             /**
              * Gets the maximum value allowed.
              *
@@ -1109,14 +1088,13 @@ declare namespace Xrm
              *
              * @remarks Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: number ): void;
+            setValue(value: number): void;
         }
 
         /**
          * Interface for a String attribute.
          */
-        export interface StringAttribute extends Attribute
-        {
+        export interface StringAttribute extends Attribute {
             /**
              * Gets maximum length allowed.
              *
@@ -1142,14 +1120,13 @@ declare namespace Xrm
              *              address formatting. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue( value: string ): void;
+            setValue(value: string): void;
         }
 
         /**
          * Common interface for enumeration attributes (OptionSet and Boolean).
          */
-        export interface EnumAttribute extends Attribute
-        {
+        export interface EnumAttribute extends Attribute {
             /**
              * Gets the initial value of the attribute.
              *
@@ -1162,8 +1139,7 @@ declare namespace Xrm
         /**
          * Interface for a Boolean attribute.
          */
-        export interface BooleanAttribute extends EnumAttribute
-        {
+        export interface BooleanAttribute extends EnumAttribute {
             /**
              * Gets the value.
              *
@@ -1178,14 +1154,13 @@ declare namespace Xrm
              *
              * @remarks  Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: boolean ): void;
+            setValue(value: boolean): void;
         }
 
         /**
          * Interface for a Date attribute.
          */
-        export interface DateAttribute extends Attribute
-        {
+        export interface DateAttribute extends Attribute {
             /**
              * Gets the value.
              *
@@ -1200,14 +1175,13 @@ declare namespace Xrm
              *
              * @remarks  Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: Date ): void;
+            setValue(value: Date): void;
         }
 
         /**
          * Interface an OptionSet attribute.
          */
-        export interface OptionSetAttribute extends EnumAttribute
-        {
+        export interface OptionSetAttribute extends EnumAttribute {
             /**
              * Gets the option matching a value.
              *
@@ -1215,7 +1189,7 @@ declare namespace Xrm
              *
              * @return  The option.
              */
-            getOption( value: number ): OptionSetValue;
+            getOption(value: number): OptionSetValue;
 
             /**
              * Gets the option matching a label.
@@ -1224,7 +1198,7 @@ declare namespace Xrm
              *
              * @return  The option.
              */
-            getOption( label: string ): OptionSetValue;
+            getOption(label: string): OptionSetValue;
 
             /**
              * Gets all of the options.
@@ -1264,14 +1238,13 @@ declare namespace Xrm
              *              OptionSet attribute. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue( value: number ): void;
+            setValue(value: number): void;
         }
 
         /**
          * Interface a Lookup attribute.
          */
-        export interface LookupAttribute extends Attribute
-        {
+        export interface LookupAttribute extends Attribute {
             /**
              * Gets a boolean value indicating whether the Lookup is a multi-value PartyList.
              *
@@ -1293,20 +1266,19 @@ declare namespace Xrm
              *
              * @remarks Attributes on Quick Create Forms will not save values set with this method.
              */
-            setValue( value: LookupValue[] ): void;
+            setValue(value: LookupValue[]): void;
         }
 
         /**
          * Interface for the form's record context, Xrm.Page.data.entity
          */
-        export interface Entity
-        {
+        export interface Entity {
             /**
              * Adds a handler to be called when the record is saved.
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            addOnSave( handler: ContextSensitiveHandler ): void;
+            addOnSave(handler: ContextSensitiveHandler): void;
 
             /**
              * Gets an serialized-XML string representing data that will be passed to the server upon saving
@@ -1357,7 +1329,7 @@ declare namespace Xrm
              *
              * @param   {ContextSensitiveHandler}   handler The handler.
              */
-            removeOnSave( handler: ContextSensitiveHandler ): void;
+            removeOnSave(handler: ContextSensitiveHandler): void;
 
             /**
              * Saves the record.
@@ -1374,7 +1346,7 @@ declare namespace Xrm
              * @param   {string}    saveMode    (Optional) the save mode to save, as either "saveandclose" or
              *                                  "saveandnew".
              */
-            save( saveMode: SaveMode | string): void;
+            save(saveMode: SaveMode | string): void;
 
             /**
              * The collection of attributes for the record.
@@ -1385,8 +1357,7 @@ declare namespace Xrm
         /**
          * Interface for save event arguments.
          */
-        export interface SaveEventArguments
-        {
+        export interface SaveEventArguments {
             /**
              * Gets save mode, as an integer.
              *
@@ -1423,13 +1394,11 @@ declare namespace Xrm
         /**
          * Module for the Xrm.Page.data API.
          */
-        export namespace data
-        {
+        export namespace data {
             /**
              * Interface for the Xrm.Page.data.process API.
              */
-            export interface ProcessManager
-            {
+            export interface ProcessManager {
                 /**
                  * Returns a Process object representing the active process.
                  *
@@ -1443,7 +1412,7 @@ declare namespace Xrm
                  * @param   {string}    processId           The Id of the process to make the active process.
                  * @param   {function}  callbackFunction    (Optional) a function to call when the operation is complete.
                  */
-                setActiveProcess( processId: string, callbackFunction?: ProcessCallbackDelegate ): void;
+                setActiveProcess(processId: string, callbackFunction?: ProcessCallbackDelegate): void;
 
                 /**
                  * Returns a Stage object representing the active stage.
@@ -1458,7 +1427,7 @@ declare namespace Xrm
                  * @param   {string}    stageId             the Id of the stage to make the active stage.
                  * @param   {function}  callbackFunction    (Optional) a function to call when the operation is complete.
                  */
-                setActiveStage( stageId: string, callbackFunction?: ProcessCallbackDelegate ): void;
+                setActiveStage(stageId: string, callbackFunction?: ProcessCallbackDelegate): void;
 
                 /**
                  * Use this method to get a collection of stages currently in the active path with methods to interact with the
@@ -1485,7 +1454,7 @@ declare namespace Xrm
                  *                                      list of enabled processes is the same ones a user can see in the UI if they
                  *                                      want to change the process manually.
                  */
-                getEnabledProcesses( callbackFunction: ( enabledProcesses: ProcessDictionary ) => void ): void;
+                getEnabledProcesses(callbackFunction: (enabledProcesses: ProcessDictionary) => void): void;
 
                 /**
                  * Use this method to get the currently selected stage.
@@ -1505,7 +1474,7 @@ declare namespace Xrm
                  *                                              anonymous function if you may later want to remove the
                  *                                              event handler.
                  */
-                addOnStageChange( handler: ContextSensitiveHandler ): void;
+                addOnStageChange(handler: ContextSensitiveHandler): void;
 
                 /**
                  * Use this to add a function as an event handler for the OnStageSelected event so that it will be called
@@ -1535,7 +1504,7 @@ declare namespace Xrm
                  * @param   {ContextSensitiveHandler}   handler If an anonymous function is set using the addOnStageChange method it
                  *                                              cannot be removed using this method.
                  */
-                removeOnStageSelected( handler: ContextSensitiveHandler ): void;
+                removeOnStageSelected(handler: ContextSensitiveHandler): void;
 
                 /**
                  * Progresses to the next stage.
@@ -1543,7 +1512,7 @@ declare namespace Xrm
                  * @param   {ProcessCallbackDelegate}   callbackFunction    (Optional) A function to call when the operation is
                  *                                                          complete.
                  */
-                moveNext( callbackFunction?: ProcessCallbackDelegate ): void;
+                moveNext(callbackFunction?: ProcessCallbackDelegate): void;
 
                 /**
                  * Moves to the previous stage.
@@ -1551,7 +1520,7 @@ declare namespace Xrm
                  * @param   {ProcessCallbackDelegate}   callbackFunction    (Optional) A function to call when the operation is
                  *                                                          complete.
                  */
-                movePrevious( callbackFunction?: ProcessCallbackDelegate ): void;
+                movePrevious(callbackFunction?: ProcessCallbackDelegate): void;
             }
 
             /**
@@ -1565,7 +1534,7 @@ declare namespace Xrm
              *                                   as the active stage.)
              *                                   unreachable    (The stage exists on a different path.)
              */
-            export type ProcessCallbackDelegate = ( status: string ) => void;
+            export type ProcessCallbackDelegate = (status: string) => void;
 
             /**
              * Represents a key-value pair, where the key is the Process Flow's ID, and the value is the name thereof.
@@ -1576,8 +1545,7 @@ declare namespace Xrm
         /**
          * Interface for Xrm.Page.ui controls.
          */
-        export interface Control extends UiElement, UiFocusable
-        {
+        export interface Control extends UiElement, UiFocusable {
             /**
              * Clears the notification identified by uniqueId.
              *
@@ -1587,7 +1555,7 @@ declare namespace Xrm
              *
              * @remarks If the uniqueId parameter is not used, the current notification shown will be removed.
              */
-            clearNotification( uniqueId?: string ): boolean;
+            clearNotification(uniqueId?: string): boolean;
 
             /**
              * Gets the control's type.
@@ -1642,7 +1610,7 @@ declare namespace Xrm
              *
              * @param   {boolean}   disabled    true to disable, false to enable.
              */
-            setDisabled( disabled: boolean ): void;
+            setDisabled(disabled: boolean): void;
 
             /**
              * Sets a control-local notification message.
@@ -1655,14 +1623,13 @@ declare namespace Xrm
              * @remarks     When this method is used on Microsoft Dynamics CRM for tablets a red "X" icon
              *              appears next to the control. Tapping on the icon will display the message.
              */
-            setNotification( message: string, uniqueId: string ): boolean;
+            setNotification(message: string, uniqueId: string): boolean;
         }
 
         /**
          * Interface for a standard control.
          */
-        export interface StandardControl extends Control
-        {
+        export interface StandardControl extends Control {
             /**
              * Gets the control's bound attribute.
              *
@@ -1683,8 +1650,7 @@ declare namespace Xrm
         /**
          * Interface for a Date control.
          */
-        export interface DateControl extends StandardControl
-        {
+        export interface DateControl extends StandardControl {
             /**
              * Gets the control's bound attribute.
              *
@@ -1704,20 +1670,19 @@ declare namespace Xrm
              *
              * @param   {boolean}   showTimeValue   true to show, false to hide the time value.
              */
-            setShowTime( showTimeValue: boolean ): void;
+            setShowTime(showTimeValue: boolean): void;
         }
 
         /**
          * Interface for a Lookup control.
          */
-        export interface LookupControl extends StandardControl
-        {
+        export interface LookupControl extends StandardControl {
             /**
              * Adds a handler to the "pre search" event of the Lookup control.
              *
              * @param   {Function}  handler The handler.
              */
-            addPreSearch( handler: ContextSensitiveHandler ): void;
+            addPreSearch(handler: ContextSensitiveHandler): void;
 
             /**
              * Adds an additional custom filter to the lookup, with the "AND" filter operator.
@@ -1733,7 +1698,7 @@ declare namespace Xrm
              *                              <condition attribute="address1_city" operator="eq" value="Redmond" />
              *                              </filter>
              */
-            addCustomFilter( filter: string, entityLogicalName?: string ): void;
+            addCustomFilter(filter: string, entityLogicalName?: string): void;
 
             /**
              * Adds a custom view for the Lookup dialog.
@@ -1751,7 +1716,14 @@ declare namespace Xrm
              *          Example viewId value: "{00000000-0000-0000-0000-000000000001}"
              *          Layout XML Reference: {@link http://msdn.microsoft.com/en-us/library/gg334522.aspx}
              */
-            addCustomView( viewId: string, entityName: string, viewDisplayName: string, fetchXml: string, layoutXml: string, isDefault: boolean ): void;
+            addCustomView(
+                viewId: string,
+                entityName: string,
+                viewDisplayName: string,
+                fetchXml: string,
+                layoutXml: string,
+                isDefault: boolean,
+            ): void;
 
             /**
              * Gets the control's bound attribute.
@@ -1774,7 +1746,7 @@ declare namespace Xrm
              *
              * @param   {Function}  handler The handler.
              */
-            removePreSearch( handler: () => void ): void;
+            removePreSearch(handler: () => void): void;
 
             /**
              * Sets the Lookup's default view.
@@ -1783,14 +1755,13 @@ declare namespace Xrm
              *
              * @remarks Example viewGuid value: "{00000000-0000-0000-0000-000000000000}"
              */
-            setDefaultView( viewGuid: string ): void;
+            setDefaultView(viewGuid: string): void;
         }
 
         /**
          * Interface for an OptionSet control.
          */
-        export interface OptionSetControl extends StandardControl
-        {
+        export interface OptionSetControl extends StandardControl {
             /**
              * Adds an option.
              *
@@ -1800,7 +1771,7 @@ declare namespace Xrm
              * @remarks This method does not check that the values within the options you add are valid.
              *          If index is not provided, the new option will be added to the end of the list.
              */
-            addOption( option: OptionSetValue, index?: number ): void;
+            addOption(option: OptionSetValue, index?: number): void;
 
             /**
              * Clears all options.
@@ -1819,20 +1790,19 @@ declare namespace Xrm
              *
              * @param   {number}    value   The value.
              */
-            removeOption( value: number ): void;
+            removeOption(value: number): void;
         }
 
         /**
          * Interface for a CRM grid control.
          */
-        export interface GridControl extends Control
-        {
+        export interface GridControl extends Control {
             /**
              * Use this method to add event handlers to the GridControl's OnLoad event.
              *
              * @param   {Function} handler The event handler.
              */
-            addOnLoad( handler: () => void ): void;
+            addOnLoad(handler: () => void): void;
 
             /**
              * This method returns context information about the GridControl.
@@ -1874,7 +1844,7 @@ declare namespace Xrm
              *
              * @param   {Function} handler The handler.
              */
-            removeOnLoad( handler: () => void ): void;
+            removeOnLoad(handler: () => void): void;
         }
 
         /**
@@ -1883,8 +1853,7 @@ declare namespace Xrm
          * @remarks     An Iframe control provides additional methods, so use {@link IframeControl} where
          *              appropriate.  Silverlight controls should use {@link SilverlightControl}.
          */
-        export interface FramedControl extends Control
-        {
+        export interface FramedControl extends Control {
             /**
              * Gets the DOM element containing the control.
              *
@@ -1910,14 +1879,13 @@ declare namespace Xrm
              *
              * @remarks Unavailable for Microsoft Dynamics CRM for tablets.
              */
-            setSrc( src: string ): void;
+            setSrc(src: string): void;
         }
 
         /**
          * Interface for an Iframe control.
          */
-        export interface IframeControl extends FramedControl
-        {
+        export interface IframeControl extends FramedControl {
             /**
              * Gets initial URL defined for the Iframe.
              *
@@ -1931,8 +1899,7 @@ declare namespace Xrm
         /**
          * Interface for a Silverlight control.
          */
-        export interface SilverlightControl extends Control
-        {
+        export interface SilverlightControl extends Control {
             /**
              * Gets the query string value passed to Silverlight.
              *
@@ -1949,7 +1916,7 @@ declare namespace Xrm
              *
              * @remarks Unavailable for Microsoft Dynamics CRM for tablets.
              */
-            setData( data: string ): void;
+            setData(data: string): void;
 
             /**
              * Gets the DOM element containing the control.
@@ -1964,8 +1931,7 @@ declare namespace Xrm
         /**
          * Interface for a form tab.
          */
-        export interface Tab extends UiElement, UiFocusable
-        {
+        export interface Tab extends UiElement, UiFocusable {
             /**
              * Gets display state of the tab.
              *
@@ -1992,7 +1958,7 @@ declare namespace Xrm
              *
              * @param   {string}    displayState   Display state of the tab, as either "expanded" or "collapsed"
              */
-            setDisplayState(displayState: ui.DisplayState | string ): void;
+            setDisplayState(displayState: ui.DisplayState | string): void;
 
             /**
              * A reference to the collection of form sections within this tab.
@@ -2003,8 +1969,7 @@ declare namespace Xrm
         /**
          * Interface for a form section.
          */
-        export interface Section extends UiElement
-        {
+        export interface Section extends UiElement {
             /**
              * Gets the name of the section.
              *
@@ -2028,8 +1993,7 @@ declare namespace Xrm
         /**
          * Module for Xrm.Page.ui API.
          */
-        export namespace ui
-        {
+        export namespace ui {
             /**
              * Form Notification Levels for Xrm.Ui.setFormNotification().
              */
@@ -2043,29 +2007,27 @@ declare namespace Xrm
             /**
              * Interface for Xrm.Page.ui.process API
              */
-            export interface ProcessManager
-            {
+            export interface ProcessManager {
                 /**
                  * Sets display state of the process flow control.
                  *
                  * @param   {string}    displayState   Display state of the process flow control, as either "expanded" or "collapsed"
                  */
-                setDisplayState(displayState: ui.DisplayState ): void;
+                setDisplayState(displayState: ui.DisplayState): void;
 
                 /**
                  * Sets the visibility state.
                  *
                  * @param   {boolean}   visible true to show, false to hide.
                  */
-                setVisible( visible: boolean ): void;
+                setVisible(visible: boolean): void;
             }
 
             /**
              * Interface for a grid.  Use Grid methods to access information about data in the grid. Grid is returned by the
              * GridControl.getGrid method.
              */
-            export interface Grid
-            {
+            export interface Grid {
                 /**
                  * Returns a collection of every GridRow in the Grid.
                  *
@@ -2092,8 +2054,7 @@ declare namespace Xrm
              * Interface for a grid row.  Use the GridRow.getData method to access the GridRowData. A collection of GridRow is
              * returned by Grid.getRows and Grid.getSelectedRows methods.
              */
-            export interface GridRow
-            {
+            export interface GridRow {
                 /**
                  * Returns the GridRowData for the GridRow.
                  *
@@ -2106,8 +2067,7 @@ declare namespace Xrm
              * Interface for grid row data.  Use the GridRowData.getEntity method to access the GridEntity. GridRowData is
              * returned by the GridRow.getData method.
              */
-            export interface GridRowData
-            {
+            export interface GridRowData {
                 /**
                  * Returns the GridEntity for the GridRowData.
                  *
@@ -2120,8 +2080,7 @@ declare namespace Xrm
              * Interface for a grid entity.  Use the GridEntity methods to access data about the specific records in the rows.
              * GridEntity is returned by the GridRowData.getEntity method.
              */
-            export interface GridEntity
-            {
+            export interface GridEntity {
                 /**
                  * Returns the logical name for the record in the row.
                  *
@@ -2157,8 +2116,7 @@ declare namespace Xrm
              * Interface for the view selector.  Use the ViewSelector methods to get or set information about the view selector
              * of the grid control.
              */
-            export interface ViewSelector
-            {
+            export interface ViewSelector {
                 /**
                  * Use this method to get a reference to the current view.
                  *
@@ -2178,15 +2136,14 @@ declare namespace Xrm
                  *
                  * @param   {ViewSelectorItem}  viewSelectorItem    The view selector item.
                  */
-                setCurrentView( viewSelectorItem: ViewSelectorItem ): void;
+                setCurrentView(viewSelectorItem: ViewSelectorItem): void;
             }
 
             /**
              * Interface for a view selector item.  This object contains data that identifies a view. Use this as a parameter to
              * the ViewSelector.setCurrentView method.
              */
-            export interface ViewSelectorItem
-            {
+            export interface ViewSelectorItem {
                 /**
                  * Returns a LookupValue that references this view.
                  *
@@ -2199,8 +2156,7 @@ declare namespace Xrm
         /**
          * Interface for a navigation item.
          */
-        export interface NavigationItem extends UiElement, UiFocusable
-        {
+        export interface NavigationItem extends UiElement, UiFocusable {
             /**
              * Gets the name of the item.
              *
@@ -2212,8 +2168,7 @@ declare namespace Xrm
         /**
          * Interface for Xrm.Page.ui.navigation.
          */
-        export interface Navigation
-        {
+        export interface Navigation {
             /**
              * A reference to the collection of available navigation items.
              */
@@ -2223,8 +2178,7 @@ declare namespace Xrm
         /**
          * Interface for an entity's form selector item.
          */
-        export interface FormItem
-        {
+        export interface FormItem {
             /**
              * Gets the unique identifier of the form.
              *
@@ -2248,8 +2202,7 @@ declare namespace Xrm
         /**
          * Interface for the form selector API.
          */
-        export interface FormSelector
-        {
+        export interface FormSelector {
             /**
              * Gets current form.
              *
@@ -2271,8 +2224,7 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
      */
-    export namespace Url
-    {
+    export namespace Url {
         /**
          * Command Bar Display options for Xrm.Url.FormOpenParameters.cmdbar, Xrm.Url.ViewOpenParameters.cmdbar, and Xrm.Utility.FormOpenParameters.cmdbar.
          */
@@ -2296,8 +2248,7 @@ declare namespace Xrm
          * @remarks  A member for "pagetype" is not provided.  The value "entityrecord" is required in
          *           the URL, for forms. Example:  "pagetype=entityrecord"
          */
-        export interface FormOpenParameters
-        {
+        export interface FormOpenParameters {
             /**
              * The logical name of the entity.
              */
@@ -2339,8 +2290,7 @@ declare namespace Xrm
          * @remarks  A member for "pagetype" is not provided.  The value "entitylist" is required in
          *           the URL, for views. Example:  "pagetype=entitylist"
          */
-        export interface ViewOpenParameters
-        {
+        export interface ViewOpenParameters {
             /**
              * The logical name of the entity.
              */
@@ -2384,8 +2334,7 @@ declare namespace Xrm
          *
          * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
          */
-        export interface DialogOpenParameters
-        {
+        export interface DialogOpenParameters {
             /**
              * The unique identifier of the dialog, in Guid format, which is valid for the entity described
              * by: {@link EntityName}
@@ -2410,8 +2359,7 @@ declare namespace Xrm
          *
          * @see {@link http://msdn.microsoft.com/en-us/library/gg328483.aspx} for details.
          */
-        export interface ReportOpenParameters
-        {
+        export interface ReportOpenParameters {
             /**
              * The action to perform, as either "run" or "filter".
              *
@@ -2438,10 +2386,8 @@ declare namespace Xrm
      *
      * @see {@link http://msdn.microsoft.com/en-us/library/gg328255.aspx|Documentation} for details.
      */
-    export namespace Utility
-    {
-        export interface OpenParameters
-        {
+    export namespace Utility {
+        export interface OpenParameters {
             /**
              * Additional parameters can be provided to the request, by overloading
              * this object with additional key and value pairs. This can only be used
@@ -2454,8 +2400,7 @@ declare namespace Xrm
         /**
          * Interface for defining parameters on a Xrm.Utility.openEntityForm() request.
          */
-        export interface FormOpenParameters extends OpenParameters
-        {
+        export interface FormOpenParameters extends OpenParameters {
             /**
              * The identifier of the form to use, when several are available.
              */
@@ -2481,8 +2426,7 @@ declare namespace Xrm
         /**
          * Interface for window options.
          */
-        export interface WindowOptions
-        {
+        export interface WindowOptions {
             /**
              * Direct the form to open in a new window.
              */
@@ -2491,26 +2435,23 @@ declare namespace Xrm
     }
 }
 
-declare namespace XrmEnum
-{
+declare namespace XrmEnum {
     /**
      * Enumeration of entity form states/types.
      */
-    export const enum FormType
-    {
+    export const enum FormType {
         Undefined = 0,
         Create = 1,
         Update = 2,
         ReadOnly = 3,
         Disabled = 4,
-        BulkEdit = 6
+        BulkEdit = 6,
     }
 
     /**
      * Enumeration of entity form save modes.
      */
-    export const enum SaveMode
-    {
+    export const enum SaveMode {
         Save = 1,
         SaveAndClose = 2,
         SaveAndNew = 59,
@@ -2521,41 +2462,38 @@ declare namespace XrmEnum
         Assign = 47,
         Send = 7,
         Qualify = 16,
-        Disqualify = 15
+        Disqualify = 15,
     }
 
     /**
      * Enumeration of stage categories.
      */
-    export const enum StageCategory
-    {
+    export const enum StageCategory {
         Qualify = 0,
         Develop = 1,
         Propose = 2,
         Close = 3,
         Identify = 4,
         Research = 5,
-        Resolve = 6
+        Resolve = 6,
     }
 
     /**
      * Enumeration of grid control context resolutions.
      */
-    export const enum GridControlContext
-    {
+    export const enum GridControlContext {
         Unknown = 0,
         RibbonContextForm = 1,
         RibbonContextListing = 2,
         FormContextUnrelated = 3,
-        FormContextRelated = 4
+        FormContextRelated = 4,
     }
 
     /**
      * An enumeration for view types.
      */
-    export const enum ViewType
-    {
+    export const enum ViewType {
         SystemView = 1039,
-        UserView = 4230
+        UserView = 4230,
     }
 }

--- a/types/xrm/v7/parature.d.ts
+++ b/types/xrm/v7/parature.d.ts
@@ -1,23 +1,21 @@
-declare namespace Xrm.Page
-{
+declare namespace Xrm.Page {
     /**
      * Interface for Parature's knowledge base search control.
      */
-    export interface KbSearchControl extends Xrm.Page.Control
-    {
+    export interface KbSearchControl extends Xrm.Page.Control {
         /**
          * Use this method to add an event handler to the OnResultOpened event.
          *
          * @param   {Function} handler The handler.
          */
-        addOnResultOpened( handler: () => void ): void;
+        addOnResultOpened(handler: () => void): void;
 
         /**
          * Use this method to add an event handler to the OnSelection event.
          *
          * @param   {Function} handler The handler.
          */
-        addOnSelection( handler: () => void ): void;
+        addOnSelection(handler: () => void): void;
 
         /**
          * Use this method to get the text used as the search criteria for the knowledge base management control.
@@ -39,28 +37,27 @@ declare namespace Xrm.Page
          *
          * @param   {Function} handler The handler.
          */
-        removeOnResultOpened( handler: () => void ): void;
+        removeOnResultOpened(handler: () => void): void;
 
         /**
          * Use this method to remove an event handler from the OnSelection event.
          *
          * @param   {Function} handler The handler.
          */
-        removeOnSelection( handler: () => void ): void;
+        removeOnSelection(handler: () => void): void;
 
         /**
          * Use this method to set the text used as the search criteria for the knowledge base management control.
          *
          * @param   {string}    query   The text for the search query.
          */
-        setSearchQuery( query: string ): void;
+        setSearchQuery(query: string): void;
     }
 
     /**
      * Interface for a Parature knowledge base search result.
      */
-    export interface KbSearchResult
-    {
+    export interface KbSearchResult {
         /**
          * The HTML markup containing the content of the article.
          */

--- a/types/xrm/v7/xrm-tests.ts
+++ b/types/xrm/v7/xrm-tests.ts
@@ -1,22 +1,18 @@
 /// Demonstrate usage in the browser's window object
 
-window.Xrm.Utility.alertDialog( "message", () => {} );
+window.Xrm.Utility.alertDialog("message", () => {});
 parent.Xrm.Page.context.getOrgLcid();
 
 /// Demonstrate clientglobalcontext.d.ts
 
-function _getContext()
-{
+function _getContext() {
     const errorMessage = "Context is not available.";
-    if ( typeof GetGlobalContext !== "undefined" )
-    { return GetGlobalContext(); }
-    else
-    {
-        if ( typeof Xrm !== "undefined" )
-        {
+    if (typeof GetGlobalContext !== "undefined") {
+        return GetGlobalContext();
+    } else {
+        if (typeof Xrm !== "undefined") {
             return Xrm.Page.context;
-        }
-        else { throw new Error( errorMessage ); }
+        } else throw new Error(errorMessage);
     }
 }
 
@@ -24,8 +20,7 @@ const crmContext = _getContext();
 
 /// Demonstrate iterator typing
 
-const grids = Xrm.Page.getControl(( control ) =>
-{
+const grids = Xrm.Page.getControl((control) => {
     return control.getControlType() === "subgrid";
 });
 
@@ -33,79 +28,92 @@ const selectedGridReferences: Xrm.Page.LookupValue[] = [];
 
 /// Demonstrate iterator typing with v7.1 additions
 
-grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
-{
-    gridControl.getGrid().getSelectedRows().forEach(( row ) =>
-    {
-        selectedGridReferences.push( row.getData().getEntity().getEntityReference() );
+grids.forEach((gridControl: Xrm.Page.GridControl) => {
+    gridControl.getGrid().getSelectedRows().forEach((row) => {
+        selectedGridReferences.push(row.getData().getEntity().getEntityReference());
     });
 });
 
 /// Demonstrate generic overload vs typecast
 
-const lookupAttribute = Xrm.Page.getControl( "customerid" ) as Xrm.Page.LookupControl;
-const lookupAttribute2 = Xrm.Page.getControl( "customerid" ) as Xrm.Page.LookupControl;
+const lookupAttribute = Xrm.Page.getControl("customerid") as Xrm.Page.LookupControl;
+const lookupAttribute2 = Xrm.Page.getControl("customerid") as Xrm.Page.LookupControl;
 
 /// Demonstrate ES6 String literal syntax
 
-lookupAttribute.addCustomFilter( `<filter type="and">
+lookupAttribute.addCustomFilter(
+    `<filter type="and">
     <condition attribute="address1_city" operator="eq" value="Redmond" />
-</filter>`, "account" );
+</filter>`,
+    "account",
+);
 
-lookupAttribute.addPreSearch(() => { alert( "A search was performed." ); });
+lookupAttribute.addPreSearch(() => {
+    alert("A search was performed.");
+});
 
 /// Demonstrate strong-typed attribute association with strong-typed control
 
 const lookupValues = lookupAttribute.getAttribute().getValue();
 
-if ( lookupValues !== null )
-    if ( !lookupValues[0].id || !lookupValues[0].entityType )
+if (lookupValues !== null) {
+    if (!lookupValues[0].id || !lookupValues[0].entityType) {
         throw new Error("Invalid value in Lookup control.");
+    }
+}
 
 /// Demonstrate v7.0 BPF API
 
-if (Xrm.Page.data.process != null)
-    Xrm.Page.data.process.moveNext(( status ) => { alert( `Process moved forward with status: ${status}` ); });
+if (Xrm.Page.data.process != null) {
+    Xrm.Page.data.process.moveNext((status) => {
+        alert(`Process moved forward with status: ${status}`);
+    });
+}
 
 /// Demonstrate v7.1 Quick Create form
 
-Xrm.Utility.openQuickCreate(( newRecord ) => { alert( `Newly created record Id: ${newRecord.id}` ); }, "account" );
+Xrm.Utility.openQuickCreate((newRecord) => {
+    alert(`Newly created record Id: ${newRecord.id}`);
+}, "account");
 
 /// Make all controls visible.
 
-Xrm.Page.ui.controls.forEach(( control ) => { control.setVisible( true ); });
+Xrm.Page.ui.controls.forEach((control) => {
+    control.setVisible(true);
+});
 
 /// Make all tabs and sections visible.
 
-Xrm.Page.ui.tabs.forEach(( tab ) =>
-{
-    tab.setVisible( true );
+Xrm.Page.ui.tabs.forEach((tab) => {
+    tab.setVisible(true);
 
-    tab.sections.forEach(( section ) =>
-    {
-        section.setVisible( true );
+    tab.sections.forEach((section) => {
+        section.setVisible(true);
     });
 });
 
 /// Demonstrate OnSave event context.
 
-Xrm.Page.data.entity.addOnSave(( context ) =>
-{
+Xrm.Page.data.entity.addOnSave((context) => {
     const eventArgs = context.getEventArgs();
 
-    if ( eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose )
+    if (
+        eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave
+        || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose
+    ) {
         eventArgs.preventDefault();
+    }
 });
 
 /// Demonstrate ES6 String literal with templates
 
-alert( `The current form type is: ${Xrm.Page.ui.getFormType() }` );
+alert(`The current form type is: ${Xrm.Page.ui.getFormType()}`);
 
-alert( `The current entity type is: ${Xrm.Page.data.entity.getEntityName() }` );
+alert(`The current entity type is: ${Xrm.Page.data.entity.getEntityName()}`);
 
 /// Demonstrate Optionset Value as int in Turbo Forms
 
-const optionSetAttribute = Xrm.Page.getAttribute( "statuscode" ) as Xrm.Page.OptionSetAttribute;
+const optionSetAttribute = Xrm.Page.getAttribute("statuscode") as Xrm.Page.OptionSetAttribute;
 const optionValue: number = optionSetAttribute.getOptions()[0].value;
 
 /// Demonstrate Control.setFocus();

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -517,8 +517,11 @@ declare namespace Xrm {
          *                                                  error.
          * @return   Returns an asynchronous promise.
          */
-        openQuickCreate(entityLogicalName: string, createFromEntity?: Page.LookupValue, parameters?: Utility.OpenParameters):
-            Async.XrmPromise<Async.QuickCreateSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        openQuickCreate(
+            entityLogicalName: string,
+            createFromEntity?: Page.LookupValue,
+            parameters?: Utility.OpenParameters,
+        ): Async.XrmPromise<Async.QuickCreateSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
 
         /**
          * Opens an entity form.
@@ -528,7 +531,12 @@ declare namespace Xrm {
          * @param       parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
          * @param    windowOptions   (Optional) Options for controlling the window.
          */
-        openEntityForm(name: string, id?: string, parameters?: Utility.FormOpenParameters, windowOptions?: Utility.WindowOptions): void;
+        openEntityForm(
+            name: string,
+            id?: string,
+            parameters?: Utility.FormOpenParameters,
+            windowOptions?: Utility.WindowOptions,
+        ): void;
 
         /**
          * Opens an HTML Web Resource in a new browser window.
@@ -595,7 +603,10 @@ declare namespace Xrm {
          *             Integer, Lookup, Memo, Money, Owner, Picklist, String, State
          *             Status, UniqueIdentifier
          */
-        createRecord(entityType: string, data: { [attributeName: string]: any }): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        createRecord(
+            entityType: string,
+            data: { [attributeName: string]: any },
+        ): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
 
         /**
          * Retrieves an entity record in mobile clients while working in the offline mode.
@@ -613,7 +624,11 @@ declare namespace Xrm {
          *             Integer, Lookup, Memo, Money, Owner, Picklist, String, State
          *             Status, UniqueIdentifier
          */
-        retrieveRecord(entityType: string, id: string, options: string): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        retrieveRecord(
+            entityType: string,
+            id: string,
+            options: string,
+        ): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
 
         /**
          * Retrieves a collection of entity records in mobile clients while working in the offline mode.
@@ -636,7 +651,11 @@ declare namespace Xrm {
          *             Integer, Lookup, Memo, Money, Owner, Picklist, String, State
          *             Status, UniqueIdentifier
          */
-        retrieveMultipleRecords(entityType: string, options: string, maxPageSize: number): Async.XrmPromise<Async.OfflineRetrieveMultipleSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        retrieveMultipleRecords(
+            entityType: string,
+            options: string,
+            maxPageSize: number,
+        ): Async.XrmPromise<Async.OfflineRetrieveMultipleSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
 
         /**
          * Updates an entity record in mobile clients while working in the offline mode.
@@ -653,7 +672,11 @@ declare namespace Xrm {
          *             Integer, Lookup, Memo, Money, Owner, Picklist, String, State
          *             Status, UniqueIdentifier
          */
-        updateRecord(entityType: string, id: string, data: { [attributeName: string]: any }): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        updateRecord(
+            entityType: string,
+            id: string,
+            data: { [attributeName: string]: any },
+        ): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
 
         /**
          * Deletes an entity record in mobile clients while working in the offline mode.
@@ -665,7 +688,10 @@ declare namespace Xrm {
          *
          * @remarks  You cannot delete intersect and activity party entities.
          */
-        deleteRecord(entityType: string, id: string): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
+        deleteRecord(
+            entityType: string,
+            id: string,
+        ): Async.XrmPromise<Async.OfflineOperationSuccessCallbackDelegate, Async.ErrorCallbackDelegate>;
     }
 
     interface Panel {
@@ -918,7 +944,17 @@ declare namespace Xrm {
         /**
          * Control types for Xrm.Page.Control.getControlType().
          */
-        type ControlType = "standard" | "iframe" | "lookup" | "optionset" | "subgrid" | "webresource" | "notes" | "timercontrol" | "kbsearch" | ControlQuickFormType;
+        type ControlType =
+            | "standard"
+            | "iframe"
+            | "lookup"
+            | "optionset"
+            | "subgrid"
+            | "webresource"
+            | "notes"
+            | "timercontrol"
+            | "kbsearch"
+            | ControlQuickFormType;
 
         /**
          * Date attribute formats for Xrm.Page.Attribute.getFormat(), used by DateAttribute.
@@ -943,7 +979,17 @@ declare namespace Xrm {
         /**
          * Attribute types for Xrm.ui.ProcessMonitor Xrm.Page.Attribute.setDisplayState().
          */
-        type AttributeType = "boolean" | "datetime" | "decimal" | "double" | "integer" | "lookup" | "memo" | "money" | "optionset" | "string";
+        type AttributeType =
+            | "boolean"
+            | "datetime"
+            | "decimal"
+            | "double"
+            | "integer"
+            | "lookup"
+            | "memo"
+            | "money"
+            | "optionset"
+            | "string";
 
         /**
          * Direction types for a process stage change event
@@ -953,7 +999,11 @@ declare namespace Xrm {
         /**
          * Attribute formats for Xrm.Page.Attribute.getFormat().
          */
-        type AttributeFormat = DateAttributeFormat | IntegerAttributeFormat | OptionSetAttributeFormat | StringAttributeFormat;
+        type AttributeFormat =
+            | DateAttributeFormat
+            | IntegerAttributeFormat
+            | OptionSetAttributeFormat
+            | StringAttributeFormat;
 
         /**
          * Interface for a CRM Business Process Flow instance.
@@ -1162,7 +1212,6 @@ declare namespace Xrm {
              * Gets process stage change event arguments.
              *
              * @return  The event arguments.
-             *
              */
             getEventArgs(): StageChangeEventArguments;
         }
@@ -1172,7 +1221,6 @@ declare namespace Xrm {
              * Gets process stage selected event arguments.
              *
              * @return  The event arguments.
-             *
              */
             getEventArgs(): StageSelectedEventArguments;
         }
@@ -2256,7 +2304,9 @@ declare namespace Xrm {
             /**
              * Represents a key-value pair, where the key is the Process Flow's ID, and the value is the name thereof.
              */
-            interface ProcessDictionary { [index: string]: string; }
+            interface ProcessDictionary {
+                [index: string]: string;
+            }
         }
 
         /**
@@ -2488,7 +2538,14 @@ declare namespace Xrm {
              *          Example viewId value: "{00000000-0000-0000-0000-000000000001}"
              *          Layout XML Reference: {@link http://msdn.microsoft.com/en-us/library/gg334522.aspx}
              */
-            addCustomView(viewId: string, entityName: string, viewDisplayName: string, fetchXml: string, layoutXml: string, isDefault: boolean): void;
+            addCustomView(
+                viewId: string,
+                entityName: string,
+                viewDisplayName: string,
+                fetchXml: string,
+                layoutXml: string,
+                isDefault: boolean,
+            ): void;
 
             /**
              * Gets the control's bound attribute.
@@ -3298,7 +3355,7 @@ declare namespace XrmEnum {
         Update = 2,
         ReadOnly = 3,
         Disabled = 4,
-        BulkEdit = 6
+        BulkEdit = 6,
     }
 
     /**
@@ -3315,7 +3372,7 @@ declare namespace XrmEnum {
         Assign = 47,
         Send = 7,
         Qualify = 16,
-        Disqualify = 15
+        Disqualify = 15,
     }
 
     /**
@@ -3328,7 +3385,7 @@ declare namespace XrmEnum {
         Close = 3,
         Identify = 4,
         Research = 5,
-        Resolve = 6
+        Resolve = 6,
     }
 
     /**
@@ -3339,7 +3396,7 @@ declare namespace XrmEnum {
         RibbonContextForm = 1,
         RibbonContextListing = 2,
         FormContextUnrelated = 3,
-        FormContextRelated = 4
+        FormContextRelated = 4,
     }
 
     /**
@@ -3347,6 +3404,6 @@ declare namespace XrmEnum {
      */
     const enum ViewType {
         SystemView = 1039,
-        UserView = 4230
+        UserView = 4230,
     }
 }

--- a/types/xrm/v8/xrm-tests.ts
+++ b/types/xrm/v8/xrm-tests.ts
@@ -41,35 +41,52 @@ const lookupAttribute2 = Xrm.Page.getControl<Xrm.Page.LookupControl>("customerid
 
 /// Demonstrate ES6 String literal syntax
 
-lookupAttribute.addCustomFilter(`<filter type="and">
+lookupAttribute.addCustomFilter(
+    `<filter type="and">
     <condition attribute="address1_city" operator="eq" value="Redmond" />
-</filter>`, "account");
+</filter>`,
+    "account",
+);
 
-lookupAttribute.addPreSearch(() => { alert("A search was performed."); });
+lookupAttribute.addPreSearch(() => {
+    alert("A search was performed.");
+});
 
 /// Demonstrate strong-typed attribute association with strong-typed control
 
 const lookupValues = lookupAttribute.getAttribute().getValue();
 
-if (lookupValues !== null)
-    if (!lookupValues[0].id || !lookupValues[0].entityType)
+if (lookupValues !== null) {
+    if (!lookupValues[0].id || !lookupValues[0].entityType) {
         throw new Error("Invalid value in Lookup control.");
+    }
+}
 
 /// Demonstrate v7.0 BPF API
 
-if (Xrm.Page.data.process != null)
-    Xrm.Page.data.process.moveNext((status) => { alert(`Process moved forward with status: ${status}`); });
+if (Xrm.Page.data.process != null) {
+    Xrm.Page.data.process.moveNext((status) => {
+        alert(`Process moved forward with status: ${status}`);
+    });
+}
 
 /// Demonstrate v7.1 Quick Create form
 
 Xrm.Utility.openQuickCreate("account").then(
-    (object) => { if (object) alert(`Newly created record Id: ${object.savedEntityReference.id}`); },
-    (error) => {console.log(`Code: ${error.errorCode}, Message: ${error.message}`); });
+    (object) => {
+        if (object) alert(`Newly created record Id: ${object.savedEntityReference.id}`);
+    },
+    (error) => {
+        console.log(`Code: ${error.errorCode}, Message: ${error.message}`);
+    },
+);
 
 /// Make all controls visible.
 
 // Xrm.Page.ui.controls.forEach((control) => { control.setVisible(true); }); // No longer works
-Xrm.Page.ui.controls.forEach((control: Xrm.Page.StandardControl) => { control.setVisible(true); }); // Must cast to StandardControl
+Xrm.Page.ui.controls.forEach((control: Xrm.Page.StandardControl) => {
+    control.setVisible(true);
+}); // Must cast to StandardControl
 
 /// Make all tabs and sections visible.
 
@@ -86,15 +103,19 @@ Xrm.Page.ui.tabs.forEach((tab) => {
 Xrm.Page.data.entity.addOnSave((context: Xrm.Page.SaveEventContext) => {
     const eventArgs = context.getEventArgs();
 
-    if (eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose)
+    if (
+        eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave
+        || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose
+    ) {
         eventArgs.preventDefault();
+    }
 });
 
 /// Demonstrate ES6 String literal with templates
 
-alert(`The current form type is: ${Xrm.Page.ui.getFormType() }`);
+alert(`The current form type is: ${Xrm.Page.ui.getFormType()}`);
 
-alert(`The current entity type is: ${Xrm.Page.data.entity.getEntityName() }`);
+alert(`The current entity type is: ${Xrm.Page.data.entity.getEntityName()}`);
 
 /// Demonstrate Optionset Value as int in Turbo Forms
 
@@ -128,7 +149,7 @@ attribute.setRequiredLevel(requirementLevelString); // Works if the string is a 
 
 let autoCompleteControl = Xrm.Page.getControl<Xrm.Page.AutoLookupControl>("name");
 const userInput = autoCompleteControl.getValue();
-const accountResult = {  };
+const accountResult = {};
 const resultSet: Xrm.Page.AutoCompleteResultSet = {
     results: new Array() as Xrm.Page.AutoCompleteResult[],
     commands: {
@@ -142,14 +163,14 @@ const resultSet: Xrm.Page.AutoCompleteResultSet = {
             // that provides information on working with
             // accounts in CRM.
             window.open("http://www.microsoft.com/en-us/dynamics/crm-customer-center/create-or-edit-an-account.aspx");
-        }
-    }
+        },
+    },
 };
 resultSet.results.push({
     id: 0,
-    fields: ["A. Datum Corporation"]
+    fields: ["A. Datum Corporation"],
 });
-autoCompleteControl.addOnKeyPress(() => { });
+autoCompleteControl.addOnKeyPress(() => {});
 autoCompleteControl.fireOnKeyPress();
 autoCompleteControl.removeOnKeyPress(() => {});
 autoCompleteControl.showAutoComplete(resultSet);

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -59,8 +59,9 @@ lookupAttribute.addPreSearch(() => {
 
 const lookupValues = lookupAttribute.getAttribute().getValue();
 
-if (lookupValues !== null)
+if (lookupValues !== null) {
     if (lookupValues[0].id || lookupValues[0].entityType) throw new Error("Invalid value in Lookup control.");
+}
 
 lookupAttribute.getAttribute().setValue(null);
 lookupAttribute.getAttribute().setValue([
@@ -72,10 +73,11 @@ lookupAttribute.getAttribute().setValue([
 
 /// Demonstrate v7.0 BPF API
 
-if (Xrm.Page.data.process != null)
+if (Xrm.Page.data.process != null) {
     Xrm.Page.data.process.moveNext((status) => {
         alert(`Process moved forward with status: ${status}`);
     });
+}
 
 /// Demonstrate v7.1 Quick Create form
 
@@ -112,10 +114,11 @@ Xrm.Page.data.entity.addOnSave((context: Xrm.Page.SaveEventContext) => {
     const eventArgs = context.getEventArgs();
 
     if (
-        eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave ||
-        eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose
-    )
+        eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave
+        || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose
+    ) {
         eventArgs.preventDefault();
+    }
 
     // @ts-expect-error
     eventArgs.disableAsyncTimeout();
@@ -418,7 +421,8 @@ async function ribbonCommand(commandProperties: Xrm.CommandProperties, primaryEn
         await Promise.resolve(
             Xrm.Navigation.openAlertDialog({
                 title: `${commandProperties.CommandValueId}`,
-                text: `Thanks for clicking on ${primaryEntity.Name} of type ${primaryEntity.TypeName} and id ${primaryEntity.Id}`,
+                text:
+                    `Thanks for clicking on ${primaryEntity.Name} of type ${primaryEntity.TypeName} and id ${primaryEntity.Id}`,
             }),
         );
     }
@@ -549,8 +553,9 @@ function onChangeHeaderField(executionContext: Xrm.Events.EventContext): void {
 }
 
 function booleanAttributeControls(formContext: Xrm.FormContext) {
-    let booleanAttribute: Xrm.Attributes.BooleanAttribute =
-        formContext.getAttribute<Xrm.Attributes.BooleanAttribute>("prefx_myattribute");
+    let booleanAttribute: Xrm.Attributes.BooleanAttribute = formContext.getAttribute<Xrm.Attributes.BooleanAttribute>(
+        "prefx_myattribute",
+    );
     const booleanValue: boolean | null = booleanAttribute.getValue();
 
     // @ts-expect-error
@@ -594,7 +599,7 @@ function onStageChange(context: Xrm.Events.StageChangeEventContext) {
 Xrm.Navigation.navigateTo({
     pageType: "entityrecord",
     entityName: "account",
-    tabName: "tab"
+    tabName: "tab",
 }).then(
     (success) => {
         console.log("Entity opened");

--- a/types/xsalsa20-encoding/index.d.ts
+++ b/types/xsalsa20-encoding/index.d.ts
@@ -120,7 +120,7 @@ declare namespace createCodec {
     type ValueToEncode = Buffer | string | readonly number[] | JSONParsedBuffer;
 
     interface JSONParsedBuffer {
-        type: 'Buffer';
+        type: "Buffer";
         data: readonly number[];
     }
 

--- a/types/xsalsa20-encoding/xsalsa20-encoding-tests.ts
+++ b/types/xsalsa20-encoding/xsalsa20-encoding-tests.ts
@@ -1,5 +1,5 @@
-import * as crypto from 'node:crypto';
-import createCodec = require('xsalsa20-encoding');
+import * as crypto from "node:crypto";
+import createCodec = require("xsalsa20-encoding");
 
 // test type exports
 type Options = createCodec.Options;
@@ -20,7 +20,7 @@ const strCodec = createCodec(secretKey, {
         decode(buffer, offset) {
             buffer; // $ExpectType Buffer
             offset; // $ExpectType number
-            return buffer.toString('utf8');
+            return buffer.toString("utf8");
         },
         encode(value: string) {
             return Buffer.from(value) as createCodec.ValueToEncode;
@@ -28,18 +28,18 @@ const strCodec = createCodec(secretKey, {
     },
 });
 
-codec.encode(Buffer.from('foo')); // $ExpectType Buffer
-codec.encode('foo'); // $ExpectType Buffer
+codec.encode(Buffer.from("foo")); // $ExpectType Buffer
+codec.encode("foo"); // $ExpectType Buffer
 codec.encode([1]); // $ExpectType Buffer
-codec.encode(Buffer.from('foo').toJSON()); // $ExpectType Buffer
-codec.encode(Buffer.from('foo'), Buffer.alloc(10)); // $ExpectType Buffer
-codec.encode(Buffer.from('foo'), Buffer.alloc(10), 1); // $ExpectType Buffer
+codec.encode(Buffer.from("foo").toJSON()); // $ExpectType Buffer
+codec.encode(Buffer.from("foo"), Buffer.alloc(10)); // $ExpectType Buffer
+codec.encode(Buffer.from("foo"), Buffer.alloc(10), 1); // $ExpectType Buffer
 
-strCodec.encode('foo'); // $ExpectType Buffer
+strCodec.encode("foo"); // $ExpectType Buffer
 // @ts-expect-error
-strCodec.encode(Buffer.from('foo'));
-strCodec.encode('foo', Buffer.alloc(10)); // $ExpectType Buffer
-strCodec.encode('foo', Buffer.alloc(10), 1); // $ExpectType Buffer
+strCodec.encode(Buffer.from("foo"));
+strCodec.encode("foo", Buffer.alloc(10)); // $ExpectType Buffer
+strCodec.encode("foo", Buffer.alloc(10), 1); // $ExpectType Buffer
 
 codec.encode.bytes; // $ExpectType number
 strCodec.encode.bytes; // $ExpectType number

--- a/types/xsalsa20/index.d.ts
+++ b/types/xsalsa20/index.d.ts
@@ -35,7 +35,7 @@ declare namespace XSalsa20 {
          * @param nonce Should be 24 bytes.
          * @param key Should be 32 bytes.
          */
-        new (nonce: Uint8Array | Buffer, key: Uint8Array | Buffer): Xor;
+        new(nonce: Uint8Array | Buffer, key: Uint8Array | Buffer): Xor;
     }
 
     interface Xor {

--- a/types/xsd-schema-validator/index.d.ts
+++ b/types/xsd-schema-validator/index.d.ts
@@ -5,8 +5,12 @@
 
 /// <reference types="node" />
 
-export function validateXML(xml: string|NodeJS.ReadableStream|{file: string}, pathToXsd: string, callback: (err: Error, result: {
-    valid: boolean;
-    messages: string[];
-    result: string;
-}) => void): void;
+export function validateXML(
+    xml: string | NodeJS.ReadableStream | { file: string },
+    pathToXsd: string,
+    callback: (err: Error, result: {
+        valid: boolean;
+        messages: string[];
+        result: string;
+    }) => void,
+): void;

--- a/types/xsd-schema-validator/xsd-schema-validator-tests.ts
+++ b/types/xsd-schema-validator/xsd-schema-validator-tests.ts
@@ -1,12 +1,12 @@
 import fs = require("fs");
 import validator = require("xsd-schema-validator");
 
-validator.validateXML("<foo:bar />", 'resources/foo.xsd', (err, result) => {
+validator.validateXML("<foo:bar />", "resources/foo.xsd", (err, result) => {
     if (err) {
         throw err;
     } else return result.valid;
 });
-validator.validateXML(fs.createReadStream('some.xml'), "schema.xsd", (err) => {
+validator.validateXML(fs.createReadStream("some.xml"), "schema.xsd", (err) => {
     if (err) throw err;
 });
 validator.validateXML({ file: "some.xml" }, "schema.xsd", (err) => {

--- a/types/xsockets/index.d.ts
+++ b/types/xsockets/index.d.ts
@@ -9,7 +9,12 @@ declare namespace XSockets {
         constructor(url: string, subprotocol?: string, settings?: any);
         on(event: string, handler: (data: any) => void, confirmation?: (arg: ConfirmationArgument) => void): void;
         one(event: string, handler: (data: any) => void, confirmation?: (arg: ConfirmationArgument) => void): void;
-        many(event: string, times: number, handler: (data: any) => void, confirmation?: (arg: ConfirmationArgument) => void): void;
+        many(
+            event: string,
+            times: number,
+            handler: (data: any) => void,
+            confirmation?: (arg: ConfirmationArgument) => void,
+        ): void;
         unbind(event: string): void;
         publish(topic: string, data: any): void;
     }

--- a/types/xsockets/xsockets-tests.ts
+++ b/types/xsockets/xsockets-tests.ts
@@ -1,40 +1,38 @@
+var conn = new XSockets.WebSocket("ws://localhost:4502/Generic");
 
-
-var conn = new XSockets.WebSocket('ws://localhost:4502/Generic');
-
-conn.on(XSockets.Events.open,function (clientInfo) {
-    console.log('Open', clientInfo);
+conn.on(XSockets.Events.open, function(clientInfo) {
+    console.log("Open", clientInfo);
 });
 
-conn.on(XSockets.Events.onError, function (err) {
-    console.log('Error', err);
+conn.on(XSockets.Events.onError, function(err) {
+    console.log("Error", err);
 });
 
-conn.on(XSockets.Events.close, function () {
-    console.log('Closed');
+conn.on(XSockets.Events.close, function() {
+    console.log("Closed");
 });
 
-conn.publish('foo', {text:'Hello Real-Time World'});
+conn.publish("foo", { text: "Hello Real-Time World" });
 
-conn.on('foo', function(data) {
-    console.log('subscription to foo fired with data = ', data);
+conn.on("foo", function(data) {
+    console.log("subscription to foo fired with data = ", data);
 });
 
-conn.unbind('foo');
+conn.unbind("foo");
 
-conn.one('foo', function(data) {
-    console.log('subscription to foo fired with data = ', data);
+conn.one("foo", function(data) {
+    console.log("subscription to foo fired with data = ", data);
 });
 
-conn.many('foo',4, function(data) {
-    console.log('subscription to foo fired with data = ', data);
+conn.many("foo", 4, function(data) {
+    console.log("subscription to foo fired with data = ", data);
 });
 
-conn.on('foo', function (data) {
-    console.log('subscription to foo fired with data = ', data);
-}, function (confirmation) {
-    console.log('subscription confirmed',confirmation);
-    conn.publish('foo', { text: 'Hello Real-Time World' });
+conn.on("foo", function(data) {
+    console.log("subscription to foo fired with data = ", data);
+}, function(confirmation) {
+    console.log("subscription confirmed", confirmation);
+    conn.publish("foo", { text: "Hello Real-Time World" });
 });
 
 conn.publish(XSockets.Events.storage.set, {
@@ -42,20 +40,22 @@ conn.publish(XSockets.Events.storage.set, {
     Value: {
         Name: "John Doe",
         Age: 40,
-        Likes: ["Beer", "Food", "Coffe"]
-    }
+        Likes: ["Beer", "Food", "Coffe"],
+    },
 });
 
-conn.publish(XSockets.Events.storage.remove, {Key: 'yourKey'});
+conn.publish(XSockets.Events.storage.remove, { Key: "yourKey" });
 
-conn.on(XSockets.Events.storage.getAll, function (data) {
-    data.forEach(function (item: any) {
+conn.on(XSockets.Events.storage.getAll, function(data) {
+    data.forEach(function(item: any) {
         console.log(item);
     });
 });
 
 conn.publish(XSockets.Events.storage.getAll, {});
 
-conn.publish('set_MyProp',{value:'New Value'});
+conn.publish("set_MyProp", { value: "New Value" });
 
-conn.on('get_MyProp',function(prop){console.log('Value Of MyProp',prop)});
+conn.on("get_MyProp", function(prop) {
+    console.log("Value Of MyProp", prop);
+});

--- a/types/xss-filters/index.d.ts
+++ b/types/xss-filters/index.d.ts
@@ -4,40 +4,40 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface XSSFilters {
-  inHTMLComment(s:string):string;
-  inHTMLData(s:string):string;
-  inDoubleQuotedAttr(s:string):string;
-  inSingleQuotedAttr(s:string):string;
-  inUnQuotedAttr(s:string):string;
-  uriInHTMLComment(s:string):string;
-  uriInHTMLData(s:string):string;
-  uriInDoubleQuotedAttr(s:string):string;
-  uriInSingleQuotedAttr(s:string):string;
-  uriInUnQuotedAttr(s:string):string;
-  uriPathInHTMLComment(s:string):string;
-  uriPathInHTMLData(s:string):string;
-  uriPathInDoubleQuotedAttr(s:string):string;
-  uriPathInSingleQuotedAttr(s:string):string;
-  uriPathInUnQuotedAttr(s:string):string;
-  uriQueryInHTMLComment(s:string):string;
-  uriQueryInHTMLData(s:string):string;
-  uriQueryInDoubleQuotedAttr(s:string):string;
-  uriQueryInSingleQuotedAttr(s:string):string;
-  uriQueryInUnQuotedAttr(s:string):string;
-  uriComponentInHTMLComment(s:string):string;
-  uriComponentInHTMLData(s:string):string;
-  uriComponentInDoubleQuotedAttr(s:string):string;
-  uriComponentInSingleQuotedAttr(s:string):string;
-  uriComponentInUnQuotedAttr(s:string):string;
-  uriFragmentInHTMLComment(s:string):string;
-  uriFragmentInHTMLData(s:string):string;
-  uriFragmentInDoubleQuotedAttr(s:string):string;
-  uriFragmentInSingleQuotedAttr(s:string):string;
-  uriFragmentInUnQuotedAttr(s:string):string;
+    inHTMLComment(s: string): string;
+    inHTMLData(s: string): string;
+    inDoubleQuotedAttr(s: string): string;
+    inSingleQuotedAttr(s: string): string;
+    inUnQuotedAttr(s: string): string;
+    uriInHTMLComment(s: string): string;
+    uriInHTMLData(s: string): string;
+    uriInDoubleQuotedAttr(s: string): string;
+    uriInSingleQuotedAttr(s: string): string;
+    uriInUnQuotedAttr(s: string): string;
+    uriPathInHTMLComment(s: string): string;
+    uriPathInHTMLData(s: string): string;
+    uriPathInDoubleQuotedAttr(s: string): string;
+    uriPathInSingleQuotedAttr(s: string): string;
+    uriPathInUnQuotedAttr(s: string): string;
+    uriQueryInHTMLComment(s: string): string;
+    uriQueryInHTMLData(s: string): string;
+    uriQueryInDoubleQuotedAttr(s: string): string;
+    uriQueryInSingleQuotedAttr(s: string): string;
+    uriQueryInUnQuotedAttr(s: string): string;
+    uriComponentInHTMLComment(s: string): string;
+    uriComponentInHTMLData(s: string): string;
+    uriComponentInDoubleQuotedAttr(s: string): string;
+    uriComponentInSingleQuotedAttr(s: string): string;
+    uriComponentInUnQuotedAttr(s: string): string;
+    uriFragmentInHTMLComment(s: string): string;
+    uriFragmentInHTMLData(s: string): string;
+    uriFragmentInDoubleQuotedAttr(s: string): string;
+    uriFragmentInSingleQuotedAttr(s: string): string;
+    uriFragmentInUnQuotedAttr(s: string): string;
 }
 
-declare var xssFilters:XSSFilters;
+declare var xssFilters: XSSFilters;
 
-declare module 'xss-filters' {
-  export = xssFilters;
+declare module "xss-filters" {
+    export = xssFilters;
 }

--- a/types/xss-filters/xss-filters-tests.ts
+++ b/types/xss-filters/xss-filters-tests.ts
@@ -1,8 +1,6 @@
+import xssFilters = require("xss-filters");
 
-
-import xssFilters = require('xss-filters');
-
-var s = '<script>alert("hello")</script>';
+var s = "<script>alert(\"hello\")</script>";
 
 xssFilters.inHTMLComment(s);
 xssFilters.inHTMLData(s);
@@ -34,4 +32,3 @@ xssFilters.uriFragmentInHTMLData(s);
 xssFilters.uriFragmentInDoubleQuotedAttr(s);
 xssFilters.uriFragmentInSingleQuotedAttr(s);
 xssFilters.uriFragmentInUnQuotedAttr(s);
-

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -4,24 +4,24 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import * as React from 'react';
+import { SystemProps } from "@xstyled/system";
+import * as React from "react";
 import _styled, {
-    StyledComponent,
-    ThemedStyledFunction,
     DefaultTheme,
     FlattenSimpleInterpolation,
-} from 'styled-components';
-import { SystemProps } from '@xstyled/system';
+    StyledComponent,
+    ThemedStyledFunction,
+} from "styled-components";
 
 /**
  * @see {@link https://github.com/smooth-code/xstyled/blob/v1.19.1/packages/styled-components/src/index.js#L1-L16}
  */
-export * from 'styled-components';
+export * from "styled-components";
 
 /**
  * @see {@link https://github.com/smooth-code/xstyled/blob/v1.19.1/packages/styled-components/src/index.js#L20}
  */
-export * from '@xstyled/system';
+export * from "@xstyled/system";
 
 /**
  * @see {@link https://github.com/smooth-code/xstyled/blob/v1.19.1/packages/styled-components/src/colorModes.js#L11}
@@ -134,7 +134,7 @@ export type BoxProps = WithBreakpointArgs<SystemProps>;
 /**
  * @see {@link https://github.com/smooth-code/xstyled/blob/v1.19.1/packages/styled-components/src/styled.js#L27}
  */
-export const Box: StyledComponent<'div', DefaultTheme, BoxProps>;
+export const Box: StyledComponent<"div", DefaultTheme, BoxProps>;
 
 export function breakpoints(styles: BreakpointObject<FlattenSimpleInterpolation | string>): TemplateStringsArray;
 
@@ -147,145 +147,145 @@ export function breakpoints(styles: BreakpointObject<FlattenSimpleInterpolation 
  */
 
 declare const styled: typeof _styled & {
-    aBox: ThemedStyledFunction<'a', DefaultTheme, BoxProps>;
-    abbrBox: ThemedStyledFunction<'abbr', DefaultTheme, BoxProps>;
-    addressBox: ThemedStyledFunction<'address', DefaultTheme, BoxProps>;
-    areaBox: ThemedStyledFunction<'area', DefaultTheme, BoxProps>;
-    articleBox: ThemedStyledFunction<'article', DefaultTheme, BoxProps>;
-    asideBox: ThemedStyledFunction<'aside', DefaultTheme, BoxProps>;
-    audioBox: ThemedStyledFunction<'audio', DefaultTheme, BoxProps>;
-    bBox: ThemedStyledFunction<'b', DefaultTheme, BoxProps>;
-    baseBox: ThemedStyledFunction<'base', DefaultTheme, BoxProps>;
-    bdiBox: ThemedStyledFunction<'bdi', DefaultTheme, BoxProps>;
-    bdoBox: ThemedStyledFunction<'bdo', DefaultTheme, BoxProps>;
-    bigBox: ThemedStyledFunction<'big', DefaultTheme, BoxProps>;
-    blockquoteBox: ThemedStyledFunction<'blockquote', DefaultTheme, BoxProps>;
-    bodyBox: ThemedStyledFunction<'body', DefaultTheme, BoxProps>;
-    brBox: ThemedStyledFunction<'br', DefaultTheme, BoxProps>;
-    buttonBox: ThemedStyledFunction<'button', DefaultTheme, BoxProps>;
-    canvasBox: ThemedStyledFunction<'canvas', DefaultTheme, BoxProps>;
-    captionBox: ThemedStyledFunction<'caption', DefaultTheme, BoxProps>;
-    citeBox: ThemedStyledFunction<'cite', DefaultTheme, BoxProps>;
-    codeBox: ThemedStyledFunction<'code', DefaultTheme, BoxProps>;
-    colBox: ThemedStyledFunction<'col', DefaultTheme, BoxProps>;
-    colgroupBox: ThemedStyledFunction<'colgroup', DefaultTheme, BoxProps>;
-    dataBox: ThemedStyledFunction<'data', DefaultTheme, BoxProps>;
-    datalistBox: ThemedStyledFunction<'datalist', DefaultTheme, BoxProps>;
-    ddBox: ThemedStyledFunction<'dd', DefaultTheme, BoxProps>;
-    delBox: ThemedStyledFunction<'del', DefaultTheme, BoxProps>;
-    detailsBox: ThemedStyledFunction<'details', DefaultTheme, BoxProps>;
-    dfnBox: ThemedStyledFunction<'dfn', DefaultTheme, BoxProps>;
-    dialogBox: ThemedStyledFunction<'dialog', DefaultTheme, BoxProps>;
-    divBox: ThemedStyledFunction<'div', DefaultTheme, BoxProps>;
-    dlBox: ThemedStyledFunction<'dl', DefaultTheme, BoxProps>;
-    dtBox: ThemedStyledFunction<'dt', DefaultTheme, BoxProps>;
-    emBox: ThemedStyledFunction<'em', DefaultTheme, BoxProps>;
-    embedBox: ThemedStyledFunction<'embed', DefaultTheme, BoxProps>;
-    fieldsetBox: ThemedStyledFunction<'fieldset', DefaultTheme, BoxProps>;
-    figcaptionBox: ThemedStyledFunction<'figcaption', DefaultTheme, BoxProps>;
-    figureBox: ThemedStyledFunction<'figure', DefaultTheme, BoxProps>;
-    footerBox: ThemedStyledFunction<'footer', DefaultTheme, BoxProps>;
-    formBox: ThemedStyledFunction<'form', DefaultTheme, BoxProps>;
-    h1Box: ThemedStyledFunction<'h1', DefaultTheme, BoxProps>;
-    h2Box: ThemedStyledFunction<'h2', DefaultTheme, BoxProps>;
-    h3Box: ThemedStyledFunction<'h3', DefaultTheme, BoxProps>;
-    h4Box: ThemedStyledFunction<'h4', DefaultTheme, BoxProps>;
-    h5Box: ThemedStyledFunction<'h5', DefaultTheme, BoxProps>;
-    h6Box: ThemedStyledFunction<'h6', DefaultTheme, BoxProps>;
-    headBox: ThemedStyledFunction<'head', DefaultTheme, BoxProps>;
-    headerBox: ThemedStyledFunction<'header', DefaultTheme, BoxProps>;
-    hgroupBox: ThemedStyledFunction<'hgroup', DefaultTheme, BoxProps>;
-    hrBox: ThemedStyledFunction<'hr', DefaultTheme, BoxProps>;
-    htmlBox: ThemedStyledFunction<'html', DefaultTheme, BoxProps>;
-    iBox: ThemedStyledFunction<'i', DefaultTheme, BoxProps>;
-    iframeBox: ThemedStyledFunction<'iframe', DefaultTheme, BoxProps>;
-    imgBox: ThemedStyledFunction<'img', DefaultTheme, BoxProps>;
-    inputBox: ThemedStyledFunction<'input', DefaultTheme, BoxProps>;
-    insBox: ThemedStyledFunction<'ins', DefaultTheme, BoxProps>;
-    kbdBox: ThemedStyledFunction<'kbd', DefaultTheme, BoxProps>;
-    keygenBox: ThemedStyledFunction<'keygen', DefaultTheme, BoxProps>;
-    labelBox: ThemedStyledFunction<'label', DefaultTheme, BoxProps>;
-    legendBox: ThemedStyledFunction<'legend', DefaultTheme, BoxProps>;
-    liBox: ThemedStyledFunction<'li', DefaultTheme, BoxProps>;
-    linkBox: ThemedStyledFunction<'link', DefaultTheme, BoxProps>;
-    mainBox: ThemedStyledFunction<'main', DefaultTheme, BoxProps>;
-    mapBox: ThemedStyledFunction<'map', DefaultTheme, BoxProps>;
-    markBox: ThemedStyledFunction<'mark', DefaultTheme, BoxProps>;
+    aBox: ThemedStyledFunction<"a", DefaultTheme, BoxProps>;
+    abbrBox: ThemedStyledFunction<"abbr", DefaultTheme, BoxProps>;
+    addressBox: ThemedStyledFunction<"address", DefaultTheme, BoxProps>;
+    areaBox: ThemedStyledFunction<"area", DefaultTheme, BoxProps>;
+    articleBox: ThemedStyledFunction<"article", DefaultTheme, BoxProps>;
+    asideBox: ThemedStyledFunction<"aside", DefaultTheme, BoxProps>;
+    audioBox: ThemedStyledFunction<"audio", DefaultTheme, BoxProps>;
+    bBox: ThemedStyledFunction<"b", DefaultTheme, BoxProps>;
+    baseBox: ThemedStyledFunction<"base", DefaultTheme, BoxProps>;
+    bdiBox: ThemedStyledFunction<"bdi", DefaultTheme, BoxProps>;
+    bdoBox: ThemedStyledFunction<"bdo", DefaultTheme, BoxProps>;
+    bigBox: ThemedStyledFunction<"big", DefaultTheme, BoxProps>;
+    blockquoteBox: ThemedStyledFunction<"blockquote", DefaultTheme, BoxProps>;
+    bodyBox: ThemedStyledFunction<"body", DefaultTheme, BoxProps>;
+    brBox: ThemedStyledFunction<"br", DefaultTheme, BoxProps>;
+    buttonBox: ThemedStyledFunction<"button", DefaultTheme, BoxProps>;
+    canvasBox: ThemedStyledFunction<"canvas", DefaultTheme, BoxProps>;
+    captionBox: ThemedStyledFunction<"caption", DefaultTheme, BoxProps>;
+    citeBox: ThemedStyledFunction<"cite", DefaultTheme, BoxProps>;
+    codeBox: ThemedStyledFunction<"code", DefaultTheme, BoxProps>;
+    colBox: ThemedStyledFunction<"col", DefaultTheme, BoxProps>;
+    colgroupBox: ThemedStyledFunction<"colgroup", DefaultTheme, BoxProps>;
+    dataBox: ThemedStyledFunction<"data", DefaultTheme, BoxProps>;
+    datalistBox: ThemedStyledFunction<"datalist", DefaultTheme, BoxProps>;
+    ddBox: ThemedStyledFunction<"dd", DefaultTheme, BoxProps>;
+    delBox: ThemedStyledFunction<"del", DefaultTheme, BoxProps>;
+    detailsBox: ThemedStyledFunction<"details", DefaultTheme, BoxProps>;
+    dfnBox: ThemedStyledFunction<"dfn", DefaultTheme, BoxProps>;
+    dialogBox: ThemedStyledFunction<"dialog", DefaultTheme, BoxProps>;
+    divBox: ThemedStyledFunction<"div", DefaultTheme, BoxProps>;
+    dlBox: ThemedStyledFunction<"dl", DefaultTheme, BoxProps>;
+    dtBox: ThemedStyledFunction<"dt", DefaultTheme, BoxProps>;
+    emBox: ThemedStyledFunction<"em", DefaultTheme, BoxProps>;
+    embedBox: ThemedStyledFunction<"embed", DefaultTheme, BoxProps>;
+    fieldsetBox: ThemedStyledFunction<"fieldset", DefaultTheme, BoxProps>;
+    figcaptionBox: ThemedStyledFunction<"figcaption", DefaultTheme, BoxProps>;
+    figureBox: ThemedStyledFunction<"figure", DefaultTheme, BoxProps>;
+    footerBox: ThemedStyledFunction<"footer", DefaultTheme, BoxProps>;
+    formBox: ThemedStyledFunction<"form", DefaultTheme, BoxProps>;
+    h1Box: ThemedStyledFunction<"h1", DefaultTheme, BoxProps>;
+    h2Box: ThemedStyledFunction<"h2", DefaultTheme, BoxProps>;
+    h3Box: ThemedStyledFunction<"h3", DefaultTheme, BoxProps>;
+    h4Box: ThemedStyledFunction<"h4", DefaultTheme, BoxProps>;
+    h5Box: ThemedStyledFunction<"h5", DefaultTheme, BoxProps>;
+    h6Box: ThemedStyledFunction<"h6", DefaultTheme, BoxProps>;
+    headBox: ThemedStyledFunction<"head", DefaultTheme, BoxProps>;
+    headerBox: ThemedStyledFunction<"header", DefaultTheme, BoxProps>;
+    hgroupBox: ThemedStyledFunction<"hgroup", DefaultTheme, BoxProps>;
+    hrBox: ThemedStyledFunction<"hr", DefaultTheme, BoxProps>;
+    htmlBox: ThemedStyledFunction<"html", DefaultTheme, BoxProps>;
+    iBox: ThemedStyledFunction<"i", DefaultTheme, BoxProps>;
+    iframeBox: ThemedStyledFunction<"iframe", DefaultTheme, BoxProps>;
+    imgBox: ThemedStyledFunction<"img", DefaultTheme, BoxProps>;
+    inputBox: ThemedStyledFunction<"input", DefaultTheme, BoxProps>;
+    insBox: ThemedStyledFunction<"ins", DefaultTheme, BoxProps>;
+    kbdBox: ThemedStyledFunction<"kbd", DefaultTheme, BoxProps>;
+    keygenBox: ThemedStyledFunction<"keygen", DefaultTheme, BoxProps>;
+    labelBox: ThemedStyledFunction<"label", DefaultTheme, BoxProps>;
+    legendBox: ThemedStyledFunction<"legend", DefaultTheme, BoxProps>;
+    liBox: ThemedStyledFunction<"li", DefaultTheme, BoxProps>;
+    linkBox: ThemedStyledFunction<"link", DefaultTheme, BoxProps>;
+    mainBox: ThemedStyledFunction<"main", DefaultTheme, BoxProps>;
+    mapBox: ThemedStyledFunction<"map", DefaultTheme, BoxProps>;
+    markBox: ThemedStyledFunction<"mark", DefaultTheme, BoxProps>;
 
     /* This one breaks, it looks like marquee is not supported in JSX.IntrinsicElements */
     // marqueeBox: ThemedStyledFunction<'marquee', DefaultTheme, BoxProps>
 
-    menuBox: ThemedStyledFunction<'menu', DefaultTheme, BoxProps>;
-    menuitemBox: ThemedStyledFunction<'menuitem', DefaultTheme, BoxProps>;
-    metaBox: ThemedStyledFunction<'meta', DefaultTheme, BoxProps>;
-    meterBox: ThemedStyledFunction<'meter', DefaultTheme, BoxProps>;
-    navBox: ThemedStyledFunction<'nav', DefaultTheme, BoxProps>;
-    noscriptBox: ThemedStyledFunction<'noscript', DefaultTheme, BoxProps>;
-    objectBox: ThemedStyledFunction<'object', DefaultTheme, BoxProps>;
-    olBox: ThemedStyledFunction<'ol', DefaultTheme, BoxProps>;
-    optgroupBox: ThemedStyledFunction<'optgroup', DefaultTheme, BoxProps>;
-    optionBox: ThemedStyledFunction<'option', DefaultTheme, BoxProps>;
-    outputBox: ThemedStyledFunction<'output', DefaultTheme, BoxProps>;
-    pBox: ThemedStyledFunction<'p', DefaultTheme, BoxProps>;
-    paramBox: ThemedStyledFunction<'param', DefaultTheme, BoxProps>;
-    pictureBox: ThemedStyledFunction<'picture', DefaultTheme, BoxProps>;
-    preBox: ThemedStyledFunction<'pre', DefaultTheme, BoxProps>;
-    progressBox: ThemedStyledFunction<'progress', DefaultTheme, BoxProps>;
-    qBox: ThemedStyledFunction<'q', DefaultTheme, BoxProps>;
-    rpBox: ThemedStyledFunction<'rp', DefaultTheme, BoxProps>;
-    rtBox: ThemedStyledFunction<'rt', DefaultTheme, BoxProps>;
-    rubyBox: ThemedStyledFunction<'ruby', DefaultTheme, BoxProps>;
-    sBox: ThemedStyledFunction<'s', DefaultTheme, BoxProps>;
-    sampBox: ThemedStyledFunction<'samp', DefaultTheme, BoxProps>;
-    scriptBox: ThemedStyledFunction<'script', DefaultTheme, BoxProps>;
-    sectionBox: ThemedStyledFunction<'section', DefaultTheme, BoxProps>;
-    selectBox: ThemedStyledFunction<'select', DefaultTheme, BoxProps>;
-    smallBox: ThemedStyledFunction<'small', DefaultTheme, BoxProps>;
-    sourceBox: ThemedStyledFunction<'source', DefaultTheme, BoxProps>;
-    spanBox: ThemedStyledFunction<'span', DefaultTheme, BoxProps>;
-    strongBox: ThemedStyledFunction<'strong', DefaultTheme, BoxProps>;
-    styleBox: ThemedStyledFunction<'style', DefaultTheme, BoxProps>;
-    subBox: ThemedStyledFunction<'sub', DefaultTheme, BoxProps>;
-    summaryBox: ThemedStyledFunction<'summary', DefaultTheme, BoxProps>;
-    supBox: ThemedStyledFunction<'sup', DefaultTheme, BoxProps>;
-    tableBox: ThemedStyledFunction<'table', DefaultTheme, BoxProps>;
-    tbodyBox: ThemedStyledFunction<'tbody', DefaultTheme, BoxProps>;
-    tdBox: ThemedStyledFunction<'td', DefaultTheme, BoxProps>;
-    textareaBox: ThemedStyledFunction<'textarea', DefaultTheme, BoxProps>;
-    tfootBox: ThemedStyledFunction<'tfoot', DefaultTheme, BoxProps>;
-    thBox: ThemedStyledFunction<'th', DefaultTheme, BoxProps>;
-    theadBox: ThemedStyledFunction<'thead', DefaultTheme, BoxProps>;
-    timeBox: ThemedStyledFunction<'time', DefaultTheme, BoxProps>;
-    titleBox: ThemedStyledFunction<'title', DefaultTheme, BoxProps>;
-    trBox: ThemedStyledFunction<'tr', DefaultTheme, BoxProps>;
-    trackBox: ThemedStyledFunction<'track', DefaultTheme, BoxProps>;
-    uBox: ThemedStyledFunction<'u', DefaultTheme, BoxProps>;
-    ulBox: ThemedStyledFunction<'ul', DefaultTheme, BoxProps>;
-    varBox: ThemedStyledFunction<'var', DefaultTheme, BoxProps>;
-    videoBox: ThemedStyledFunction<'video', DefaultTheme, BoxProps>;
-    wbrBox: ThemedStyledFunction<'wbr', DefaultTheme, BoxProps>;
+    menuBox: ThemedStyledFunction<"menu", DefaultTheme, BoxProps>;
+    menuitemBox: ThemedStyledFunction<"menuitem", DefaultTheme, BoxProps>;
+    metaBox: ThemedStyledFunction<"meta", DefaultTheme, BoxProps>;
+    meterBox: ThemedStyledFunction<"meter", DefaultTheme, BoxProps>;
+    navBox: ThemedStyledFunction<"nav", DefaultTheme, BoxProps>;
+    noscriptBox: ThemedStyledFunction<"noscript", DefaultTheme, BoxProps>;
+    objectBox: ThemedStyledFunction<"object", DefaultTheme, BoxProps>;
+    olBox: ThemedStyledFunction<"ol", DefaultTheme, BoxProps>;
+    optgroupBox: ThemedStyledFunction<"optgroup", DefaultTheme, BoxProps>;
+    optionBox: ThemedStyledFunction<"option", DefaultTheme, BoxProps>;
+    outputBox: ThemedStyledFunction<"output", DefaultTheme, BoxProps>;
+    pBox: ThemedStyledFunction<"p", DefaultTheme, BoxProps>;
+    paramBox: ThemedStyledFunction<"param", DefaultTheme, BoxProps>;
+    pictureBox: ThemedStyledFunction<"picture", DefaultTheme, BoxProps>;
+    preBox: ThemedStyledFunction<"pre", DefaultTheme, BoxProps>;
+    progressBox: ThemedStyledFunction<"progress", DefaultTheme, BoxProps>;
+    qBox: ThemedStyledFunction<"q", DefaultTheme, BoxProps>;
+    rpBox: ThemedStyledFunction<"rp", DefaultTheme, BoxProps>;
+    rtBox: ThemedStyledFunction<"rt", DefaultTheme, BoxProps>;
+    rubyBox: ThemedStyledFunction<"ruby", DefaultTheme, BoxProps>;
+    sBox: ThemedStyledFunction<"s", DefaultTheme, BoxProps>;
+    sampBox: ThemedStyledFunction<"samp", DefaultTheme, BoxProps>;
+    scriptBox: ThemedStyledFunction<"script", DefaultTheme, BoxProps>;
+    sectionBox: ThemedStyledFunction<"section", DefaultTheme, BoxProps>;
+    selectBox: ThemedStyledFunction<"select", DefaultTheme, BoxProps>;
+    smallBox: ThemedStyledFunction<"small", DefaultTheme, BoxProps>;
+    sourceBox: ThemedStyledFunction<"source", DefaultTheme, BoxProps>;
+    spanBox: ThemedStyledFunction<"span", DefaultTheme, BoxProps>;
+    strongBox: ThemedStyledFunction<"strong", DefaultTheme, BoxProps>;
+    styleBox: ThemedStyledFunction<"style", DefaultTheme, BoxProps>;
+    subBox: ThemedStyledFunction<"sub", DefaultTheme, BoxProps>;
+    summaryBox: ThemedStyledFunction<"summary", DefaultTheme, BoxProps>;
+    supBox: ThemedStyledFunction<"sup", DefaultTheme, BoxProps>;
+    tableBox: ThemedStyledFunction<"table", DefaultTheme, BoxProps>;
+    tbodyBox: ThemedStyledFunction<"tbody", DefaultTheme, BoxProps>;
+    tdBox: ThemedStyledFunction<"td", DefaultTheme, BoxProps>;
+    textareaBox: ThemedStyledFunction<"textarea", DefaultTheme, BoxProps>;
+    tfootBox: ThemedStyledFunction<"tfoot", DefaultTheme, BoxProps>;
+    thBox: ThemedStyledFunction<"th", DefaultTheme, BoxProps>;
+    theadBox: ThemedStyledFunction<"thead", DefaultTheme, BoxProps>;
+    timeBox: ThemedStyledFunction<"time", DefaultTheme, BoxProps>;
+    titleBox: ThemedStyledFunction<"title", DefaultTheme, BoxProps>;
+    trBox: ThemedStyledFunction<"tr", DefaultTheme, BoxProps>;
+    trackBox: ThemedStyledFunction<"track", DefaultTheme, BoxProps>;
+    uBox: ThemedStyledFunction<"u", DefaultTheme, BoxProps>;
+    ulBox: ThemedStyledFunction<"ul", DefaultTheme, BoxProps>;
+    varBox: ThemedStyledFunction<"var", DefaultTheme, BoxProps>;
+    videoBox: ThemedStyledFunction<"video", DefaultTheme, BoxProps>;
+    wbrBox: ThemedStyledFunction<"wbr", DefaultTheme, BoxProps>;
 
     // SVG
-    circleBox: ThemedStyledFunction<'circle', DefaultTheme, BoxProps>;
-    clipPathBox: ThemedStyledFunction<'clipPath', DefaultTheme, BoxProps>;
-    defsBox: ThemedStyledFunction<'defs', DefaultTheme, BoxProps>;
-    ellipseBox: ThemedStyledFunction<'ellipse', DefaultTheme, BoxProps>;
-    foreignObjectBox: ThemedStyledFunction<'foreignObject', DefaultTheme, BoxProps>;
-    gBox: ThemedStyledFunction<'g', DefaultTheme, BoxProps>;
-    imageBox: ThemedStyledFunction<'image', DefaultTheme, BoxProps>;
-    lineBox: ThemedStyledFunction<'line', DefaultTheme, BoxProps>;
-    linearGradientBox: ThemedStyledFunction<'linearGradient', DefaultTheme, BoxProps>;
-    markerBox: ThemedStyledFunction<'marker', DefaultTheme, BoxProps>;
-    maskBox: ThemedStyledFunction<'mask', DefaultTheme, BoxProps>;
-    pathBox: ThemedStyledFunction<'path', DefaultTheme, BoxProps>;
-    patternBox: ThemedStyledFunction<'pattern', DefaultTheme, BoxProps>;
-    polygonBox: ThemedStyledFunction<'polygon', DefaultTheme, BoxProps>;
-    polylineBox: ThemedStyledFunction<'polyline', DefaultTheme, BoxProps>;
-    radialGradientBox: ThemedStyledFunction<'radialGradient', DefaultTheme, BoxProps>;
-    rectBox: ThemedStyledFunction<'rect', DefaultTheme, BoxProps>;
-    stopBox: ThemedStyledFunction<'stop', DefaultTheme, BoxProps>;
-    svgBox: ThemedStyledFunction<'svg', DefaultTheme, BoxProps>;
-    textBox: ThemedStyledFunction<'text', DefaultTheme, BoxProps>;
-    tspanBox: ThemedStyledFunction<'tspan', DefaultTheme, BoxProps>;
+    circleBox: ThemedStyledFunction<"circle", DefaultTheme, BoxProps>;
+    clipPathBox: ThemedStyledFunction<"clipPath", DefaultTheme, BoxProps>;
+    defsBox: ThemedStyledFunction<"defs", DefaultTheme, BoxProps>;
+    ellipseBox: ThemedStyledFunction<"ellipse", DefaultTheme, BoxProps>;
+    foreignObjectBox: ThemedStyledFunction<"foreignObject", DefaultTheme, BoxProps>;
+    gBox: ThemedStyledFunction<"g", DefaultTheme, BoxProps>;
+    imageBox: ThemedStyledFunction<"image", DefaultTheme, BoxProps>;
+    lineBox: ThemedStyledFunction<"line", DefaultTheme, BoxProps>;
+    linearGradientBox: ThemedStyledFunction<"linearGradient", DefaultTheme, BoxProps>;
+    markerBox: ThemedStyledFunction<"marker", DefaultTheme, BoxProps>;
+    maskBox: ThemedStyledFunction<"mask", DefaultTheme, BoxProps>;
+    pathBox: ThemedStyledFunction<"path", DefaultTheme, BoxProps>;
+    patternBox: ThemedStyledFunction<"pattern", DefaultTheme, BoxProps>;
+    polygonBox: ThemedStyledFunction<"polygon", DefaultTheme, BoxProps>;
+    polylineBox: ThemedStyledFunction<"polyline", DefaultTheme, BoxProps>;
+    radialGradientBox: ThemedStyledFunction<"radialGradient", DefaultTheme, BoxProps>;
+    rectBox: ThemedStyledFunction<"rect", DefaultTheme, BoxProps>;
+    stopBox: ThemedStyledFunction<"stop", DefaultTheme, BoxProps>;
+    svgBox: ThemedStyledFunction<"svg", DefaultTheme, BoxProps>;
+    textBox: ThemedStyledFunction<"text", DefaultTheme, BoxProps>;
+    tspanBox: ThemedStyledFunction<"tspan", DefaultTheme, BoxProps>;
 };
 export default styled;

--- a/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
+++ b/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
@@ -1,31 +1,33 @@
-import * as React from 'react';
 import styled, {
     Box,
+    ColorModeProvider,
     css,
+    getColorModeInitScriptElement,
+    getColorModeInitScriptTag,
     useBreakpoint,
     useBreakpoints,
+    useColorMode,
     useDown,
     useUp,
     useViewportWidth,
-    useColorMode,
-    ColorModeProvider,
-    getColorModeInitScriptElement,
-    getColorModeInitScriptTag
-} from '@xstyled/styled-components';
+} from "@xstyled/styled-components";
+import * as React from "react";
 
 interface WithFoo {
     foo: boolean;
 }
 
 const WithRequiredProp = styled.div<WithFoo>`
-    ${({ foo }) => css`
-        display: ${foo ? 'block' : 'none'};
+    ${({ foo }) =>
+    css`
+        display: ${foo ? "block" : "none"};
     `}
 `;
 
 const WithOptionalProp = styled.div<Partial<WithFoo>>`
-    ${({ foo }) => css`
-        display: ${foo ? 'block' : 'none'};
+    ${({ foo }) =>
+    css`
+        display: ${foo ? "block" : "none"};
     `}
 `;
 
@@ -34,7 +36,7 @@ const StyledDivBox = styled.divBox``;
 
 const sum = (a: number) => a * a;
 // @ts-expect-error
-sum('b');
+sum("b");
 
 const Main = () => {
     const breakpoints = useBreakpoints();
@@ -42,28 +44,28 @@ const Main = () => {
     const breakpoint = useBreakpoint();
 
     // @ts-expect-error
-    breakpoint = 'abc';
+    breakpoint = "abc";
 
     let width = useViewportWidth();
 
     // @ts-expect-error
     width = false;
 
-    let isUp = useUp('md');
+    let isUp = useUp("md");
 
     // @ts-expect-error
     isUp = useUp(1);
 
     // @ts-expect-error
-    isUp = '';
+    isUp = "";
 
-    let isDown = useDown('md');
+    let isDown = useDown("md");
 
     // @ts-expect-error
     isDown = useDown(1);
 
     // @ts-expect-error
-    isDown = '';
+    isDown = "";
 
     const [colorMode, setColorMode] = useColorMode();
 
@@ -101,7 +103,7 @@ const ColorMode = () => {
         <>
             <ColorModeProvider target={document.body} targetSelector="#small-react-app">
                 {getColorModeInitScriptElement()}
-                {getColorModeInitScriptElement({ target: 'document.body' })}
+                {getColorModeInitScriptElement({ target: "document.body" })}
                 {/* @ts-expect-error */}
                 {getColorModeInitScriptElement({})}
             </ColorModeProvider>
@@ -114,7 +116,7 @@ const ColorMode = () => {
 };
 
 let colorModeScriptTag = getColorModeInitScriptTag();
-colorModeScriptTag = getColorModeInitScriptTag({ target: 'document.getElementById("small-react-app")' });
+colorModeScriptTag = getColorModeInitScriptTag({ target: "document.getElementById(\"small-react-app\")" });
 // @ts-expect-error
 colorModeScriptTag = getColorModeInitScriptTag({});
 

--- a/types/xstyled__system/index.d.ts
+++ b/types/xstyled__system/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import * as React from 'react';
-import * as CSS from 'csstype';
+import * as CSS from "csstype";
+import * as React from "react";
 
 export interface StyleFunc {
     (...args: any[]): any;
@@ -165,7 +165,8 @@ export interface PaddingYProps<TLength = StyledSystemLength> {
 }
 
 export interface SpaceProps
-    extends MarginProps,
+    extends
+        MarginProps,
         MarginTopProps,
         MarginRightProps,
         MarginBottomProps,
@@ -178,7 +179,8 @@ export interface SpaceProps
         PaddingBottomProps,
         PaddingLeftProps,
         PaddingXProps,
-        PaddingYProps {}
+        PaddingYProps
+{}
 
 // ----- LAYOUT -----
 
@@ -230,7 +232,8 @@ export interface VerticalAlignProps<TLength = StyledSystemLength> {
 }
 
 export interface LayoutProps
-    extends DisplayProps,
+    extends
+        DisplayProps,
         WidthProps,
         HeightProps,
         MaxWidthProps,
@@ -238,7 +241,8 @@ export interface LayoutProps
         MinWidthProps,
         MinHeightProps,
         SizeProps,
-        VerticalAlignProps {}
+        VerticalAlignProps
+{}
 
 // ----- XGRID -----
 
@@ -301,7 +305,8 @@ export interface TextTransformProps {
 }
 
 export interface TypographyProps
-    extends FontFamilyProps,
+    extends
+        FontFamilyProps,
         FontSizeProps,
         LineHeightProps,
         FontWeightProps,
@@ -309,7 +314,8 @@ export interface TypographyProps
         TextAlignProps,
         LetterSpacingProps,
         ColorProps,
-        TextTransformProps {}
+        TextTransformProps
+{}
 
 // ----- FLEXBOXES -----
 
@@ -381,7 +387,8 @@ export interface OrderProps {
 }
 
 export interface FlexboxesProps
-    extends DisplayProps,
+    extends
+        DisplayProps,
         AlignItemsProps,
         AlignContentProps,
         JustifyContentProps,
@@ -394,7 +401,8 @@ export interface FlexboxesProps
         FlexProps,
         JustifySelfProps,
         AlignSelfProps,
-        OrderProps {}
+        OrderProps
+{}
 
 // ----- GRIDS -----
 
@@ -463,7 +471,8 @@ export interface GridAreaProps {
 }
 
 export interface GridsProps
-    extends GridGapProps,
+    extends
+        GridGapProps,
         GridColumnGapProps,
         GridRowGapProps,
         GridColumnProps,
@@ -474,7 +483,8 @@ export interface GridsProps
         GridTemplateColumnsProps,
         GridTemplateRowsProps,
         GridTemplateAreasProps,
-        GridAreaProps {}
+        GridAreaProps
+{}
 
 // ----- BACKGROUNDS -----
 
@@ -512,12 +522,14 @@ export interface BackgroundRepeatProps {
 }
 
 export interface BackgroundsProps
-    extends BackgroundProps,
+    extends
+        BackgroundProps,
         BackgroundColorProps,
         BackgroundImageProps,
         BackgroundSizeProps,
         BackgroundPositionProps,
-        BackgroundRepeatProps {}
+        BackgroundRepeatProps
+{}
 
 // ----- POSITIONING -----
 
@@ -625,7 +637,8 @@ export interface BorderRadiusProps<TLength = StyledSystemLength> {
 }
 
 export interface BordersProps
-    extends BorderProps,
+    extends
+        BorderProps,
         BorderTopProps,
         BorderTopColorProps,
         BorderRightProps,
@@ -637,7 +650,8 @@ export interface BordersProps
         BorderColorProps,
         BorderWidthProps,
         BorderStyleProps,
-        BorderRadiusProps {}
+        BorderRadiusProps
+{}
 
 // ----- SHADOWS -----
 
@@ -660,7 +674,8 @@ export interface ShadowsProps extends BoxShadowProps, TextShadowProps {}
 export const system: StyleFunc;
 
 export interface SystemProps
-    extends BackgroundsProps,
+    extends
+        BackgroundsProps,
         BasicsProps,
         BordersProps,
         FlexboxesProps,
@@ -670,7 +685,8 @@ export interface SystemProps
         ShadowsProps,
         SpaceProps,
         TypographyProps,
-        XGridProps {}
+        XGridProps
+{}
 
 // ----- COMPOSE -----
 

--- a/types/xstyled__system/xstyled__system-tests.tsx
+++ b/types/xstyled__system/xstyled__system-tests.tsx
@@ -1,118 +1,118 @@
-import * as React from 'react';
-import styled from 'styled-components';
 import {
     backgrounds,
+    BackgroundsProps,
     basics,
+    BasicsProps,
     between,
     borders,
+    BordersProps,
     breakpoints,
     color,
+    ColorProps,
     compose,
     createSystemComponent,
     down,
     flexboxes,
-    getColor,
-    getPx,
-    getPercent,
-    getRadius,
-    getTransition,
-    getSpace,
-    getSize,
-    getFont,
-    getLineHeight,
-    getFontWeight,
-    getLetterSpacing,
-    getFontSize,
-    getZIndex,
-    getBorder,
-    getBorderWidth,
-    getBorderStyle,
-    getShadow,
-    grids,
-    layout,
-    margin,
-    padding,
-    positioning,
-    shadows,
-    space,
-    style,
-    system,
-    th,
-    typography,
-    up,
-    variant,
-    xgrids,
-    BackgroundsProps,
-    BasicsProps,
-    BordersProps,
-    ColorProps,
     FlexboxesProps,
     FontSizeProps,
+    getBorder,
+    getBorderStyle,
+    getBorderWidth,
+    getColor,
+    getFont,
+    getFontSize,
+    getFontWeight,
+    getLetterSpacing,
+    getLineHeight,
+    getPercent,
+    getPx,
+    getRadius,
+    getShadow,
+    getSize,
+    getSpace,
+    getTransition,
+    getZIndex,
+    grids,
     GridsProps,
+    layout,
     LayoutProps,
+    margin,
     MarginProps,
+    padding,
     PaddingProps,
+    positioning,
     PositioningProps,
-    ShadowsProps,
-    SpaceProps,
-    SystemProps,
-    TypographyProps,
-    XGridProps,
     rpxTransformers,
-} from '@xstyled/system';
+    shadows,
+    ShadowsProps,
+    space,
+    SpaceProps,
+    style,
+    system,
+    SystemProps,
+    th,
+    typography,
+    TypographyProps,
+    up,
+    variant,
+    XGridProps,
+    xgrids,
+} from "@xstyled/system";
+import * as React from "react";
+import styled from "styled-components";
 
 // Getters
 
 getColor(2)({});
-getColor('primary')({});
+getColor("primary")({});
 
 getPx(2)({});
-getPx('2rpx')({});
+getPx("2rpx")({});
 
 getPercent(0.3)({});
-getPercent('20em')({});
+getPercent("20em")({});
 
 getRadius(2)({});
-getRadius('sm')({});
+getRadius("sm")({});
 
 getTransition(2)({});
-getTransition('fade')({});
+getTransition("fade")({});
 
 getSpace(2)({});
-getSpace('sm')({});
+getSpace("sm")({});
 
 getSize(2)({});
-getSize('sm')({});
+getSize("sm")({});
 
 getFont(2)({});
-getFont('body')({});
+getFont("body")({});
 
 getLineHeight(2)({});
-getLineHeight('sm')({});
+getLineHeight("sm")({});
 
 getFontWeight(2)({});
-getFontWeight('heavy')({});
+getFontWeight("heavy")({});
 
 getLetterSpacing(2)({});
-getLetterSpacing('sm')({});
+getLetterSpacing("sm")({});
 
 getFontSize(2)({});
-getFontSize('sm')({});
+getFontSize("sm")({});
 
 getZIndex(2)({});
-getZIndex('modal')({});
+getZIndex("modal")({});
 
 getBorder(2)({});
-getBorder('main')({});
+getBorder("main")({});
 
 getBorderWidth(2)({});
-getBorderWidth('sm')({});
+getBorderWidth("sm")({});
 
 getBorderStyle(2)({});
-getBorderStyle('selected')({});
+getBorderStyle("selected")({});
 
 getShadow(2)({});
-getShadow('xl')({});
+getShadow("xl")({});
 
 // Color
 
@@ -123,8 +123,8 @@ const Color = styled.div<ColorProps>`
 const colorTest = () => (
     <div>
         <Color color="primary" />
-        <Color color={{ sm: 'primary', md: 'secondary' }} />
-        <Color color={['primary', 'secondary']} />
+        <Color color={{ sm: "primary", md: "secondary" }} />
+        <Color color={["primary", "secondary"]} />
     </div>
 );
 
@@ -138,16 +138,16 @@ const basicsTest = () => (
     <div>
         <Basics opacity={0.5} />
         <Basics opacity="inherit" />
-        <Basics opacity={{ sm: 0.3, md: 'inherit' }} />
-        <Basics opacity={[0.3, 'inherit']} />
+        <Basics opacity={{ sm: 0.3, md: "inherit" }} />
+        <Basics opacity={[0.3, "inherit"]} />
         <Basics overflow="hidden" />
-        <Basics overflow={{ sm: 'hidden', md: 'visible' }} />
-        <Basics overflow={['hidden', 'visible']} />
+        <Basics overflow={{ sm: "hidden", md: "visible" }} />
+        <Basics overflow={["hidden", "visible"]} />
         <Basics transition={2} />
         <Basics transition="sm" />
         <Basics transition="opacity 1s" />
-        <Basics transition={{ sm: 'opacity 1s', md: 'sm' }} />
-        <Basics transition={['opacity 1s', 'sm']} />
+        <Basics transition={{ sm: "opacity 1s", md: "sm" }} />
+        <Basics transition={["opacity 1s", "sm"]} />
     </div>
 );
 
@@ -161,92 +161,92 @@ const spaceTest = () => (
     <div>
         <Space m={2} />
         <Space m="sm" />
-        <Space m={{ sm: 1, md: 'sm' }} />
-        <Space m={[1, 'sm']} />
+        <Space m={{ sm: 1, md: "sm" }} />
+        <Space m={[1, "sm"]} />
         <Space margin={2} />
         <Space margin="sm" />
-        <Space margin={{ sm: 1, md: 'sm' }} />
-        <Space margin={[1, 'sm']} />
+        <Space margin={{ sm: 1, md: "sm" }} />
+        <Space margin={[1, "sm"]} />
         <Space mr={2} />
         <Space mr="sm" />
-        <Space mr={{ sm: 1, md: 'sm' }} />
-        <Space mr={[1, 'sm']} />
+        <Space mr={{ sm: 1, md: "sm" }} />
+        <Space mr={[1, "sm"]} />
         <Space marginRight={2} />
         <Space marginRight="sm" />
-        <Space marginRight={{ sm: 1, md: 'sm' }} />
-        <Space marginRight={[1, 'sm']} />
+        <Space marginRight={{ sm: 1, md: "sm" }} />
+        <Space marginRight={[1, "sm"]} />
         <Space mb={2} />
         <Space mb="sm" />
-        <Space mb={{ sm: 1, md: 'sm' }} />
-        <Space mb={[1, 'sm']} />
+        <Space mb={{ sm: 1, md: "sm" }} />
+        <Space mb={[1, "sm"]} />
         <Space marginBottom={2} />
         <Space marginBottom="sm" />
-        <Space marginBottom={{ sm: 1, md: 'sm' }} />
-        <Space marginBottom={[1, 'sm']} />
+        <Space marginBottom={{ sm: 1, md: "sm" }} />
+        <Space marginBottom={[1, "sm"]} />
         <Space ml={2} />
         <Space ml="sm" />
-        <Space ml={{ sm: 1, md: 'sm' }} />
-        <Space ml={[1, 'sm']} />
+        <Space ml={{ sm: 1, md: "sm" }} />
+        <Space ml={[1, "sm"]} />
         <Space marginLeft={2} />
         <Space marginLeft="sm" />
-        <Space marginLeft={{ sm: 1, md: 'sm' }} />
-        <Space marginLeft={[1, 'sm']} />
+        <Space marginLeft={{ sm: 1, md: "sm" }} />
+        <Space marginLeft={[1, "sm"]} />
         <Space mx={2} />
         <Space mx="sm" />
-        <Space mx={{ sm: 1, md: 'sm' }} />
-        <Space mx={[1, 'sm']} />
+        <Space mx={{ sm: 1, md: "sm" }} />
+        <Space mx={[1, "sm"]} />
         <Space my={2} />
         <Space my="sm" />
-        <Space my={{ sm: 1, md: 'sm' }} />
-        <Space my={[1, 'sm']} />
+        <Space my={{ sm: 1, md: "sm" }} />
+        <Space my={[1, "sm"]} />
         <Space p={2} />
         <Space p="sm" />
-        <Space p={{ sm: 1, md: 'sm' }} />
-        <Space p={[1, 'sm']} />
+        <Space p={{ sm: 1, md: "sm" }} />
+        <Space p={[1, "sm"]} />
         <Space padding={2} />
         <Space padding="sm" />
-        <Space padding={{ sm: 1, md: 'sm' }} />
-        <Space padding={[1, 'sm']} />
+        <Space padding={{ sm: 1, md: "sm" }} />
+        <Space padding={[1, "sm"]} />
         <Space pt={2} />
         <Space pt="sm" />
-        <Space pt={{ sm: 1, md: 'sm' }} />
-        <Space pt={[1, 'sm']} />
+        <Space pt={{ sm: 1, md: "sm" }} />
+        <Space pt={[1, "sm"]} />
         <Space paddingTop={2} />
         <Space paddingTop="sm" />
-        <Space paddingTop={{ sm: 1, md: 'sm' }} />
-        <Space paddingTop={[1, 'sm']} />
+        <Space paddingTop={{ sm: 1, md: "sm" }} />
+        <Space paddingTop={[1, "sm"]} />
         <Space pr={2} />
         <Space pr="sm" />
-        <Space pr={{ sm: 1, md: 'sm' }} />
-        <Space pr={[1, 'sm']} />
+        <Space pr={{ sm: 1, md: "sm" }} />
+        <Space pr={[1, "sm"]} />
         <Space paddingRight={2} />
         <Space paddingRight="sm" />
-        <Space paddingRight={{ sm: 1, md: 'sm' }} />
-        <Space paddingRight={[1, 'sm']} />
+        <Space paddingRight={{ sm: 1, md: "sm" }} />
+        <Space paddingRight={[1, "sm"]} />
         <Space pb={2} />
         <Space pb="sm" />
-        <Space pb={{ sm: 1, md: 'sm' }} />
-        <Space pb={[1, 'sm']} />
+        <Space pb={{ sm: 1, md: "sm" }} />
+        <Space pb={[1, "sm"]} />
         <Space paddingBottom={2} />
         <Space paddingBottom="sm" />
-        <Space paddingBottom={{ sm: 1, md: 'sm' }} />
-        <Space paddingBottom={[1, 'sm']} />
+        <Space paddingBottom={{ sm: 1, md: "sm" }} />
+        <Space paddingBottom={[1, "sm"]} />
         <Space pl={2} />
         <Space pl="sm" />
-        <Space pl={{ sm: 1, md: 'sm' }} />
-        <Space pl={[1, 'sm']} />
+        <Space pl={{ sm: 1, md: "sm" }} />
+        <Space pl={[1, "sm"]} />
         <Space paddingLeft={2} />
         <Space paddingLeft="sm" />
-        <Space paddingLeft={{ sm: 1, md: 'sm' }} />
-        <Space paddingLeft={[1, 'sm']} />
+        <Space paddingLeft={{ sm: 1, md: "sm" }} />
+        <Space paddingLeft={[1, "sm"]} />
         <Space px={2} />
         <Space px="sm" />
-        <Space px={{ sm: 1, md: 'sm' }} />
-        <Space px={[1, 'sm']} />
+        <Space px={{ sm: 1, md: "sm" }} />
+        <Space px={[1, "sm"]} />
         <Space py={2} />
         <Space py="sm" />
-        <Space py={{ sm: 1, md: 'sm' }} />
-        <Space py={[1, 'sm']} />
+        <Space py={{ sm: 1, md: "sm" }} />
+        <Space py={[1, "sm"]} />
     </div>
 );
 
@@ -259,40 +259,40 @@ const Layout = styled.div<LayoutProps>`
 const layoutTest = () => (
     <div>
         <Layout display="flex" />
-        <Layout display={{ sm: 'flex', md: 'block' }} />
-        <Layout display={['flex', 'block']} />
+        <Layout display={{ sm: "flex", md: "block" }} />
+        <Layout display={["flex", "block"]} />
         <Layout width={2} />
         <Layout width="sm" />
-        <Layout width={{ sm: 2, md: 'sm' }} />
-        <Layout width={[2, 'sm']} />
+        <Layout width={{ sm: 2, md: "sm" }} />
+        <Layout width={[2, "sm"]} />
         <Layout height={2} />
         <Layout height="sm" />
-        <Layout height={{ sm: 2, md: 'sm' }} />
-        <Layout height={[2, 'sm']} />
+        <Layout height={{ sm: 2, md: "sm" }} />
+        <Layout height={[2, "sm"]} />
         <Layout maxWidth={2} />
         <Layout maxWidth="sm" />
-        <Layout maxWidth={{ sm: 2, md: 'sm' }} />
-        <Layout maxWidth={[2, 'sm']} />
+        <Layout maxWidth={{ sm: 2, md: "sm" }} />
+        <Layout maxWidth={[2, "sm"]} />
         <Layout maxHeight={2} />
         <Layout maxHeight="sm" />
-        <Layout maxHeight={{ sm: 2, md: 'sm' }} />
-        <Layout maxHeight={[2, 'sm']} />
+        <Layout maxHeight={{ sm: 2, md: "sm" }} />
+        <Layout maxHeight={[2, "sm"]} />
         <Layout minWidth={2} />
         <Layout minWidth="sm" />
-        <Layout minWidth={{ sm: 2, md: 'sm' }} />
-        <Layout minWidth={[2, 'sm']} />
+        <Layout minWidth={{ sm: 2, md: "sm" }} />
+        <Layout minWidth={[2, "sm"]} />
         <Layout minHeight={2} />
         <Layout minHeight="sm" />
-        <Layout minHeight={{ sm: 2, md: 'sm' }} />
-        <Layout minHeight={[2, 'sm']} />
+        <Layout minHeight={{ sm: 2, md: "sm" }} />
+        <Layout minHeight={[2, "sm"]} />
         <Layout size={2} />
         <Layout size="sm" />
-        <Layout size={{ sm: 2, md: 'sm' }} />
-        <Layout size={[2, 'sm']} />
+        <Layout size={{ sm: 2, md: "sm" }} />
+        <Layout size={[2, "sm"]} />
         <Layout verticalAlign={200} />
         <Layout verticalAlign="top" />
-        <Layout verticalAlign={{ sm: 200, md: 'top' }} />
-        <Layout verticalAlign={[200, 'top']} />
+        <Layout verticalAlign={{ sm: 200, md: "top" }} />
+        <Layout verticalAlign={[200, "top"]} />
     </div>
 );
 
@@ -307,11 +307,11 @@ const xgridsTest = () => (
         <XGrids col="auto" />
         <XGrids col={0.2} />
         <XGrids col={true} />
-        <XGrids col={{ xs: 0.2, md: 'auto' }} />
+        <XGrids col={{ xs: 0.2, md: "auto" }} />
         <XGrids row="auto" />
         <XGrids row={0.2} />
         <XGrids row={true} />
-        <XGrids row={{ xs: 0.2, md: 'auto' }} />
+        <XGrids row={{ xs: 0.2, md: "auto" }} />
     </div>
 );
 
@@ -325,34 +325,34 @@ const typographyTest = () => (
     <div>
         <Typography fontFamily={2} />
         <Typography fontFamily="body" />
-        <Typography fontFamily={{ sm: 2, md: 'display' }} />
-        <Typography fontFamily={[2, 'display']} />
+        <Typography fontFamily={{ sm: 2, md: "display" }} />
+        <Typography fontFamily={[2, "display"]} />
         <Typography fontSize={2} />
         <Typography fontSize="sm" />
-        <Typography fontSize={{ sm: 2, md: 'sm' }} />
-        <Typography fontSize={[2, 'sm']} />
+        <Typography fontSize={{ sm: 2, md: "sm" }} />
+        <Typography fontSize={[2, "sm"]} />
         <Typography lineHeight={2} />
         <Typography lineHeight="sm" />
-        <Typography lineHeight={{ sm: 1, md: 'sm' }} />
-        <Typography lineHeight={[1, 'sm']} />
+        <Typography lineHeight={{ sm: 1, md: "sm" }} />
+        <Typography lineHeight={[1, "sm"]} />
         <Typography fontWeight={2} />
         <Typography fontWeight="sm" />
         <Typography fontWeight="bold" />
-        <Typography fontWeight={{ sm: 1, md: 'sm', lg: 'bold' }} />
-        <Typography fontWeight={[1, 'sm', 'bold']} />
+        <Typography fontWeight={{ sm: 1, md: "sm", lg: "bold" }} />
+        <Typography fontWeight={[1, "sm", "bold"]} />
         <Typography fontStyle="normal" />
         <Typography fontStyle="italic" />
         <Typography fontStyle="oblique" />
         <Typography textAlign="start" />
-        <Typography textAlign={{ sm: 'start', md: 'end' }} />
-        <Typography textAlign={['start', 'end']} />
+        <Typography textAlign={{ sm: "start", md: "end" }} />
+        <Typography textAlign={["start", "end"]} />
         <Typography letterSpacing={2} />
         <Typography letterSpacing="sm" />
-        <Typography letterSpacing={{ sm: 1, md: 'sm' }} />
-        <Typography letterSpacing={[1, 'sm']} />
+        <Typography letterSpacing={{ sm: 1, md: "sm" }} />
+        <Typography letterSpacing={[1, "sm"]} />
         <Typography textTransform="lowercase" />
-        <Typography textTransform={{ sm: 'lowercase', md: 'uppercase' }} />
-        <Typography textTransform={['lowercase', 'uppercase']} />
+        <Typography textTransform={{ sm: "lowercase", md: "uppercase" }} />
+        <Typography textTransform={["lowercase", "uppercase"]} />
     </div>
 );
 
@@ -365,20 +365,20 @@ const Flexboxes = styled.div<FlexboxesProps>`
 const flexboxesTest = () => (
     <div>
         <Flexboxes alignItems="flex-start" />
-        <Flexboxes alignItems={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes alignItems={['flex-start', 'flex-end']} />
+        <Flexboxes alignItems={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes alignItems={["flex-start", "flex-end"]} />
         <Flexboxes alignContent="flex-start" />
-        <Flexboxes alignContent={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes alignContent={['flex-start', 'flex-end']} />
+        <Flexboxes alignContent={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes alignContent={["flex-start", "flex-end"]} />
         <Flexboxes justifyContent="flex-start" />
-        <Flexboxes justifyContent={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes justifyContent={['flex-start', 'flex-end']} />
+        <Flexboxes justifyContent={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes justifyContent={["flex-start", "flex-end"]} />
         <Flexboxes justifyItems="flex-start" />
-        <Flexboxes justifyItems={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes justifyItems={['flex-start', 'flex-end']} />
+        <Flexboxes justifyItems={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes justifyItems={["flex-start", "flex-end"]} />
         <Flexboxes flexWrap="wrap" />
-        <Flexboxes flexWrap={{ sm: 'wrap', md: 'nowrap' }} />
-        <Flexboxes flexWrap={['wrap', 'nowrap']} />
+        <Flexboxes flexWrap={{ sm: "wrap", md: "nowrap" }} />
+        <Flexboxes flexWrap={["wrap", "nowrap"]} />
         <Flexboxes flexGrow={2} />
         <Flexboxes flexGrow={{ sm: 2, md: 3 }} />
         <Flexboxes flexGrow={[2, 3]} />
@@ -387,25 +387,25 @@ const flexboxesTest = () => (
         <Flexboxes flexShrink={[2, 3]} />
         <Flexboxes flexBasis={2} />
         <Flexboxes flexBasis="sm" />
-        <Flexboxes flexBasis={{ sm: 2, md: 'sm' }} />
-        <Flexboxes flexBasis={[2, 'sm']} />
+        <Flexboxes flexBasis={{ sm: 2, md: "sm" }} />
+        <Flexboxes flexBasis={[2, "sm"]} />
         <Flexboxes flexDirection="column" />
-        <Flexboxes flexDirection={{ sm: 'column', md: 'row' }} />
-        <Flexboxes flexDirection={['column', 'row']} />
+        <Flexboxes flexDirection={{ sm: "column", md: "row" }} />
+        <Flexboxes flexDirection={["column", "row"]} />
         <Flexboxes flex={2} />
         <Flexboxes flex="1 30px" />
-        <Flexboxes flex={{ sm: 2, md: '1 30px' }} />
-        <Flexboxes flex={[2, '1 30px']} />
+        <Flexboxes flex={{ sm: 2, md: "1 30px" }} />
+        <Flexboxes flex={[2, "1 30px"]} />
         <Flexboxes justifySelf="flex-start" />
-        <Flexboxes justifySelf={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes justifySelf={['flex-start', 'flex-end']} />
+        <Flexboxes justifySelf={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes justifySelf={["flex-start", "flex-end"]} />
         <Flexboxes alignSelf="flex-start" />
-        <Flexboxes alignSelf={{ sm: 'flex-start', md: 'flex-end' }} />
-        <Flexboxes alignSelf={['flex-start', 'flex-end']} />
+        <Flexboxes alignSelf={{ sm: "flex-start", md: "flex-end" }} />
+        <Flexboxes alignSelf={["flex-start", "flex-end"]} />
         <Flexboxes order={2} />
         <Flexboxes order="inherit" />
-        <Flexboxes order={{ sm: 2, md: 'initial' }} />
-        <Flexboxes order={[2, 'initial']} />
+        <Flexboxes order={{ sm: 2, md: "initial" }} />
+        <Flexboxes order={[2, "initial"]} />
     </div>
 );
 
@@ -419,50 +419,50 @@ const gridsTest = () => (
     <div>
         <Grids gridGap={2} />
         <Grids gridGap="sm" />
-        <Grids gridGap={{ sm: 2, md: 'sm' }} />
-        <Grids gridGap={[2, 'sm']} />
+        <Grids gridGap={{ sm: 2, md: "sm" }} />
+        <Grids gridGap={[2, "sm"]} />
         <Grids gridColumnGap={2} />
         <Grids gridColumnGap="sm" />
-        <Grids gridColumnGap={{ sm: 2, md: 'sm' }} />
-        <Grids gridColumnGap={[2, 'sm']} />
+        <Grids gridColumnGap={{ sm: 2, md: "sm" }} />
+        <Grids gridColumnGap={[2, "sm"]} />
         <Grids gridRowGap={2} />
         <Grids gridRowGap="sm" />
-        <Grids gridRowGap={{ sm: 2, md: 'sm' }} />
-        <Grids gridRowGap={[2, 'sm']} />
+        <Grids gridRowGap={{ sm: 2, md: "sm" }} />
+        <Grids gridRowGap={[2, "sm"]} />
         <Grids gridColumn={10} />
         <Grids gridColumn="1 / 3" />
-        <Grids gridColumn={{ sm: 10, md: '1 / 3' }} />
-        <Grids gridColumn={[10, '1 / 3']} />
+        <Grids gridColumn={{ sm: 10, md: "1 / 3" }} />
+        <Grids gridColumn={[10, "1 / 3"]} />
         <Grids gridRow={10} />
         <Grids gridRow="auto" />
-        <Grids gridRow={{ sm: 10, md: 'auto' }} />
-        <Grids gridRow={[10, 'auto']} />
+        <Grids gridRow={{ sm: 10, md: "auto" }} />
+        <Grids gridRow={[10, "auto"]} />
         <Grids gridAutoFlow="column" />
-        <Grids gridAutoFlow={{ sm: 'row', md: 'column' }} />
-        <Grids gridAutoFlow={['row', 'column']} />
+        <Grids gridAutoFlow={{ sm: "row", md: "column" }} />
+        <Grids gridAutoFlow={["row", "column"]} />
         <Grids gridAutoColumns={200} />
         <Grids gridAutoColumns="min-content" />
-        <Grids gridAutoColumns={{ sm: 200, md: 'min-content' }} />
-        <Grids gridAutoColumns={[200, 'min-content']} />
+        <Grids gridAutoColumns={{ sm: 200, md: "min-content" }} />
+        <Grids gridAutoColumns={[200, "min-content"]} />
         <Grids gridAutoRows={200} />
         <Grids gridAutoRows="sm" />
-        <Grids gridAutoRows={{ sm: 200, md: 'min-content' }} />
-        <Grids gridAutoRows={[200, 'min-content']} />
+        <Grids gridAutoRows={{ sm: 200, md: "min-content" }} />
+        <Grids gridAutoRows={[200, "min-content"]} />
         <Grids gridTemplateColumns={200} />
         <Grids gridTemplateColumns="min-content" />
-        <Grids gridTemplateColumns={{ sm: 200, md: 'min-content' }} />
-        <Grids gridTemplateColumns={[200, 'min-content']} />
+        <Grids gridTemplateColumns={{ sm: 200, md: "min-content" }} />
+        <Grids gridTemplateColumns={[200, "min-content"]} />
         <Grids gridTemplateRows={200} />
         <Grids gridTemplateRows="min-content" />
-        <Grids gridTemplateRows={{ sm: 200, md: 'min-content' }} />
-        <Grids gridTemplateRows={[200, 'min-content']} />
+        <Grids gridTemplateRows={{ sm: 200, md: "min-content" }} />
+        <Grids gridTemplateRows={[200, "min-content"]} />
         <Grids gridTemplateAreas="inherit" />
-        <Grids gridTemplateAreas={{ sm: 'none', md: 'inherit' }} />
-        <Grids gridTemplateAreas={['none', 'inherit']} />
+        <Grids gridTemplateAreas={{ sm: "none", md: "inherit" }} />
+        <Grids gridTemplateAreas={["none", "inherit"]} />
         <Grids gridArea="2" />
         <Grids gridArea="auto" />
-        <Grids gridArea={{ sm: '2 / 1 / 2 / 4', md: 'auto' }} />
-        <Grids gridArea={['2 / 1 / 2 / 4', 'auto']} />
+        <Grids gridArea={{ sm: "2 / 1 / 2 / 4", md: "auto" }} />
+        <Grids gridArea={["2 / 1 / 2 / 4", "auto"]} />
     </div>
 );
 
@@ -475,30 +475,30 @@ const Backgrounds = styled.div<BackgroundsProps>`
 const backgroundsTest = () => (
     <div>
         <Backgrounds background="green" />
-        <Backgrounds background={{ sm: 'content-box red', md: 'green' }} />
-        <Backgrounds background={['content-box red', 'green']} />
+        <Backgrounds background={{ sm: "content-box red", md: "green" }} />
+        <Backgrounds background={["content-box red", "green"]} />
         <Backgrounds bg={2} />
         <Backgrounds bg="sm" />
-        <Backgrounds bg={{ sm: 2, md: 'sm' }} />
-        <Backgrounds bg={[2, 'sm']} />
+        <Backgrounds bg={{ sm: 2, md: "sm" }} />
+        <Backgrounds bg={[2, "sm"]} />
         <Backgrounds backgroundColor={2} />
         <Backgrounds backgroundColor="sm" />
-        <Backgrounds backgroundColor={{ sm: 2, md: 'sm' }} />
-        <Backgrounds backgroundColor={[2, 'sm']} />
+        <Backgrounds backgroundColor={{ sm: 2, md: "sm" }} />
+        <Backgrounds backgroundColor={[2, "sm"]} />
         <Backgrounds backgroundImage='url("../a.png")' />
-        <Backgrounds backgroundImage={{ sm: 'url("../a.png")', md: 'url("../b.png")' }} />
-        <Backgrounds backgroundImage={['url("../a.png")', 'url("../b.png")']} />
+        <Backgrounds backgroundImage={{ sm: "url(\"../a.png\")", md: "url(\"../b.png\")" }} />
+        <Backgrounds backgroundImage={["url(\"../a.png\")", "url(\"../b.png\")"]} />
         <Backgrounds backgroundSize={200} />
         <Backgrounds backgroundSize="cover" />
-        <Backgrounds backgroundSize={{ sm: 200, md: 'cover' }} />
-        <Backgrounds backgroundSize={[200, 'cover']} />
+        <Backgrounds backgroundSize={{ sm: 200, md: "cover" }} />
+        <Backgrounds backgroundSize={[200, "cover"]} />
         <Backgrounds backgroundPosition={200} />
         <Backgrounds backgroundPosition="center" />
-        <Backgrounds backgroundPosition={{ sm: 200, md: 'center' }} />
-        <Backgrounds backgroundPosition={[200, 'center']} />
+        <Backgrounds backgroundPosition={{ sm: 200, md: "center" }} />
+        <Backgrounds backgroundPosition={[200, "center"]} />
         <Backgrounds backgroundRepeat="repeat" />
-        <Backgrounds backgroundRepeat={{ sm: 'repeat', md: 'no-repeat' }} />
-        <Backgrounds backgroundRepeat={['repeat', 'no-repeat']} />
+        <Backgrounds backgroundRepeat={{ sm: "repeat", md: "no-repeat" }} />
+        <Backgrounds backgroundRepeat={["repeat", "no-repeat"]} />
     </div>
 );
 
@@ -511,29 +511,29 @@ const Positioning = styled.div<PositioningProps>`
 const positioningTest = () => (
     <div>
         <Positioning position="relative" />
-        <Positioning position={{ sm: 'relative', md: 'absolute' }} />
-        <Positioning position={['relative', 'absolute']} />
+        <Positioning position={{ sm: "relative", md: "absolute" }} />
+        <Positioning position={["relative", "absolute"]} />
         <Positioning zIndex={2} />
         <Positioning zIndex="sm" />
         <Positioning zIndex="auto" />
-        <Positioning zIndex={{ sm: 2, md: 'auto' }} />
-        <Positioning zIndex={[2, 'auto']} />
+        <Positioning zIndex={{ sm: 2, md: "auto" }} />
+        <Positioning zIndex={[2, "auto"]} />
         <Positioning top={200} />
         <Positioning top="auto" />
-        <Positioning top={{ sm: 200, md: 'auto' }} />
-        <Positioning top={[200, 'auto']} />
+        <Positioning top={{ sm: 200, md: "auto" }} />
+        <Positioning top={[200, "auto"]} />
         <Positioning right={200} />
         <Positioning right="auto" />
-        <Positioning right={{ sm: 200, md: 'auto' }} />
-        <Positioning right={[200, 'auto']} />
+        <Positioning right={{ sm: 200, md: "auto" }} />
+        <Positioning right={[200, "auto"]} />
         <Positioning bottom={200} />
         <Positioning bottom="auto" />
-        <Positioning bottom={{ sm: 200, md: 'auto' }} />
-        <Positioning bottom={[200, 'auto']} />
+        <Positioning bottom={{ sm: 200, md: "auto" }} />
+        <Positioning bottom={[200, "auto"]} />
         <Positioning left={200} />
         <Positioning left="auto" />
-        <Positioning left={{ sm: 200, md: 'auto' }} />
-        <Positioning left={[200, 'auto']} />
+        <Positioning left={{ sm: 200, md: "auto" }} />
+        <Positioning left={[200, "auto"]} />
     </div>
 );
 
@@ -548,57 +548,57 @@ const bordersTest = () => (
         <Borders border={200} />
         <Borders border="sm" />
         <Borders border="solid" />
-        <Borders border={{ sm: 2, md: 'solid' }} />
-        <Borders border={[2, 'solid']} />
+        <Borders border={{ sm: 2, md: "solid" }} />
+        <Borders border={[2, "solid"]} />
         <Borders borderColor="primary" />
-        <Borders borderColor={{ sm: 'primary', md: 'green' }} />
-        <Borders borderColor={['primary', 'green']} />
+        <Borders borderColor={{ sm: "primary", md: "green" }} />
+        <Borders borderColor={["primary", "green"]} />
         <Borders borderTop={200} />
         <Borders borderTop="sm" />
         <Borders borderTop="solid" />
-        <Borders borderTop={{ sm: 2, md: 'solid' }} />
-        <Borders borderTop={[2, 'solid']} />
+        <Borders borderTop={{ sm: 2, md: "solid" }} />
+        <Borders borderTop={[2, "solid"]} />
         <Borders borderTopColor="primary" />
-        <Borders borderTopColor={{ sm: 'primary', md: 'green' }} />
-        <Borders borderTopColor={['primary', 'green']} />
+        <Borders borderTopColor={{ sm: "primary", md: "green" }} />
+        <Borders borderTopColor={["primary", "green"]} />
         <Borders borderRight={200} />
         <Borders borderRight="sm" />
         <Borders borderRight="solid" />
-        <Borders borderRight={{ sm: 2, md: 'solid' }} />
-        <Borders borderRight={[2, 'solid']} />
+        <Borders borderRight={{ sm: 2, md: "solid" }} />
+        <Borders borderRight={[2, "solid"]} />
         <Borders borderRightColor="primary" />
-        <Borders borderRightColor={{ sm: 'primary', md: 'green' }} />
-        <Borders borderRightColor={['primary', 'green']} />
+        <Borders borderRightColor={{ sm: "primary", md: "green" }} />
+        <Borders borderRightColor={["primary", "green"]} />
         <Borders borderBottom={200} />
         <Borders borderBottom="sm" />
         <Borders borderBottom="solid" />
-        <Borders borderBottom={{ sm: 2, md: 'solid' }} />
-        <Borders borderBottom={[2, 'solid']} />
+        <Borders borderBottom={{ sm: 2, md: "solid" }} />
+        <Borders borderBottom={[2, "solid"]} />
         <Borders borderBottomColor="primary" />
-        <Borders borderBottomColor={{ sm: 'primary', md: 'green' }} />
-        <Borders borderBottomColor={['primary', 'green']} />
+        <Borders borderBottomColor={{ sm: "primary", md: "green" }} />
+        <Borders borderBottomColor={["primary", "green"]} />
         <Borders borderLeft={200} />
         <Borders borderLeft="sm" />
         <Borders borderLeft="solid" />
-        <Borders borderLeft={{ sm: 2, md: 'solid' }} />
-        <Borders borderLeft={[2, 'solid']} />
+        <Borders borderLeft={{ sm: 2, md: "solid" }} />
+        <Borders borderLeft={[2, "solid"]} />
         <Borders borderLeftColor="primary" />
-        <Borders borderLeftColor={{ sm: 'primary', md: 'green' }} />
-        <Borders borderLeftColor={['primary', 'green']} />
+        <Borders borderLeftColor={{ sm: "primary", md: "green" }} />
+        <Borders borderLeftColor={["primary", "green"]} />
         <Borders borderWidth={2} />
         <Borders borderWidth={200} />
         <Borders borderWidth="hair" />
-        <Borders borderWidth={{ sm: 0, md: 'hair' }} />
-        <Borders borderWidth={[200, 'hair']} />
+        <Borders borderWidth={{ sm: 0, md: "hair" }} />
+        <Borders borderWidth={[200, "hair"]} />
         <Borders borderStyle={2} />
         <Borders borderStyle="sm" />
         <Borders borderStyle="dotted" />
-        <Borders borderStyle={{ sm: 2, md: 'dotted' }} />
-        <Borders borderStyle={[2, 'dotted']} />
+        <Borders borderStyle={{ sm: 2, md: "dotted" }} />
+        <Borders borderStyle={[2, "dotted"]} />
         <Borders borderRadius={2} />
         <Borders borderRadius="sm" />
-        <Borders borderRadius={{ sm: 200, md: 'sm' }} />
-        <Borders borderRadius={[200, 'sm']} />
+        <Borders borderRadius={{ sm: 200, md: "sm" }} />
+        <Borders borderRadius={[200, "sm"]} />
     </div>
 );
 
@@ -612,12 +612,12 @@ const shadowsTest = () => (
     <div>
         <Shadows boxShadow={2} />
         <Shadows boxShadow="sm" />
-        <Shadows boxShadow={{ sm: 2, md: 'none' }} />
-        <Shadows boxShadow={[2, 'none']} />
+        <Shadows boxShadow={{ sm: 2, md: "none" }} />
+        <Shadows boxShadow={[2, "none"]} />
         <Shadows textShadow={2} />
         <Shadows textShadow="sm" />
-        <Shadows textShadow={{ sm: 2, md: 'none' }} />
-        <Shadows textShadow={[2, 'none']} />
+        <Shadows textShadow={{ sm: 2, md: "none" }} />
+        <Shadows textShadow={[2, "none"]} />
     </div>
 );
 
@@ -662,7 +662,7 @@ const customSystemBoxTest = () => (
 
 // createSystemComponent
 
-const InnerSystemComponentBox = createSystemComponent<ShadowsProps>(React, 'div', shadows);
+const InnerSystemComponentBox = createSystemComponent<ShadowsProps>(React, "div", shadows);
 
 const SystemComponentBox = styled(InnerSystemComponentBox)`
     ${shadows}
@@ -676,68 +676,68 @@ const systemComponentBoxTest = () => (
 
 // TH
 
-th('colors.primary900')({});
+th("colors.primary900")({});
 
 th.color(2)({});
-th.color('primary')({});
+th.color("primary")({});
 
 th.px(2)({});
-th.px('2rpx')({});
+th.px("2rpx")({});
 
 th.percent(0.3)({});
-th.percent('20em')({});
+th.percent("20em")({});
 
 th.radius(2)({});
-th.radius('sm')({});
+th.radius("sm")({});
 
 th.transition(2)({});
-th.transition('fade')({});
+th.transition("fade")({});
 
 th.space(2)({});
-th.space('sm')({});
+th.space("sm")({});
 
 th.size(2)({});
-th.size('sm')({});
+th.size("sm")({});
 
 th.font(2)({});
-th.font('body')({});
+th.font("body")({});
 
 th.lineHeight(2)({});
-th.lineHeight('sm')({});
+th.lineHeight("sm")({});
 
 th.fontWeight(2)({});
-th.fontWeight('heavy')({});
+th.fontWeight("heavy")({});
 
 th.letterSpacing(2)({});
-th.letterSpacing('sm')({});
+th.letterSpacing("sm")({});
 
 th.fontSize(2)({});
-th.fontSize('sm')({});
+th.fontSize("sm")({});
 
 th.zIndex(2)({});
-th.zIndex('modal')({});
+th.zIndex("modal")({});
 
 th.border(2)({});
-th.border('main')({});
+th.border("main")({});
 
 th.borderWidth(2)({});
-th.borderWidth('sm')({});
+th.borderWidth("sm")({});
 
 th.borderStyle(2)({});
-th.borderStyle('selected')({});
+th.borderStyle("selected")({});
 
 th.shadow(2)({});
-th.shadow('xl')({});
+th.shadow("xl")({});
 
 // Style
 
 const size = style({
-    prop: ['size', 's'],
-    cssProperty: ['width', 'height'],
+    prop: ["size", "s"],
+    cssProperty: ["width", "height"],
     themeGet: getFontSize,
 });
 
-const StyleBox = styled.div<{ size: FontSizeProps['fontSize']; s: FontSizeProps['fontSize'] }>`
+const StyleBox = styled.div<{ size: FontSizeProps["fontSize"]; s: FontSizeProps["fontSize"] }>`
     ${size}
 `;
 
@@ -750,30 +750,30 @@ const styleTest = () => (
 // Variant
 
 variant({
-    default: 'primary',
+    default: "primary",
     variants: {
-        primary: 'color: red',
-        secondary: 'color: blue',
+        primary: "color: red",
+        secondary: "color: blue",
     },
 })({});
 
 // Responsive Utilities
 
 breakpoints({
-    xs: 'color: red',
-    md: 'color: blue',
-    lg: 'color: green',
+    xs: "color: red",
+    md: "color: blue",
+    lg: "color: green",
 })({});
 
-up('md', 'color: red')({});
+up("md", "color: red")({});
 
-down('md', 'color: red')({});
+down("md", "color: red")({});
 
-between('md', 'lg', 'color: red')({});
+between("md", "lg", "color: red")({});
 
 // RPX Transformers
 
 rpxTransformers.px(16).toString();
-rpxTransformers.px('16rpx').toString();
+rpxTransformers.px("16rpx").toString();
 rpxTransformers.border(10).toString();
-rpxTransformers.border('10px solid').toString();
+rpxTransformers.border("10px solid").toString();

--- a/types/xtend/xtend-tests.ts
+++ b/types/xtend/xtend-tests.ts
@@ -1,4 +1,4 @@
-import xtend = require('xtend');
+import xtend = require("xtend");
 
 interface Target {
     hellow: string;
@@ -26,48 +26,48 @@ type Result4 = Result3 & Source4;
 type Result5 = Result4 & Source5;
 
 function assign1(): Result1 {
-    return xtend({ hellow: 'world' }, { source1: 'U' });
+    return xtend({ hellow: "world" }, { source1: "U" });
 }
 
 function assign2(): Result2 {
-    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' });
+    return xtend({ hellow: "world" }, { source1: "U" }, { source2: "V" });
 }
 
 function assign3(): Result3 {
-    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' }, { source3: 'W' });
+    return xtend({ hellow: "world" }, { source1: "U" }, { source2: "V" }, { source3: "W" });
 }
 
 function assign4(): Result4 {
-    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' }, { source3: 'W' }, { source4: 'Q' });
+    return xtend({ hellow: "world" }, { source1: "U" }, { source2: "V" }, { source3: "W" }, { source4: "Q" });
 }
 
 function assign5(): Result5 {
     return xtend(
-        { hellow: 'world' },
-        { source1: 'U' },
-        { source2: 'V' },
-        { source3: 'W' },
-        { source4: 'Q' },
-        { source5: 'R' },
+        { hellow: "world" },
+        { source1: "U" },
+        { source2: "V" },
+        { source3: "W" },
+        { source4: "Q" },
+        { source5: "R" },
     );
 }
 
 function assign(): object {
     return xtend(
-        { hellow: 'world' },
-        { source1: 'U' },
-        { source2: 'V' },
-        { source3: 'W' },
-        { source4: 'Q' },
-        { source5: 'R' },
+        { hellow: "world" },
+        { source1: "U" },
+        { source2: "V" },
+        { source3: "W" },
+        { source4: "Q" },
+        { source5: "R" },
         {
-            hellow: 'hellow',
-            source1: 'source1',
-            source2: 'source2',
-            source3: 'source3',
-            source4: 'source4',
-            source5: 'source5',
-            generic: 'any',
+            hellow: "hellow",
+            source1: "source1",
+            source2: "source2",
+            source3: "source3",
+            source4: "source4",
+            source5: "source5",
+            generic: "any",
         },
     );
 }

--- a/types/xxhashjs/xxhashjs-tests.ts
+++ b/types/xxhashjs/xxhashjs-tests.ts
@@ -1,8 +1,8 @@
-import * as XXH from 'xxhashjs';
+import * as XXH from "xxhashjs";
 
 // Test data
 const seed = 0xABCD;
-const stringData = 'abcd';
+const stringData = "abcd";
 const arrayBufferData = new ArrayBuffer(4);
 const bufferData = Buffer.from([1, 2, 3, 4]);
 


### PR DESCRIPTION
> 👉 Partial implementation of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65993. If you're seeing this and are surprised it's happening, please read the discussion and give feedback! ❤️ 

Implements the dprint formatting changes on packages whose names start with `x`. We're splitting up the changes to make it a bit easier to apply & review them en masse - and, if we need later on, revert / bisect for issues. These changes generated with roughly:

```shell
git checkout dprint-onboarding -- .dprint.jsonc
time npx dprint fmt "types/x*/**/*.t*"
# Formatted 166 files.
npx dprint fmt "types/x*/**/*.t*"  2.19s user 0.53s system 166% cpu 1.625 total
rm .dprint.jsonc
```

CI failures are due to [DefinitelyTyped-tools > feat: remove formatting rules rules from dtslint](https://github.com/microsoft/DefinitelyTyped-tools/pull/699) not being ~merged~ included in CI yet.
