### PR TITLE
Add wildcard property to PlotData type in plotly.js to support traces not yet explicitly typed.

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1437,6 +1437,7 @@ export interface PlotData {
     ncontours: number;
     uirevision: string | number;
     uid: string;
+    [wildcard: string]: any;
 }
 
 /**


### PR DESCRIPTION
- [✔] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔] Test the change in your own code. (Compile and run.)
- [✔] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [✔] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✔] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [✔] Provide a URL to documentation or source code which provides context for the suggested changes:
[sankey chart](https://plotly.com/javascript/reference/sankey/#sankey), [overall figure reference](https://plotly.com/javascript/reference/index/)

Sankey trace types are supported by plotly.js but not by the DefinitelyTyped package. Also the overall figure reference is quite extensive and I suspect that there are other trace types inaccessible through typescript. Adding a wildcard property to the PlotData type circumvents this issue by allowing you to have types and intellisense for the explicitly supported charts while not excluding additional fields required for charts that have not yet been manually typed.