### PR TITLE
Update quill-delta version to 5.1.0

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -11,7 +11,7 @@
 // TypeScript Version: 2.9
 
 import { Blot } from "parchment/dist/src/blot/abstract/blot";
-import Delta = require("quill-delta");
+import Delta from "quill-delta";
 
 /**
  * A stricter type definition would be:

--- a/types/quill/package.json
+++ b/types/quill/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "parchment": "^1.1.2",
-        "quill-delta": "^4.0.1"
+        "quill-delta": "^5.1.0"
     }
 }

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -1,6 +1,6 @@
 import { Blot } from "parchment/src/blot/abstract/blot";
 import { Quill, RangeStatic, StringMap } from "quill";
-import Delta = require("quill-delta");
+import Delta from "quill-delta";
 
 function test_quill() {
     const quillEditor = new Quill("#editor", {


### PR DESCRIPTION
Hi, 

I found the changes from quill-delta, and this change will cause the definition error, and it seems like quill-delta is import by installed package, so I only modify the quill-delta version. Hope it can work. Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Op.ts url here](https://github.com/quilljs/delta/blob/main/src/Op.ts)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

