### PR TITLE
[chai] add support for Set and Map to assert.lengthOf

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1809,6 +1809,8 @@ suite("assert", () => {
         assert.lengthOf("foobar", 6);
         assert.lengthOf("foobar", 5);
         assert.lengthOf({ length: 1 }, 5);
+        assert.lengthOf(new Set([1, 2, 3]), 3);
+        assert.lengthOf(new Map([['a', 1], ['b', 2], ['c', 3]]), 3);
     });
 
     test("match", () => {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1210,7 +1210,11 @@ declare namespace Chai {
          * @param length   Potential expected length of object.
          * @param message   Message to display on error.
          */
-        lengthOf<T extends { readonly length?: number | undefined }>(object: T, length: number, message?: string): void;
+        lengthOf<T extends { readonly length?: number | undefined } | { readonly size?: number | undefined }>(
+            object: T,
+            length: number,
+            message?: string,
+        ): void;
 
         /**
          * Asserts that fn will throw an error.


### PR DESCRIPTION
Documentation of chai says that I can check the size property of objects such as Set or Map with `assert.lengthOf`, but TypeScript gives error: `Type 'Map<string, number>' has no properties in common with type '{ readonly length?: number | undefined; }'.`
This PR fixes this error.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  - The common mistakes section in readme suggests to run prettier, but I didn't because it produced diffs where I did not changed.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/assert/#method_lengthof, https://github.com/chaijs/chai/pull/1131
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
