### PR TITLE
[mapbox-gl] `rotateTo` method accepts CameraOptions & AnimationOptions

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -489,7 +489,7 @@ declare namespace mapboxgl {
          */
         setPadding(padding: PaddingOptions, eventData?: EventData): this;
 
-        rotateTo(bearing: number, options?: mapboxgl.AnimationOptions, eventData?: EventData): this;
+        rotateTo(bearing: number, options?: AnimationOptions & CameraOptions, eventData?: EventData): this;
 
         resetNorth(options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this;
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -328,6 +328,16 @@ map.flyTo({
     maxDuration: 1,
 });
 
+// RotateTo
+map.rotateTo(45, {
+    duration: 2000,
+    animate: true,
+    easing: (t) => t,
+    center: [-122.3085, 47.5505],
+    zoom: 10,
+    pitch: 60,
+});
+
 // QueryRenderedFeatures
 const features = map.queryRenderedFeatures([0, 0], { layers: ['custom'], validate: false });
 features; // $ExpectType MapboxGeoJSONFeature[]


### PR DESCRIPTION
### Description 
I noticed today that the `rotateTo` method was working well even though TypeScript was showing an error about my options containing keys that did not belong in `AnimationOptions`. 

I double checked against the Mapbox GL JS repo and saw that both `AnimationOptions` and `CameraOptions` are accepted. This is reflected in the [docblock](https://github.com/mapbox/mapbox-gl-js/blob/93ef85650244e67c3b666c93e2c1c4205dfdca3b/src/ui/camera.js#L468-L490) and in the [documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#rotateto). 

Added a test to showcase this, let me know if there is anything else I need to change as well!

### Template Checklist

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#rotateto)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
    - I left this unchanged. The version at the top is 2.7 which seems to be up-to-date to me.
