### PR TITLE
Fix express-brute-mongodb's dependencies

### DIFF
--- a/types/express-brute-mongo/package.json
+++ b/types/express-brute-mongo/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^2.1.28"
+        "@types/mongodb": "2.1.28"
     }
 }


### PR DESCRIPTION
Fix `@types/mongodb` to exactly 2.1.28, because 2.2 has compile errors.
