### PR TITLE
d3-hexbin: x & y coord accessor passing array index and array

### DIFF
--- a/types/d3-hexbin/index.d.ts
+++ b/types/d3-hexbin/index.d.ts
@@ -63,7 +63,7 @@ export interface Hexbin<T> {
      * of each point. The default value assumes each point is specified as
      * a two-element array of numbers [x, y].
      */
-    x(x: (d: T) => number): this;
+    x(x: (d: T, i: number, a: T[]) => number): this;
 
     /**
      * Returns the current x-coordinate accessor, which defaults to: `x(d) => d[0]`.
@@ -72,7 +72,7 @@ export interface Hexbin<T> {
      * of each point. The default value assumes each point is specified as
      * a two-element array of numbers [x, y].
      */
-    x(): (d: T) => number;
+    x(): (d: T, i: number, a: T[]) => number;
 
     /**
      * Sets the y-coordinate accessor to the specified function and returns this hexbin generator.
@@ -81,7 +81,7 @@ export interface Hexbin<T> {
      * of each point. The default value assumes each point is specified as
      * a two-element array of numbers [x, y].
      */
-    y(y: (d: T) => number): this;
+    y(y: (d: T, i: number, a: T[]) => number): this;
 
     /**
      * Returns the current y-coordinate accessor, which defaults to: `y(d) => d[1]`.
@@ -90,7 +90,7 @@ export interface Hexbin<T> {
      * of each point. The default value assumes each point is specified as
      * a two-element array of numbers [x, y].
      */
-    y(): (d: T) => number;
+    y(): (d: T, i: number, a: T[]) => number;
 
     /**
      * Sets the radius of the hexagon to the specified number.


### PR DESCRIPTION
in D3 accessor methods usually get passed 3 parameters, the datum (= current item), the index of the current item and complete array. 

The implementation of d3-hexbin looks like it also has these 3 parameters: <https://github.com/d3/d3-hexbin/blob/d5523c9ece75032a180dcce19f20d49f64e949e1/src/hexbin.js#L27>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-hexbin/blob/d5523c9ece75032a180dcce19f20d49f64e949e1/src/hexbin.js#L27>>

