### PR TITLE
[mapbox-gl-draw] Fix isOfMetaType type in CommonSelectors

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -390,10 +390,9 @@ declare namespace MapboxDraw {
         values(): string | number[];
         clear(): StringSet;
     }
-
     interface Lib {
         CommonSelectors: {
-            isOfMetaType: (e: MapMouseEvent | MapTouchEvent) => boolean;
+            isOfMetaType: (type: Constants['meta'][keyof Constants['meta']]) => (e: MapMouseEvent | MapTouchEvent) => boolean;
             isShiftMousedown: (e: MapboxEvent) => boolean;
             isActiveFeature: (e: MapMouseEvent | MapTouchEvent) => boolean;
             isInactiveFeature: (e: MapMouseEvent | MapTouchEvent) => boolean;

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -116,6 +116,9 @@ const customMode: CustomMode = {
         // $ExpectType void
         this.changeMode(constants.modes.SIMPLE_SELECT);
 
+        // $ExpectType (e: MapMouseEvent | MapTouchEvent) => boolean
+        lib.CommonSelectors.isOfMetaType('feature');
+
         // $ExpectType boolean
         lib.CommonSelectors.isVertex(e);
 


### PR DESCRIPTION
## CommonSelectors
- Fix isOfMetaType type in CommonSelectors: `isOfMetaType` takes a `meta` that is a properties of `Constants` argument and returns a function.
cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/common_selectors.js#L3

=======================================
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.