### PR TITLE
upgrade `apollo-upload-client` dependency version

### DIFF
--- a/types/apollo-upload-client/package.json
+++ b/types/apollo-upload-client/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@apollo/client": "^3.7.0",
+        "@apollo/client": "^3.8.3",
         "graphql": "14 - 16"
     }
 }


### PR DESCRIPTION
Update the @apollo/client dependency to use the latest ApolloLink type to 3.8.3

---

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
