### PR TITLE
Add `has-property-descriptors` types

### DIFF
--- a/types/has-property-descriptors/has-property-descriptors-tests.ts
+++ b/types/has-property-descriptors/has-property-descriptors-tests.ts
@@ -1,0 +1,7 @@
+import hasPropertyDescriptors = require('has-property-descriptors');
+
+import { hasArrayLengthDefineBug } from 'has-property-descriptors';
+
+hasPropertyDescriptors(); // $ExpectType boolean
+
+hasArrayLengthDefineBug; // $ExpectType () => boolean

--- a/types/has-property-descriptors/index.d.ts
+++ b/types/has-property-descriptors/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for has-property-descriptors 1.0
+// Project: https://github.com/inspect-js/has-property-descriptors#readme
+// Definitions by: Jordan Harband <https://github.com/ljharb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function hasPropertyDescriptors(): boolean;
+
+declare namespace hasPropertyDescriptors {
+    function hasArrayLengthDefineBug(): boolean
+}
+
+export = hasPropertyDescriptors;

--- a/types/has-property-descriptors/tsconfig.json
+++ b/types/has-property-descriptors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "has-property-descriptors-tests.ts"
+    ]
+}

--- a/types/has-property-descriptors/tslint.json
+++ b/types/has-property-descriptors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
