### PR TITLE
improve(lodash): allow sumBy iterator to return null or undefined

### DIFF
--- a/types/lodash/common/math.d.ts
+++ b/types/lodash/common/math.d.ts
@@ -388,18 +388,18 @@ declare module "../index" {
          * _.sumBy(objects, 'n');
          * // => 20
          */
-        sumBy<T>(collection: List<T> | null | undefined, iteratee?: ((value: T) => number) | string): number;
+        sumBy<T>(collection: List<T> | null | undefined, iteratee?: ((value: T) => number | null | undefined) | string): number;
     }
     interface Collection<T> {
         /**
          * @see _.sumBy
          */
-        sumBy(iteratee?: ((value: T) => number) | string): number;
+        sumBy(iteratee?: ((value: T) => number | null | undefined) | string): number;
     }
     interface CollectionChain<T> {
         /**
          * @see _.sumBy
          */
-        sumBy(iteratee?: ((value: T) => number) | string): PrimitiveChain<number>;
+        sumBy(iteratee?: ((value: T) => number | null | undefined) | string): PrimitiveChain<number>;
     }
 }

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -4066,9 +4066,9 @@ declare namespace _ {
     type LodashSubtract1x2 = (minuend: number) => number;
     type LodashSum = (collection: lodash.List<any> | null | undefined) => number;
     interface LodashSumBy {
-        <T>(iteratee: ((value: T) => number) | string): LodashSumBy1x1<T>;
+        <T>(iteratee: ((value: T) => number | null | undefined) | string): LodashSumBy1x1<T>;
         <T>(iteratee: lodash.__, collection: lodash.List<T> | null | undefined): LodashSumBy1x2<T>;
-        <T>(iteratee: ((value: T) => number) | string, collection: lodash.List<T> | null | undefined): number;
+        <T>(iteratee: ((value: T) => number | null | undefined) | string, collection: lodash.List<T> | null | undefined): number;
     }
     type LodashSumBy1x1<T> = (collection: lodash.List<T> | null | undefined) => number;
     type LodashSumBy1x2<T> = (iteratee: ((value: T) => number) | string) => number;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4922,8 +4922,11 @@ fp.now(); // $ExpectType number
 {
     const listIterator = (value: AbcObject) => 0;
 
-    const listWithNullAndUndefined: _.List<Partial<AbcObject>> = anything
-    const partialIterator = (value: Partial<AbcObject>) => value.a
+    type NullableAbcObject = {
+        [k in keyof AbcObject]?: AbcObject[k] | null
+    }
+    const listWithNullAndUndefined: _.List<NullableAbcObject> = anything
+    const partialIterator = (value: Partial<NullableAbcObject>) => value.a
 
     _.sumBy(list, listIterator); // $ExpectType number
     _.sumBy(list, "a"); // $ExpectType number

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4922,15 +4922,26 @@ fp.now(); // $ExpectType number
 {
     const listIterator = (value: AbcObject) => 0;
 
+    const listWithNullAndUndefined: _.List<Partial<AbcObject>> = anything
+    const partialIterator = (value: Partial<AbcObject>) => value.a
+
     _.sumBy(list, listIterator); // $ExpectType number
     _.sumBy(list, "a"); // $ExpectType number
+    _.sumBy(listWithNullAndUndefined, partialIterator) // $ExpectType number
+    _.sumBy(listWithNullAndUndefined, "a") // $ExpectType number
     _(list).sumBy(listIterator); // $ExpectType number
     _(list).sumBy("a"); // $ExpectType number
+    _(listWithNullAndUndefined).sumBy(`a`) // $ExpectType number
+    _(listWithNullAndUndefined).sumBy(partialIterator) // $ExpectType number
     _(list).chain().sumBy(listIterator); // $ExpectType PrimitiveChain<number>
     _(list).chain().sumBy("a"); // $ExpectType PrimitiveChain<number>
+    _(listWithNullAndUndefined).chain().sumBy(partialIterator) // $ExpectType PrimitiveChain<number>
+    _(listWithNullAndUndefined).chain().sumBy("a") // $ExpectType PrimitiveChain<number>
 
     fp.sumBy(listIterator, list); // $ExpectType number
     fp.sumBy("a")(list); // $ExpectType number
+    fp.sumBy(partialIterator)(listWithNullAndUndefined); // $ExpectType number
+    fp.sumBy("a")(listWithNullAndUndefined); // $ExpectType number
 }
 
 /**********


### PR DESCRIPTION
`sum` allows array elements to be `null | undefined`, but `sumBy` does not allow this when provided with an iterator function. `sumBy` still allows to pick a `number | null | undefined` property when called with a string (`sumBy(xs, "x")`). This diff allows the iterator function to return `number | null | undefined`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codesandbox.io/s/intelligent-flower-yc7c9y?file=/src/index.ts


![Screenshot from 2023-09-22 09-33-21](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/10573234/3c5fabb8-0f23-4d84-92b1-270345af0cd9)
![Screenshot from 2023-09-22 09-33-31](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/10573234/09e312f4-accd-4b47-955c-ae631e19e116)
