### PR TITLE
[wicg-file-system-access] remove WritableStream augmentation

### DIFF
--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -86,12 +86,6 @@ interface FileSystemRemoveOptions {
 
 // type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 
-// TODO: remove this once https://github.com/microsoft/TSJS-lib-generator/issues/881 is fixed.
-// Native File System API especially needs this method.
-interface WritableStream {
-    close(): Promise<void>;
-}
-
 // class FileSystemWritableFileStream extends WritableStream {
 //     write(data: FileSystemWriteChunkType): Promise<void>;
 //     seek(position: number): Promise<void>;


### PR DESCRIPTION
https://github.com/microsoft/TSJS-lib-generator/issues/881 was resolved over 2 years ago. Since the minimum TypeScript version for this package is `4.6`, this override appears to be redundant, and it causes IDE commands like go-to-definition to link to this implementation of `WritableStream` instead of the canonical source (`lib.dom.ts`)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~ Not Applicable
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~