### PR TITLE
[d3-dsv] Remove `undefined` from DSVRowString

### DIFF
--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -37,7 +37,6 @@ let parsedTestObject: ParsedTestObject;
 
 let num: number;
 let str: string;
-let strMaybe: string | undefined;
 
 let columns: string[];
 let headers: Headers[];
@@ -56,9 +55,9 @@ str = row2.Make;
 str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
-strMaybe = raw.make;
+str = raw.make;
 // @ts-expect-error
-strMaybe = raw.property;
+str = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
 str = rowArray[0].property;

--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -48,12 +48,12 @@ let parsedHeaders: ParsedHeaders[];
 // ------------------------------------------------------------------------------------------
 
 declare let row: d3Dsv.DSVRowString;
-strMaybe = row.property;
+str = row.property;
 
 declare let row2: d3Dsv.DSVRowString<Headers>;
-strMaybe = row2.Make;
+str = row2.Make;
 // @ts-expect-error
-strMaybe = row2.Property;
+str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
 strMaybe = raw.make;
@@ -61,27 +61,27 @@ strMaybe = raw.make;
 strMaybe = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
-strMaybe = rowArray[0].property;
+str = rowArray[0].property;
 columns = rowArray.columns;
 num = rowArray.length;
 
 declare let rowArrayHeader: d3Dsv.DSVRowArray<Headers>;
-strMaybe = rowArrayHeader[0].Make;
+str = rowArrayHeader[0].Make;
 // @ts-expect-error
-strMaybe = rowArrayHeader[0].Property;
+str = rowArrayHeader[0].Property;
 headers = rowArrayHeader.columns;
 num = rowArrayHeader.length;
 
 declare let parseMappedArray: d3Dsv.DSVParsedArray<ParsedTestObject>;
-strMaybe = parseMappedArray[0].make;
+str = parseMappedArray[0].make;
 // @ts-expect-error
-strMaybe = parseMappedArray[0].property;
+str = parseMappedArray[0].property;
 parsedTestObject = parseMappedArray[0];
 parsedHeaders = parseMappedArray.columns;
 num = parseMappedArray.length;
 
 declare let parseArray: d3Dsv.DSVParsedArray<d3Dsv.DSVRowString>;
-strMaybe = parseArray[0].property;
+str = parseArray[0].property;
 columns = parseArray.columns;
 num = parseArray.length;
 
@@ -130,7 +130,7 @@ parseMappedArray = d3Dsv.csvParse<ParsedTestObject, Headers>(csvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.csvParseRows(csvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -232,7 +232,7 @@ parseMappedArray = d3Dsv.tsvParse<ParsedTestObject, Headers>(tsvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.tsvParseRows(tsvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -338,7 +338,7 @@ parseMappedArray = dsv.parse<ParsedTestObject, Headers>(pipedTestStringWithHeade
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = dsv.parseRows(pipedTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -22,7 +22,6 @@ export type DSVRowString<Columns extends string = string> = {
 
 /**
  * An object in raw format before parsing, that is with only string values.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
     [key in keyof T]: string;

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -15,7 +15,6 @@
 
 /**
  * An object representing a DSV parsed row with values represented as strings.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
     [key in Columns]: string;

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -25,7 +25,7 @@ export type DSVRowString<Columns extends string = string> = {
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
-    [key in keyof T]: string | undefined;
+    [key in keyof T]: string;
 };
 
 /**

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -18,7 +18,7 @@
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
-    [key in Columns]: string | undefined;
+    [key in Columns]: string;
 };
 
 /**

--- a/types/d3-dsv/v1/d3-dsv-tests.ts
+++ b/types/d3-dsv/v1/d3-dsv-tests.ts
@@ -37,7 +37,6 @@ let parsedTestObject: ParsedTestObject;
 
 let num: number;
 let str: string;
-let strMaybe: string | undefined;
 
 let columns: string[];
 let headers: Headers[];
@@ -56,9 +55,9 @@ str = row2.Make;
 str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
-strMaybe = raw.make;
+str = raw.make;
 // @ts-expect-error
-strMaybe = raw.property;
+str = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
 str = rowArray[0].property;

--- a/types/d3-dsv/v1/d3-dsv-tests.ts
+++ b/types/d3-dsv/v1/d3-dsv-tests.ts
@@ -48,12 +48,12 @@ let parsedHeaders: ParsedHeaders[];
 // ------------------------------------------------------------------------------------------
 
 declare let row: d3Dsv.DSVRowString;
-strMaybe = row.property;
+str = row.property;
 
 declare let row2: d3Dsv.DSVRowString<Headers>;
-strMaybe = row2.Make;
+str = row2.Make;
 // @ts-expect-error
-strMaybe = row2.Property;
+str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
 strMaybe = raw.make;
@@ -61,27 +61,27 @@ strMaybe = raw.make;
 strMaybe = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
-strMaybe = rowArray[0].property;
+str = rowArray[0].property;
 columns = rowArray.columns;
 num = rowArray.length;
 
 declare let rowArrayHeader: d3Dsv.DSVRowArray<Headers>;
-strMaybe = rowArrayHeader[0].Make;
+str = rowArrayHeader[0].Make;
 // @ts-expect-error
-strMaybe = rowArrayHeader[0].Property;
+str = rowArrayHeader[0].Property;
 headers = rowArrayHeader.columns;
 num = rowArrayHeader.length;
 
 declare let parseMappedArray: d3Dsv.DSVParsedArray<ParsedTestObject>;
-strMaybe = parseMappedArray[0].make;
+str = parseMappedArray[0].make;
 // @ts-expect-error
-strMaybe = parseMappedArray[0].property;
+str = parseMappedArray[0].property;
 parsedTestObject = parseMappedArray[0];
 parsedHeaders = parseMappedArray.columns;
 num = parseMappedArray.length;
 
 declare let parseArray: d3Dsv.DSVParsedArray<d3Dsv.DSVRowString>;
-strMaybe = parseArray[0].property;
+str = parseArray[0].property;
 columns = parseArray.columns;
 num = parseArray.length;
 
@@ -130,7 +130,7 @@ parseMappedArray = d3Dsv.csvParse<ParsedTestObject, Headers>(csvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.csvParseRows(csvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -231,7 +231,7 @@ parseMappedArray = d3Dsv.tsvParse<ParsedTestObject, Headers>(tsvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.tsvParseRows(tsvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -337,7 +337,7 @@ parseMappedArray = dsv.parse<ParsedTestObject, Headers>(pipedTestStringWithHeade
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = dsv.parseRows(pipedTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 

--- a/types/d3-dsv/v1/index.d.ts
+++ b/types/d3-dsv/v1/index.d.ts
@@ -26,7 +26,7 @@ export type DSVRowString<Columns extends string = string> = {
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
-    [key in keyof T]: string | undefined;
+    [key in keyof T]: string;
 };
 
 /**

--- a/types/d3-dsv/v1/index.d.ts
+++ b/types/d3-dsv/v1/index.d.ts
@@ -16,7 +16,6 @@
 
 /**
  * An object representing a DSV parsed row with values represented as strings.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
     [key in Columns]: string;

--- a/types/d3-dsv/v1/index.d.ts
+++ b/types/d3-dsv/v1/index.d.ts
@@ -23,7 +23,6 @@ export type DSVRowString<Columns extends string = string> = {
 
 /**
  * An object in raw format before parsing, that is with only string values.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
     [key in keyof T]: string;

--- a/types/d3-dsv/v1/index.d.ts
+++ b/types/d3-dsv/v1/index.d.ts
@@ -19,7 +19,7 @@
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
-    [key in Columns]: string | undefined;
+    [key in Columns]: string;
 };
 
 /**

--- a/types/d3-dsv/v2/d3-dsv-tests.ts
+++ b/types/d3-dsv/v2/d3-dsv-tests.ts
@@ -37,7 +37,6 @@ let parsedTestObject: ParsedTestObject;
 
 let num: number;
 let str: string;
-let strMaybe: string | undefined;
 
 let columns: string[];
 let headers: Headers[];
@@ -56,9 +55,9 @@ str = row2.Make;
 str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
-strMaybe = raw.make;
+str = raw.make;
 // @ts-expect-error
-strMaybe = raw.property;
+str = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
 str = rowArray[0].property;

--- a/types/d3-dsv/v2/d3-dsv-tests.ts
+++ b/types/d3-dsv/v2/d3-dsv-tests.ts
@@ -48,12 +48,12 @@ let parsedHeaders: ParsedHeaders[];
 // ------------------------------------------------------------------------------------------
 
 declare let row: d3Dsv.DSVRowString;
-strMaybe = row.property;
+str = row.property;
 
 declare let row2: d3Dsv.DSVRowString<Headers>;
-strMaybe = row2.Make;
+str = row2.Make;
 // @ts-expect-error
-strMaybe = row2.Property;
+str = row2.Property;
 
 declare let raw: d3Dsv.DSVRaw<ParsedTestObject>;
 strMaybe = raw.make;
@@ -61,27 +61,27 @@ strMaybe = raw.make;
 strMaybe = raw.property;
 
 declare let rowArray: d3Dsv.DSVRowArray;
-strMaybe = rowArray[0].property;
+str = rowArray[0].property;
 columns = rowArray.columns;
 num = rowArray.length;
 
 declare let rowArrayHeader: d3Dsv.DSVRowArray<Headers>;
-strMaybe = rowArrayHeader[0].Make;
+str = rowArrayHeader[0].Make;
 // @ts-expect-error
-strMaybe = rowArrayHeader[0].Property;
+str = rowArrayHeader[0].Property;
 headers = rowArrayHeader.columns;
 num = rowArrayHeader.length;
 
 declare let parseMappedArray: d3Dsv.DSVParsedArray<ParsedTestObject>;
-strMaybe = parseMappedArray[0].make;
+str = parseMappedArray[0].make;
 // @ts-expect-error
-strMaybe = parseMappedArray[0].property;
+str = parseMappedArray[0].property;
 parsedTestObject = parseMappedArray[0];
 parsedHeaders = parseMappedArray.columns;
 num = parseMappedArray.length;
 
 declare let parseArray: d3Dsv.DSVParsedArray<d3Dsv.DSVRowString>;
-strMaybe = parseArray[0].property;
+str = parseArray[0].property;
 columns = parseArray.columns;
 num = parseArray.length;
 
@@ -130,7 +130,7 @@ parseMappedArray = d3Dsv.csvParse<ParsedTestObject, Headers>(csvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.csvParseRows(csvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -232,7 +232,7 @@ parseMappedArray = d3Dsv.tsvParse<ParsedTestObject, Headers>(tsvTestStringWithHe
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.tsvParseRows(tsvTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -338,7 +338,7 @@ parseMappedArray = dsv.parse<ParsedTestObject, Headers>(pipedTestStringWithHeade
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = dsv.parseRows(pipedTestString);
-strMaybe = parseRowsArray[0][0]; // 'Year' of first row
+str = parseRowsArray[0][0]; // 'Year' of first row
 
 // with row mapper ---------------------------------------------------------------------------
 

--- a/types/d3-dsv/v2/index.d.ts
+++ b/types/d3-dsv/v2/index.d.ts
@@ -26,7 +26,7 @@ export type DSVRowString<Columns extends string = string> = {
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
-    [key in keyof T]: string | undefined;
+    [key in keyof T]: string;
 };
 
 /**

--- a/types/d3-dsv/v2/index.d.ts
+++ b/types/d3-dsv/v2/index.d.ts
@@ -16,7 +16,6 @@
 
 /**
  * An object representing a DSV parsed row with values represented as strings.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
     [key in Columns]: string;

--- a/types/d3-dsv/v2/index.d.ts
+++ b/types/d3-dsv/v2/index.d.ts
@@ -23,7 +23,6 @@ export type DSVRowString<Columns extends string = string> = {
 
 /**
  * An object in raw format before parsing, that is with only string values.
- * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRaw<T extends object> = {
     [key in keyof T]: string;

--- a/types/d3-dsv/v2/index.d.ts
+++ b/types/d3-dsv/v2/index.d.ts
@@ -19,7 +19,7 @@
  * When the DSV content is not well-structured and some column-values are missing, `undefined` is used as value.
  */
 export type DSVRowString<Columns extends string = string> = {
-    [key in Columns]: string | undefined;
+    [key in Columns]: string;
 };
 
 /**


### PR DESCRIPTION
Currently, `DSVRowString` is defined as `[key in Columns]: string | undefined;` for all versions. This represents correct behavior for d3-dsv 0.4, where values returned from `parse()` can be either a string or undefined for missing fields.

However, a [change made in d3-dsv v1.1.2](https://github.com/d3/d3-dsv/releases/tag/v1.1.2) changed `parse()` such that it only returns strings. Instead of returning undefined for missing fields, empty strings are returned. The `DSVRowString` for v1, v2, and v3 should only be string, not undefined, as `parse()` should never return undefined values.

This pull request updates the `DSVRowString` for d3-dsv v1, v2, and v3 to reflect this change correctly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/d3/d3-dsv/releases/tag/v1.1.2)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
