### PR TITLE
[node] Update types to v20.6.0

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -21,6 +21,7 @@ declare module 'async_hooks' {
      * import fs from 'node:fs';
      *
      * console.log(executionAsyncId());  // 1 - bootstrap
+     * const path = '.';
      * fs.open(path, 'r', (err, fd) => {
      *   console.log(executionAsyncId());  // 6 - open()
      * });

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3924,17 +3924,22 @@ declare module 'fs' {
     }
 
     /**
-     * Returns a Blob whose data is backed by the given file.
+     * Returns a `Blob` whose data is backed by the given file.
      *
-     * The file must not be modified after the `Blob` is created.
-     * Any modifications will cause reading the `Blob` data to fail with a `DOMException` error.
-     * Synchronous stat operations on the file when the `Blob` is created, and before each read in order to detect whether the file data has been modified on disk.
+     * The file must not be modified after the `Blob` is created. Any modifications
+     * will cause reading the `Blob` data to fail with a `DOMException` error.
+     * Synchronous stat operations on the file when the `Blob` is created, and before
+     * each read in order to detect whether the file data has been modified on disk.
      *
-     * @param path
-     * @param [options]
+     * ```js
+     * import { openAsBlob } from 'node:fs';
      *
-     * @experimental
+     * const blob = await openAsBlob('the.file.txt');
+     * const ab = await blob.arrayBuffer();
+     * blob.stream();
+     * ```
      * @since v19.8.0
+     * @experimental
      */
     export function openAsBlob(path: PathLike, options?: OpenAsBlobOptions): Promise<Blob>;
 

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -803,7 +803,7 @@ declare module 'http' {
          * may run into a 'ECONNRESET' error.
          *
          * ```js
-         * const http = require('node:http');
+         * import http from 'node:http';
          *
          * // Server has a 5 seconds keep-alive timeout by default
          * http
@@ -827,7 +827,7 @@ declare module 'http' {
          * automatic error retry base on it.
          *
          * ```js
-         * const http = require('node:http');
+         * import http from 'node:http';
          * const agent = new http.Agent({ keepAlive: true });
          *
          * function retriableRequest() {
@@ -1375,6 +1375,37 @@ declare module 'http' {
      *
      * The `requestListener` is a function which is automatically
      * added to the `'request'` event.
+     *
+     * ```js
+     * import http from 'node:http';
+     *
+     * // Create a local server to receive data from
+     * const server = http.createServer((req, res) => {
+     *   res.writeHead(200, { 'Content-Type': 'application/json' });
+     *   res.end(JSON.stringify({
+     *     data: 'Hello World!',
+     *   }));
+     * });
+     *
+     * server.listen(8000);
+     * ```
+     *
+     * ```js
+     * import http from 'node:http';
+     *
+     * // Create a local server to receive data from
+     * const server = http.createServer();
+     *
+     * // Listen to the request event
+     * server.on('request', (request, res) => {
+     *   res.writeHead(200, { 'Content-Type': 'application/json' });
+     *   res.end(JSON.stringify({
+     *     data: 'Hello World!',
+     *   }));
+     * });
+     *
+     * server.listen(8000);
+     * ```
      * @since v0.1.13
      */
     function createServer<
@@ -1409,7 +1440,8 @@ declare module 'http' {
      * upload a file with a POST request, then write to the `ClientRequest` object.
      *
      * ```js
-     * const http = require('node:http');
+     * import http from 'node:http';
+     * import { Buffer } from 'node:buffer';
      *
      * const postData = JSON.stringify({
      *   'msg': 'Hello World!',
@@ -1582,8 +1614,8 @@ declare module 'http' {
     function request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     /**
      * Since most requests are GET requests without bodies, Node.js provides this
-     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET and calls `req.end()`automatically. The callback must take care to consume the
-     * response
+     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET by default and calls `req.end()`automatically. The callback must take care to
+     * consume the response
      * data for reasons stated in {@link ClientRequest} section.
      *
      * The `callback` is invoked with a single argument that is an instance of {@link IncomingMessage}.
@@ -1638,7 +1670,7 @@ declare module 'http' {
      * server.listen(8000);
      * ```
      * @since v0.3.6
-     * @param options Accepts the same `options` as {@link request}, with the `method` always set to `GET`. Properties that are inherited from the prototype are ignored.
+     * @param options Accepts the same `options` as {@link request}, with the method set to GET by default.
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
@@ -1655,7 +1687,7 @@ declare module 'http' {
      * Example:
      *
      * ```js
-     * const { validateHeaderName } = require('node:http');
+     * import { validateHeaderName } from 'node:http';
      *
      * try {
      *   validateHeaderName('');
@@ -1683,7 +1715,7 @@ declare module 'http' {
      * Examples:
      *
      * ```js
-     * const { validateHeaderValue } = require('node:http');
+     * import { validateHeaderValue } from 'node:http';
      *
      * try {
      *   validateHeaderValue('x-my-header', undefined);

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.5
+// Type definitions for non-npm package Node.js 20.6
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -2705,8 +2705,9 @@ declare module 'inspector' {
      * @param [port='what was specified on the CLI'] Port to listen on for inspector connections. Optional.
      * @param [host='what was specified on the CLI'] Host to listen on for inspector connections. Optional.
      * @param [wait=false] Block until a client has connected. Optional.
+     * @returns Disposable that calls `inspector.close()`.
      */
-    function open(port?: number, host?: string, wait?: boolean): void;
+    function open(port?: number, host?: string, wait?: boolean): Disposable;
     /**
      * Deactivate the inspector. Blocks until there are no active connections.
      */

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -546,7 +546,8 @@ declare module 'process' {
                  * parent thread's `process.env`, or whatever was specified as the `env` option
                  * to the `Worker` constructor. Changes to `process.env` will not be visible
                  * across `Worker` threads, and only the main thread can make changes that
-                 * are visible to the operating system or to native add-ons.
+                 * are visible to the operating system or to native add-ons. On Windows, a copy of`process.env` on a `Worker` instance operates in a case-sensitive manner
+                 * unlike the main thread.
                  * @since v0.1.27
                  */
                 env: ProcessEnv;
@@ -1275,7 +1276,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/test/inspector.ts
+++ b/types/node/test/inspector.ts
@@ -4,7 +4,8 @@ const b: inspector.Console.ConsoleMessage = { source: 'test', text: 'test', leve
 inspector.open();
 inspector.open(0);
 inspector.open(0, 'localhost');
-inspector.open(0, 'localhost', true);
+const disposable = inspector.open(0, 'localhost', true);
+disposable[Symbol.dispose]();
 inspector.close();
 const inspectorUrl: string | undefined = inspector.url();
 

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -53,10 +53,12 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
     importmeta.url; // $ExpectType string
-    importmeta.resolve!('local', '/parent'); // $ExpectType Promise<string>
-    importmeta.resolve!('local', new URL('https://parent.module')); // $ExpectType Promise<string>
+    importmeta.resolve('local'); // $ExpectType string
+    importmeta.resolve('local', '/parent'); // $ExpectType string
+    importmeta.resolve('local', new URL('https://parent.module')); // $ExpectType string
 }
 
+// Hooks
 {
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
@@ -106,5 +108,35 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
+    };
+}
+
+// Initialize hook
+{
+    const specifier = './myLoader.js';
+    const parentURL = 'some-url'; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, parentURL);
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    const registerResult1 = Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+    registerResult1; // $ExpectType any
+
+    interface TransferableData { number: number; }
+    const registerResult2 = Module.register<TransferableData, "ok" | "fail">(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+    registerResult2; // $ExpectType "ok" | "fail"
+
+    type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
+    const initializeHook: MyInitializeHook = ({ number }) => {
+        number; // $ExpectType number
+        return 'ok';
     };
 }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -132,7 +132,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
         parentURL,
         data: { number: 1 },
     });
-    registerResult2; // $ExpectType "ok" | "fail"
+    registerResult2; // $ExpectType "ok" | "fail" || "fail" | "ok"
 
     type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
     const initializeHook: MyInitializeHook = ({ number }) => {

--- a/types/node/ts4.8/async_hooks.d.ts
+++ b/types/node/ts4.8/async_hooks.d.ts
@@ -21,6 +21,7 @@ declare module 'async_hooks' {
      * import fs from 'node:fs';
      *
      * console.log(executionAsyncId());  // 1 - bootstrap
+     * const path = '.';
      * fs.open(path, 'r', (err, fd) => {
      *   console.log(executionAsyncId());  // 6 - open()
      * });

--- a/types/node/ts4.8/fs.d.ts
+++ b/types/node/ts4.8/fs.d.ts
@@ -3924,17 +3924,22 @@ declare module 'fs' {
     }
 
     /**
-     * Returns a Blob whose data is backed by the given file.
+     * Returns a `Blob` whose data is backed by the given file.
      *
-     * The file must not be modified after the `Blob` is created.
-     * Any modifications will cause reading the `Blob` data to fail with a `DOMException` error.
-     * Synchronous stat operations on the file when the `Blob` is created, and before each read in order to detect whether the file data has been modified on disk.
+     * The file must not be modified after the `Blob` is created. Any modifications
+     * will cause reading the `Blob` data to fail with a `DOMException` error.
+     * Synchronous stat operations on the file when the `Blob` is created, and before
+     * each read in order to detect whether the file data has been modified on disk.
      *
-     * @param path
-     * @param [options]
+     * ```js
+     * import { openAsBlob } from 'node:fs';
      *
-     * @experimental
+     * const blob = await openAsBlob('the.file.txt');
+     * const ab = await blob.arrayBuffer();
+     * blob.stream();
+     * ```
      * @since v19.8.0
+     * @experimental
      */
     export function openAsBlob(path: PathLike, options?: OpenAsBlobOptions): Promise<Blob>;
 

--- a/types/node/ts4.8/http.d.ts
+++ b/types/node/ts4.8/http.d.ts
@@ -803,7 +803,7 @@ declare module 'http' {
          * may run into a 'ECONNRESET' error.
          *
          * ```js
-         * const http = require('node:http');
+         * import http from 'node:http';
          *
          * // Server has a 5 seconds keep-alive timeout by default
          * http
@@ -827,7 +827,7 @@ declare module 'http' {
          * automatic error retry base on it.
          *
          * ```js
-         * const http = require('node:http');
+         * import http from 'node:http';
          * const agent = new http.Agent({ keepAlive: true });
          *
          * function retriableRequest() {
@@ -1375,6 +1375,37 @@ declare module 'http' {
      *
      * The `requestListener` is a function which is automatically
      * added to the `'request'` event.
+     *
+     * ```js
+     * import http from 'node:http';
+     *
+     * // Create a local server to receive data from
+     * const server = http.createServer((req, res) => {
+     *   res.writeHead(200, { 'Content-Type': 'application/json' });
+     *   res.end(JSON.stringify({
+     *     data: 'Hello World!',
+     *   }));
+     * });
+     *
+     * server.listen(8000);
+     * ```
+     *
+     * ```js
+     * import http from 'node:http';
+     *
+     * // Create a local server to receive data from
+     * const server = http.createServer();
+     *
+     * // Listen to the request event
+     * server.on('request', (request, res) => {
+     *   res.writeHead(200, { 'Content-Type': 'application/json' });
+     *   res.end(JSON.stringify({
+     *     data: 'Hello World!',
+     *   }));
+     * });
+     *
+     * server.listen(8000);
+     * ```
      * @since v0.1.13
      */
     function createServer<
@@ -1409,7 +1440,8 @@ declare module 'http' {
      * upload a file with a POST request, then write to the `ClientRequest` object.
      *
      * ```js
-     * const http = require('node:http');
+     * import http from 'node:http';
+     * import { Buffer } from 'node:buffer';
      *
      * const postData = JSON.stringify({
      *   'msg': 'Hello World!',
@@ -1582,8 +1614,8 @@ declare module 'http' {
     function request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     /**
      * Since most requests are GET requests without bodies, Node.js provides this
-     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET and calls `req.end()`automatically. The callback must take care to consume the
-     * response
+     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET by default and calls `req.end()`automatically. The callback must take care to
+     * consume the response
      * data for reasons stated in {@link ClientRequest} section.
      *
      * The `callback` is invoked with a single argument that is an instance of {@link IncomingMessage}.
@@ -1638,7 +1670,7 @@ declare module 'http' {
      * server.listen(8000);
      * ```
      * @since v0.3.6
-     * @param options Accepts the same `options` as {@link request}, with the `method` always set to `GET`. Properties that are inherited from the prototype are ignored.
+     * @param options Accepts the same `options` as {@link request}, with the method set to GET by default.
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
@@ -1655,7 +1687,7 @@ declare module 'http' {
      * Example:
      *
      * ```js
-     * const { validateHeaderName } = require('node:http');
+     * import { validateHeaderName } from 'node:http';
      *
      * try {
      *   validateHeaderName('');
@@ -1683,7 +1715,7 @@ declare module 'http' {
      * Examples:
      *
      * ```js
-     * const { validateHeaderValue } = require('node:http');
+     * import { validateHeaderValue } from 'node:http';
      *
      * try {
      *   validateHeaderValue('x-my-header', undefined);

--- a/types/node/ts4.8/inspector.d.ts
+++ b/types/node/ts4.8/inspector.d.ts
@@ -2705,8 +2705,9 @@ declare module 'inspector' {
      * @param [port='what was specified on the CLI'] Port to listen on for inspector connections. Optional.
      * @param [host='what was specified on the CLI'] Host to listen on for inspector connections. Optional.
      * @param [wait=false] Block until a client has connected. Optional.
+     * @returns Disposable that calls `inspector.close()`.
      */
-    function open(port?: number, host?: string, wait?: boolean): void;
+    function open(port?: number, host?: string, wait?: boolean): Disposable;
     /**
      * Deactivate the inspector. Blocks until there are no active connections.
      */

--- a/types/node/ts4.8/process.d.ts
+++ b/types/node/ts4.8/process.d.ts
@@ -546,7 +546,8 @@ declare module 'process' {
                  * parent thread's `process.env`, or whatever was specified as the `env` option
                  * to the `Worker` constructor. Changes to `process.env` will not be visible
                  * across `Worker` threads, and only the main thread can make changes that
-                 * are visible to the operating system or to native add-ons.
+                 * are visible to the operating system or to native add-ons. On Windows, a copy of`process.env` on a `Worker` instance operates in a case-sensitive manner
+                 * unlike the main thread.
                  * @since v0.1.27
                  */
                 env: ProcessEnv;
@@ -1275,7 +1276,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/ts4.8/test/inspector.ts
+++ b/types/node/ts4.8/test/inspector.ts
@@ -4,7 +4,8 @@ const b: inspector.Console.ConsoleMessage = { source: 'test', text: 'test', leve
 inspector.open();
 inspector.open(0);
 inspector.open(0, 'localhost');
-inspector.open(0, 'localhost', true);
+const disposable = inspector.open(0, 'localhost', true);
+disposable[Symbol.dispose]();
 inspector.close();
 const inspectorUrl: string | undefined = inspector.url();
 

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -53,10 +53,12 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
     importmeta.url; // $ExpectType string
-    importmeta.resolve!('local', '/parent'); // $ExpectType Promise<string>
-    importmeta.resolve!('local', new URL('https://parent.module')); // $ExpectType Promise<string>
+    importmeta.resolve('local'); // $ExpectType string
+    importmeta.resolve('local', '/parent'); // $ExpectType string
+    importmeta.resolve('local', new URL('https://parent.module')); // $ExpectType string
 }
 
+// Hooks
 {
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
@@ -106,5 +108,35 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
+    };
+}
+
+// Initialize hook
+{
+    const specifier = './myLoader.js';
+    const parentURL = 'some-url'; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, parentURL);
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    const registerResult1 = Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+    registerResult1; // $ExpectType any
+
+    interface TransferableData { number: number; }
+    const registerResult2 = Module.register<TransferableData, "ok" | "fail">(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+    registerResult2; // $ExpectType "ok" | "fail"
+
+    type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
+    const initializeHook: MyInitializeHook = ({ number }) => {
+        number; // $ExpectType number
+        return 'ok';
     };
 }

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -132,7 +132,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
         parentURL,
         data: { number: 1 },
     });
-    registerResult2; // $ExpectType "ok" | "fail"
+    registerResult2; // $ExpectType "ok" | "fail" || "fail" | "ok"
 
     type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
     const initializeHook: MyInitializeHook = ({ number }) => {

--- a/types/node/ts4.8/worker_threads.d.ts
+++ b/types/node/ts4.8/worker_threads.d.ts
@@ -303,7 +303,8 @@ declare module 'worker_threads' {
      * are not available.
      * * `process.env` is a copy of the parent thread's environment variables,
      * unless otherwise specified. Changes to one copy are not visible in other
-     * threads, and are not visible to native add-ons (unless `worker.SHARE_ENV` is passed as the `env` option to the `Worker` constructor).
+     * threads, and are not visible to native add-ons (unless `worker.SHARE_ENV` is passed as the `env` option to the `Worker` constructor). On Windows, unlike the main thread, a copy of the
+     * environment variables operates in a case-sensitive manner.
      * * `process.title` cannot be modified.
      * * Signals are not delivered through `process.on('...')`.
      * * Execution may stop at any point as a result of `worker.terminate()` being invoked.

--- a/types/node/v16/process.d.ts
+++ b/types/node/v16/process.d.ts
@@ -1262,7 +1262,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/v16/ts4.8/process.d.ts
+++ b/types/node/v16/ts4.8/process.d.ts
@@ -1262,7 +1262,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/v18/process.d.ts
+++ b/types/node/v18/process.d.ts
@@ -1269,7 +1269,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/v18/ts4.8/process.d.ts
+++ b/types/node/v18/ts4.8/process.d.ts
@@ -1269,7 +1269,7 @@ declare module 'process' {
                  * If Node.js is spawned with an IPC channel, the `process.send()` method can be
                  * used to send messages to the parent process. Messages will be received as a `'message'` event on the parent's `ChildProcess` object.
                  *
-                 * If Node.js was not spawned with an IPC channel, `process.send` will be`undefined`.
+                 * If Node.js was not spawned with an IPC channel, `process.send` will be `undefined`.
                  *
                  * The message goes through serialization and parsing. The resulting message might
                  * not be the same as what is originally sent.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -303,7 +303,8 @@ declare module 'worker_threads' {
      * are not available.
      * * `process.env` is a copy of the parent thread's environment variables,
      * unless otherwise specified. Changes to one copy are not visible in other
-     * threads, and are not visible to native add-ons (unless `worker.SHARE_ENV` is passed as the `env` option to the `Worker` constructor).
+     * threads, and are not visible to native add-ons (unless `worker.SHARE_ENV` is passed as the `env` option to the `Worker` constructor). On Windows, unlike the main thread, a copy of the
+     * environment variables operates in a case-sensitive manner.
      * * `process.title` cannot be modified.
      * * Signals are not delivered through `process.on('...')`.
      * * Execution may stop at any point as a result of `worker.terminate()` being invoked.

--- a/types/rollup-plugin-add-git-msg/index.d.ts
+++ b/types/rollup-plugin-add-git-msg/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-/// <reference types="node" />
 import { Plugin } from 'rollup';
 
 declare namespace addGitMsg {

--- a/types/rollup-plugin-add-git-msg/rollup-plugin-add-git-msg-tests.ts
+++ b/types/rollup-plugin-add-git-msg/rollup-plugin-add-git-msg-tests.ts
@@ -1,7 +1,7 @@
 import addGitMsg from 'rollup-plugin-add-git-msg';
 
-addGitMsg(); // $ExpectType Plugin
+addGitMsg(); // $ExpectType Plugin || Plugin<any>
 
-addGitMsg({ copyright: 'Myself' }); // $ExpectType Plugin
+addGitMsg({ copyright: 'Myself' }); // $ExpectType Plugin || Plugin<any>
 
-addGitMsg({ copyright: 'Myself', showCommitID: true, showDate: false, showTag: false }); // $ExpectType Plugin
+addGitMsg({ copyright: 'Myself', showCommitID: true, showDate: false, showTag: false }); // $ExpectType Plugin || Plugin<any>


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.6.0

- `import.meta.resolve` unflagged
- New node:module API `register` for module customization hooks; new `initialize` hook
- inspector: open add SymbolDispose

---
Also:
- fix #66627
