### PR TITLE
Refactor raphael to improve compile performance

### DIFF
--- a/types/raphael/index.d.ts
+++ b/types/raphael/index.d.ts
@@ -456,11 +456,13 @@ export type RaphaelPaperPluginRegistry<
         /**
          * Either the paper plugin method or a new namespace with methods.
          */
-        [P in keyof T]: T[P] extends (...args: any) => any
-        ? RaphaelPaperPluginMethod<TTechnology, Parameters<T[P]>, ReturnType<T[P]>>
-        : RaphaelPaperPluginRegistry<TTechnology, T[P]>;
+        [P in keyof T]: RaphaelPaperPluginMethodOrRegistry<TTechnology, T[P]>;
     };
 
+type RaphaelPaperPluginMethodOrRegistry<TTechnology extends RaphaelTechnology, T> =
+    T extends (...args: any) => any
+        ? RaphaelPaperPluginMethod<TTechnology, Parameters<T>, ReturnType<T>>
+        : RaphaelPaperPluginRegistry<TTechnology, T>;
 /**
  * You can add your own method to elements. This is useful when you want to hack default functionality or want
  * to wrap some common transformation or attributes in one method. In contrast to canvas methods, you can


### PR DESCRIPTION
Based on https://github.com/microsoft/TypeScript/pull/55638#issuecomment-1712567661

Extracts the conditional type into a separate type alias. Cheaper to compile and arguably easier to read.