### PR TITLE
[semver] Add toString method to SemVer class

### DIFF
--- a/types/semver/classes/semver.d.ts
+++ b/types/semver/classes/semver.d.ts
@@ -7,6 +7,7 @@ declare class SemVer {
     loose: boolean;
     options: semver.Options;
     format(): string;
+    toString(): string;
     inspect(): string;
 
     major: number;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -121,6 +121,8 @@ const anyVersion = Math.random() < 0.5 ? undefined : Math.random() < 0.5 ? strn 
 sem = new semver.SemVer(str, { includePrerelease: false });
 sem = new semver.SemVer(str, { loose: true });
 
+sem.toString();
+
 sem = semver.parse(str);
 strn = semver.valid(str);
 strn = semver.clean(str);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-semver/blob/14d263faa156e408a033b9b12a2f87735c2df42c/classes/semver.js#L87-L89. This function relies on `format` being call, which is done at the end of the constructor.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Looking through the history of this module, the `toString` method has existed since `2.0.1`: https://github.com/npm/node-semver/blob/b536a15eea9e9f98dbbf4dcf1b984d6a7ca359f1/semver.js#L282-L284