### PR TITLE
Mark node:util#inspect options as optional

### DIFF
--- a/types/node/v14/ts4.8/util.d.ts
+++ b/types/node/v14/ts4.8/util.d.ts
@@ -11,7 +11,7 @@ declare module 'util' {
     /** @deprecated since v0.11.3 - use a third party module instead. */
     function log(string: string): void;
     function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
-    function inspect(object: any, options: InspectOptions): string;
+    function inspect(object: any, options?: InspectOptions): string;
     namespace inspect {
         let colors: NodeJS.Dict<[number, number]>;
         let styles: {

--- a/types/node/v14/util.d.ts
+++ b/types/node/v14/util.d.ts
@@ -11,7 +11,7 @@ declare module 'util' {
     /** @deprecated since v0.11.3 - use a third party module instead. */
     function log(string: string): void;
     function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
-    function inspect(object: any, options: InspectOptions): string;
+    function inspect(object: any, options?: InspectOptions): string;
     namespace inspect {
         let colors: NodeJS.Dict<[number, number]>;
         let styles: {

--- a/types/node/v16/ts4.8/util.d.ts
+++ b/types/node/v16/ts4.8/util.d.ts
@@ -317,7 +317,7 @@ declare module 'util' {
      * @return The representation of `object`.
      */
     export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
-    export function inspect(object: any, options: InspectOptions): string;
+    export function inspect(object: any, options?: InspectOptions): string;
     export namespace inspect {
         let colors: NodeJS.Dict<[number, number]>;
         let styles: {

--- a/types/node/v16/util.d.ts
+++ b/types/node/v16/util.d.ts
@@ -317,7 +317,7 @@ declare module 'util' {
      * @return The representation of `object`.
      */
     export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
-    export function inspect(object: any, options: InspectOptions): string;
+    export function inspect(object: any, options?: InspectOptions): string;
     export namespace inspect {
         let colors: NodeJS.Dict<[number, number]>;
         let styles: {


### PR DESCRIPTION
This was already correct for `@types/node` 18 and 20, but not 14 and 16.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v16.x/api/util.html#utilinspectobject-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
