### PR TITLE
fix(conventional-recommended-bump): update typings for v9 of the library

### DIFF
--- a/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
+++ b/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
@@ -5,30 +5,16 @@ import conventionalCommitsParser from "conventional-commits-parser";
 import conventionalRecommendedBump from "conventional-recommended-bump";
 
 namespace Module {
-    declare const callback: conventionalRecommendedBump.Callback;
     declare const options: conventionalRecommendedBump.Options;
     declare const parserOpts: conventionalCommitsParser.Options;
 
-    // $ExpectType void
-    conventionalRecommendedBump(options, callback);
-    // $ExpectType void
-    conventionalRecommendedBump(options, parserOpts, callback);
+    // $ExpectType Promise<void>
+    conventionalRecommendedBump(options);
+    // $ExpectType Promise<void>
+    conventionalRecommendedBump(options, parserOpts);
 
     // @ts-expect-error
     conventionalRecommendedBump();
-}
-
-namespace Module.Callback {
-    const callback: conventionalRecommendedBump.Callback = (error, recommendation) => {
-        // $ExpectType any
-        error;
-
-        // $ExpectType Recommendation
-        recommendation;
-        recommendation.level; // $ExpectType number | undefined
-        recommendation.reason; // $ExpectType string | undefined
-        recommendation.releaseType; // $ExpectType "major" | "minor" | "patch" | undefined || ReleaseType | undefined
-    };
 }
 
 namespace Module.Options {

--- a/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
+++ b/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
@@ -1,16 +1,16 @@
 /* tslint:disable:no-mergeable-namespace no-namespace */
 "use strict";
 
-import conventionalCommitsParser from "conventional-commits-parser";
-import conventionalRecommendedBump from "conventional-recommended-bump";
+import type conventionalCommitsParser from "conventional-commits-parser";
+import conventionalRecommendedBump, { type Recommendation } from "conventional-recommended-bump";
 
 namespace Module {
     declare const options: conventionalRecommendedBump.Options;
     declare const parserOpts: conventionalCommitsParser.Options;
 
-    // $ExpectType Promise<void>
+    // $ExpectType Promise<Recommendation>
     conventionalRecommendedBump(options);
-    // $ExpectType Promise<void>
+    // $ExpectType Promise<Recommendation>
     conventionalRecommendedBump(options, parserOpts);
 
     // @ts-expect-error

--- a/types/conventional-recommended-bump/index.d.ts
+++ b/types/conventional-recommended-bump/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for conventional-recommended-bump 6.1
+// Type definitions for conventional-recommended-bump 9.0
 // Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump#readme
 // Definitions by: Jason Kwok <https://github.com/JasonHK>
+//                 Jeroen "Favna" Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -10,27 +11,18 @@ import { Commit, Options as ParserOptions } from "conventional-commits-parser";
 
 /**
  * @param options  `options` is an object with the following properties:
- *
  *                 * `ignoreReverted`
  *                 * `preset`
  *                 * `config`
  *                 * `whatBump`
- * @param callback
- */
-declare function conventionalRecommendedBump(options: Options, callback: Callback): void;
-
-/**
- * @param options    `options` is an object with the following properties:
- *
- *                   * `ignoreReverted`
- *                   * `preset`
- *                   * `config`
- *                   * `whatBump`
- * @param parserOpts See the [conventional-commits-parser](https://github.com/conventional-changelog/conventional-commits-parser)
+ *                 * `tagPrefix`
+ *                 * `skipUnstable`
+ *                 * `lernaPackage`
+ *                 * `path`
+ * @param parserOpts See the [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser)
  *                   documentation for available options.
- * @param callback
  */
-declare function conventionalRecommendedBump(options: Options, parserOpts: ParserOptions, callback: Callback): void;
+declare function conventionalRecommendedBump(options: Options, parserOpts?: ParserOptions): Promise<void>;
 
 declare namespace conventionalRecommendedBump {
     /**
@@ -77,6 +69,10 @@ declare namespace conventionalRecommendedBump {
      * * `preset`
      * * `config`
      * * `whatBump`
+     * * `tagPrefix`
+     * * `skipUnstable`
+     * * `lernaPackage`
+     * * `path`
      */
     interface Options {
         /**

--- a/types/conventional-recommended-bump/index.d.ts
+++ b/types/conventional-recommended-bump/index.d.ts
@@ -22,7 +22,7 @@ import { Commit, Options as ParserOptions } from "conventional-commits-parser";
  * @param parserOpts See the [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser)
  *                   documentation for available options.
  */
-declare function conventionalRecommendedBump(options: Options, parserOpts?: ParserOptions): Promise<void>;
+declare function conventionalRecommendedBump(options: Options, parserOpts?: ParserOptions): Promise<Recommendation>;
 
 declare namespace conventionalRecommendedBump {
     /**
@@ -32,35 +32,17 @@ declare namespace conventionalRecommendedBump {
      * or `undefined` if `whatBump` does not return a valid `level` property, or
      * the `level` property is not set by `whatBump`.
      */
-    interface Callback {
+    interface Recommendation extends Options.WhatBump.Result {
         /**
-         * @param error
-         * @param recommendation `recommendation` is an `object` with a single property,
-         *                       `releaseType`.
-         */
-        (error: any, recommendation: Callback.Recommendation): void;
-    }
-
-    namespace Callback {
-        /**
-         * `recommendation` is an `object` with a single property, `releaseType`.
-         *
          * `releaseType` is a `string`: Possible values: `major`, `minor` and `patch`,
          * or `undefined` if `whatBump` does not return a valid `level` property, or
          * the `level` property is not set by `whatBump`.
          */
-        interface Recommendation extends Options.WhatBump.Result {
-            /**
-             * `releaseType` is a `string`: Possible values: `major`, `minor` and `patch`,
-             * or `undefined` if `whatBump` does not return a valid `level` property, or
-             * the `level` property is not set by `whatBump`.
-             */
-            releaseType?: Recommendation.ReleaseType | undefined;
-        }
+        releaseType?: Recommendation.ReleaseType | undefined;
+    }
 
-        namespace Recommendation {
-            type ReleaseType = "major" | "minor" | "patch";
-        }
+    namespace Recommendation {
+        type ReleaseType = 'major' | 'minor' | 'patch';
     }
 
     /**
@@ -166,7 +148,7 @@ declare namespace conventionalRecommendedBump {
     }
 }
 
-type Callback = conventionalRecommendedBump.Callback;
+type Recommendation = conventionalRecommendedBump.Recommendation;
 type Options = conventionalRecommendedBump.Options;
 
 export = conventionalRecommendedBump;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/conventional-changelog/conventional-changelog/releases/tag/conventional-recommended-bump-v9.0.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.