### PR TITLE
[dcp-client] Add exported wallet module symbols

### DIFF
--- a/types/dcp-client/test/dcp-client-global.tests.ts
+++ b/types/dcp-client/test/dcp-client-global.tests.ts
@@ -10,10 +10,3 @@ compute;
 wallet;
 // $ExpectType Worker
 worker;
-
-const { Keystore } = wallet;
-
-// $ExpectType Keystore
-new Keystore();
-// $ExpectType Keystore
-new Keystore(null, '');

--- a/types/dcp-client/test/dcp-client-module.tests.ts
+++ b/types/dcp-client/test/dcp-client-module.tests.ts
@@ -4,7 +4,7 @@
 
 import { init, initSync, type PaymentParams } from 'dcp-client';
 import { RangeObject, ResultHandle, SuperRangeObject, MultiRangeObject } from 'dcp/compute';
-import { AuthKeystoreOptions, LoadOptions, Keystore } from 'dcp/wallet';
+import { AuthKeystoreOptions, LoadOptions, Keystore, Address, AuthKeystore } from 'dcp/wallet';
 import { Sandbox } from 'dcp/worker';
 
 // @ts-expect-error
@@ -77,10 +77,20 @@ export const loadOptions: LoadOptions = {
 
     //#endregion
 
+    // #region Wallet Tests
+
+    // $ExpectType Keystore
+    await new Keystore(null, '');
+    // $ExpectType Address
+    new Address('');
+
+    // #endregion
+
     //#region Job Tests
     const initialSliceProfile = {};
     // $ExpectType Keystore
-    const keystore = new Keystore();
+    const keystore = await new Keystore();
+
     const iterable = [1, 2, 3, 4, 5];
     const MY_RESEARCH_URL = 'https://localhost:8080/someURL';
 

--- a/types/dcp-client/wallet.d.ts
+++ b/types/dcp-client/wallet.d.ts
@@ -42,7 +42,9 @@ declare module 'dcp/wallet' {
          */
         load(options: LoadOptions): Promise<LoadResult>;
 
-        Keystore: typeof Keystore;
+        Keystore: KeystoreConstructor;
+        Address: typeof Address;
+        PrivateKey: typeof PrivateKey;
     }
 
     interface AuthKeystoreOptions {
@@ -72,27 +74,7 @@ declare module 'dcp/wallet' {
      * preferred way to communicate both addresses and private keys through DCP APIs. This is not the keystore object
      * used by an underlying API / third-party library.
      */
-    class Keystore {
-        /**
-         * Constructs a locked keystore.
-         *
-         * This form accepts no arguments and returns a Keystore object that
-         * corresponds to a randomly-selected private key. This form will prompt the
-         * user for a password to encrypt itself with.
-         */
-        constructor();
-
-        /**
-         * Constructs a locked keystore.
-         *
-         * This form accepts as its argument null and a passphrase, and returns a
-         * Keystore object that corresponds to a randomly-selected private key,
-         * encrypted with the supplied passphrase.
-         *
-         * @param privateKey - If null, a randomly private key will be used.
-         * @param passphrase - The passphrase to encrypt the private key.
-         */
-        constructor(privateKey: null, passphrase: string);
+    interface Keystore {
         /**
          * An instance of {@link Address} which represents the (public) address in
          * the {@link Keystore}.
@@ -105,10 +87,113 @@ declare module 'dcp/wallet' {
         label?: string;
     }
 
+    interface KeystoreConstructor {
+        /**
+         * Constructs a locked keystore.
+         *
+         * This form accepts no arguments and returns a Keystore object that
+         * corresponds to a randomly-selected private key. This form will prompt the
+         * user for a password to encrypt itself with.
+         */
+        new (): Promise<Keystore>;
+
+        /**
+         * Constructs a locked keystore.
+         *
+         * This form accepts as its argument null and a passphrase, and returns a
+         * Keystore object that corresponds to a randomly-selected private key,
+         * encrypted with the supplied passphrase.
+         *
+         * @param privateKey If null, a randomly private key will be used.
+         * @param passphrase The passphrase to encrypt the private key.
+         */
+        new (privateKey: null, passphrase: string): Promise<Keystore>;
+    }
+
+    const Keystore: KeystoreConstructor;
+
     class AuthKeystore extends Keystore {}
 
+    /**
+     * An object representing DCP Addresses.
+     *
+     * All Addresses used within DCP or DCP Applications should be represented by Address objects, and all comparisons
+     * between Addresses and Address-like values must be done with the {@link Address.prototype.eq} method.
+     */
     class Address {
-        account: string;
+        /**
+         * If the passed address is a string, it should be (but is not required to be) in checksum format; a leading
+         * `0x` is not required.
+         *
+         * If the passed address is a instance of {@link PrivateKey} or {@link Address}, the address associated with the
+         * object used.
+         *
+         * If the passed address is any other type of object, we coerce the object with `toString(16)` before working
+         * with it (`BigNumber` and similar objects are expected to “just work”).
+         *
+         * @param address The address value used to construct the object.
+         */
+        constructor(address: string | Address | PrivateKey | object);
+        /**
+         * Compares the equality two Addresses, or an {@link Address} and a {@link PrivateKey}.
+         * @param address The address to check equality against.
+         */
+        eq(address: Address | PrivateKey): boolean;
+        /**
+         * Determines if the {@link Address} corresponds to a given {@link PrivateKey}.
+         *
+         * @param privateKey The private key to check.
+         */
+        ct(privateKey: PrivateKey): boolean;
+        /**
+         * Validates signatures in order to implement the `Connection.Request.authorizedFor method`.
+         *
+         * The first argument is the `messageBody` as a `string` or an `object`, and the second argument is the
+         * `signature`.
+         *
+         * @param messageBody The thing to verify the signature against.
+         * @param signature The signature to verify.
+         */
+        verifySignature(messageBody: string | object, signature: string): boolean;
+    }
+
+    /**
+     * An object that represents DCP private keys.
+     *
+     * All raw private keys used throughout DCP or DCP Applications should be stored in PrivateKey objects, however for
+     * security reasons, raw private keys should stored as little as possible: the preferred method to store a private
+     * key is via a keystore file or Keystore object.
+     *
+     * All comparisons between PrivateKeys and PrivateKey-like values must be done with the
+     * {@link PrivateKey.prototype.eq} method.
+     */
+    class PrivateKey {
+        /**
+         * The PrivateKey Constructor accepts as its argument a `string` or `object` corresponding to the private key
+         * we want to represent.
+         *
+         * If the passed private key is a `string`, it should (but is not required to) have the `0x` prefix. If the
+         * argument is an `object`, and is a {@link Keystore} object, we extract the private key; otherwise we coerce
+         * the object with `toString(16)` before working with it (`BigNumber` and similar objects are expected to "just
+         * work").
+         *
+         * @param privateKey The private key value to construct the object with.
+         */
+        constructor(privateKey: string | Keystore | object);
+        /**
+         * Compares this {@link PrivateKey} against another private key.
+         *
+         * Any argument which is acceptable to the constructor is acceptable to this method.
+         *
+         * @param privateKey The private key to compare against.
+         */
+        eq(privateKey: string | Keystore | object): boolean;
+        /**
+         * Determines if the {@link PrivateKey} corresponds to a given {@link Address}.
+         *
+         * @param address The address to check the correspondence of.
+         */
+        ct(address: Address): boolean;
     }
 
     interface LoadResult {


### PR DESCRIPTION
The Wallet API from `dcp-client` also exports constructors for `Address` and `PrivateKey`, so types have been added to indicate that they're exposed.

The need to `await` the `Keystore` constructor is now also expressed properly in the types.

The tests for the global types has been minimized since the key part of the test is `window.dcp` & it's properties' types. As long as those are correct, the module tests should cover the deeper types.

Refs: https://stackoverflow.com/a/71513155

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `mkad` from `dcp-util` destructuring the `Keystore` constructor from the Wallet API: https://github.com/Distributed-Compute-Labs/dcp-util/blob/fbb0e82a0a891d8ca9922115f5ec556170820922/bin/mkad#L20
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.