### PR TITLE
[mapbox-gl-draw] Fixes to createSupplementaryPoints and related functions types

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -407,13 +407,13 @@ declare namespace MapboxDraw {
 
         constrainFeatureMovement(geojsonFeatures: DrawFeature[], delta: { lng: number; lat: number }): number;
 
-        createMidPoint(parent: string, startVertex: DrawFeature, endVertex: DrawFeature): GeoJSON;
+        createMidPoint(parent: string, startVertex: Feature, endVertex: Feature): Feature<Point> | null;
 
         createSupplementaryPoints(
-            geojson: DrawFeature,
+            geojson: Feature,
             options?: { midpoints?: boolean; selectedPaths?: string[] },
             basePath?: string,
-        ): GeoJSON[];
+        ): Array<Feature<Point>>;
 
         /**
          * Returns GeoJSON for a Point representing the
@@ -426,7 +426,7 @@ declare namespace MapboxDraw {
          * @param selected
          * @return GeoJSON Point
          */
-        createVertex(parentId: string, coordinates: Position, path: string, selected: boolean): GeoJSON;
+        createVertex(parentId: string, coordinates: Position, path: string, selected: boolean): Feature<Point>;
 
         // TODO: define a proper type for ctx since is not exposed correctly
         // https://github.com/mapbox/mapbox-gl-draw/issues/1156

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -12,7 +12,9 @@ import MapboxDraw, {
 const draw = new MapboxDraw({});
 
 // @ts-expect-error
-const feature: DrawFeature = {};
+const drawFeature: DrawFeature = {};
+// @ts-expect-error
+const feature: Feature = {}
 
 // $ExpectType string[]
 draw.add({
@@ -123,15 +125,15 @@ const customMode: CustomMode = {
         lib.CommonSelectors.isVertex(e);
 
         // $ExpectType number
-        lib.constrainFeatureMovement([feature], { lng: e.lngLat.lng, lat: e.lngLat.lat });
+        lib.constrainFeatureMovement([drawFeature], { lng: e.lngLat.lng, lat: e.lngLat.lat });
 
-        // $ExpectType GeoJSON
+        // $ExpectType Feature<Point, GeoJsonProperties> | null
         lib.createMidPoint('1', feature, feature);
 
-        // $ExpectType GeoJSON[]
+        // $ExpectType Feature<Point, GeoJsonProperties>[]
         lib.createSupplementaryPoints(feature, { midpoints: false });
 
-        // $ExpectType GeoJSON
+        // $ExpectType Feature<Point, GeoJsonProperties>
         lib.createVertex('1', [e.lngLat.lng, e.lngLat.lat], '0', true);
 
         // $ExpectType number
@@ -156,10 +158,10 @@ const customMode: CustomMode = {
         // TODO: add tests to ModeHandler
 
         // $ExpectType void
-        lib.moveFeatures([feature], { lng: 12, lat: 13 });
+        lib.moveFeatures([drawFeature], { lng: 12, lat: 13 });
 
         // $ExpectType DrawFeature[]
-        lib.sortFeatures([feature]);
+        lib.sortFeatures([drawFeature]);
 
         // $ExpectType boolean
         lib.stringSetsAreEqual([{ id: 'Feature1' }, { id: 'Feature2' }], [{ id: 'Feature1' }, { id: 'Feature2' }]);
@@ -207,67 +209,67 @@ const options: MapboxDrawOptions = {
 const drawWithCustomMode = new MapboxDraw(options);
 
 // $ExpectType void
-feature.changed();
+drawFeature.changed();
 
 // $ExpectType boolean
-feature.isValid();
+drawFeature.isValid();
 
 // $ExpectType Position
-feature.getCoordinate('');
+drawFeature.getCoordinate('');
 
 // $ExpectType void
-feature.updateCoordinate('', 0, 0);
+drawFeature.updateCoordinate('', 0, 0);
 
 // $ExpectType void
-feature.setProperty('', 0);
+drawFeature.setProperty('', 0);
 
 // $ExpectType GeoJSON
-feature.toGeoJSON();
+drawFeature.toGeoJSON();
 
-if (feature.type === 'Point') {
+if (drawFeature.type === 'Point') {
     // $ExpectType Position
-    feature.coordinates;
+    drawFeature.coordinates;
 
     // $ExpectType Position
-    feature.getCoordinate();
+    drawFeature.getCoordinate();
 
     // $ExpectType void
-    feature.updateCoordinate(0, 0);
+    drawFeature.updateCoordinate(0, 0);
 }
 
-if (feature.type === 'LineString') {
+if (drawFeature.type === 'LineString') {
     // $ExpectType Position[]
-    feature.coordinates;
+    drawFeature.coordinates;
 
     // $ExpectType void
-    feature.addCoordinate('', 0, 0);
+    drawFeature.addCoordinate('', 0, 0);
 
     // $ExpectType void
-    feature.removeCoordinate('');
+    drawFeature.removeCoordinate('');
 }
 
-if (feature.type === 'Polygon') {
+if (drawFeature.type === 'Polygon') {
     // $ExpectType Position[][]
-    feature.coordinates;
+    drawFeature.coordinates;
 
     // $ExpectType void
-    feature.addCoordinate('', 0, 0);
+    drawFeature.addCoordinate('', 0, 0);
 
     // $ExpectType void
-    feature.removeCoordinate('');
+    drawFeature.removeCoordinate('');
 }
 
-if (feature.type === 'MultiPoint') {
+if (drawFeature.type === 'MultiPoint') {
     // $ExpectType DrawPoint[]
-    feature.features;
+    drawFeature.features;
 }
 
-if (feature.type === 'MultiLineString') {
+if (drawFeature.type === 'MultiLineString') {
     // $ExpectType DrawLineString[]
-    feature.features;
+    drawFeature.features;
 }
 
-if (feature.type === 'MultiPolygon') {
+if (drawFeature.type === 'MultiPolygon') {
     // $ExpectType DrawPolygon[]
-    feature.features;
+    drawFeature.features;
 }


### PR DESCRIPTION
- **`createSupplementaryPoints`** : 
    - The `geojson.geometry` properties are read in this function indicates that the `geojson` argument is of type `Feature`.
    (The `DrawFeature` type doesn't have the `geometry` property.)
cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/create_supplementary_points.js#L6

- **`createMidPoint`** : 
    - The `geojson.geometry` properties are read in this function indicates that the` geojson` argument is of type `Feature`.
    (The `DrawFeature` type doesn't have the `geometry` property.)
cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/create_midpoint.js#L4-L5

    - The return value is of type `Feature<Point> | null` because it contains `type` has `Feature` and `geometry.type` has `Point` , or it is `null`
cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/create_midpoint.js#L13 , https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/create_midpoint.js#L22-L33

- **`createVertex`** : 
    - The return value is of type `Feature<Point>` because it contains `type` has `Feature` and `geometry.type` has `Point`
cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/create_vertex.js#L16-L26

=======================================
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
