### PR TITLE
Add ExpertEncoder API to @types/draco3d and @types/draco3dgltf

### DIFF
--- a/types/draco3d/draco3d-tests.ts
+++ b/types/draco3d/draco3d-tests.ts
@@ -3,9 +3,10 @@ import { createEncoderModule, createDecoderModule, EncoderModule, DecoderModule 
 /* Encode */
 
 createEncoderModule().then((encoderModule: EncoderModule) => {
-    const encoder = new encoderModule.Encoder();
     const builder = new encoderModule.MeshBuilder();
     const mesh = new encoderModule.Mesh();
+    const encoder = new encoderModule.Encoder();
+    const expertEncoder = new encoderModule.ExpertEncoder(mesh);
     const dracoBuffer = new encoderModule.DracoInt8Array();
 
     builder.AddUInt8Attribute(mesh, 5120, 100, 3, new Uint8Array(10));
@@ -24,6 +25,49 @@ createEncoderModule().then((encoderModule: EncoderModule) => {
     encoder.SetTrackEncodedProperties(true);
     encoder.SetEncodingMethod(encoderModule.MESH_EDGEBREAKER_ENCODING);
     encoder.EncodeMeshToDracoBuffer(mesh, dracoBuffer);
+
+    expertEncoder.SetSpeedOptions(5, 5);
+    expertEncoder.SetTrackEncodedProperties(true);
+    expertEncoder.SetEncodingMethod(encoderModule.MESH_EDGEBREAKER_ENCODING);
+    expertEncoder.EncodeToDracoBuffer(true, dracoBuffer);
+
+    let numVertices: number = encoder.GetNumberOfEncodedPoints();
+    let numIndices: number = encoder.GetNumberOfEncodedFaces() * 3;
+
+    numVertices = expertEncoder.GetNumberOfEncodedPoints();
+    numIndices = expertEncoder.GetNumberOfEncodedFaces() * 3;
+
+    encoderModule.destroy(dracoBuffer);
+    encoderModule.destroy(mesh);
+    encoderModule.destroy(builder);
+    encoderModule.destroy(encoder);
+    encoderModule.destroy(expertEncoder);
+});
+
+/* Encode (Expert) */
+
+createEncoderModule().then((encoderModule: EncoderModule) => {
+    const builder = new encoderModule.MeshBuilder();
+    const mesh = new encoderModule.Mesh();
+    const encoder = new encoderModule.ExpertEncoder(mesh);
+    const dracoBuffer = new encoderModule.DracoInt8Array();
+
+    builder.AddUInt8Attribute(mesh, 5120, 100, 3, new Uint8Array(10));
+    builder.AddInt8Attribute(mesh, 5120, 100, 3, new Int8Array(10));
+    builder.AddUInt16Attribute(mesh, 5120, 100, 3, new Uint16Array(10));
+    builder.AddInt16Attribute(mesh, 5120, 100, 3, new Int16Array(10));
+    builder.AddUInt32Attribute(mesh, 5120, 100, 3, new Uint32Array(10));
+    builder.AddFloatAttribute(mesh, 5120, 100, 3, new Float32Array(10));
+
+    encoder.SetAttributeQuantization(encoderModule.POSITION, 12);
+    encoder.SetAttributeExplicitQuantization(encoderModule.POSITION, 14, 2, [0, 0, 0], 10);
+
+    builder.AddFacesToMesh(mesh, 32, new Uint32Array(96));
+
+    encoder.SetSpeedOptions(5, 5);
+    encoder.SetTrackEncodedProperties(true);
+    encoder.SetEncodingMethod(encoderModule.MESH_EDGEBREAKER_ENCODING);
+    encoder.EncodeToDracoBuffer(true, dracoBuffer);
 
     const numVertices: number = encoder.GetNumberOfEncodedPoints();
     const numIndices: number = encoder.GetNumberOfEncodedFaces() * 3;

--- a/types/draco3d/index.d.ts
+++ b/types/draco3d/index.d.ts
@@ -20,12 +20,12 @@ export interface BaseModule {
     DracoUInt16Array: new () => DracoUInt16Array;
     DracoUInt32Array: new () => DracoUInt32Array;
 
-    POSITION: number;
-    NORMAL: number;
-    TEX_COORD: number;
-    COLOR: number;
-    GENERIC: number;
-    INVALID: number;
+    POSITION: GeometryAttributeType;
+    NORMAL: GeometryAttributeType;
+    TEX_COORD: GeometryAttributeType;
+    COLOR: GeometryAttributeType;
+    GENERIC: GeometryAttributeType;
+    INVALID: GeometryAttributeType;
 
     _malloc: (ptr: number) => number;
     _free: (ptr: number) => void;
@@ -43,6 +43,7 @@ export interface BaseModule {
 
 export interface EncoderModule extends BaseModule {
     Encoder: new () => Encoder;
+    ExpertEncoder: new (pc: PointCloud) => ExpertEncoder;
     MeshBuilder: new () => MeshBuilder;
 
     MESH_SEQUENTIAL_ENCODING: number;
@@ -75,21 +76,36 @@ export interface DecoderModule extends BaseModule {
     DT_UINT32: DataType;
 }
 
-export interface Encoder {
-    SetAttributeQuantization(attribute: number, bits: number): void;
+interface EncoderBase {
+    SetSpeedOptions(encodeSpeed: number, decodeSpeed: number): void;
+    SetEncodingMethod(method: number): void;
+    SetTrackEncodedProperties(track: boolean): void;
+    GetNumberOfEncodedPoints(): number;
+    GetNumberOfEncodedFaces(): number;
+}
+
+export interface Encoder extends EncoderBase {
+    SetAttributeQuantization(attributeType: GeometryAttributeType, bits: number): void;
     SetAttributeExplicitQuantization(
-        attribute: number,
+        attributeType: GeometryAttributeType,
         bits: number,
         itemSize: number,
         origin: [number, number, number],
         range: number,
     ): void;
-    SetSpeedOptions(encodeSpeed: number, decodeSpeed: number): void;
-    SetEncodingMethod(method: number): void;
-    SetTrackEncodedProperties(track: boolean): void;
     EncodeMeshToDracoBuffer(mesh: Mesh, array: DracoInt8Array): number;
-    GetNumberOfEncodedPoints(): number;
-    GetNumberOfEncodedFaces(): number;
+}
+
+export interface ExpertEncoder extends EncoderBase {
+    SetAttributeQuantization(attributeId: number, bits: number): void;
+    SetAttributeExplicitQuantization(
+        attributeId: number,
+        bits: number,
+        itemSize: number,
+        origin: [number, number, number],
+        range: number,
+    ): void;
+    EncodeToDracoBuffer(deduplicateValues: boolean, array: DracoInt8Array): number;
 }
 
 export interface Decoder {
@@ -152,6 +168,9 @@ export interface Attribute {
 
 // tslint:disable-next-line:no-empty-interface
 export enum GeometryType {}
+
+// tslint:disable-next-line:no-empty-interface
+export enum GeometryAttributeType {}
 
 // tslint:disable-next-line:no-empty-interface
 export enum DataType {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google/draco/blob/d44cb5bc7d1fecad4b377ed6b3a611931e87ef87/src/draco/javascript/emscripten/draco_web_encoder.idl#L188
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)

***

The Encoder and ExpertEncoder APIs are very similar, but differ in a subtle way. The `SetAttributeQuantization` methods take numbers as the first argument for both, but for Encoder that number is an enum value, and for ExpertEncoder it is an arbitrary numeric ID.
