### PR TITLE
jquery: Specialize .val() for elements with known value types

### DIFF
--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -12781,7 +12781,17 @@ $( "input" )
 </html>
 ```
      */
-    val(): string | number | string[] | undefined;
+    val():
+        | (TElement extends HTMLSelectElement & {type: "select-one"}
+              ? string
+              : TElement extends HTMLSelectElement & {type: "select-multiple"}
+              ? string[]
+              : TElement extends HTMLSelectElement
+              ? string | string[]
+              : TElement extends {value: string | number}
+              ? TElement["value"]
+              : string | number | string[])
+        | undefined;
     /**
      * Set the CSS width of each element in the set of matched elements.
      * @param value_function _&#x40;param_ `value_function`

--- a/types/jquery/test/val.ts
+++ b/types/jquery/test/val.ts
@@ -1,0 +1,22 @@
+let string_val: string | undefined = $<
+    | HTMLButtonElement
+    | HTMLDataElement
+    | HTMLInputElement
+    | HTMLOptionElement
+    | HTMLOutputElement
+    | HTMLParamElement
+    | (HTMLSelectElement & { type: 'select-one' })
+    | HTMLTextAreaElement
+>('button, data, input, option, output, param, select:not([multiple]), textarea').val();
+
+let number_val: number | undefined = $<HTMLLIElement | HTMLMeterElement | HTMLProgressElement>(
+    'li, meter, progress',
+).val();
+
+let select_multiple_val: string[] | undefined = $<HTMLSelectElement & { type: 'select-multiple' }>(
+    'select[multiple]',
+).val();
+
+let select_unspecified_val: string | string[] | undefined = $<HTMLSelectElement>('select').val();
+
+let unspecified_val: string | number | string[] | undefined = $('*').val();

--- a/types/jquery/tsconfig.json
+++ b/types/jquery/tsconfig.json
@@ -27,6 +27,7 @@
         "test/jquery-no-window-module-tests.ts",
         "test/jquery-window-module-tests.ts",
         "test/jquery-slim-no-window-module-tests.ts",
-        "test/jquery-slim-window-module-tests.ts"
+        "test/jquery-slim-window-module-tests.ts",
+        "test/val.ts"
     ]
 }


### PR DESCRIPTION
If the user explicitly provides a specific element class like `$<HTMLInputElement>("input").val()`, this lets us infer the result as `string | undefined` rather than `string | number | string[] | undefined`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jquery/jquery/blob/3.x-stable/src/attributes/val.js>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
