### PR TITLE
yargs: Fix arg type declaration regression in command modules

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -175,7 +175,8 @@ declare namespace yargs {
             builder?: O,
             handler?: (args: ArgumentsCamelCase<InferredOptionTypes<O>>) => void | Promise<void>,
         ): Argv<T>;
-        command(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, any>): Argv<T>;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        command<U = any>(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, U>): Argv<T>;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         command<U = any>(module: CommandModule<T, U>): Argv<T>;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -159,7 +159,8 @@ declare namespace yargs {
             middlewares?: Array<MiddlewareFunction<O>>,
             deprecated?: boolean | string,
         ): Argv<T>;
-        command(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, any>): Argv<T>;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        command<U = any>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<T>;
         command<U = T>(
             command: string | ReadonlyArray<string>,
             showInHelp: false,
@@ -175,8 +176,10 @@ declare namespace yargs {
             handler?: (args: ArgumentsCamelCase<InferredOptionTypes<O>>) => void | Promise<void>,
         ): Argv<T>;
         command(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, any>): Argv<T>;
-        command(module: CommandModule<T, any>): Argv<T>;
-        command(modules: Array<CommandModule<T, any>>): Argv<T>;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        command<U = any>(module: CommandModule<T, U>): Argv<T>;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        command<U = any>(modules: Array<CommandModule<T, U>>): Argv<T>;
 
         // Advanced API
         /** Apply command modules from a directory relative to the module calling this method. */

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1443,6 +1443,53 @@ function Argv$commandsWithAsynchronousBuilders() {
     }).parseSync();
     // @ts-expect-error
     const arg2: string = argv2.arg;
+
+    const argv3 = yargs.command("command <arg>", "some command", {
+        builder: (yargs) =>
+            Promise.resolve(
+                yargs.positional("arg", {
+                    demandOption: true,
+                    describe: "argument",
+                    type: "string",
+                })),
+        handler: (argv) => { const arg3: string = argv.arg; }
+    }).parseSync();
+    // @ts-expect-error
+    const arg3: string = argv3.arg;
+}
+
+function Argv$commandHandlersWithExplicitArgTypes() {
+    yargs.command<{ str: string, num: number }>(
+        "command <str> <num>",
+        "some command",
+        () => {},
+        (argv) => {
+            // $ExpectType string
+            const str = argv.str;
+            // $ExpectType number
+            const num = argv.num;
+        }
+    ).parseSync(['text', '1']);
+
+    yargs.command<{ str: string, num: number }>({
+        command: "command <str> <num>",
+        describe: "some command",
+        handler: (argv) => {
+            // $ExpectType string
+            const str = argv.str;
+            // $ExpectType number
+            const num = argv.num;
+        }
+    }).parseSync(['text', '1']);
+
+    yargs.command<{ str: string, num: number }>("command <str> <num>", "some command", {
+        handler: (argv) => {
+            // $ExpectType string
+            const str = argv.str;
+            // $ExpectType number
+            const num = argv.num;
+        }
+    }).parseSync(['text', '1']);
 }
 
 const wait = (n: number) => new Promise(resolve => setTimeout(resolve, n));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - This test case: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66725/files#diff-68379c677eef47abe34460c219eaa9dc6857a510d0a686da417e927c610f8c76R1474-R1483
  - Another user reported this issue here: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63990#discussioncomment-4731596
    - Regression caused by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63694
  - Examples of how to use command modules: https://github.com/yargs/yargs/blob/e517318cea0087b813f5de414b3cdec7b70efe33/docs/advanced.md#command-aliases
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

