### PR TITLE
pg: Pool callback gets err ^ client

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -173,7 +173,7 @@ export class Pool extends events.EventEmitter {
     readonly waitingCount: number;
 
     connect(): Promise<PoolClient>;
-    connect(callback: (err: Error, client: PoolClient, done: (release?: any) => void) => void): void;
+    connect(callback: (err: Error | undefined, client: PoolClient | undefined, done: (release?: any) => void) => void): void;
 
     end(): Promise<void>;
     end(callback: () => void): void;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -222,7 +222,9 @@ pool.connect((err, client, done) => {
         console.error("error fetching client from pool", err);
         return;
     }
-    client.query("SELECT $1::int AS number", ["1"], (err, result) => {
+    // @ts-expect-error
+    client.query("SELECT");
+    client?.query("SELECT $1::int AS number", ["1"], (err, result) => {
         done();
 
         if (err) {


### PR DESCRIPTION
e.g. on error, `err` is set and `client` is undefined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-postgres.com/apis/pool#poolconnect (doesn't seem to document the callback variant, alas)
