### PR TITLE
[chrome] Update WebRequestBodyEvent listener

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11258,11 +11258,11 @@ declare namespace chrome.webRequest {
 
     export interface WebRequestBodyEvent extends
         chrome.events.EventWithRequiredFilterInAddListener<
-            (details: WebRequestBodyDetails) => BlockingResponse | void
+            (details: WebRequestBodyDetails) => BlockingResponse | void | Promise<BlockingResponse | void>
         >
     {
         addListener(
-            callback: (details: WebRequestBodyDetails) => BlockingResponse | void,
+            callback: (details: WebRequestBodyDetails) => BlockingResponse | void | Promise<BlockingResponse | void>,
             filter: RequestFilter,
             opt_extraInfoSpec?: string[],
         ): void;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2131,3 +2131,9 @@ function testSidePanelAPI() {
         console.log("Behavior set successfully.");
     });
 }
+
+function testAddRemoveWebRequestListeners() {
+    async function handleOnBeforeRequest() {}
+    chrome.webRequest.onBeforeRequest.addListener(handleOnBeforeRequest, { urls: ["<all_urls>"] });
+    chrome.webRequest.onBeforeRequest.removeListener(handleOnBeforeRequest);
+}


### PR DESCRIPTION
[chrome.webRequest event listeners ](https://developer.chrome.com/docs/extensions/reference/webRequest/)can be async.

For example:
```js
chrome.webRequest.onBeforeRequest.addListener(async () => {
  // ...
}, { urls: ["<all_urls>"] });
```


