### PR TITLE
[workerpool ] add 'maxQueueSize' to WorkerPoolOptions

### DIFF
--- a/types/workerpool/index.d.ts
+++ b/types/workerpool/index.d.ts
@@ -132,6 +132,13 @@ export interface WorkerPoolOptions extends WorkerCreationOptions {
     maxWorkers?: number | undefined;
 
     /**
+     * The maximum number of tasks allowed to be queued. Can be used to prevent running out of memory.
+     * If the maximum is exceeded, adding a new task will throw an error.
+     * The default value is `Infinity`.
+     */
+    maxQueueSize?: number | undefined;
+
+    /**
      * - In case of `'auto'` (default), workerpool will automatically pick a suitable type of worker:
      *   when in a browser environment, `'web'` will be used. When in a node.js environment, `worker_threads` will be used
      *   if available (Node.js >= 11.7.0), else `child_process` will be used.

--- a/types/workerpool/workerpool-tests.ts
+++ b/types/workerpool/workerpool-tests.ts
@@ -6,6 +6,7 @@ wp.pool({ minWorkers: 'max' });
 wp.pool({ minWorkers: 'max', maxWorkers: 1 });
 wp.pool({ minWorkers: 1, maxWorkers: 1 });
 wp.pool({ maxWorkers: 1 });
+wp.pool({ maxQueueSize: 5 });
 wp.pool({ workerType: 'process' });
 wp.pool({ workerType: 'thread' });
 wp.pool({ workerType: 'web' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. _Code compiles and runs as expected when the commit is applied to [this](https://github.com/jake-albert/workerpool-definitely-typed-test) minimal example project. (Without the change, [`@ts-ignore` is needed](https://github.com/jake-albert/workerpool-definitely-typed-test/blob/f9408678f9c39af5012f9920bffbf237fb4ceb05/src/workerPoolFactory.ts#L11).)_
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _`workerpool` [README](https://github.com/josdejong/workerpool/blob/a35f8dabefc9d4ef280b18c9e4a0c49138cf7bd1/README.md?plain=1#L191). Inspecting the [code](https://github.com/josdejong/workerpool/blob/a35f8dabefc9d4ef280b18c9e4a0c49138cf7bd1/src/Pool.js#L32) reveals that the option may be passed when invoking `workerpool.pool(...)`._
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _Not a breaking change. `maxQueueSize` seems to have been added as early as `workerpool@4.0.0` given [HISTORY.md](https://github.com/josdejong/workerpool/blob/a35f8dabefc9d4ef280b18c9e4a0c49138cf7bd1/HISTORY.md?plain=1#L159), and is still used in `6.4.x`._
