### PR TITLE
facebook-js-sdk: Support Facebook Login for Business

### DIFF
--- a/types/facebook-js-sdk/facebook-js-sdk-tests.ts
+++ b/types/facebook-js-sdk/facebook-js-sdk-tests.ts
@@ -49,15 +49,24 @@ FB.login({
     scope: "public_profile",
 });
 
+FB.login({ auth_type: "reauthenticate" });
+FB.login({ auth_type: "reauthorize" });
+FB.login({ auth_type: "rerequest" });
+
+FB.login({ config_id: "10000019" });
+FB.login(function(response: fb.StatusResponse) {
+    console.log(response);
+    console.log(response.status);
+    console.log(response.authResponse.code);
+},
+    { config_id: "10000019", response_type: "code", override_default_response_type: true }
+);
+
 FB.logout(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);
     console.log(response.authResponse.accessToken);
 });
-
-FB.login({ auth_type: "reauthenticate" });
-FB.login({ auth_type: "reauthorize" });
-FB.login({ auth_type: "rerequest" });
 
 FB.logout();
 

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -339,6 +339,9 @@ declare namespace facebook {
         return_scopes?: boolean | undefined;
         enable_profile_selector?: boolean | undefined;
         profile_selector_ids?: string | undefined;
+        config_id?: string | undefined;
+        response_type?: string | undefined;
+        override_default_response_type?: boolean | undefined;
     }
 
     ////////////////////////
@@ -476,13 +479,14 @@ declare namespace facebook {
     //
     ////////////////////////
     interface AuthResponse {
-        accessToken: string;
-        data_access_expiration_time: number;
+        accessToken?: string | undefined;
+        data_access_expiration_time?: number | undefined;
         expiresIn: number;
-        signedRequest: string;
+        signedRequest?: string | undefined;
         userID: string;
         grantedScopes?: string | undefined;
         reauthorize_required_in?: number | undefined;
+        code?: string | undefined;
     }
 
     interface StatusResponse {


### PR DESCRIPTION
- Adding `config_id` to support Facebook Login for Business for requesting user access token
- Adding `response_type` and `override_default_response_type` to support Facebook Login for Business for requesting system-user access token
- Marking some fields in `AuthResponse` as optional because they are not returned for Facebook system-user access token
<img width="473" alt="20-57-zh9se-bnhuv" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/11549926/b0c30185-d412-4f03-93cb-075fabf14fd9">


Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.facebook.com/docs/facebook-login/facebook-login-for-business


