### PR TITLE
[chai] add missing _super parameter to overwriteProperty getter parameter

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1141,6 +1141,23 @@ function use() {
             );
         });
 
+        Assertion.overwriteProperty('ok', function (_super: any) {
+            return function checkModel(this: Chai.Assertion & Chai.AssertionStatic) {
+                const obj = this._obj
+                if (obj && obj instanceof FakeArgs) {
+                    const negate = utils.flag(this, 'negate') as boolean
+                    if (negate && !('length' in obj)) {
+                        return
+                    }
+                    const assertLength = new Assertion(obj.length, 'FakeArgs exists')
+                    utils.transferFlags(this, assertLength, false)
+                    assertLength.is.a('number')
+                } else {
+                    _super.call(this)
+                }
+            }
+        })
+
         function compare(expected: Object, actual: Object): boolean {
             if (expected === actual) {
                 return true;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -53,7 +53,7 @@ declare namespace Chai {
         addMethod(ctx: object, name: string, method: Function): void;
         addProperty(ctx: object, name: string, getter: () => any): void;
         overwriteMethod(ctx: object, name: string, method: Function): void;
-        overwriteProperty(ctx: object, name: string, getter: () => any): void;
+        overwriteProperty(ctx: object, name: string, getter: (this: AssertionStatic, _super: any) => any): void;
         compareByInspect(a: object, b: object): -1 | 1;
         expectTypes(obj: object, types: string[]): void;
         flag(obj: object, key: string, value?: any): any;
@@ -144,7 +144,7 @@ declare namespace Chai {
             method: (this: AssertionStatic, ...args: any[]) => void,
             chainingBehavior?: () => void,
         ): void;
-        overwriteProperty(name: string, getter: (this: AssertionStatic) => any): void;
+        overwriteProperty(name: string, getter: (this: AssertionStatic, _super: any) => any): void;
         overwriteMethod(name: string, method: (this: AssertionStatic, ...args: any[]) => any): void;
         overwriteChainableMethod(
             name: string,


### PR DESCRIPTION
The `getter` parameter passed to [Assertion.overwriteProperty](https://www.chaijs.com/guide/helpers/#overwriting-properties) takes `_super` as an argument that is currently not typed.

The [implementation of Assertion.overwriteProperty](https://github.com/chaijs/chai/blob/4.x.x/lib/chai/assertion.js#L106) delegates to [util.overwriteProperty](https://github.com/chaijs/chai/blob/4.x.x/lib/chai/utils/overwriteProperty.js#L46C27-L46C44). The  `getter` is [called here](https://github.com/chaijs/chai/blob/4.x.x/lib/chai/utils/overwriteProperty.js#L79) and `_super` is passed as the first argument

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/guide/helpers/#overwriting-properties
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
