### PR TITLE
Formatted mp4frag with dprint and removed node/buffer import

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,0 +1,37 @@
+{
+  "excludes": [
+    // These files are auto-generated and don't need to be formatted.
+    // NOTE: We generally prefer that packages be formatted with dprint.
+    // Packages are generally only listed if they predate our using dprint (August 2023).
+    // If your package is listed, please consider adding dprint fmt to its generation.
+    "./types/custom-functions-runtime",
+    "./types/dojo",
+    "./types/facebook-nodejs-business-sdk",
+    "./types/fhir",
+    "./types/fibjs",
+    "./types/get-intrinsic",
+    "./types/locutus",
+    "./types/lodash",
+    "./types/material-ui",
+    "./types/meteor",
+    "./types/microsoft-graph",
+    "./types/nginstack__engine",
+    "./types/node/**/inspector.d.ts",
+    "./types/office-js-preview",
+    "./types/office-js",
+    "./types/office-runtime",
+    "./types/oibackoff",
+    "./types/openui5",
+    "./types/p5",
+    "./types/react-native",
+    "./types/sawtooth-sdk",
+    "./types/three",
+    "./types/winrt-uwp",
+    "./types/vscode"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.85.1.wasm"
+  ],
+  "indentWidth": 4,
+  "lineWidth": 120
+}

--- a/types/mp4frag/index.d.ts
+++ b/types/mp4frag/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-import { Transform } from 'stream';
-import 'node/buffer';
+import { Transform } from "stream";
+import "node/buffer";
 
 declare namespace Mp4Frag {
     /**

--- a/types/mp4frag/index.d.ts
+++ b/types/mp4frag/index.d.ts
@@ -5,7 +5,6 @@
 /// <reference types="node" />
 
 import { Transform } from "stream";
-import "node/buffer";
 
 declare namespace Mp4Frag {
     /**

--- a/types/mp4frag/mp4frag-tests.ts
+++ b/types/mp4frag/mp4frag-tests.ts
@@ -1,4 +1,4 @@
-import Mp4Frag = require('mp4frag');
+import Mp4Frag = require("mp4frag");
 
 // $ExpectType Mp4Frag
 const m4f = new Mp4Frag({});
@@ -8,7 +8,7 @@ new Mp4Frag();
 
 // $ExpectType Mp4Frag
 new Mp4Frag({
-    hlsPlaylistBase: 'test',
+    hlsPlaylistBase: "test",
     hlsPlaylistInit: true,
     hlsPlaylistExtra: 1,
     hlsPlaylistSize: 1,
@@ -63,7 +63,7 @@ m4f.segmentObjects;
 // $ExpectType SegmentObject | null
 m4f.getSegmentObject(1);
 // $ExpectType SegmentObject | null
-m4f.getSegmentObject('1');
+m4f.getSegmentObject("1");
 // @ts-expect-error
 m4f.getSegmentObject(null);
 
@@ -81,7 +81,7 @@ const segmentObject = {
 
 // $ExpectType Mp4FragOptions
 const mp4FragOptions = {
-    hlsPlaylistBase: 'abc',
+    hlsPlaylistBase: "abc",
     hlsPlaylistSize: 1,
     hlsPlaylistExtra: 1,
     hlsPlaylistInit: true,


### PR DESCRIPTION
> 👉 Partial implementation of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65993. If you're seeing this and are surprised it's happening, please read the discussion and give feedback! ❤️ 

We're splitting up the changes to make it a bit easier to apply & review them en masse - and, if we need later on, revert / bisect for issues. These changes generated with roughly:

This PR is split out from #66534. Implements the dprint formatting changes on `mp4frag` since it was failing in CI. Specifically:

```plaintext
1> Error: Errors in typescript@4.5 for external dependencies:
Error: 1> ../node/buffer.d.ts(46,1): error TS6200: Definitions of the following identifiers conflict with those in another file: INSPECT_MAX_BYTES, kMaxLength, kStringMaxLength, constants, TranscodeEncoding, SlowBuffer, Buffer, Blob, File, atob, btoa, BufferEncoding, WithImplicitCoercion
```

That seems to have come from:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ba980e20d83c88bc5476e5c8a1df95d5dea68478/types/mp4frag/index.d.ts#L8

No other types package still includes `import node/`. I think the line can be removed.