### PR TITLE
dxf - fix for old typo for capital letters in entity type and polyline exports type corrected

### DIFF
--- a/types/dxf/Helper.d.ts
+++ b/types/dxf/Helper.d.ts
@@ -1,5 +1,6 @@
 import * as Entities from "./handlers/entities";
 import * as Information from "./Information";
+import { PolylineExport } from "./toPolylines";
 
 export default class Helper {
   constructor(contents: string);
@@ -17,7 +18,7 @@ export default class Helper {
   denormalise(): Entities.Entity[] | null;
   group(): Entities.LayerGroupedEntities | null;
   toSVG(): Information.SVG;
-  toPolylines(): Information.Polyline[];
+  toPolylines(): PolylineExport;
 }
 
 export function parseValue(type: number, value: any): number;

--- a/types/dxf/dxf-tests.ts
+++ b/types/dxf/dxf-tests.ts
@@ -14,13 +14,14 @@ helper.denormalised;
 // $ExpectType string
 helper.toSVG();
 
-// $ExpectType Polyline[]
+// $ExpectType PolylineExport
 helper.toPolylines();
+
 
 const { entities } = helper.parsed!;
 
 // $ExpectType PointEntityData[]
-const points = entities.filter(entity => entity.TYPE === 'POINT') as Entities.Point[];
+const points = entities.filter(entity => entity.type === 'POINT') as Entities.Point[];
 
 // $ExpectType PolylineEntityData[]
-const polylines = entities.filter(entity => entity.TYPE === 'POLYLINE') as Entities.Polyline[];
+const polylines = entities.filter(entity => entity.type === 'POLYLINE') as Entities.Polyline[];

--- a/types/dxf/dxf-tests.ts
+++ b/types/dxf/dxf-tests.ts
@@ -25,3 +25,6 @@ const points = entities.filter(entity => entity.type === 'POINT') as Entities.Po
 
 // $ExpectType PolylineEntityData[]
 const polylines = entities.filter(entity => entity.type === 'POLYLINE') as Entities.Polyline[];
+
+// $ExpectType LineEntityData[]
+const lines = entities.filter(entity => entity.type === 'LINE') as Entities.Line[];

--- a/types/dxf/handlers/entity/common.d.ts
+++ b/types/dxf/handlers/entity/common.d.ts
@@ -1,4 +1,5 @@
 import * as Common from '../../Common';
+import { EntityType } from '../entities';
 
 export interface CommonEntityData {
   layer: string;
@@ -10,7 +11,7 @@ export interface CommonEntityData {
   extrusionY: any;
   extrusionZ: any;
   $INSUNITS?: Common.UnitTypes;
-  TYPE: string;
+  type: EntityType;
 }
 
 export default function common(type: number, value: any): CommonEntityData;

--- a/types/dxf/toPolylines.d.ts
+++ b/types/dxf/toPolylines.d.ts
@@ -1,4 +1,7 @@
 import * as Information from './Information';
 import { Box } from './Utils';
 
-export default function toPolylines(parsed: Information.FileInfo): { bbox: Box, polylines: Information.Polyline[] };
+export interface PolylineExport { bbox: Box, polylines: Information.Polyline[] }
+
+
+export default function toPolylines(parsed: Information.FileInfo): PolylineExport;

--- a/types/dxf/toPolylines.d.ts
+++ b/types/dxf/toPolylines.d.ts
@@ -1,3 +1,4 @@
 import * as Information from './Information';
+import { Box } from './Utils';
 
-export default function toPolylines(parsed: Information.FileInfo): Information.Polyline[];
+export default function toPolylines(parsed: Information.FileInfo): { bbox: Box, polylines: Information.Polyline[] };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [dxf - type in entities should not be capital letters](https://github.com/skymakerolof/dxf/blob/develop/src/handlers/entity/line.js#L39)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (NO, old bug affecting all versions)
