### PR TITLE
Remove unused eslint disables

### DIFF
--- a/types/abstract-leveldown/index.d.ts
+++ b/types/abstract-leveldown/index.d.ts
@@ -56,7 +56,7 @@ export interface AbstractLevelDOWN<K = any, V = any> extends AbstractOptions {
 }
 
 export interface AbstractLevelDOWNConstructor {
-  // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+   
   new <K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
   // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
   <K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
@@ -97,7 +97,7 @@ export interface AbstractChainedBatch<K = any, V = any> extends AbstractOptions 
 }
 
 export interface AbstractChainedBatchConstructor {
-  // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+   
   new <K = any, V = any>(db: any): AbstractChainedBatch<K, V>;
   // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
   <K = any, V = any>(db: any): AbstractChainedBatch<K, V>;
@@ -110,7 +110,7 @@ export interface AbstractIterator<K, V> extends AbstractOptions {
 }
 
 export interface AbstractIteratorConstructor {
-  // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+   
   new <K = any, V = any>(db: any): AbstractIterator<K, V>;
   // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
   <K = any, V = any>(db: any): AbstractIterator<K, V>;

--- a/types/activex-faxcomexlib/index.d.ts
+++ b/types/activex-faxcomexlib/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="activex-stdole" />
 
 declare namespace FAXCOMEXLib {
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_ACCESS_RIGHTS_ENUM {
         farMANAGE_CONFIG = 64,
         farMANAGE_IN_ARCHIVE = 256,
@@ -22,7 +22,7 @@ declare namespace FAXCOMEXLib {
         farSUBMIT_NORMAL = 2,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_ACCESS_RIGHTS_ENUM_2 {
         far2MANAGE_ARCHIVES = 256,
         far2MANAGE_CONFIG = 64,
@@ -36,7 +36,7 @@ declare namespace FAXCOMEXLib {
         far2SUBMIT_NORMAL = 2,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_ACCOUNT_EVENTS_TYPE_ENUM {
         faetFXSSVC_ENDED = 16,
         faetIN_ARCHIVE = 4,
@@ -46,21 +46,21 @@ declare namespace FAXCOMEXLib {
         faetOUT_QUEUE = 2,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_COVERPAGE_TYPE_ENUM {
         fcptLOCAL = 1,
         fcptNONE = 0,
         fcptSERVER = 2,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_DEVICE_RECEIVE_MODE_ENUM {
         fdrmAUTO_ANSWER = 1,
         fdrmMANUAL_ANSWER = 2,
         fdrmNO_ANSWER = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_GROUP_STATUS_ENUM {
         fgsALL_DEV_NOT_VALID = 2,
         fgsALL_DEV_VALID = 0,
@@ -68,7 +68,7 @@ declare namespace FAXCOMEXLib {
         fgsSOME_DEV_NOT_VALID = 3,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_JOB_EXTENDED_STATUS_ENUM {
         fjesANSWERED = 5,
         fjesBAD_ADDRESS = 10,
@@ -93,7 +93,7 @@ declare namespace FAXCOMEXLib {
         fjesTRANSMITTING = 4,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_JOB_OPERATIONS_ENUM {
         fjoDELETE = 16,
         fjoPAUSE = 2,
@@ -104,7 +104,7 @@ declare namespace FAXCOMEXLib {
         fjoVIEW = 1,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_JOB_STATUS_ENUM {
         fjsCANCELED = 512,
         fjsCANCELING = 1024,
@@ -119,14 +119,14 @@ declare namespace FAXCOMEXLib {
         fjsROUTING = 2048,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_JOB_TYPE_ENUM {
         fjtRECEIVE = 1,
         fjtROUTING = 2,
         fjtSEND = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_LOG_LEVEL_ENUM {
         fllMAX = 3,
         fllMED = 2,
@@ -134,14 +134,14 @@ declare namespace FAXCOMEXLib {
         fllNONE = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_PRIORITY_TYPE_ENUM {
         fptHIGH = 2,
         fptLOW = 0,
         fptNORMAL = 1,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_PROVIDER_STATUS_ENUM {
         fpsBAD_GUID = 2,
         fpsBAD_VERSION = 3,
@@ -152,19 +152,19 @@ declare namespace FAXCOMEXLib {
         fpsSUCCESS = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_RECEIPT_TYPE_ENUM {
         frtMAIL = 1,
         frtMSGBOX = 4,
         frtNONE = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_ROUTING_RULE_CODE_ENUM {
         frrcANY_CODE = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_RULE_STATUS_ENUM {
         frsALL_GROUP_DEV_NOT_VALID = 2,
         frsBAD_DEVICE = 4,
@@ -173,14 +173,14 @@ declare namespace FAXCOMEXLib {
         frsVALID = 0,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_SCHEDULE_TYPE_ENUM {
         fstDISCOUNT_PERIOD = 2,
         fstNOW = 0,
         fstSPECIFIC_TIME = 1,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_SERVER_APIVERSION_ENUM {
         fsAPI_VERSION_0 = 0,
         fsAPI_VERSION_1 = 65536,
@@ -188,7 +188,7 @@ declare namespace FAXCOMEXLib {
         fsAPI_VERSION_3 = 196608,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_SERVER_EVENTS_TYPE_ENUM {
         fsetACTIVITY = 8,
         fsetCONFIG = 4,
@@ -203,14 +203,14 @@ declare namespace FAXCOMEXLib {
         fsetQUEUE_STATE = 16,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FAX_SMTP_AUTHENTICATION_TYPE_ENUM {
         fsatANONYMOUS = 0,
         fsatBASIC = 1,
         fsatNTLM = 2,
     }
 
-    // eslint-disable-next-line @definitelytyped/no-const-enum
+     
     const enum FaxConstants {
         bstrGROUPNAME_ALLDEVICES = '<All Devices>',
         lDEFAULT_PREFETCH_SIZE = 100,

--- a/types/agnostic-http-error-handler/agnostic-http-error-handler-tests.ts
+++ b/types/agnostic-http-error-handler/agnostic-http-error-handler-tests.ts
@@ -7,6 +7,6 @@ import { Request, Response } from 'express';
   native: (err: Error, req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>>) => void;
 } */
 errorHandler(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     (err: Error, _responsePayload, req: Request, _res: Response) => {},
 );

--- a/types/base64util/index.d.ts
+++ b/types/base64util/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jonathan Ehman <https://github.com/jpehman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/* eslint-disable @typescript-eslint/naming-convention */
+ 
 export const VERSION: string;
 
 export namespace BASE64 {

--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CSSObject } from '../index';
 
 type ApparentComponentProps<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
 > = C extends React.JSXElementConstructor<infer P>
     ? JSX.LibraryManagedAttributes<C, P>
@@ -12,7 +12,7 @@ declare const cxsComponent: {
     <
         Component extends
             | keyof JSX.IntrinsicElements
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+             
             | React.JSXElementConstructor<any>,
         PropsType extends object & ApparentComponentProps<Component>
     >(

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -746,7 +746,7 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
         update?: (elem: Selection<GElement, Datum, PElement, PDatum>) => Selection<GElement, Datum, PElement, PDatum> | TransitionLike<GElement, Datum> | undefined,
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         exit?: (elem: Selection<GElement, OldDatum, PElement, PDatum>) => void
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     ): Selection<ChildElement | GElement, Datum, PElement, PDatum>;
 
     /**

--- a/types/devexpress-aspnetcore-bootstrap/index.d.ts
+++ b/types/devexpress-aspnetcore-bootstrap/index.d.ts
@@ -158,7 +158,7 @@ declare namespace DevExpress.AspNetCore {
         setWidth(width: number): void;
         on<K extends keyof ControlEventMap>(eventName: K, callback: (this: Control, args?: ControlEventMap[K]) => void): this;
         once<K extends keyof ControlEventMap>(eventName: K, callback: (this: Control, args?: ControlEventMap[K]) => void): this;
-        off<K extends keyof ControlEventMap>(): this; // eslint-disable-line @definitelytyped/no-unnecessary-generics
+        off<K extends keyof ControlEventMap>(): this;  
         off<K extends keyof ControlEventMap>(eventName: K): this; // tslint:disable-line:unified-signatures no-unnecessary-generics
         off<K extends keyof ControlEventMap>(eventName: K, callback: (this: Control, args?: ControlEventMap[K]) => void): this; // tslint:disable-line:unified-signatures
     }

--- a/types/double-ended-queue/index.d.ts
+++ b/types/double-ended-queue/index.d.ts
@@ -131,7 +131,7 @@ declare const Deque: {
      * Creates an empty double-ended queue with initial capacity of 16.
      * If you know the optimal size before-hand, use `new Deque(capacity: number)`.
      */
-    new <Item>(): Deque<Item>; // eslint-disable-line @definitelytyped/no-unnecessary-generics
+    new <Item>(): Deque<Item>;  
 
     /**
      * Creates a double-ended queue from `items`.
@@ -143,7 +143,7 @@ declare const Deque: {
      * Capacity should be the maximum amount of items the queue will hold at a given time.
      * The reason to give an initial capacity is to avoid potentially expensive resizing operations at runtime.
      */
-    new <Item>(capacity: number): Deque<Item>; // eslint-disable-line @definitelytyped/no-unnecessary-generics
+    new <Item>(capacity: number): Deque<Item>;  
 };
 
 // tslint:enable:unified-signatures

--- a/types/editor-info/index.d.ts
+++ b/types/editor-info/index.d.ts
@@ -10,7 +10,7 @@ interface EditorMap {
     ATOM: 'Atom';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- This is intentional
+ 
 type EditorData<Constant extends keyof EditorMap> = Simplify<
     {
         [key in keyof EditorMap]: key extends Constant ? true : false;

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -130,7 +130,7 @@ export default class Helper<S = unknown> extends EmberObject {
 // information supplied via this generic. While it may appear useless on this
 // class definition and extension, it is used by external tools and should not
 // be removed.
-// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+ 
 export default interface Helper<S> extends Opaque<S> {}
 
 // This type exists to provide a non-user-constructible, non-subclassable

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -25,7 +25,7 @@ interface TemplateFactory {
 // information supplied via this generic. While it may appear useless on this
 // class definition and extension, it is used by external tools and should not
 // be removed.
-// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+ 
 export default interface Component<S = unknown> extends ViewMixin, ClassNamesSupport, Opaque<S> {}
 export default class Component<S = unknown> extends CoreView {
     // methods

--- a/types/ember__ordered-set/index.d.ts
+++ b/types/ember__ordered-set/index.d.ts
@@ -20,7 +20,7 @@ export default class OrderedSet<T = unknown> {
     // `let set: OrderedSet<string> = OrderedSet.create();`. If TS could infer
     // from usage what the type would be, this wouldn't be required, but until
     // it does, this is better than *not* allowing it.
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     static create<T = unknown>(): OrderedSet<T>;
 
     add(value: T): this;

--- a/types/ember__ordered-set/v3/index.d.ts
+++ b/types/ember__ordered-set/v3/index.d.ts
@@ -20,7 +20,7 @@ export default class OrderedSet<T = unknown> {
     // `let set: OrderedSet<string> = OrderedSet.create();`. If TS could infer
     // from usage what the type would be, this wouldn't be required, but until
     // it does, this is better than *not* allowing it.
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     static create<T = unknown>(): OrderedSet<T>;
 
     add(value: T): this;

--- a/types/encoding-down/index.d.ts
+++ b/types/encoding-down/index.d.ts
@@ -50,7 +50,7 @@ declare namespace EncodingDown {
   interface Constructor {
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     <K = any, V = any>(db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown<K, V>;
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     new <K = any, V = any>(db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown<K, V>;
   }
 }

--- a/types/estimated-read-time/index.d.ts
+++ b/types/estimated-read-time/index.d.ts
@@ -13,7 +13,7 @@ export interface TextOptions {
 }
 
 export interface TextResult {
-    // eslint-disable-next-line camelcase
+     
     word_count: number;
     seconds: number;
 }

--- a/types/express-prometheus-middleware/express-prometheus-middleware-tests.ts
+++ b/types/express-prometheus-middleware/express-prometheus-middleware-tests.ts
@@ -16,7 +16,7 @@ app.use(
         prefix: "app_prefix_",
         customLabels: ["contentType"],
         transformLabels(labels, req) {
-            // eslint-disable-next-line no-param-reassign
+             
             labels.contentType = req.headers["content-type"] as string;
         },
         normalizeStatus: true,

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -3844,9 +3844,9 @@ export class Server {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-await-serverregisterplugins-options)
      */
-     /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+      
     register<T>(plugin: ServerRegisterPluginObject<T>, options?: ServerRegisterOptions): Promise<void>;
-    /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+     
     register<T, U, V, W, X, Y, Z>(plugins: ServerRegisterPluginObjectArray<T, U, V, W, X, Y, Z>, options?: ServerRegisterOptions): Promise<void>;
     register(plugins: Array<ServerRegisterPluginObject<any>>, options?: ServerRegisterOptions): Promise<void>;
     /* tslint:disable-next-line:unified-signatures */

--- a/types/hapi/v17/index.d.ts
+++ b/types/hapi/v17/index.d.ts
@@ -3803,9 +3803,9 @@ export class Server {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-await-serverregisterplugins-options)
      */
-     /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+      
     register<T>(plugin: ServerRegisterPluginObject<T>, options?: ServerRegisterOptions): Promise<void>;
-    /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+     
     register<T, U, V, W, X, Y, Z>(plugins: ServerRegisterPluginObjectArray<T, U, V, W, X, Y, Z>, options?: ServerRegisterOptions): Promise<void>;
     register(plugins: Array<ServerRegisterPluginObject<any>>, options?: ServerRegisterOptions): Promise<void>;
     /* tslint:disable-next-line:unified-signatures */

--- a/types/hyperdeck-js-lib/index.d.ts
+++ b/types/hyperdeck-js-lib/index.d.ts
@@ -125,7 +125,7 @@ export class HyperdeckCore {
      * @return The promise which will resolve/reject when a response has been received
      *         (or connection lost).
      */
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     makeRequest<T>(command: string): Promise<Hyperdeck.Response<T>>;
 
     /**

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -502,10 +502,10 @@ declare namespace jest {
     } & { [K in PropertyKeysOf<T>]: MaybeMockedDeep<T[K]> };
     type MaybeMockedDeep<T> = T extends MockableFunction
         ? MockedFunctionDeep<T>
-        : T extends object // eslint-disable-line @typescript-eslint/ban-types
+        : T extends object  
         ? MockedObjectDeep<T>
         : T;
-    // eslint-disable-next-line @typescript-eslint/ban-types
+     
     type MaybeMocked<T> = T extends MockableFunction ? MockedFn<T> : T extends object ? MockedObject<T> : T;
     type EmptyFunction = () => void;
     type ArgsType<T> = T extends (...args: infer A) => any ? A : never;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @definitelytyped/no-relative-import-in-test
+ 
 import fp = require("./fp");
 import _ = require("lodash");
 

--- a/types/ltijs/lib/Utils/Platform.d.ts
+++ b/types/ltijs/lib/Utils/Platform.d.ts
@@ -24,7 +24,7 @@ export interface PlatformContext {
         id: string;
         label: string;
         title: string;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+         
         type: any[];
     };
     resource: {
@@ -45,7 +45,7 @@ export interface PlatformContext {
     createdAt: Date;
     __v: number;
     __id: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     custom: any;
 }
 

--- a/types/memdown/index.d.ts
+++ b/types/memdown/index.d.ts
@@ -10,7 +10,7 @@ import { AbstractLevelDOWN } from 'abstract-leveldown';
 export interface MemDown<K, V> extends AbstractLevelDOWN<K, V> {}
 
 export interface MemDownConstructor {
-  // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+   
   new <K = any, V = any>(): MemDown<K, V>;
   // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
   <K = any, V = any>(): MemDown<K, V>;

--- a/types/neo-async/index.d.ts
+++ b/types/neo-async/index.d.ts
@@ -559,7 +559,7 @@ export function queue<T, R, E = Error>(worker: AsyncResultIterator<T, R, E>, con
 export function priorityQueue<T, E = Error>(worker: AsyncWorker<T, E>, concurrency?: number): AsyncPriorityQueue<T>;
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
 export function cargo<T, E = Error>(worker: AsyncWorker<T[], E>, payload?: number): QueueObject<T>;
-// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+ 
 export function cargoQueue<T, E = Error>(
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     worker: AsyncWorker<T[], E>,

--- a/types/node-red__registry/index.d.ts
+++ b/types/node-red__registry/index.d.ts
@@ -44,12 +44,12 @@ declare namespace registry {
          * @param constructor - the constructor function for this node type
          * @param opts - optional additional options for the node
          */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+         
         registerType<TNode extends Node<TCreds>, TNodeDef extends NodeDef, TSets, TCreds extends {}>(
             type: string,
             constructor: NodeConstructor<TNode, TNodeDef, TCreds>, // eslint-disable-line @definitelytyped/no-unnecessary-generics
             opts?: {
-                credentials?: NodeCredentials<TCreds> | undefined; // eslint-disable-line @definitelytyped/no-unnecessary-generics
+                credentials?: NodeCredentials<TCreds> | undefined;  
                 settings?: NodeSettings<TSets> | undefined; // eslint-disable-line @definitelytyped/no-unnecessary-generics
             },
         ): void;
@@ -123,7 +123,7 @@ declare namespace registry {
          * @param id - the string id of the plugin
          * @param definition - the definition object of the plugin
          */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+         
         registerPlugin<TPluginDef extends PluginDef = PluginDef>(
             id: string,
             definition: PluginDefinition<TPluginDef>, // eslint-disable-line @definitelytyped/no-unnecessary-generics

--- a/types/preact-i18n/index.d.ts
+++ b/types/preact-i18n/index.d.ts
@@ -55,7 +55,7 @@ export function useText(
     mapping: { [key: string]: string | JSX.Element } | string | JSX.Element,
 ): { [key: string]: string };
 
-// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+ 
 export function withText<Props, Context = IntlContext>(mapping: {}): (
     Child: ComponentChild,
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics

--- a/types/promise-deferred/index.d.ts
+++ b/types/promise-deferred/index.d.ts
@@ -22,7 +22,7 @@ export = DeferredCtor;
 declare const DeferredCtor: {
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     <T>(): DeferredCtor.Deferred<T>;
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     new <T>(): DeferredCtor.Deferred<T>;
 
     Promise: typeof Promise;

--- a/types/psd/psd.d.ts
+++ b/types/psd/psd.d.ts
@@ -256,7 +256,7 @@ export namespace PSD {
      * channel. The dimensions can also differ per channel if we're parsing mask
      * data (channel ID < -1).
      */
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+     
     interface ChannelImage extends Image {
         /** The width of the image. */
         width(): number;

--- a/types/rdfjs__term-map/Factory.d.ts
+++ b/types/rdfjs__term-map/Factory.d.ts
@@ -2,7 +2,7 @@ import TermMap from './index.js';
 import { Term } from '@rdfjs/types';
 
 export interface TermMapFactory {
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+     
     termMap<T extends Term = Term, V = any>(entries?: Array<[T, V]>): TermMap<T, V>;
 }
 

--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -163,7 +163,7 @@ export type UserInfo<CustomClaims = {}> = {
 
 export class Auth {
     authorizeUrl(params: AuthorizeUrlParams): string;
-    /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+     
     createUser<T>(user: CreateUserParams<T>): Promise<CreateUserResponse>;
     exchange(params: ExchangeParams): Promise<Credentials>;
     exchangeNativeSocial(params: ExchangeNativeSocialParams): Promise<Credentials>;
@@ -172,7 +172,7 @@ export class Auth {
     refreshToken(params: RefreshTokenParams): Promise<Credentials>;
     resetPassword(params: ResetPasswordParams): Promise<any>;
     revoke(params: RevokeParams): Promise<any>;
-    /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+     
     userInfo<CustomClaims = {}>(params: UserInfoParams): Promise<UserInfo<CustomClaims>>;
     passwordlessWithEmail(params: PasswordlessWithEmailParams): Promise<any>;
     passwordlessWithSMS(params: PasswordlessWithSMSParams): Promise<any>;
@@ -214,7 +214,7 @@ export interface PatchUserParams<T> {
 
 export class Users {
     constructor(options: UsersOptions);
-    /* eslint-disable-next-line @definitelytyped/no-unnecessary-generics */
+     
     getUser<T>(parameters: GetUserParams): Promise<Auth0User<T>>;
     patchUser<T>(parameters: PatchUserParams<T>): Promise<Auth0User<T>>;
 }


### PR DESCRIPTION

Remove eslint-disables which are not actually disabling a violation.

This is a follow-up of this PR -> https://github.com/microsoft/DefinitelyTyped-tools/pull/718


The strategy is to bulk remove the redundant eslint-disables in one batch and then add enforcement on the tools repository.


My M1 went on fire doing this 🥵 

```sh

npx eslint  --fix --ext .ts

types_dir="types"
folder_names=$(ls -d $types_dir/*/ | sed "s|$types_dir/||;s|/$||")

for folder_name in $folder_names; do
  folder_name=${folder_name%*/}
  echo "Linting $folder_name"
  npx eslint  --fix --ext .ts types/$folder_name
done
```