### PR TITLE
Update types for migrate-mongo 11

### DIFF
--- a/types/migrate-mongo/package.json
+++ b/types/migrate-mongo/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "mongodb": "^5.3.0"
+        "mongodb": "^6.1.0"
     }
 }


### PR DESCRIPTION
Adapt types for migrate-mongo 11 (https://github.com/seppevs/migrate-mongo/pull/439)
This is only about changing the mongo version to version 6 - no other changes.

