### PR TITLE
add optional alt-property to LatLngLiteral and LatLngTuple

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -171,9 +171,10 @@ export class LatLng {
 export interface LatLngLiteral {
     lat: number;
     lng: number;
+    alt?: number;
 }
 
-export type LatLngTuple = [number, number];
+export type LatLngTuple = [number, number, number?];
 
 export type LatLngExpression = LatLng | LatLngLiteral | LatLngTuple;
 
@@ -390,8 +391,7 @@ export interface LeafletEventHandlerFnMap {
  * with an object (e.g. the user clicks on the map, causing the map to fire
  * 'click' event).
  */
-// tslint:disable:strict-export-declare-modifiers
-declare class Events {
+export class Events {
     /**
      * Adds a listener function (fn) to a particular event type of the object.
      * You can optionally specify the context of the listener (object the this
@@ -1015,8 +1015,7 @@ declare class Events {
     hasEventListeners(type: string): boolean;
 }
 
-// tslint:disable:strict-export-declare-modifiers
-declare class MixinType {
+export class MixinType {
     Events: Events;
 }
 

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1016,7 +1016,8 @@ declare class Events {
     hasEventListeners(type: string): boolean;
 }
 
-export class MixinType {
+// eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
+declare class MixinType {
     Events: Events;
 }
 

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -391,7 +391,8 @@ export interface LeafletEventHandlerFnMap {
  * with an object (e.g. the user clicks on the map, causing the map to fire
  * 'click' event).
  */
-export class Events {
+// eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
+declare class Events {
     /**
      * Adds a listener function (fn) to a particular event type of the object.
      * You can optionally specify the context of the listener (object the this

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -4,14 +4,18 @@ import * as L from "leaflet";
 const version = L.version;
 
 const latLngLiteral: L.LatLngLiteral = { lat: 12, lng: 13 };
+const latLngAltLiteral: L.LatLngLiteral = { lat: 12, lng: 13, alt: 100 };
 const latLngTuple: L.LatLngTuple = [12, 13];
+const latLngAltTuple: L.LatLngTuple = [12, 13, 100];
 
 let latLng: L.LatLng;
 latLng = L.latLng(12, 13);
 latLng = L.latLng(12, 13, 0);
 latLng = L.latLng(latLngLiteral);
+latLng = L.latLng(latLngAltLiteral);
 latLng = L.latLng({ lat: 12, lng: 13, alt: 0 });
 latLng = L.latLng(latLngTuple);
+latLng = L.latLng(latLngAltTuple);
 latLng = L.latLng([12, 13, 0]);
 
 latLng = new L.LatLng(12, 13);
@@ -762,7 +766,7 @@ const multiPolygonLatLngs2: L.LatLng[][][] = polygon.getLatLngs() as L.LatLng[][
 let polyline: L.Polyline;
 
 // simple polyline
-const simplePolylineLatLngs: L.LatLngExpression[] = [[45.51, -122.68], [37.77, -122.43], [34.04, -118.2]];
+const simplePolylineLatLngs: L.LatLngExpression[] = [[45.51, -122.68, 100], [37.77, -122.43], [34.04, -118.2, 200]];    // mix in some altitudes
 polyline = L.polyline(simplePolylineLatLngs);
 polyline = new L.Polyline(simplePolylineLatLngs);
 polyline.setLatLngs(simplePolylineLatLngs);


### PR DESCRIPTION
Leaflet's LatLng-Class support an optional alt-property (altitude of a point) upon creation via literals or tuples. This PR adds this to the typings as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference.html#latlng
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
