### PR TITLE
[node] - Fix stream/consumers iterable types

### DIFF
--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
     import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -495,6 +495,13 @@ async function testConsumers() {
     await arrayBuffer(r);
     // $ExpectType Blob
     await blob(r);
+
+    const iterable: AsyncGenerator<Buffer> = async function*(){}();
+    await buffer(iterable);
+
+    const iterator: AsyncIterator<Buffer> = { next: () => iterable.next() }
+    // @ts-expect-error
+    await buffer(iterator);
 }
 
 // https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options

--- a/types/node/ts4.8/stream/consumers.d.ts
+++ b/types/node/ts4.8/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
     import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v16/stream/consumers.d.ts
+++ b/types/node/v16/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Readable } from "node:stream";
     import { Blob as NodeBlob } from "node:buffer";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v16/ts4.8/stream/consumers.d.ts
+++ b/types/node/v16/ts4.8/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Readable } from "node:stream";
     import { Blob as NodeBlob } from "node:buffer";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v18/stream/consumers.d.ts
+++ b/types/node/v18/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
     import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v18/ts4.8/stream/consumers.d.ts
+++ b/types/node/v18/ts4.8/stream/consumers.d.ts
@@ -1,11 +1,11 @@
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
     import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
+    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
+    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
+    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
+    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";


### PR DESCRIPTION
@favna, re: 07e9b3d9d301b7d17390c16816c02cdf92706ecb

These types weren't correct. The functions accept an *iterable* not an *iterator*. We can confirm the incorrectness with this program that passes compilation but fails at runtime:
```ts
import consumers from "node:stream/consumers";
const iterable = async function*() {}();
const iterator: AsyncIterator<any> = {
	next: () => iterable.next(),
};
await consumers.buffer(iterator);
```

```
node:stream/consumers:31
  for await (const chunk of stream)
                            ^

TypeError: stream is not async iterable
    at blob (node:stream/consumers:31:29)
    at arrayBuffer (node:stream/consumers:41:21)
    at Object.buffer (node:stream/consumers:50:28)
    at <anonymous> (/Users/marcel/braid/web/packages/backend/usercontent/images/test.ts:14:17)
    at ModuleJob.run (node:internal/modules/esm/module_job:192:25)

Node.js v20.1.0
```

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/nodejs/node/blob/fef7927cc3a7a3fb81c355301aada4a679c5661c/lib/stream/consumers.js#L29-L71)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.