### PR TITLE
[@types/aws-lambda] Update FirehoseTransformationResultRecord data property to optional

### DIFF
--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -82,7 +82,7 @@ const firehoseHandler: FirehoseTransformationHandler = async (event, context, ca
             {
                 recordId: event.records[0].recordId,
                 result: 'Ok' as FirehoseRecordTransformationStatus,
-                data: 'eyJmb28iOiJiYXIifQ==',
+                data: strOrUndefined,
                 metadata: {
                     partitionKeys: {
                         testPart: 'test1',

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -42,7 +42,7 @@ export interface FirehoseTransformationResultRecord {
     recordId: string;
     result: FirehoseRecordTransformationStatus;
     /** Encode in Base64 */
-    data: string;
+    data?: string;
     metadata?: FirehoseTransformationMetadata;
 }
 


### PR DESCRIPTION


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Not documented anywhere, but lamda blueprint suggests that the property is optional:
    - [Process CloudWatch logs sent to Kinesis Firehose blueprint nodejs](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/create/function?blueprint=kinesis-firehose-cloudwatch-logs-processor&intent=blueprints) (processRecords function)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
