### PR TITLE
build: run npm ls --all after install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Get local dependencies
       - run: npm install
-      - run: npm ls --all
+      - run: npm ls --all || true
 
       # Run tests
       - run: npm run test-all

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
 
       # Get local dependencies
       - run: npm install
+      - run: npm ls --all
 
       # Run tests
       - run: npm run test-all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: 'npm install'
     inputs:
       verbose: false
-  - script: npm ls --all
+  - script: npm ls --all || true
 
   - script: |
       if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && npm run update-codeowners; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ jobs:
     displayName: 'npm install'
     inputs:
       verbose: false
+  - script: npm ls --all
 
   - script: |
       if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && npm run update-codeowners; fi


### PR DESCRIPTION
This way we can see versions of 'latest' packages before the potentially-hours-long `npm run test-all` finishes.

In other words, I don't want to wait 2-3 hours each time https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66522 or a similarly large PR runs to know what version of `dtslint-runner` it used...