### PR TITLE
Add missing lint exemptions

### DIFF
--- a/types/auth0-js/v7/index.d.ts
+++ b/types/auth0-js/v7/index.d.ts
@@ -172,6 +172,7 @@ interface Auth0DelegationToken {
 
 declare const Auth0: Auth0Static;
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "auth0-js" {
     export = Auth0;
 }

--- a/types/bluebird/v1/index.d.ts
+++ b/types/bluebird/v1/index.d.ts
@@ -662,6 +662,7 @@ declare namespace Promise {
     }
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module 'bluebird' {
     export = Promise;
 }

--- a/types/ember__application/v3/.eslintrc.json
+++ b/types/ember__application/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__array/v3/.eslintrc.json
+++ b/types/ember__array/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__component/v3/.eslintrc.json
+++ b/types/ember__component/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__engine/v3/.eslintrc.json
+++ b/types/ember__engine/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__object/v3/.eslintrc.json
+++ b/types/ember__object/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__routing/v3/.eslintrc.json
+++ b/types/ember__routing/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/ember__runloop/v3/.eslintrc.json
+++ b/types/ember__runloop/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-self-import": "off"
+    }
+}

--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -6,6 +6,7 @@
 
 import { Application } from '@feathersjs/feathers';
 import { Request } from 'express';
+// eslint-disable-next-line @definitelytyped/no-self-import
 import * as self from '@feathersjs/authentication-jwt';
 
 declare const feathersAuthenticationJwt: ((options?: Partial<FeathersAuthenticationJWTOptions>) => () => void) & typeof self;

--- a/types/feathersjs__authentication-oauth1/index.d.ts
+++ b/types/feathersjs__authentication-oauth1/index.d.ts
@@ -9,6 +9,7 @@ import {
     Paginated
 } from '@feathersjs/feathers';
 import { Request } from 'express';
+// eslint-disable-next-line @definitelytyped/no-self-import
 import * as self from '@feathersjs/authentication-oauth1';
 
 declare const feathersAuthenticationOAuth1: ((options?: FeathersAuthenticationOAuth1Options) => () => void) & typeof self;

--- a/types/feathersjs__authentication/index.d.ts
+++ b/types/feathersjs__authentication/index.d.ts
@@ -7,6 +7,7 @@
 // TypeScript Version: 2.3
 
 import { Hook, Params } from '@feathersjs/feathers';
+// eslint-disable-next-line @definitelytyped/no-self-import
 import * as self from '@feathersjs/authentication';
 import { RequestHandler, Application } from 'express';
 import { create } from 'domain';

--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -7,6 +7,7 @@
 
 import { Application as FeathersApplication, ServiceMethods, SetupMethod } from '@feathersjs/feathers';
 import * as express from 'express';
+// eslint-disable-next-line @definitelytyped/no-self-import
 import * as self from '@feathersjs/express';
 import { IRouterHandler, PathParams, RequestHandler, RequestHandlerParams } from 'express-serve-static-core';
 

--- a/types/google-cloud__datastore/.eslintrc.json
+++ b/types/google-cloud__datastore/.eslintrc.json
@@ -1,5 +1,7 @@
 {
     "rules": {
-        "@definitelytyped/no-single-element-tuple-type": "off"
+        "@definitelytyped/no-single-element-tuple-type": "off",
+        "@definitelytyped/no-declare-current-package": "off",
+        "@definitelytyped/no-self-import": "off"
     }
 }

--- a/types/hapi/v12/index.d.ts
+++ b/types/hapi/v12/index.d.ts
@@ -10,6 +10,7 @@
 
 /// <reference types="node" />
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "hapi" {
     import http = require("http");
     import stream = require("stream");

--- a/types/hapi__catbox-redis/index.d.ts
+++ b/types/hapi__catbox-redis/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line:no-single-declare-module
 declare module '@hapi/catbox-redis' {
     import { Redis, Cluster } from 'ioredis';

--- a/types/humblebee__styled-components-breakpoint/index.d.ts
+++ b/types/humblebee__styled-components-breakpoint/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Carl Ribbegårdh <https://github.com/CarlRibbegaardh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line:no-single-declare-module
 declare module "@humblebee/styled-components-breakpoint" {
     import { CSSObject, SimpleInterpolation } from "styled-components";

--- a/types/isomorphic-git__lightning-fs/index.d.ts
+++ b/types/isomorphic-git__lightning-fs/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: DefinitelyTyped <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module '@isomorphic-git/lightning-fs' {
   /**
    * You can procrastinate initializing the FS object until later. And, if you're really adventurous, you can re-initialize it with a different name to switch between IndexedDb databases.
@@ -301,6 +302,7 @@ declare module '@isomorphic-git/lightning-fs' {
     export = FS;
   }
 
+  // eslint-disable-next-line @definitelytyped/no-declare-current-package
   declare module '@isomorphic-git/lightning-fs/src/path' {
     namespace Path {
       function join(...parts: string[]): string;

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -3808,6 +3808,7 @@ interface JQuery {
      */
     extend(object: { [method: string]: (...args: any[]) => any; }): JQuery;
 }
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "jquery" {
     export = $;
 }

--- a/types/keystonejs__email/index.d.ts
+++ b/types/keystonejs__email/index.d.ts
@@ -7,6 +7,7 @@
 
 // Because this is a scoped package, without this line Typescript doesn't associate the
 // types with the right package.
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line:no-single-declare-module
 declare module '@keystonejs/email' {
     type Sender = (

--- a/types/keystonejs__session/index.d.ts
+++ b/types/keystonejs__session/index.d.ts
@@ -7,5 +7,6 @@
 
 // Because this is a scoped package, without this line Typescript doesn't associate the
 // types with the right package.
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line:no-single-declare-module
 declare module '@keystonejs/session' {}

--- a/types/mapbox__shelf-pack/index.d.ts
+++ b/types/mapbox__shelf-pack/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Gyusun Yeom <https://github.com/Perlmint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line no-single-declare-module
 declare module "@mapbox/shelf-pack" {
     export = ShelfPack;

--- a/types/needle/v1/index.d.ts
+++ b/types/needle/v1/index.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="node" />
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "needle" {
     import * as http from 'http';
     import * as Buffer from 'buffer';

--- a/types/node-notifier/v5/index.d.ts
+++ b/types/node-notifier/v5/index.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="node" />
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier" {
     import NotificationCenter = require('node-notifier/notifiers/notificationcenter');
     import NotifySend = require("node-notifier/notifiers/notifysend");
@@ -76,6 +77,7 @@ declare module "node-notifier" {
     export = nodeNotifier;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier/notifiers/notificationcenter" {
     import notifier = require('node-notifier');
 
@@ -117,6 +119,7 @@ declare module "node-notifier/notifiers/notificationcenter" {
     export = NotificationCenter;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier/notifiers/notifysend" {
     import notifier = require('node-notifier');
 
@@ -144,6 +147,7 @@ declare module "node-notifier/notifiers/notifysend" {
     export = NotifySend;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier/notifiers/toaster" {
     import notifier = require('node-notifier');
 
@@ -175,6 +179,7 @@ declare module "node-notifier/notifiers/toaster" {
     export = WindowsToaster;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier/notifiers/growl" {
     import notifier = require('node-notifier');
 
@@ -203,6 +208,7 @@ declare module "node-notifier/notifiers/growl" {
     export = Growl;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "node-notifier/notifiers/balloon" {
     import notifier = require('node-notifier');
 

--- a/types/openlayers/v3/index.d.ts
+++ b/types/openlayers/v3/index.d.ts
@@ -12442,6 +12442,7 @@ declare namespace olx {
 
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "openlayers" {
     export = ol;
 }

--- a/types/parse/v1/index.d.ts
+++ b/types/parse/v1/index.d.ts
@@ -1153,16 +1153,21 @@ declare namespace Parse {
     function setAsyncStorage(AsyncStorage: any): void;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module 'parse/node' {
     export = Parse;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module 'parse' {
+    // eslint-disable-next-line @definitelytyped/no-self-import
     import * as parse from 'parse/node';
     export = parse;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module 'parse/react-native' {
+    // eslint-disable-next-line @definitelytyped/no-self-import
     import * as parse from 'parse/node';
     export = parse;
 }

--- a/types/rbush/v2/index.d.ts
+++ b/types/rbush/v2/index.d.ts
@@ -104,6 +104,7 @@ declare namespace rbush {
   }
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module 'rbush' {
   const temp: rbush.IRBush;
   export = temp;

--- a/types/riderize__passport-strava-oauth2/index.d.ts
+++ b/types/riderize__passport-strava-oauth2/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: edilson <https://github.com/edilson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/* eslint-disable @definitelytyped/no-declare-current-package */
 // tslint:disable-next-line:no-single-declare-module
 declare module '@riderize/passport-strava-oauth2' {
     import { Request } from 'express';

--- a/types/stampit/v2/index.d.ts
+++ b/types/stampit/v2/index.d.ts
@@ -290,6 +290,7 @@ declare namespace stampit {
     export function convertConstructor(Constructor:any): Stamp;
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "stampit" {
     export = stampit;
 }

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -26,6 +26,7 @@ export interface BlocksStoreDescriptor extends StoreDescriptor {
     name: 'core/blocks';
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module '@wordpress/blocks' {
     const store: BlocksStoreDescriptor;
 }

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -17,6 +17,7 @@ export interface EditorStoreDescriptor extends StoreDescriptor {
     name: 'core/editor';
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module '@wordpress/editor' {
     const store: EditorStoreDescriptor;
 }

--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -121,6 +121,7 @@ export interface NoticesStoreDescriptor extends StoreDescriptor {
     name: 'core/notices';
 }
 
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module '@wordpress/notices' {
     const store: NoticesStoreDescriptor;
 }


### PR DESCRIPTION
These lint rules were recently fixed to be more correct, and now catch problems in old versions and scoped packages.