### PR TITLE
fix(semver): add missing RELEASE_TYPES constant

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -109,6 +109,8 @@ export import rcompareIdentifiers = identifiers.rcompareIdentifiers;
 
 export const SEMVER_SPEC_VERSION: '2.0.0';
 
+export const RELEASE_TYPES: ReleaseType[];
+
 export type ReleaseType = 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease';
 
 export interface Options {

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -346,3 +346,7 @@ bool = range.intersects(new semver.Range('', { includePrerelease: true }));
 const sets: ReadonlyArray<ReadonlyArray<semver.Comparator>> = range.set;
 
 const lims: ReadonlyArray<semver.Comparator> = range.parseRange(str);
+
+function isRelativeVersionKeyword(val: string): val is semver.ReleaseType {
+  return semver.RELEASE_TYPES.indexOf(val as semver.ReleaseType) > -1;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

=> https://github.com/npm/node-semver#release_types

Seen in release code here:
https://unpkg.com/semver@7.5.4/index.js
...which exports from:
https://unpkg.com/semver@7.5.4/internal/constants.js

