### PR TITLE
[@wordpress/block-editor] MediaPlaceholder: include string as 'multiple' type

### DIFF
--- a/types/wordpress__block-editor/components/media-placeholder.d.ts
+++ b/types/wordpress__block-editor/components/media-placeholder.d.ts
@@ -77,7 +77,7 @@ declare namespace MediaPlaceholder {
          */
         onError?(message: string): void;
         onSelectURL?(src: string): void;
-        multiple?: T | undefined;
+        multiple?: T | string | undefined;
         value?: T extends true ? number[] : number | undefined | undefined | undefined | undefined;
         onSelect(
             value: T extends true ? Array<{ id: number } & { [k: string]: any }> : { id: number } & { [k: string]: any }

--- a/types/wordpress__block-editor/components/media-placeholder.d.ts
+++ b/types/wordpress__block-editor/components/media-placeholder.d.ts
@@ -3,6 +3,8 @@ import { Dashicon, DropZone } from '@wordpress/components';
 import { ComponentType, MouseEventHandler } from 'react';
 
 declare namespace MediaPlaceholder {
+    type MediaPlaceholderMultipleAction = 'add';
+
     interface Props<T extends boolean> extends Pick<DropZone.Props, 'onHTMLDrop'> {
         /**
          * A string passed to `FormFileUpload` that tells the browser which file types can be uploaded
@@ -77,7 +79,7 @@ declare namespace MediaPlaceholder {
          */
         onError?(message: string): void;
         onSelectURL?(src: string): void;
-        multiple?: T | string | undefined;
+        multiple?: T | MediaPlaceholderMultipleAction | undefined;
         value?: T extends true ? number[] : number | undefined | undefined | undefined | undefined;
         onSelect(
             value: T extends true ? Array<{ id: number } & { [k: string]: any }> : { id: number } & { [k: string]: any }

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -237,6 +237,12 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
     allowedTypes={['image']}
     labels={{ title: 'The Image' }}
 />;
+<be.MediaPlaceholder
+    multiple={"add"}
+    onSelect={items => console.log(items.map((i: { id: string; }) => i.id).join())}
+    allowedTypes={['image']}
+    labels={{ title: 'The Image' }}
+/>;
 
 //
 // media-upload


### PR DESCRIPTION
The `MediaPlaceholder` component has a `multiple` prop which currently only allows `boolean` values, but the component also handles a `string` value, so this updates the appropriate types to include `string` and `boolean`. For more details, please see https://github.com/WordPress/gutenberg/issues/9137.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/issues/9137 & https://github.com/WordPress/gutenberg/pull/53350
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
