### PR TITLE
Update cytoscape.EventHandler 'extraParams' to use spread operator.

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1407,7 +1407,7 @@ declare namespace cytoscape {
         edges: EdgeDefinition[];
     }
 
-    type EventHandler = (event: EventObject, extraParams?: any) => void;
+    type EventHandler = (event: EventObject, ...extraParams: any) => void;
 
     /**
      * The output is a collection of node and edge elements OR single element.


### PR DESCRIPTION
Update cytoscape.EventHandler 'extraParams' parameter use spread operator instead of optional 'any' type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [?] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - Sorry I'm not sure how to do this/if applicable.

- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
Other extension libraries (cytoscape-edgehandles) have events with many extra parameters, spread operator should be backwards-compatible.
https://github.com/cytoscape/cytoscape.js-edgehandles#events
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
