### PR TITLE
[node] Update types to v18.18

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -378,7 +378,7 @@ declare module "events" {
          * ```
          * @since v20.5.0
          * @experimental
-         * @return that removes the `abort` listener.
+         * @return Disposable that removes the `abort` listener.
          */
         static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
         /**

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -64,6 +64,24 @@ declare module "module" {
             originalLine: number;
             originalColumn: number;
         }
+        interface SourceOrigin {
+            /**
+             * The name of the range in the source map, if one was provided
+             */
+            name?: string;
+            /**
+             * The file name of the original source, as reported in the SourceMap
+             */
+            fileName: string;
+            /**
+             * The 1-indexed lineNumber of the corresponding call site in the original source
+             */
+            lineNumber: number;
+            /**
+             * The 1-indexed columnNumber of the corresponding call site in the original source
+             */
+            columnNumber: number;
+        }
         /**
          * @since v13.7.0, v12.17.0
          */
@@ -92,6 +110,16 @@ declare module "module" {
              * @param columnOffset The zero-indexed column number offset in the generated source
              */
             findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            /**
+             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
+             * find the corresponding call site location in the original source.
+             *
+             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
+             * then an empty object is returned.
+             * @param lineNumber The 1-indexed line number of the call site in the generated source
+             * @param columnNumber The 1-indexed column number of the call site in the generated source
+             */
+            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
         }
         interface ImportAssertions extends NodeJS.Dict<string> {
             type?: string | undefined;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -235,6 +235,14 @@ declare module "net" {
          */
         ref(): this;
         /**
+         * This property is only present if the family autoselection algorithm is enabled in `socket.connect(options)`
+         * and it is an array of the addresses that have been attempted.
+         *
+         * Each address is a string in the form of `$IP:$PORT`.
+         * If the connection was successful, then the last address is the one that the socket is currently connected to.
+         */
+        readonly autoSelectFamilyAttemptedAddresses: string[];
+        /**
          * This property shows the number of characters buffered for writing. The buffer
          * may contain strings whose length after encoding is not yet known. So this number
          * is only an approximation of the number of bytes in the buffer.
@@ -824,6 +832,10 @@ declare module "net" {
     function createConnection(options: NetConnectOpts, connectionListener?: () => void): Socket;
     function createConnection(port: number, host?: string, connectionListener?: () => void): Socket;
     function createConnection(path: string, connectionListener?: () => void): Socket;
+    function getDefaultAutoSelectFamily(): boolean;
+    function setDefaultAutoSelectFamily(value: boolean): void;
+    function getDefaultAutoSelectFamilyAttemptTimeout(): number;
+    function setDefaultAutoSelectFamilyAttemptTimeout(value: number): void;
     /**
      * Returns `6` if `input` is an IPv6 address. Returns `4` if `input` is an IPv4
      * address in [dot-decimal notation](https://en.wikipedia.org/wiki/Dot-decimal_notation) with no leading zeroes. Otherwise, returns`0`.

--- a/types/node/v18/child_process.d.ts
+++ b/types/node/v18/child_process.d.ts
@@ -306,6 +306,11 @@ declare module "child_process" {
          */
         kill(signal?: NodeJS.Signals | number): boolean;
         /**
+         * Calls {@link ChildProcess.kill} with `'SIGTERM'`.
+         * @since v18.18.0
+         */
+        [Symbol.dispose](): void;
+        /**
          * When an IPC channel has been established between the parent and child (
          * i.e. when using {@link fork}), the `subprocess.send()` method can
          * be used to send messages to the child process. When the child process is a

--- a/types/node/v18/dgram.d.ts
+++ b/types/node/v18/dgram.d.ts
@@ -574,6 +574,11 @@ declare module "dgram" {
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "listening", listener: () => void): this;
         prependOnceListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
+        /**
+         * Calls `socket.close()` and returns a promise that fulfills when the socket has closed.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 }
 declare module "node:dgram" {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -353,6 +353,41 @@ declare module "events" {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v18.18.0
+         * @experimental
+         * @return Disposable that removes the `abort` listener.
+         */
+        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        /**
          * This symbol shall be used to install a listener for only monitoring `'error'`
          * events. Listeners installed using this symbol are called before the regular
          * `'error'` listeners are called.

--- a/types/node/v18/fs/promises.d.ts
+++ b/types/node/v18/fs/promises.d.ts
@@ -468,6 +468,11 @@ declare module "fs/promises" {
          * @return Fulfills with `undefined` upon success.
          */
         close(): Promise<void>;
+        /**
+         * An alias for {@link FileHandle.close()}.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 
     const constants: typeof fsConstants;

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -82,6 +82,28 @@ declare var AbortSignal: typeof globalThis extends { onmessage: any; AbortSignal
     };
 // #endregion borrowed
 
+// #region Disposable
+interface SymbolConstructor {
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    readonly dispose: unique symbol;
+
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}
+// #endregion Disposable
+
 // #region ArrayLike.at()
 interface RelativeIndexable<T> {
     /**

--- a/types/node/v18/index.d.ts
+++ b/types/node/v18/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 18.17
+// Type definitions for non-npm package Node.js 18.18
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -63,6 +63,24 @@ declare module "module" {
             originalLine: number;
             originalColumn: number;
         }
+        interface SourceOrigin {
+            /**
+             * The name of the range in the source map, if one was provided
+             */
+            name?: string;
+            /**
+             * The file name of the original source, as reported in the SourceMap
+             */
+            fileName: string;
+            /**
+             * The 1-indexed lineNumber of the corresponding call site in the original source
+             */
+            lineNumber: number;
+            /**
+             * The 1-indexed columnNumber of the corresponding call site in the original source
+             */
+            columnNumber: number;
+        }
         /**
          * @since v13.7.0, v12.17.0
          */
@@ -73,11 +91,34 @@ declare module "module" {
             readonly payload: SourceMapPayload;
             constructor(payload: SourceMapPayload);
             /**
-             * Given a line number and column number in the generated source file, returns
-             * an object representing the position in the original file. The object returned
-             * consists of the following keys:
+             * Given a line offset and column offset in the generated source
+             * file, returns an object representing the SourceMap range in the
+             * original file if found, or an empty object if not.
+             *
+             * The object returned contains the following keys:
+             *
+             * The returned value represents the raw range as it appears in the
+             * SourceMap, based on zero-indexed offsets, _not_ 1-indexed line and
+             * column numbers as they appear in Error messages and CallSite
+             * objects.
+             *
+             * To get the corresponding 1-indexed line and column numbers from a
+             * lineNumber and columnNumber as they are reported by Error stacks
+             * and CallSite objects, use `sourceMap.findOrigin(lineNumber, columnNumber)`
+             * @param lineOffset The zero-indexed line number offset in the generated source
+             * @param columnOffset The zero-indexed column number offset in the generated source
              */
-            findEntry(line: number, column: number): SourceMapping;
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            /**
+             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
+             * find the corresponding call site location in the original source.
+             *
+             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
+             * then an empty object is returned.
+             * @param lineNumber The 1-indexed line number of the call site in the generated source
+             * @param columnNumber The 1-indexed column number of the call site in the generated source
+             */
+            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
         }
         interface ImportAssertions extends NodeJS.Dict<string> {
             type?: string | undefined;

--- a/types/node/v18/net.d.ts
+++ b/types/node/v18/net.d.ts
@@ -654,6 +654,11 @@ declare module "net" {
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "listening", listener: () => void): this;
         prependOnceListener(event: "drop", listener: (data?: DropArgument) => void): this;
+        /**
+         * Calls {@link Server.close()} and returns a promise that fulfills when the server has closed.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     type IPVersion = "ipv4" | "ipv6";
     /**

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -675,6 +675,11 @@ declare module "stream" {
             removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+            /**
+             * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
+             * @since v18.18.0
+             */
+            [Symbol.asyncDispose](): Promise<void>;
         }
         interface WritableOptions extends StreamOptions<Writable> {
             decodeStrings?: boolean | undefined;

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -59,31 +59,33 @@ declare module "node:test" {
      * @param options Configuration options for the suite
      * @param fn The function under suite. Default: A no-op function.
      */
-    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-    function describe(name?: string, fn?: SuiteFn): void;
-    function describe(options?: TestOptions, fn?: SuiteFn): void;
-    function describe(fn?: SuiteFn): void;
+    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(name?: string, fn?: SuiteFn): Promise<void>;
+    function describe(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(fn?: SuiteFn): Promise<void>;
     namespace describe {
-        // Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function skip(name?: string, fn?: SuiteFn): void;
-        function skip(options?: TestOptions, fn?: SuiteFn): void;
-        function skip(fn?: SuiteFn): void;
-
-        // Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function todo(name?: string, fn?: SuiteFn): void;
-        function todo(options?: TestOptions, fn?: SuiteFn): void;
-        function todo(fn?: SuiteFn): void;
-
+        /**
+         * Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(name?: string, fn?: SuiteFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(fn?: SuiteFn): Promise<void>;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(name?: string, fn?: SuiteFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(fn?: SuiteFn): Promise<void>;
         /**
          * Shorthand for marking a suite as `only`, same as `describe([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function only(name?: string, fn?: SuiteFn): void;
-        function only(options?: TestOptions, fn?: SuiteFn): void;
-        function only(fn?: SuiteFn): void;
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(name?: string, fn?: SuiteFn): Promise<void>;
+        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(fn?: SuiteFn): Promise<void>;
     }
 
     /**
@@ -94,31 +96,33 @@ declare module "node:test" {
      * @param fn The function under test. If the test uses callbacks, the callback function is
      *    passed as the second argument. Default: A no-op function.
      */
-    function it(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function it(name?: string, fn?: TestFn): void;
-    function it(options?: TestOptions, fn?: TestFn): void;
-    function it(fn?: TestFn): void;
+    function it(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(name?: string, fn?: TestFn): Promise<void>;
+    function it(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(fn?: TestFn): Promise<void>;
     namespace it {
-        // Shorthand for skipping a test, same as `it([name], { skip: true }[, fn])`.
-        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function skip(name?: string, fn?: TestFn): void;
-        function skip(options?: TestOptions, fn?: TestFn): void;
-        function skip(fn?: TestFn): void;
-
-        // Shorthand for marking a test as `TODO`, same as `it([name], { todo: true }[, fn])`.
-        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function todo(name?: string, fn?: TestFn): void;
-        function todo(options?: TestOptions, fn?: TestFn): void;
-        function todo(fn?: TestFn): void;
-
+        /**
+         * Shorthand for skipping a test, same as `it([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(name?: string, fn?: TestFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(fn?: TestFn): Promise<void>;
+        /**
+         * Shorthand for marking a test as `TODO`, same as `it([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(name?: string, fn?: TestFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(fn?: TestFn): Promise<void>;
         /**
          * Shorthand for marking a test as `only`, same as `it([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function only(name?: string, fn?: TestFn): void;
-        function only(options?: TestOptions, fn?: TestFn): void;
-        function only(fn?: TestFn): void;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(name?: string, fn?: TestFn): Promise<void>;
+        function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(fn?: TestFn): Promise<void>;
     }
     /**
      * Shorthand for skipping a test, same as `test([name], { skip: true }[, fn])`.
@@ -193,9 +197,20 @@ declare module "node:test" {
          */
         inspectPort?: number | (() => number) | undefined;
         /**
+         * That can be used to only run tests whose name matches the provided pattern.
+         * Test name patterns are interpreted as JavaScript regular expressions.
+         * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
+         */
+        testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
          * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
          */
         setup?: (root: Test) => void | Promise<void>;
+        /**
+         * Whether to run in watch mode or not.
+         * @default false
+         */
+        watch?: boolean | undefined;
     }
     class Test extends AsyncResource {
         concurrency: number;

--- a/types/node/v18/test/child_process.ts
+++ b/types/node/v18/test/child_process.ts
@@ -421,6 +421,7 @@ async function testPromisify() {
     _boolean = cp.kill();
     _boolean = cp.kill(9);
     _boolean = cp.kill("SIGTERM");
+    cp[Symbol.dispose]();
 
     _maybeNumber = cp.exitCode;
     _maybeSignal = cp.signalCode;

--- a/types/node/v18/test/dgram.ts
+++ b/types/node/v18/test/dgram.ts
@@ -24,6 +24,7 @@ import * as net from "node:net";
         sendBufferSize: 1000,
         lookup: dns.lookup,
     });
+    ds[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/v18/test/events.ts
+++ b/types/node/v18/test/events.ts
@@ -130,3 +130,16 @@ async function test() {
     const eventEmitter = new events.EventEmitter();
     events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
 }
+
+{
+    let disposable: Disposable | undefined;
+    try {
+        const signal = new AbortSignal();
+        signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+        disposable = events.addAbortListener(signal, (e) => {
+            console.log(e);
+        });
+    } finally {
+        disposable?.[Symbol.dispose]();
+    }
+}

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -37,6 +37,9 @@ import * as url from "node:url";
         keepAliveTimeout: 100,
     }, reqListener);
 
+    server.close();
+    server[Symbol.asyncDispose]();
+
     // test public props
     const maxHeadersCount: number | null = server.maxHeadersCount;
     const maxRequestsPerSocket: number | null = server.maxRequestsPerSocket;

--- a/types/node/v18/test/net.ts
+++ b/types/node/v18/test/net.ts
@@ -355,6 +355,7 @@ import * as net from "node:net";
 
     _socket.destroy();
     _server.close();
+    _server[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -515,6 +515,9 @@ function stream_readable_pipe_test() {
     r.close();
     z.close();
     rs.close();
+
+    rs.destroy();
+    rs[Symbol.asyncDispose]();
 }
 
 function stream_duplex_allowHalfOpen_test() {

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -20,7 +20,9 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    testNamePatterns: ["executed"],
     setup: (root) => {},
+    watch: true,
 });
 
 // TestsStream should be a NodeJS.ReadableStream

--- a/types/node/v18/test/timers.ts
+++ b/types/node/v18/test/timers.ts
@@ -96,9 +96,12 @@ import { promisify } from "node:util";
     function waitFor(options?: { timeout: number }) {
         const timerId = options && setTimeout(() => {}, options.timeout);
         clearTimeout(timerId);
+        timerId?.[Symbol.dispose]();
         const intervalId = options && setTimeout(() => {}, options.timeout);
         clearInterval(intervalId);
+        intervalId?.[Symbol.dispose]();
         const immediateId = options && setImmediate(() => {});
         clearImmediate(immediateId);
+        immediateId?.[Symbol.dispose]();
     }
 }

--- a/types/node/v18/test/tls.ts
+++ b/types/node/v18/test/tls.ts
@@ -245,6 +245,7 @@ import {
 
     // close callback parameter is optional
     _server = _server.close();
+    _server[Symbol.asyncDispose]();
 
     // close callback parameter doesn't specify any arguments, so any
     // function is acceptable

--- a/types/node/v18/timers.d.ts
+++ b/types/node/v18/timers.d.ts
@@ -44,6 +44,11 @@ declare module "timers" {
                  */
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
+                /**
+                 * Cancels the immediate. This is similar to calling `clearImmediate()`.
+                 * @since v18.18.0
+                 */
+                [Symbol.dispose](): void;
             }
             interface Timeout extends Timer {
                 /**
@@ -64,6 +69,11 @@ declare module "timers" {
                  */
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
+                /**
+                 * Cancels the timeout.
+                 * @since v18.18.0
+                 */
+                [Symbol.dispose](): void;
             }
         }
         /**
@@ -89,10 +99,10 @@ declare module "timers" {
             callback: (...args: TArgs) => void,
             ms?: number,
             ...args: TArgs
-        ): NodeJS.Timer;
+        ): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
-        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timer;
+        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }

--- a/types/node/v18/ts4.8/child_process.d.ts
+++ b/types/node/v18/ts4.8/child_process.d.ts
@@ -306,6 +306,11 @@ declare module "child_process" {
          */
         kill(signal?: NodeJS.Signals | number): boolean;
         /**
+         * Calls {@link ChildProcess.kill} with `'SIGTERM'`.
+         * @since v18.18.0
+         */
+        [Symbol.dispose](): void;
+        /**
          * When an IPC channel has been established between the parent and child (
          * i.e. when using {@link fork}), the `subprocess.send()` method can
          * be used to send messages to the child process. When the child process is a

--- a/types/node/v18/ts4.8/dgram.d.ts
+++ b/types/node/v18/ts4.8/dgram.d.ts
@@ -574,6 +574,11 @@ declare module "dgram" {
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "listening", listener: () => void): this;
         prependOnceListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
+        /**
+         * Calls `socket.close()` and returns a promise that fulfills when the socket has closed.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 }
 declare module "node:dgram" {

--- a/types/node/v18/ts4.8/events.d.ts
+++ b/types/node/v18/ts4.8/events.d.ts
@@ -353,6 +353,41 @@ declare module "events" {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v18.18.0
+         * @experimental
+         * @return Disposable that removes the `abort` listener.
+         */
+        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        /**
          * This symbol shall be used to install a listener for only monitoring `'error'`
          * events. Listeners installed using this symbol are called before the regular
          * `'error'` listeners are called.

--- a/types/node/v18/ts4.8/fs/promises.d.ts
+++ b/types/node/v18/ts4.8/fs/promises.d.ts
@@ -468,6 +468,11 @@ declare module "fs/promises" {
          * @return Fulfills with `undefined` upon success.
          */
         close(): Promise<void>;
+        /**
+         * An alias for {@link FileHandle.close()}.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
 
     const constants: typeof fsConstants;

--- a/types/node/v18/ts4.8/globals.d.ts
+++ b/types/node/v18/ts4.8/globals.d.ts
@@ -82,6 +82,28 @@ declare var AbortSignal: typeof globalThis extends { onmessage: any; AbortSignal
     };
 // #endregion borrowed
 
+// #region Disposable
+interface SymbolConstructor {
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    readonly dispose: unique symbol;
+
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}
+// #endregion Disposable
+
 // #region ArrayLike.at()
 interface RelativeIndexable<T> {
     /**
@@ -93,6 +115,7 @@ interface RelativeIndexable<T> {
 }
 interface String extends RelativeIndexable<string> {}
 interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
 interface Int8Array extends RelativeIndexable<number> {}
 interface Uint8Array extends RelativeIndexable<number> {}
 interface Uint8ClampedArray extends RelativeIndexable<number> {}
@@ -157,7 +180,7 @@ declare namespace NodeJS {
         /**
          * Name of the script [if this function was defined in a script]
          */
-        getFileName(): string | null;
+        getFileName(): string | undefined;
 
         /**
          * Current line number [if this function was defined in a script]

--- a/types/node/v18/ts4.8/module.d.ts
+++ b/types/node/v18/ts4.8/module.d.ts
@@ -63,6 +63,24 @@ declare module "module" {
             originalLine: number;
             originalColumn: number;
         }
+        interface SourceOrigin {
+            /**
+             * The name of the range in the source map, if one was provided
+             */
+            name?: string;
+            /**
+             * The file name of the original source, as reported in the SourceMap
+             */
+            fileName: string;
+            /**
+             * The 1-indexed lineNumber of the corresponding call site in the original source
+             */
+            lineNumber: number;
+            /**
+             * The 1-indexed columnNumber of the corresponding call site in the original source
+             */
+            columnNumber: number;
+        }
         /**
          * @since v13.7.0, v12.17.0
          */
@@ -73,11 +91,34 @@ declare module "module" {
             readonly payload: SourceMapPayload;
             constructor(payload: SourceMapPayload);
             /**
-             * Given a line number and column number in the generated source file, returns
-             * an object representing the position in the original file. The object returned
-             * consists of the following keys:
+             * Given a line offset and column offset in the generated source
+             * file, returns an object representing the SourceMap range in the
+             * original file if found, or an empty object if not.
+             *
+             * The object returned contains the following keys:
+             *
+             * The returned value represents the raw range as it appears in the
+             * SourceMap, based on zero-indexed offsets, _not_ 1-indexed line and
+             * column numbers as they appear in Error messages and CallSite
+             * objects.
+             *
+             * To get the corresponding 1-indexed line and column numbers from a
+             * lineNumber and columnNumber as they are reported by Error stacks
+             * and CallSite objects, use `sourceMap.findOrigin(lineNumber, columnNumber)`
+             * @param lineOffset The zero-indexed line number offset in the generated source
+             * @param columnOffset The zero-indexed column number offset in the generated source
              */
-            findEntry(line: number, column: number): SourceMapping;
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            /**
+             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
+             * find the corresponding call site location in the original source.
+             *
+             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
+             * then an empty object is returned.
+             * @param lineNumber The 1-indexed line number of the call site in the generated source
+             * @param columnNumber The 1-indexed column number of the call site in the generated source
+             */
+            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
         }
         interface ImportAssertions extends NodeJS.Dict<string> {
             type?: string | undefined;

--- a/types/node/v18/ts4.8/net.d.ts
+++ b/types/node/v18/ts4.8/net.d.ts
@@ -274,6 +274,12 @@ declare module "net" {
          */
         readonly connecting: boolean;
         /**
+         * This is `true` if the socket is not connected yet, either because `.connect()`
+         * has not yet been called or because it is still in the process of connecting (see `socket.connecting`).
+         * @since v10.16.0
+         */
+        readonly pending: boolean;
+        /**
          * See `writable.destroyed` for further details.
          */
         readonly destroyed: boolean;
@@ -294,12 +300,6 @@ declare module "net" {
          * @since v18.8.0
          */
         readonly localFamily?: string;
-        /**
-         * This is `true` if the socket is not connected yet, either because `.connect()`
-         * has not yet been called or because it is still in the process of connecting (see `socket.connecting`).
-         * @since v10.16.0
-         */
-        readonly pending: boolean;
         /**
          * This property represents the state of the connection as a string.
          * @see {https://nodejs.org/api/net.html#socketreadystate}
@@ -654,6 +654,11 @@ declare module "net" {
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "listening", listener: () => void): this;
         prependOnceListener(event: "drop", listener: (data?: DropArgument) => void): this;
+        /**
+         * Calls {@link Server.close()} and returns a promise that fulfills when the server has closed.
+         * @since v18.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
     }
     type IPVersion = "ipv4" | "ipv6";
     /**

--- a/types/node/v18/ts4.8/node-tests.ts
+++ b/types/node/v18/ts4.8/node-tests.ts
@@ -165,7 +165,7 @@ import * as url from "node:url";
         const func: Function | undefined = frame.getFunction();
         const funcName: string | null = frame.getFunctionName();
         const meth: string | null = frame.getMethodName();
-        const fname: string | null = frame.getFileName();
+        const fname: string | undefined = frame.getFileName();
         const lineno: number | null = frame.getLineNumber();
         const colno: number | null = frame.getColumnNumber();
         const evalOrigin: string | undefined = frame.getEvalOrigin();

--- a/types/node/v18/ts4.8/stream.d.ts
+++ b/types/node/v18/ts4.8/stream.d.ts
@@ -53,6 +53,12 @@ declare module "stream" {
             encoding?: BufferEncoding | undefined;
             read?(this: Readable, size: number): void;
         }
+        interface ArrayOptions {
+            /** the maximum concurrent invocations of `fn` to call on the stream at once. **Default: 1**. */
+            concurrency?: number;
+            /** allows destroying the stream if the signal is aborted. */
+            signal?: AbortSignal;
+        }
         /**
          * @since v0.9.4
          */
@@ -430,6 +436,164 @@ declare module "stream" {
              */
             wrap(stream: NodeJS.ReadableStream): this;
             push(chunk: any, encoding?: BufferEncoding): boolean;
+            /**
+             * The iterator created by this method gives users the option to cancel the destruction
+             * of the stream if the `for await...of` loop is exited by `return`, `break`, or `throw`,
+             * or if the iterator should destroy the stream if the stream emitted an error during iteration.
+             * @since v16.3.0
+             * @param options.destroyOnReturn When set to `false`, calling `return` on the async iterator,
+             * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
+             * **Default: `true`**.
+             */
+            iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+            /**
+             * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
+             * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
+             * @since v17.4.0, v16.14.0
+             * @param fn a function to map over every chunk in the stream. Async or not.
+             * @returns a stream mapped with the function *fn*.
+             */
+            map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            /**
+             * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
+             * and if it returns a truthy value, the chunk will be passed to the result stream.
+             * If the *fn* function returns a promise - that promise will be `await`ed.
+             * @since v17.4.0, v16.14.0
+             * @param fn a function to filter chunks from the stream. Async or not.
+             * @returns a stream filtered with the predicate *fn*.
+             */
+            filter(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Readable;
+            /**
+             * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
+             * If the *fn* function returns a promise - that promise will be `await`ed.
+             *
+             * This method is different from `for await...of` loops in that it can optionally process chunks concurrently.
+             * In addition, a `forEach` iteration can only be stopped by having passed a `signal` option
+             * and aborting the related AbortController while `for await...of` can be stopped with `break` or `return`.
+             * In either case the stream will be destroyed.
+             *
+             * This method is different from listening to the `'data'` event in that it uses the `readable` event
+             * in the underlying machinary and can limit the number of concurrent *fn* calls.
+             * @since v17.5.0
+             * @param fn a function to call on each chunk of the stream. Async or not.
+             * @returns a promise for when the stream has finished.
+             */
+            forEach(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+                options?: ArrayOptions,
+            ): Promise<void>;
+            /**
+             * This method allows easily obtaining the contents of a stream.
+             *
+             * As this method reads the entire stream into memory, it negates the benefits of streams. It's intended
+             * for interoperability and convenience, not as the primary way to consume streams.
+             * @since v17.5.0
+             * @returns a promise containing an array with the contents of the stream.
+             */
+            toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+            /**
+             * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
+             * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
+             * `await`ed return value is truthy, the stream is destroyed and the promise is fulfilled with `true`.
+             * If none of the *fn* calls on the chunks return a truthy value, the promise is fulfilled with `false`.
+             * @since v17.5.0
+             * @param fn a function to call on each chunk of the stream. Async or not.
+             * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
+             */
+            some(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Promise<boolean>;
+            /**
+             * This method is similar to `Array.prototype.find` and calls *fn* on each chunk in the stream
+             * to find a chunk with a truthy value for *fn*. Once an *fn* call's awaited return value is truthy,
+             * the stream is destroyed and the promise is fulfilled with value for which *fn* returned a truthy value.
+             * If all of the *fn* calls on the chunks return a falsy value, the promise is fulfilled with `undefined`.
+             * @since v17.5.0
+             * @param fn a function to call on each chunk of the stream. Async or not.
+             * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
+             * or `undefined` if no element was found.
+             */
+            find<T>(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+                options?: ArrayOptions,
+            ): Promise<T | undefined>;
+            find(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Promise<any>;
+            /**
+             * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
+             * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
+             * `await`ed return value is falsy, the stream is destroyed and the promise is fulfilled with `false`.
+             * If all of the *fn* calls on the chunks return a truthy value, the promise is fulfilled with `true`.
+             * @since v17.5.0
+             * @param fn a function to call on each chunk of the stream. Async or not.
+             * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
+             */
+            every(
+                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Promise<boolean>;
+            /**
+             * This method returns a new stream by applying the given callback to each chunk of the stream
+             * and then flattening the result.
+             *
+             * It is possible to return a stream or another iterable or async iterable from *fn* and the result streams
+             * will be merged (flattened) into the returned stream.
+             * @since v17.5.0
+             * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
+             * @returns a stream flat-mapped with the function *fn*.
+             */
+            flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            /**
+             * This method returns a new stream with the first *limit* chunks dropped from the start.
+             * @since v17.5.0
+             * @param limit the number of chunks to drop from the readable.
+             * @returns a stream with *limit* chunks dropped from the start.
+             */
+            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            /**
+             * This method returns a new stream with the first *limit* chunks.
+             * @since v17.5.0
+             * @param limit the number of chunks to take from the readable.
+             * @returns a stream with *limit* chunks taken.
+             */
+            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            /**
+             * This method returns a new stream with chunks of the underlying stream paired with a counter
+             * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
+             * @since v17.5.0
+             * @returns a stream of indexed pairs.
+             */
+            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+            /**
+             * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
+             * on the previous element. It returns a promise for the final value of the reduction.
+             *
+             * If no *initial* value is supplied the first chunk of the stream is used as the initial value.
+             * If the stream is empty, the promise is rejected with a `TypeError` with the `ERR_INVALID_ARGS` code property.
+             *
+             * The reducer function iterates the stream element-by-element which means that there is no *concurrency* parameter
+             * or parallelism. To perform a reduce concurrently, you can extract the async function to `readable.map` method.
+             * @since v17.5.0
+             * @param fn a reducer function to call over every chunk in the stream. Async or not.
+             * @param initial the initial value to use in the reduction.
+             * @returns a promise for the final value of the reduction.
+             */
+            reduce<T = any>(
+                fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+                initial?: undefined,
+                options?: Pick<ArrayOptions, "signal">,
+            ): Promise<T>;
+            reduce<T = any>(
+                fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+                initial: T,
+                options?: Pick<ArrayOptions, "signal">,
+            ): Promise<T>;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
              * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the readable
@@ -511,6 +675,11 @@ declare module "stream" {
             removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+            /**
+             * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
+             * @since v18.18.0
+             */
+            [Symbol.asyncDispose](): Promise<void>;
         }
         interface WritableOptions extends StreamOptions<Writable> {
             decodeStrings?: boolean | undefined;

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -3,6 +3,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/test.js)
  */
 declare module "node:test" {
+    import { AsyncResource } from "node:async_hooks";
     /**
      * Programmatically start the test runner.
      * @since v18.9.0
@@ -58,31 +59,33 @@ declare module "node:test" {
      * @param options Configuration options for the suite
      * @param fn The function under suite. Default: A no-op function.
      */
-    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-    function describe(name?: string, fn?: SuiteFn): void;
-    function describe(options?: TestOptions, fn?: SuiteFn): void;
-    function describe(fn?: SuiteFn): void;
+    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(name?: string, fn?: SuiteFn): Promise<void>;
+    function describe(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+    function describe(fn?: SuiteFn): Promise<void>;
     namespace describe {
-        // Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function skip(name?: string, fn?: SuiteFn): void;
-        function skip(options?: TestOptions, fn?: SuiteFn): void;
-        function skip(fn?: SuiteFn): void;
-
-        // Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function todo(name?: string, fn?: SuiteFn): void;
-        function todo(options?: TestOptions, fn?: SuiteFn): void;
-        function todo(fn?: SuiteFn): void;
-
+        /**
+         * Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(name?: string, fn?: SuiteFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function skip(fn?: SuiteFn): Promise<void>;
+        /**
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(name?: string, fn?: SuiteFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function todo(fn?: SuiteFn): Promise<void>;
         /**
          * Shorthand for marking a suite as `only`, same as `describe([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
-        function only(name?: string, fn?: SuiteFn): void;
-        function only(options?: TestOptions, fn?: SuiteFn): void;
-        function only(fn?: SuiteFn): void;
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(name?: string, fn?: SuiteFn): Promise<void>;
+        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+        function only(fn?: SuiteFn): Promise<void>;
     }
 
     /**
@@ -93,31 +96,33 @@ declare module "node:test" {
      * @param fn The function under test. If the test uses callbacks, the callback function is
      *    passed as the second argument. Default: A no-op function.
      */
-    function it(name?: string, options?: TestOptions, fn?: TestFn): void;
-    function it(name?: string, fn?: TestFn): void;
-    function it(options?: TestOptions, fn?: TestFn): void;
-    function it(fn?: TestFn): void;
+    function it(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(name?: string, fn?: TestFn): Promise<void>;
+    function it(options?: TestOptions, fn?: TestFn): Promise<void>;
+    function it(fn?: TestFn): Promise<void>;
     namespace it {
-        // Shorthand for skipping a test, same as `it([name], { skip: true }[, fn])`.
-        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function skip(name?: string, fn?: TestFn): void;
-        function skip(options?: TestOptions, fn?: TestFn): void;
-        function skip(fn?: TestFn): void;
-
-        // Shorthand for marking a test as `TODO`, same as `it([name], { todo: true }[, fn])`.
-        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function todo(name?: string, fn?: TestFn): void;
-        function todo(options?: TestOptions, fn?: TestFn): void;
-        function todo(fn?: TestFn): void;
-
+        /**
+         * Shorthand for skipping a test, same as `it([name], { skip: true }[, fn])`.
+         */
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(name?: string, fn?: TestFn): Promise<void>;
+        function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function skip(fn?: TestFn): Promise<void>;
+        /**
+         * Shorthand for marking a test as `TODO`, same as `it([name], { todo: true }[, fn])`.
+         */
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(name?: string, fn?: TestFn): Promise<void>;
+        function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function todo(fn?: TestFn): Promise<void>;
         /**
          * Shorthand for marking a test as `only`, same as `it([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
-        function only(name?: string, fn?: TestFn): void;
-        function only(options?: TestOptions, fn?: TestFn): void;
-        function only(fn?: TestFn): void;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(name?: string, fn?: TestFn): Promise<void>;
+        function only(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function only(fn?: TestFn): Promise<void>;
     }
     /**
      * Shorthand for skipping a test, same as `test([name], { skip: true }[, fn])`.
@@ -191,6 +196,30 @@ declare module "node:test" {
          * incremented from the primary's `process.debugPort`.
          */
         inspectPort?: number | (() => number) | undefined;
+        /**
+         * That can be used to only run tests whose name matches the provided pattern.
+         * Test name patterns are interpreted as JavaScript regular expressions.
+         * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
+         */
+        testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
+         * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
+         */
+        setup?: (root: Test) => void | Promise<void>;
+        /**
+         * Whether to run in watch mode or not.
+         * @default false
+         */
+        watch?: boolean | undefined;
+    }
+    class Test extends AsyncResource {
+        concurrency: number;
+        nesting: number;
+        only: boolean;
+        reporter: TestsStream;
+        runOnlySubtests: boolean;
+        testNumber: number;
+        timeout: number | null;
     }
 
     /**

--- a/types/node/v18/ts4.8/test/child_process.ts
+++ b/types/node/v18/ts4.8/test/child_process.ts
@@ -408,6 +408,7 @@ async function testPromisify() {
     _boolean = cp.kill();
     _boolean = cp.kill(9);
     _boolean = cp.kill("SIGTERM");
+    cp[Symbol.dispose]();
 
     _maybeNumber = cp.exitCode;
     _maybeSignal = cp.signalCode;

--- a/types/node/v18/ts4.8/test/dgram.ts
+++ b/types/node/v18/ts4.8/test/dgram.ts
@@ -24,6 +24,7 @@ import * as net from "node:net";
         sendBufferSize: 1000,
         lookup: dns.lookup,
     });
+    ds[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/v18/ts4.8/test/events.ts
+++ b/types/node/v18/ts4.8/test/events.ts
@@ -132,6 +132,19 @@ async function test() {
 }
 
 {
+    let disposable: Disposable | undefined;
+    try {
+        const signal = new AbortSignal();
+        signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+        disposable = events.addAbortListener(signal, (e) => {
+            console.log(e);
+        });
+    } finally {
+        disposable?.[Symbol.dispose]();
+    }
+}
+
+{
     // Some event properties differ from DOM types
     const evt = new Event("fake");
     evt.cancelBubble();

--- a/types/node/v18/ts4.8/test/http.ts
+++ b/types/node/v18/ts4.8/test/http.ts
@@ -37,6 +37,9 @@ import * as url from "node:url";
         keepAliveTimeout: 100,
     }, reqListener);
 
+    server.close();
+    server[Symbol.asyncDispose]();
+
     // test public props
     const maxHeadersCount: number | null = server.maxHeadersCount;
     const maxRequestsPerSocket: number | null = server.maxRequestsPerSocket;

--- a/types/node/v18/ts4.8/test/net.ts
+++ b/types/node/v18/ts4.8/test/net.ts
@@ -355,6 +355,7 @@ import * as net from "node:net";
 
     _socket.destroy();
     _server.close();
+    _server[Symbol.asyncDispose]();
 }
 
 {

--- a/types/node/v18/ts4.8/test/stream.ts
+++ b/types/node/v18/ts4.8/test/stream.ts
@@ -496,6 +496,9 @@ function stream_readable_pipe_test() {
     r.close();
     z.close();
     rs.close();
+
+    rs.destroy();
+    rs[Symbol.asyncDispose]();
 }
 
 function stream_duplex_allowHalfOpen_test() {

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -20,6 +20,9 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    testNamePatterns: ["executed"],
+    setup: (root) => {},
+    watch: true,
 });
 
 // TestsStream should be a NodeJS.ReadableStream

--- a/types/node/v18/ts4.8/test/timers.ts
+++ b/types/node/v18/ts4.8/test/timers.ts
@@ -96,9 +96,12 @@ import { promisify } from "node:util";
     function waitFor(options?: { timeout: number }) {
         const timerId = options && setTimeout(() => {}, options.timeout);
         clearTimeout(timerId);
+        timerId?.[Symbol.dispose]();
         const intervalId = options && setTimeout(() => {}, options.timeout);
         clearInterval(intervalId);
+        intervalId?.[Symbol.dispose]();
         const immediateId = options && setImmediate(() => {});
         clearImmediate(immediateId);
+        immediateId?.[Symbol.dispose]();
     }
 }

--- a/types/node/v18/ts4.8/test/tls.ts
+++ b/types/node/v18/ts4.8/test/tls.ts
@@ -245,6 +245,7 @@ import {
 
     // close callback parameter is optional
     _server = _server.close();
+    _server[Symbol.asyncDispose]();
 
     // close callback parameter doesn't specify any arguments, so any
     // function is acceptable

--- a/types/node/v18/ts4.8/timers.d.ts
+++ b/types/node/v18/ts4.8/timers.d.ts
@@ -44,6 +44,11 @@ declare module "timers" {
                  */
                 hasRef(): boolean;
                 _onImmediate: Function; // to distinguish it from the Timeout class
+                /**
+                 * Cancels the immediate. This is similar to calling `clearImmediate()`.
+                 * @since v18.18.0
+                 */
+                [Symbol.dispose](): void;
             }
             interface Timeout extends Timer {
                 /**
@@ -64,8 +69,20 @@ declare module "timers" {
                  */
                 refresh(): this;
                 [Symbol.toPrimitive](): number;
+                /**
+                 * Cancels the timeout.
+                 * @since v18.18.0
+                 */
+                [Symbol.dispose](): void;
             }
         }
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
+         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * @since v0.0.1
+         */
         function setTimeout<TArgs extends any[]>(
             callback: (...args: TArgs) => void,
             ms?: number,
@@ -82,10 +99,10 @@ declare module "timers" {
             callback: (...args: TArgs) => void,
             ms?: number,
             ...args: TArgs
-        ): NodeJS.Timer;
+        ): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
-        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timer;
+        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }

--- a/types/node/v18/ts4.8/url.d.ts
+++ b/types/node/v18/ts4.8/url.d.ts
@@ -783,9 +783,12 @@ declare module "url" {
          */
         append(name: string, value: string): void;
         /**
-         * Remove all name-value pairs whose name is `name`.
+         * If `value` is provided, removes all name-value pairs
+         * where name is `name` and value is `value`..
+         *
+         * If `value` is not provided, removes all name-value pairs whose name is `name`.
          */
-        delete(name: string): void;
+        delete(name: string, value?: string): void;
         /**
          * Returns an ES6 `Iterator` over each of the name-value pairs in the query.
          * Each item of the iterator is a JavaScript `Array`. The first item of the `Array`is the `name`, the second item of the `Array` is the `value`.
@@ -824,9 +827,15 @@ declare module "url" {
          */
         getAll(name: string): string[];
         /**
-         * Returns `true` if there is at least one name-value pair whose name is `name`.
+         * Checks if the `URLSearchParams` object contains key-value pair(s) based on`name` and an optional `value` argument.
+         *
+         * If `value` is provided, returns `true` when name-value pair with
+         * same `name` and `value` exists.
+         *
+         * If `value` is not provided, returns `true` if there is at least one name-value
+         * pair whose name is `name`.
          */
-        has(name: string): boolean;
+        has(name: string, value?: string): boolean;
         /**
          * Returns an ES6 `Iterator` over the names of each name-value pair.
          *

--- a/types/node/v18/url.d.ts
+++ b/types/node/v18/url.d.ts
@@ -783,9 +783,12 @@ declare module "url" {
          */
         append(name: string, value: string): void;
         /**
-         * Remove all name-value pairs whose name is `name`.
+         * If `value` is provided, removes all name-value pairs
+         * where name is `name` and value is `value`..
+         *
+         * If `value` is not provided, removes all name-value pairs whose name is `name`.
          */
-        delete(name: string): void;
+        delete(name: string, value?: string): void;
         /**
          * Returns an ES6 `Iterator` over each of the name-value pairs in the query.
          * Each item of the iterator is a JavaScript `Array`. The first item of the `Array`is the `name`, the second item of the `Array` is the `value`.
@@ -824,9 +827,15 @@ declare module "url" {
          */
         getAll(name: string): string[];
         /**
-         * Returns `true` if there is at least one name-value pair whose name is `name`.
+         * Checks if the `URLSearchParams` object contains key-value pair(s) based on`name` and an optional `value` argument.
+         *
+         * If `value` is provided, returns `true` when name-value pair with
+         * same `name` and `value` exists.
+         *
+         * If `value` is not provided, returns `true` if there is at least one name-value
+         * pair whose name is `name`.
          */
-        has(name: string): boolean;
+        has(name: string, value?: string): boolean;
         /**
          * Returns an ES6 `Iterator` over the names of each name-value pair.
          *


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v18.18.0

- child_process: support Symbol.dispose
- dgram: socket add asyncDispose
- events: allow safely adding listener to abortSignal
- fs, stream: initial Symbol.dispose and Symbol.asyncDispose support
- module: add SourceMap.findOrigin
- net: server add asyncDispose
- net: add autoSelectFamily global getter and setter
- test_runner: fixed test shorthands return type
- timers: support Symbol.dispose
- url: add value argument to has and delete methods
