### PR TITLE
:sparkles: Types @alpinejs/intersect

### DIFF
--- a/types/alpinejs__intersect/alpinejs__intersect-tests.ts
+++ b/types/alpinejs__intersect/alpinejs__intersect-tests.ts
@@ -1,0 +1,4 @@
+import intersectPlugin from '@alpinejs/intersect';
+import Alpine from 'alpinejs';
+
+Alpine.plugin(intersectPlugin);

--- a/types/alpinejs__intersect/index.d.ts
+++ b/types/alpinejs__intersect/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for @alpinejs/intersect 3.13
+// Project: https://github.com/alpinejs/alpine
+// Definitions by: Eric Kwoka <https://github.com/ekwoka>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.6
+
+import type { PluginCallback } from 'alpinejs';
+
+declare const intersectPlugin: PluginCallback;
+
+export default intersectPlugin;

--- a/types/alpinejs__intersect/tsconfig.json
+++ b/types/alpinejs__intersect/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@alpinejs/*": [
+                "alpinejs__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "alpinejs__intersect-tests.ts"
+    ]
+}

--- a/types/alpinejs__intersect/tslint.json
+++ b/types/alpinejs__intersect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Another simple Alpine Plugin

Maybe a maintainer could let me know: should all the plugins just be in the main @types/alpinejs instead of each in their own considering they can't be used separately? might make things simpler...idk if people would want to actually have to install all these separate types packages...

maybe both?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
