### PR TITLE
Update mixpanel-browser InTrackingOptions regarding docs v2.47.1

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -41,7 +41,7 @@ export interface ClearOptOutInOutOptions extends HasOptedInOutOptions {
 export interface InTrackingOptions extends ClearOptOutInOutOptions {
     track: () => void;
     track_event_name: string;
-    track_event_properties: Dict;
+    track_properties: Dict;
 }
 
 export interface OutTrackingOptions extends ClearOptOutInOutOptions {

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -67,7 +67,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
 mixpanel.opt_in_tracking();
 mixpanel.opt_in_tracking({
     track_event_name: 'User opted in',
-    track_event_properties: {
+    track_properties: {
         Email: 'jdoe@example.com',
     },
     cookie_expiration: 30,


### PR DESCRIPTION
Updated naming from track_event_properties to track_properties to align with the [Mixpanel docs](https://docs.mixpanel.com/docs/tracking/reference/javascript-full-api-reference#mixpanelopt_in_tracking) and the implementation. Changed tests in mixpanel-browser.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[Mixpanel docs](https://docs.mixpanel.com/docs/tracking/reference/javascript-full-api-reference#mixpanelopt_in_tracking)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

