### PR TITLE
[markdownlint-rule-helpers] fix: LineMetadata line should be string

### DIFF
--- a/types/markdownlint-rule-helpers/index.d.ts
+++ b/types/markdownlint-rule-helpers/index.d.ts
@@ -165,7 +165,7 @@ export type FilterTokensHandler = (token: MarkdownIt.Token) => void;
 export function filterTokens(params: markdownlint.RuleParams, type: string, handler: FilterTokensHandler): void;
 
 export type LineMetadata = [
-    line: number,
+    line: string,
     lineIndex: number,
     inCode: boolean,
     onFence: boolean,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DavidAnson/markdownlint/blob/c2c4a44931287c1420d937c38e85719a24c9c6a6/helpers/helpers.js#L343 & https://github.com/DavidAnson/markdownlint/blob/7f14d9b5a861b31938f72a60ce03d50b269ae251/lib/markdownlint.d.ts#L126
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

I think I'd gotten this wrong in #66413.

fyi @DavidAnson 