### PR TITLE
String#matchAll should return iterable of RegExpExecArray (fixes TypeScript#36788)

### DIFF
--- a/types/string.prototype.matchall/index.d.ts
+++ b/types/string.prototype.matchall/index.d.ts
@@ -9,7 +9,7 @@
  * @param str string to match
  * @param regexp A variable name or string literal containing the regular expression pattern and flags.
  */
-declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpMatchArray>;
+declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpExecArray>;
 
 declare namespace matchAll {
     function shim(): void;

--- a/types/string.prototype.matchall/package.json
+++ b/types/string.prototype.matchall/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=5.2": { "*": ["ts5.2/*"] }
+    }
+}

--- a/types/string.prototype.matchall/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/string.prototype.matchall-tests.ts
@@ -4,9 +4,9 @@ const str = 'aabc';
 const nonRegexStr = 'ab';
 const globalRegex = /[ac]/g;
 
-matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpMatchArray>
-matchAll(str, new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>
-matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpExecArray>
+matchAll(str, new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpExecArray>
+matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpExecArray>
 matchAll.shim(); // $ExpectType void
-str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
-str.matchAll(new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpExecArray>
+str.matchAll(new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpExecArray>

--- a/types/string.prototype.matchall/ts5.2/index.d.ts
+++ b/types/string.prototype.matchall/ts5.2/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Matches a string with a regular expression, and returns an iterable of matches
+ * containing the results of that search.
+ * @param str string to match
+ * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+ */
+declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpMatchArray>;
+
+declare namespace matchAll {
+    function shim(): void;
+}
+
+export = matchAll;

--- a/types/string.prototype.matchall/ts5.2/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/ts5.2/string.prototype.matchall-tests.ts
@@ -1,0 +1,12 @@
+import matchAll = require('string.prototype.matchall');
+
+const str = 'aabc';
+const nonRegexStr = 'ab';
+const globalRegex = /[ac]/g;
+
+matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll.shim(); // $ExpectType void
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+str.matchAll(new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>

--- a/types/string.prototype.matchall/ts5.2/tsconfig.json
+++ b/types/string.prototype.matchall/ts5.2/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "ES2020"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string.prototype.matchall-tests.ts"
+    ]
+}

--- a/types/string.prototype.matchall/ts5.2/tslint.json
+++ b/types/string.prototype.matchall/ts5.2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/55565
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.