### PR TITLE
[react] `element.key` is a string

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -14,7 +14,7 @@ export type ReactComponentLike =
 export interface ReactElementLike {
     type: ReactComponentLike;
     props: any;
-    key: string | number | bigint | null;
+    key: string | null;
 }
 
 export interface ReactNodeArray extends Iterable<ReactNodeLike> {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -164,7 +164,7 @@ declare namespace React {
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
-        key: Key | null;
+        key: string | null;
     }
 
     interface ReactComponentElement<
@@ -201,7 +201,6 @@ declare namespace React {
     }
 
     interface ReactPortal extends ReactElement {
-        key: Key | null;
         children: ReactNode;
     }
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -132,7 +132,7 @@ declare namespace React {
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
-        key: Key | null;
+        key: string | null;
     }
 
     interface ReactComponentElement<
@@ -169,7 +169,6 @@ declare namespace React {
     }
 
     interface ReactPortal extends ReactElement {
-        key: Key | null;
         children: ReactNode;
     }
 

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -143,7 +143,7 @@ declare namespace React {
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
-        key: Key | null;
+        key: string | null;
     }
 
     interface ReactComponentElement<
@@ -186,7 +186,6 @@ declare namespace React {
     }
 
     interface ReactPortal extends ReactElement {
-        key: Key | null;
         children: ReactNode;
     }
 

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -140,7 +140,7 @@ declare namespace React {
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
         type: T;
         props: P;
-        key: Key | null;
+        key: string | null;
     }
 
     interface ReactComponentElement<
@@ -182,7 +182,6 @@ declare namespace React {
     }
 
     interface ReactPortal extends ReactElement {
-        key: Key | null;
         children: ReactNode;
     }
 


### PR DESCRIPTION
React will stringify the `key` prop before setting it in elements. This technically means any `{ toString(): string }` is a valid key but we don't know if this would be correct semantically. Developers can always do `key={String(myExoticKey)}` which is what TypeScript enforces for all HTML string attributes.
