### PR TITLE
[node] http: Improve types of optional IncomingMessage properties specific to client/server contexts

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -235,7 +235,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -852,7 +855,10 @@ declare module 'http' {
          * Limits maximum response headers count. If set to 0, no limit will be applied.
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -269,6 +269,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/ts4.8/http.d.ts
+++ b/types/node/ts4.8/http.d.ts
@@ -235,7 +235,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -852,7 +855,10 @@ declare module 'http' {
          * Limits maximum response headers count. If set to 0, no limit will be applied.
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/ts4.8/test/http.ts
+++ b/types/node/ts4.8/test/http.ts
@@ -264,6 +264,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -129,7 +129,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response>) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
 
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
@@ -321,7 +324,10 @@ declare module 'http' {
         reusedSocket: boolean;
         maxHeadersCount: number;
 
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
 
         method: string;
         path: string;

--- a/types/node/v14/test/http.ts
+++ b/types/node/v14/test/http.ts
@@ -213,6 +213,22 @@ import * as dns from 'node:dns';
     res.flushHeaders();
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v14/ts4.8/http.d.ts
+++ b/types/node/v14/ts4.8/http.d.ts
@@ -128,7 +128,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response>) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
 
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
@@ -320,7 +323,10 @@ declare module 'http' {
         reusedSocket: boolean;
         maxHeadersCount: number;
 
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
 
         method: string;
         path: string;

--- a/types/node/v14/ts4.8/test/http.ts
+++ b/types/node/v14/ts4.8/test/http.ts
@@ -213,6 +213,22 @@ import * as dns from 'node:dns';
     res.flushHeaders();
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -184,7 +184,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -701,7 +704,10 @@ declare module 'http' {
          * @default 2000
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/v16/test/http.ts
+++ b/types/node/v16/test/http.ts
@@ -239,6 +239,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v16/ts4.8/http.d.ts
+++ b/types/node/v16/ts4.8/http.d.ts
@@ -183,7 +183,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -700,7 +703,10 @@ declare module 'http' {
          * @default 2000
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/v16/ts4.8/test/http.ts
+++ b/types/node/v16/ts4.8/test/http.ts
@@ -239,6 +239,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -235,7 +235,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -877,7 +880,10 @@ declare module 'http' {
          * Limits maximum response headers count. If set to 0, no limit will be applied.
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -266,6 +266,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");

--- a/types/node/v18/ts4.8/http.d.ts
+++ b/types/node/v18/ts4.8/http.d.ts
@@ -235,7 +235,10 @@ declare module 'http' {
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse = typeof ServerResponse,
-    > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
+    > = (
+        req: InstanceType<Request> & { method: string; url: string },
+        res: InstanceType<Response> & { req: InstanceType<Request> },
+    ) => void;
     /**
      * @since v0.1.17
      */
@@ -877,7 +880,10 @@ declare module 'http' {
          * Limits maximum response headers count. If set to 0, no limit will be applied.
          */
         maxHeadersCount: number;
-        constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
+        constructor(
+            url: string | URL | ClientRequestArgs,
+            cb?: (res: IncomingMessage & { statusCode: number; statusMessage: string }) => void,
+        );
         /**
          * The request method.
          * @since v0.1.97

--- a/types/node/v18/ts4.8/test/http.ts
+++ b/types/node/v18/ts4.8/test/http.ts
@@ -264,6 +264,22 @@ import * as dns from 'node:dns';
     res.req; // $ExpectType IncomingMessage
 }
 
+// http IncomingMessage properties specific to Server
+{
+    http.createServer(req => {
+        req.url; // $ExpectType string
+        req.method; // $ExpectType string
+    });
+}
+
+// http IncomingMessage properties specific to ClientRequest
+{
+    new http.ClientRequest('http://somewhere', res => {
+        res.statusCode; // $ExpectType number
+        res.statusMessage; // $ExpectType string
+    });
+}
+
 // http ClientRequest
 {
     let req: http.ClientRequest = new http.ClientRequest("https://www.google.com");


### PR DESCRIPTION
`IncomingMessage` has some properties which are only provided on instances passed to `Server` request handlers ([`method`](https://nodejs.org/docs/latest-v20.x/api/http.html#messagemethod), [`url`](https://nodejs.org/docs/latest-v20.x/api/http.html#messageurl)) or `ClientRequest` response handlers ([`statusCode`](https://nodejs.org/docs/latest-v20.x/api/http.html#messagestatuscode), [`statusMessage`](https://nodejs.org/docs/latest-v20.x/api/http.html#messagestatusmessage)) and are otherwise missing.

Currently these properties are simply typed as optional; This PR doesn't change this directly, but does change the argument types of server `RequestListener` functions and `ClientRequest` response handler functions to be intersections of `IncomingMessage` and the properties that will definitely be available in the corresponding context.

For example, the following code (adapted from the Node docs' [example of handling `IncomingMessage#url`](https://nodejs.org/docs/latest-v20.x/api/http.html#messageurl)) previously did not compile because `request.url` was possibly `undefined` - a `!` is needed:

```ts
import {createServer} from 'node:http';
import {URL} from 'node:url';

createServer((request, response) => {
	const url = new URL(request.url, `http://${request.headers.host}`);
});
```

The main benefit of this PR is that consumers don't need to assert these properties when we know contextually they will be available.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Node v20: https://nodejs.org/docs/latest-v20.x/api/http.html#class-httpincomingmessage
  - Relevant properties are documented the same way all the way back to v14 (and potentially earlier): https://nodejs.org/docs/latest-v14.x/api/http.html#http_class_http_incomingmessage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
