### PR TITLE
Formatted r* packages displaying CI issues with dprint

### DIFF
--- a/types/react-blessed/index.d.ts
+++ b/types/react-blessed/index.d.ts
@@ -5,8 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.1
 
-import * as React from "react";
 import * as Blessed from "blessed";
+import * as React from "react";
 
 export {};
 
@@ -117,11 +117,8 @@ export type ProgressBarEvent = undefined;
 export type ProgressBarEventHandler = EventHandler<ProgressBarEvent>;
 type ProgressBarEventProps = EventHandlerProp<ProgressBarEventNames, ProgressBarEventHandler>;
 interface EventProps
-    extends ScreenEventProps,
-        GenericEventProps,
-        MouseEventProps,
-        KeyPressEventProps,
-        WarningEventProps {}
+    extends ScreenEventProps, GenericEventProps, MouseEventProps, KeyPressEventProps, WarningEventProps
+{}
 
 /* BLESSED-REACT LOCALLY DEFINED PROPS **************************************/
 
@@ -176,12 +173,14 @@ type LayoutProps<T> = T extends LayoutElement ? Partial<Blessed.Widgets.LayoutOp
 // 'blessed' doesn't exist in a DOM so it probably doesn't make sense to allow any property
 type FilterOptions<T extends Record<any, any>> = Partial<Omit<KnownKeys<T>, "style" | "children">>;
 
-type ModifiedBlessedOptions<T extends Record<any, any>> = FilterOptions<T> & { children?: React.ReactNode; style?: ElementStyle } & EventProps;
+type ModifiedBlessedOptions<T extends Record<any, any>> = FilterOptions<T> & {
+    children?: React.ReactNode;
+    style?: ElementStyle;
+} & EventProps;
 
 /* REACT-BLESSED JSX ********************************************************/
 
 /**
- *
  * this type can be used to get props for 'react-blessed' elements in the same
  * manner that React.HTMLProps can be used to get DOM element props. e.g.
  * ```ts
@@ -242,47 +241,53 @@ export type BlessedIntrinsicElementsPrefixed = {
 // augment react JSX when old JSX transform is used
 declare module "react" {
     namespace JSX {
-        interface ButtonHTMLAttributes<T>
-            extends HTMLAttributes<T>,
-                Omit<
-                    DetailedBlessedProps<ButtonElement>,
-                    'draggable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'ref' | 'style'
-                > {}
+        interface ButtonHTMLAttributes<T> extends
+            HTMLAttributes<T>,
+            Omit<
+                DetailedBlessedProps<ButtonElement>,
+                "draggable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "ref" | "style"
+            >
+        {}
 
-        interface TableHTMLAttributes<T>
-            extends HTMLAttributes<T>,
-                Omit<
-                    DetailedBlessedProps<TableElement>,
-                    'border' | 'draggable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'ref' | 'style'
-                > {}
+        interface TableHTMLAttributes<T> extends
+            HTMLAttributes<T>,
+            Omit<
+                DetailedBlessedProps<TableElement>,
+                "border" | "draggable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "ref" | "style"
+            >
+        {}
 
-        interface TextareaHTMLAttributes<T>
-            extends HTMLAttributes<T>,
-                Omit<
-                    DetailedBlessedProps<TextElement>,
-                    'draggable' | 'fill' | 'focusable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'ref' | 'style'
-                > {}
+        interface TextareaHTMLAttributes<T> extends
+            HTMLAttributes<T>,
+            Omit<
+                DetailedBlessedProps<TextElement>,
+                "draggable" | "fill" | "focusable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "ref" | "style"
+            >
+        {}
 
-        interface InputHTMLAttributes<T>
-            extends HTMLAttributes<T>,
-                Omit<
-                    DetailedBlessedProps<InputElement>,
-                    'draggable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'ref' | 'style'
-                > {}
+        interface InputHTMLAttributes<T> extends
+            HTMLAttributes<T>,
+            Omit<
+                DetailedBlessedProps<InputElement>,
+                "draggable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "ref" | "style"
+            >
+        {}
 
-        interface SVGLineElementAttributes<T>
-            extends SVGProps<T>,
-                Omit<
-                    DetailedBlessedProps<LineElement>,
-                    'focusable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'orientation' | 'ref' | 'style'
-                > {}
+        interface SVGLineElementAttributes<T> extends
+            SVGProps<T>,
+            Omit<
+                DetailedBlessedProps<LineElement>,
+                "focusable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "orientation" | "ref" | "style"
+            >
+        {}
 
-        interface SVGTextElementAttributes<T>
-            extends SVGProps<T>,
-                Omit<
-                    DetailedBlessedProps<TextElement>,
-                    'fill' | 'focusable' | 'onBlur' | 'onClick' | 'onFocus' | 'onResize' | 'ref' | 'style'
-                > {}
+        interface SVGTextElementAttributes<T> extends
+            SVGProps<T>,
+            Omit<
+                DetailedBlessedProps<TextElement>,
+                "fill" | "focusable" | "onBlur" | "onClick" | "onFocus" | "onResize" | "ref" | "style"
+            >
+        {}
 
         // set IntrinsicElements to 'react-blessed' elements both with and without
         // 'blessed-' prefix

--- a/types/react-blessed/react-blessed-tests.tsx
+++ b/types/react-blessed/react-blessed-tests.tsx
@@ -2,7 +2,7 @@
 import Blessed = require("blessed");
 import ReactBlessed = require("react-blessed");
 import React = require("react");
-import { BlessedIntrinsicElementsPrefixed, BlessedAttributes, Element } from "react-blessed";
+import { BlessedAttributes, BlessedIntrinsicElementsPrefixed, Element } from "react-blessed";
 
 // Testing example from demos page
 // https://github.com/Yomguithereal/react-blessed/blob/master/examples/dashboard.jsx
@@ -121,8 +121,7 @@ class Progress extends React.Component<any, any> {
                 onComplete={() =>
                     this.setState({
                         color: "green",
-                    })
-                }
+                    })}
                 onKeypress={(...args) => {}}
                 class={stylesheet.bordered}
                 filled={progress}
@@ -231,8 +230,9 @@ const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewConte
 
 const ForwardRef3 = React.forwardRef(
     (
-        props: BlessedIntrinsicElementsPrefixed["blessed-box"] &
-            Pick<BlessedIntrinsicElementsPrefixed["blessed-box"] & { theme?: {} }, "ref" | "theme">,
+        props:
+            & BlessedIntrinsicElementsPrefixed["blessed-box"]
+            & Pick<BlessedIntrinsicElementsPrefixed["blessed-box"] & { theme?: {} }, "ref" | "theme">,
         ref?: React.Ref<ReactBlessed.BoxElement>,
     ) => <blessed-box {...props} ref={ref} />,
 );

--- a/types/react-clipboardjs-copy/index.d.ts
+++ b/types/react-clipboardjs-copy/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: DefinitelyTyped <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as React from 'react';
+import * as React from "react";
 
 export as namespace ReactClipboard;
 

--- a/types/react-clipboardjs-copy/react-clipboardjs-copy-tests.tsx
+++ b/types/react-clipboardjs-copy/react-clipboardjs-copy-tests.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import ReactClipboard from 'react-clipboardjs-copy';
+import * as React from "react";
+import ReactClipboard from "react-clipboardjs-copy";
 
 function MyApp() {
     return (
@@ -7,14 +7,15 @@ function MyApp() {
             text="text"
             target="target"
             action="action"
-            selection={ false }
-            onSuccess={ () => {} }
-            onError={ () => {} }
-            options={ {
+            selection={false}
+            onSuccess={() => {}}
+            onError={() => {}}
+            options={{
                 text: "text",
-                container: (<div/>),
-                target: () => {}
+                container: <div />,
+                target: () => {},
             }}
-        ></ReactClipboard>
+        >
+        </ReactClipboard>
     );
 }

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -13,12 +13,12 @@
 
 /// <reference lib='dom' />
 
-import * as React from 'react';
-import * as MapboxGL from 'mapbox-gl';
-import * as GeoJSON from 'geojson';
-import WebMercatorViewport from 'viewport-mercator-project';
+import * as GeoJSON from "geojson";
+import * as MapboxGL from "mapbox-gl";
+import * as React from "react";
+import WebMercatorViewport from "viewport-mercator-project";
 
-export { WebMercatorViewport } from 'viewport-mercator-project';
+export { WebMercatorViewport } from "viewport-mercator-project";
 
 export interface ViewState {
     latitude: number;
@@ -140,7 +140,7 @@ export interface ViewportProps {
     minZoom: number;
     maxPitch: number;
     minPitch: number;
-    transitionDuration?: number | 'auto' | undefined;
+    transitionDuration?: number | "auto" | undefined;
     transitionInterpolator?: TransitionInterpolator | undefined;
     transitionInterruption?: TRANSITION_EVENTS | undefined;
     transitionEasing?: EasingFunction | undefined;
@@ -272,7 +272,7 @@ export interface InteractiveMapProps extends StaticMapProps {
     onViewStateChange?: ContextViewStateChangeHandler | undefined;
     onViewportChange?: ContextViewportChangeHandler | undefined;
     onInteractionStateChange?: ((state: ExtraState) => void) | undefined;
-    transitionDuration?: number | 'auto' | undefined;
+    transitionDuration?: number | "auto" | undefined;
     transitionInterpolator?: TransitionInterpolator | undefined;
     transitionInterruption?: TRANSITION_EVENTS | undefined;
     transitionEasing?: EasingFunction | undefined;
@@ -409,7 +409,7 @@ export class GeolocateControl extends BaseControl<GeolocateControlProps, HTMLDiv
 
 export interface ScaleControlProps extends BaseControlProps {
     maxWidth?: number | undefined;
-    unit?: 'imperial' | 'metric' | 'nautical' | undefined;
+    unit?: "imperial" | "metric" | "nautical" | undefined;
 }
 
 export class ScaleControl extends BaseControl<ScaleControlProps, HTMLDivElement> {}
@@ -479,11 +479,11 @@ export interface SourceProps {
     tiles?: string[] | undefined;
     tileSize?: number | undefined;
     bounds?: number[] | undefined;
-    scheme?: 'xyz' | 'tms' | undefined;
+    scheme?: "xyz" | "tms" | undefined;
     minzoom?: number | undefined;
     maxzoom?: number | undefined;
     attribution?: string | undefined;
-    encoding?: 'terrarium' | 'mapbox' | undefined;
+    encoding?: "terrarium" | "mapbox" | undefined;
     data?: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | string | undefined;
     buffer?: number | undefined;
     tolerance?: number | undefined;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -1,5 +1,5 @@
-import * as MapboxGL from 'mapbox-gl';
-import * as React from 'react';
+import * as MapboxGL from "mapbox-gl";
+import * as React from "react";
 
 import {
     CanvasOverlay,
@@ -13,23 +13,23 @@ import {
     LinearInterpolator,
     Marker,
     Popup,
-    SVGOverlay,
-    SVGRedrawOptions,
     ScaleControl,
     Source,
     StaticMap,
+    SVGOverlay,
+    SVGRedrawOptions,
     ViewportProps,
-} from 'react-map-gl';
+} from "react-map-gl";
 
-import { FeatureCollection } from 'geojson';
+import { FeatureCollection } from "geojson";
 
 interface State {
     viewport: ViewportProps;
 }
 
 const geojson: FeatureCollection = {
-    type: 'FeatureCollection',
-    features: [{ type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [-122.4, 37.8] } }],
+    type: "FeatureCollection",
+    features: [{ type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [-122.4, 37.8] } }],
 };
 
 class MyMap extends React.Component<{}, State> {
@@ -72,11 +72,11 @@ class MyMap extends React.Component<{}, State> {
                         event.preventDefault();
                     }}
                 >
-                    <FullscreenControl className="test-class" container={document.querySelector('body')} />
+                    <FullscreenControl className="test-class" container={document.querySelector("body")} />
                     <GeolocateControl
                         auto={false}
                         className="test-class"
-                        style={{ marginTop: '8px' }}
+                        style={{ marginTop: "8px" }}
                         onGeolocate={options => {
                             console.log(options.enableHighAccuracy);
                         }}
@@ -114,7 +114,7 @@ class MyMap extends React.Component<{}, State> {
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         style={{
-                            border: '2px solid black',
+                            border: "2px solid black",
                         }}
                         captureScroll={true}
                         captureDrag={true}
@@ -126,10 +126,11 @@ class MyMap extends React.Component<{}, State> {
                         <Layer
                             type="point"
                             paint={{
-                                'circle-radius': 10,
-                                'circle-color': '#007cbf',
+                                "circle-radius": 10,
+                                "circle-color": "#007cbf",
                             }}
-                        ></Layer>
+                        >
+                        </Layer>
                     </Source>
                     <Source
                         id="raster-tiles-source"
@@ -145,7 +146,8 @@ class MyMap extends React.Component<{}, State> {
                             paint={{}}
                             minzoom={0}
                             maxzoom={22}
-                        ></Layer>
+                        >
+                        </Layer>
                     </Source>
                     <Marker
                         latitude={0}
@@ -191,8 +193,8 @@ class MyMap extends React.Component<{}, State> {
                         this.setState(prevState => ({
                             viewport: {
                                 ...prevState.viewport,
-                                width: '100vw',
-                                height: '100vh',
+                                width: "100vw",
+                                height: "100vh",
                             },
                         }));
                     }}
@@ -209,12 +211,12 @@ class MyMap extends React.Component<{}, State> {
         }
         this.map = el;
         this.mapboxMap = el.getMap();
-    }
+    };
 
     private readonly setRefStatic = (el: StaticMap | null) => {
         if (el === null) {
             return;
         }
         this.mapboxMap = el.getMap();
-    }
+    };
 }

--- a/types/react-native-awesome-card-io/index.d.ts
+++ b/types/react-native-awesome-card-io/index.d.ts
@@ -5,8 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import * as React from "react";
+import { StyleProp, ViewStyle } from "react-native";
 
 export interface CardDetails {
     /**  Localized card type. */
@@ -93,7 +93,7 @@ export interface CardIOModuleProps extends CardIOCommonProps {
     usePaypalActionbarIcon?: boolean | undefined;
 }
 
-export type CardIODetectionMode = 'IMAGE_AND_NUMBER' | 'IMAGE' | 'AUTOMATIC';
+export type CardIODetectionMode = "IMAGE_AND_NUMBER" | "IMAGE" | "AUTOMATIC";
 
 export namespace CardIOUtilities {
     /**  iOS only - prepares card.io to launch faster. */

--- a/types/react-native-awesome-card-io/react-native-awesome-card-io-tests.tsx
+++ b/types/react-native-awesome-card-io/react-native-awesome-card-io-tests.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import { CardIOView, CardDetails, CardIOUtilities, CardIOModule } from 'react-native-awesome-card-io';
-import { Platform } from 'react-native';
+import * as React from "react";
+import { Platform } from "react-native";
+import { CardDetails, CardIOModule, CardIOUtilities, CardIOView } from "react-native-awesome-card-io";
 
 export default class CardIOExample extends React.Component {
     componentWillMount() {
-        if (Platform.OS === 'ios') {
+        if (Platform.OS === "ios") {
             CardIOUtilities.preload();
         }
     }
@@ -15,7 +15,7 @@ export default class CardIOExample extends React.Component {
 
     scanCard() {
         CardIOModule.scanCard({
-            guideColor: '#FF00FF',
+            guideColor: "#FF00FF",
             requireCVV: false,
             hideCardIOLogo: true,
             suppressManualEntry: true,
@@ -31,7 +31,8 @@ export default class CardIOExample extends React.Component {
                 didScanCard={(card: CardDetails) => {
                     console.log(card);
                 }}
-            ></CardIOView>
+            >
+            </CardIOView>
         );
     }
 }

--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -14,7 +14,7 @@ interface rendererNode {
     type: "element" | "text";
     value?: string | number | undefined;
     tagName?: keyof JSX.IntrinsicElements | React.ComponentType<any> | undefined;
-    properties?: { className: any[], [key: string]: any; };
+    properties?: { className: any[]; [key: string]: any };
     children?: rendererNode[];
 }
 interface rendererProps {
@@ -23,7 +23,7 @@ interface rendererProps {
     useInlineStyles: boolean;
 }
 
-declare module 'react-syntax-highlighter' {
+declare module "react-syntax-highlighter" {
     export interface SyntaxHighlighterProps {
         language?: string | undefined;
         style?: { [key: string]: React.CSSProperties } | undefined;
@@ -53,5950 +53,5950 @@ declare module 'react-syntax-highlighter' {
         key: React.Key;
     }
 
-    export { default } from 'react-syntax-highlighter/dist/esm/default-highlight';
-    export { default as LightAsync } from 'react-syntax-highlighter/dist/esm/light-async';
-    export { default as Light } from 'react-syntax-highlighter/dist/esm/light';
+    export { default } from "react-syntax-highlighter/dist/esm/default-highlight";
+    export { default as LightAsync } from "react-syntax-highlighter/dist/esm/light-async";
+    export { default as Light } from "react-syntax-highlighter/dist/esm/light";
 
-    export { default as PrismAsyncLight } from 'react-syntax-highlighter/dist/esm/prism-async-light';
-    export { default as PrismAsync } from 'react-syntax-highlighter/dist/esm/prism-async';
-    export { default as PrismLight } from 'react-syntax-highlighter/dist/esm/prism-light';
-    export { default as Prism } from 'react-syntax-highlighter/dist/esm/prism';
+    export { default as PrismAsyncLight } from "react-syntax-highlighter/dist/esm/prism-async-light";
+    export { default as PrismAsync } from "react-syntax-highlighter/dist/esm/prism-async";
+    export { default as PrismLight } from "react-syntax-highlighter/dist/esm/prism-light";
+    export { default as Prism } from "react-syntax-highlighter/dist/esm/prism";
 
-    export { default as createElement } from 'react-syntax-highlighter/dist/esm/create-element';
+    export { default as createElement } from "react-syntax-highlighter/dist/esm/create-element";
 }
 
 // esm start
-declare module 'react-syntax-highlighter/dist/esm/default-highlight' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/default-highlight" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static supportedLanguages: string[];
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/light-async' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/light-async" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/prism-async-light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/prism-async-light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/prism-async' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/prism-async" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {}
 }
 
-declare module 'react-syntax-highlighter/dist/esm/prism-light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/prism-light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/prism' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/prism" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static supportedLanguages: string[];
     }
 }
 
-declare module 'react-syntax-highlighter/dist/esm/create-element' {
-    import * as React from 'react';
-    import { createElementProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/esm/create-element" {
+    import * as React from "react";
+    import { createElementProps } from "react-syntax-highlighter";
     function createElement(props: createElementProps): React.ReactNode;
     export default createElement;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs' {
-    export { default as a11yDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
-    export { default as a11yLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-light';
-    export { default as agate } from 'react-syntax-highlighter/dist/esm/styles/hljs/agate';
-    export { default as anOldHope } from 'react-syntax-highlighter/dist/esm/styles/hljs/an-old-hope';
-    export { default as androidstudio } from 'react-syntax-highlighter/dist/esm/styles/hljs/androidstudio';
-    export { default as arduinoLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/arduino-light';
-    export { default as arta } from 'react-syntax-highlighter/dist/esm/styles/hljs/arta';
-    export { default as ascetic } from 'react-syntax-highlighter/dist/esm/styles/hljs/ascetic';
-    export { default as atelierCaveDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-dark';
-    export { default as atelierCaveLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-light';
-    export { default as atelierDuneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-dark';
-    export { default as atelierDuneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-light';
-    export { default as atelierEstuaryDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-dark';
-    export { default as atelierEstuaryLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-light';
-    export { default as atelierForestDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-dark';
-    export { default as atelierForestLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-light';
-    export { default as atelierHeathDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-dark';
-    export { default as atelierHeathLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-light';
-    export { default as atelierLakesideDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-dark';
-    export { default as atelierLakesideLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-light';
-    export { default as atelierPlateauDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-dark';
-    export { default as atelierPlateauLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-light';
-    export { default as atelierSavannaDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-dark';
-    export { default as atelierSavannaLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-light';
-    export { default as atelierSeasideDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-dark';
-    export { default as atelierSeasideLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-light';
-    export { default as atelierSulphurpoolDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-dark';
-    export { default as atelierSulphurpoolLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-light';
-    export { default as atomOneDarkReasonable } from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark-reasonable';
-    export { default as atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark';
-    export { default as atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light';
-    export { default as brownPaper } from 'react-syntax-highlighter/dist/esm/styles/hljs/brown-paper';
-    export { default as codepenEmbed } from 'react-syntax-highlighter/dist/esm/styles/hljs/codepen-embed';
-    export { default as colorBrewer } from 'react-syntax-highlighter/dist/esm/styles/hljs/color-brewer';
-    export { default as darcula } from 'react-syntax-highlighter/dist/esm/styles/hljs/darcula';
-    export { default as dark } from 'react-syntax-highlighter/dist/esm/styles/hljs/dark';
-    export { default as defaultStyle } from 'react-syntax-highlighter/dist/esm/styles/hljs/default-style';
-    export { default as docco } from 'react-syntax-highlighter/dist/esm/styles/hljs/docco';
-    export { default as dracula } from 'react-syntax-highlighter/dist/esm/styles/hljs/dracula';
-    export { default as far } from 'react-syntax-highlighter/dist/esm/styles/hljs/far';
-    export { default as foundation } from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
-    export { default as githubGist } from 'react-syntax-highlighter/dist/esm/styles/hljs/github-gist';
-    export { default as github } from 'react-syntax-highlighter/dist/esm/styles/hljs/github';
-    export { default as gml } from 'react-syntax-highlighter/dist/esm/styles/hljs/gml';
-    export { default as googlecode } from 'react-syntax-highlighter/dist/esm/styles/hljs/googlecode';
-    export { default as gradientDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/gradient-dark';
-    export { default as grayscale } from 'react-syntax-highlighter/dist/esm/styles/hljs/grayscale';
-    export { default as gruvboxDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-dark';
-    export { default as gruvboxLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-light';
-    export { default as hopscotch } from 'react-syntax-highlighter/dist/esm/styles/hljs/hopscotch';
-    export { default as hybrid } from 'react-syntax-highlighter/dist/esm/styles/hljs/hybrid';
-    export { default as idea } from 'react-syntax-highlighter/dist/esm/styles/hljs/idea';
-    export { default as irBlack } from 'react-syntax-highlighter/dist/esm/styles/hljs/ir-black';
-    export { default as isblEditorDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-dark';
-    export { default as isblEditorLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-light';
-    export { default as kimbieDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/kimbie.dark';
-    export { default as kimbieLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/kimbie.light';
-    export { default as lightfair } from 'react-syntax-highlighter/dist/esm/styles/hljs/lightfair';
-    export { default as lioshi } from 'react-syntax-highlighter/dist/esm/styles/hljs/lioshi';
-    export { default as magula } from 'react-syntax-highlighter/dist/esm/styles/hljs/magula';
-    export { default as monoBlue } from 'react-syntax-highlighter/dist/esm/styles/hljs/mono-blue';
-    export { default as monokaiSublime } from 'react-syntax-highlighter/dist/esm/styles/hljs/monokai-sublime';
-    export { default as monokai } from 'react-syntax-highlighter/dist/esm/styles/hljs/monokai';
-    export { default as nightOwl } from 'react-syntax-highlighter/dist/esm/styles/hljs/night-owl';
-    export { default as nnfxDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/nnfx-dark';
-    export { default as nnfx } from 'react-syntax-highlighter/dist/esm/styles/hljs/nnfx';
-    export { default as nord } from 'react-syntax-highlighter/dist/esm/styles/hljs/nord';
-    export { default as obsidian } from 'react-syntax-highlighter/dist/esm/styles/hljs/obsidian';
-    export { default as ocean } from 'react-syntax-highlighter/dist/esm/styles/hljs/ocean';
-    export { default as paraisoDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/paraiso-dark';
-    export { default as paraisoLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/paraiso-light';
-    export { default as pojoaque } from 'react-syntax-highlighter/dist/esm/styles/hljs/pojoaque';
-    export { default as purebasic } from 'react-syntax-highlighter/dist/esm/styles/hljs/purebasic';
-    export { default as qtcreatorDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_dark';
-    export { default as qtcreatorLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_light';
-    export { default as railscasts } from 'react-syntax-highlighter/dist/esm/styles/hljs/railscasts';
-    export { default as rainbow } from 'react-syntax-highlighter/dist/esm/styles/hljs/rainbow';
-    export { default as routeros } from 'react-syntax-highlighter/dist/esm/styles/hljs/routeros';
-    export { default as schoolBook } from 'react-syntax-highlighter/dist/esm/styles/hljs/school-book';
-    export { default as shadesOfPurple } from 'react-syntax-highlighter/dist/esm/styles/hljs/shades-of-purple';
-    export { default as solarizedDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark';
-    export { default as solarizedLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-light';
-    export { default as srcery } from 'react-syntax-highlighter/dist/esm/styles/hljs/srcery';
-    export { default as stackoverflowDark } from 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark';
-    export { default as stackoverflowLight } from 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light';
-    export { default as sunburst } from 'react-syntax-highlighter/dist/esm/styles/hljs/sunburst';
-    export { default as tomorrowNightBlue } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-blue';
-    export { default as tomorrowNightBright } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-bright';
-    export { default as tomorrowNightEighties } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-eighties';
-    export { default as tomorrowNight } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night';
-    export { default as tomorrow } from 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow';
-    export { default as vs } from 'react-syntax-highlighter/dist/esm/styles/hljs/vs';
-    export { default as vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs/vs2015';
-    export { default as xcode } from 'react-syntax-highlighter/dist/esm/styles/hljs/xcode';
-    export { default as xt256 } from 'react-syntax-highlighter/dist/esm/styles/hljs/xt256';
-    export { default as zenburn } from 'react-syntax-highlighter/dist/esm/styles/hljs/zenburn';
+declare module "react-syntax-highlighter/dist/esm/styles/hljs" {
+    export { default as a11yDark } from "react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark";
+    export { default as a11yLight } from "react-syntax-highlighter/dist/esm/styles/hljs/a11y-light";
+    export { default as agate } from "react-syntax-highlighter/dist/esm/styles/hljs/agate";
+    export { default as anOldHope } from "react-syntax-highlighter/dist/esm/styles/hljs/an-old-hope";
+    export { default as androidstudio } from "react-syntax-highlighter/dist/esm/styles/hljs/androidstudio";
+    export { default as arduinoLight } from "react-syntax-highlighter/dist/esm/styles/hljs/arduino-light";
+    export { default as arta } from "react-syntax-highlighter/dist/esm/styles/hljs/arta";
+    export { default as ascetic } from "react-syntax-highlighter/dist/esm/styles/hljs/ascetic";
+    export { default as atelierCaveDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-dark";
+    export { default as atelierCaveLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-light";
+    export { default as atelierDuneDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-dark";
+    export { default as atelierDuneLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-light";
+    export { default as atelierEstuaryDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-dark";
+    export { default as atelierEstuaryLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-light";
+    export { default as atelierForestDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-dark";
+    export { default as atelierForestLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-light";
+    export { default as atelierHeathDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-dark";
+    export { default as atelierHeathLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-light";
+    export { default as atelierLakesideDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-dark";
+    export { default as atelierLakesideLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-light";
+    export { default as atelierPlateauDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-dark";
+    export { default as atelierPlateauLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-light";
+    export { default as atelierSavannaDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-dark";
+    export { default as atelierSavannaLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-light";
+    export { default as atelierSeasideDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-dark";
+    export { default as atelierSeasideLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-light";
+    export { default as atelierSulphurpoolDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-dark";
+    export { default as atelierSulphurpoolLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-light";
+    export { default as atomOneDarkReasonable } from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark-reasonable";
+    export { default as atomOneDark } from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark";
+    export { default as atomOneLight } from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light";
+    export { default as brownPaper } from "react-syntax-highlighter/dist/esm/styles/hljs/brown-paper";
+    export { default as codepenEmbed } from "react-syntax-highlighter/dist/esm/styles/hljs/codepen-embed";
+    export { default as colorBrewer } from "react-syntax-highlighter/dist/esm/styles/hljs/color-brewer";
+    export { default as darcula } from "react-syntax-highlighter/dist/esm/styles/hljs/darcula";
+    export { default as dark } from "react-syntax-highlighter/dist/esm/styles/hljs/dark";
+    export { default as defaultStyle } from "react-syntax-highlighter/dist/esm/styles/hljs/default-style";
+    export { default as docco } from "react-syntax-highlighter/dist/esm/styles/hljs/docco";
+    export { default as dracula } from "react-syntax-highlighter/dist/esm/styles/hljs/dracula";
+    export { default as far } from "react-syntax-highlighter/dist/esm/styles/hljs/far";
+    export { default as foundation } from "react-syntax-highlighter/dist/esm/styles/hljs/foundation";
+    export { default as githubGist } from "react-syntax-highlighter/dist/esm/styles/hljs/github-gist";
+    export { default as github } from "react-syntax-highlighter/dist/esm/styles/hljs/github";
+    export { default as gml } from "react-syntax-highlighter/dist/esm/styles/hljs/gml";
+    export { default as googlecode } from "react-syntax-highlighter/dist/esm/styles/hljs/googlecode";
+    export { default as gradientDark } from "react-syntax-highlighter/dist/esm/styles/hljs/gradient-dark";
+    export { default as grayscale } from "react-syntax-highlighter/dist/esm/styles/hljs/grayscale";
+    export { default as gruvboxDark } from "react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-dark";
+    export { default as gruvboxLight } from "react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-light";
+    export { default as hopscotch } from "react-syntax-highlighter/dist/esm/styles/hljs/hopscotch";
+    export { default as hybrid } from "react-syntax-highlighter/dist/esm/styles/hljs/hybrid";
+    export { default as idea } from "react-syntax-highlighter/dist/esm/styles/hljs/idea";
+    export { default as irBlack } from "react-syntax-highlighter/dist/esm/styles/hljs/ir-black";
+    export { default as isblEditorDark } from "react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-dark";
+    export { default as isblEditorLight } from "react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-light";
+    export { default as kimbieDark } from "react-syntax-highlighter/dist/esm/styles/hljs/kimbie.dark";
+    export { default as kimbieLight } from "react-syntax-highlighter/dist/esm/styles/hljs/kimbie.light";
+    export { default as lightfair } from "react-syntax-highlighter/dist/esm/styles/hljs/lightfair";
+    export { default as lioshi } from "react-syntax-highlighter/dist/esm/styles/hljs/lioshi";
+    export { default as magula } from "react-syntax-highlighter/dist/esm/styles/hljs/magula";
+    export { default as monoBlue } from "react-syntax-highlighter/dist/esm/styles/hljs/mono-blue";
+    export { default as monokaiSublime } from "react-syntax-highlighter/dist/esm/styles/hljs/monokai-sublime";
+    export { default as monokai } from "react-syntax-highlighter/dist/esm/styles/hljs/monokai";
+    export { default as nightOwl } from "react-syntax-highlighter/dist/esm/styles/hljs/night-owl";
+    export { default as nnfxDark } from "react-syntax-highlighter/dist/esm/styles/hljs/nnfx-dark";
+    export { default as nnfx } from "react-syntax-highlighter/dist/esm/styles/hljs/nnfx";
+    export { default as nord } from "react-syntax-highlighter/dist/esm/styles/hljs/nord";
+    export { default as obsidian } from "react-syntax-highlighter/dist/esm/styles/hljs/obsidian";
+    export { default as ocean } from "react-syntax-highlighter/dist/esm/styles/hljs/ocean";
+    export { default as paraisoDark } from "react-syntax-highlighter/dist/esm/styles/hljs/paraiso-dark";
+    export { default as paraisoLight } from "react-syntax-highlighter/dist/esm/styles/hljs/paraiso-light";
+    export { default as pojoaque } from "react-syntax-highlighter/dist/esm/styles/hljs/pojoaque";
+    export { default as purebasic } from "react-syntax-highlighter/dist/esm/styles/hljs/purebasic";
+    export { default as qtcreatorDark } from "react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_dark";
+    export { default as qtcreatorLight } from "react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_light";
+    export { default as railscasts } from "react-syntax-highlighter/dist/esm/styles/hljs/railscasts";
+    export { default as rainbow } from "react-syntax-highlighter/dist/esm/styles/hljs/rainbow";
+    export { default as routeros } from "react-syntax-highlighter/dist/esm/styles/hljs/routeros";
+    export { default as schoolBook } from "react-syntax-highlighter/dist/esm/styles/hljs/school-book";
+    export { default as shadesOfPurple } from "react-syntax-highlighter/dist/esm/styles/hljs/shades-of-purple";
+    export { default as solarizedDark } from "react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark";
+    export { default as solarizedLight } from "react-syntax-highlighter/dist/esm/styles/hljs/solarized-light";
+    export { default as srcery } from "react-syntax-highlighter/dist/esm/styles/hljs/srcery";
+    export { default as stackoverflowDark } from "react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark";
+    export { default as stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light";
+    export { default as sunburst } from "react-syntax-highlighter/dist/esm/styles/hljs/sunburst";
+    export { default as tomorrowNightBlue } from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-blue";
+    export { default as tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-bright";
+    export { default as tomorrowNightEighties } from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-eighties";
+    export { default as tomorrowNight } from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night";
+    export { default as tomorrow } from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow";
+    export { default as vs } from "react-syntax-highlighter/dist/esm/styles/hljs/vs";
+    export { default as vs2015 } from "react-syntax-highlighter/dist/esm/styles/hljs/vs2015";
+    export { default as xcode } from "react-syntax-highlighter/dist/esm/styles/hljs/xcode";
+    export { default as xt256 } from "react-syntax-highlighter/dist/esm/styles/hljs/xt256";
+    export { default as zenburn } from "react-syntax-highlighter/dist/esm/styles/hljs/zenburn";
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/a11y-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/agate' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/agate" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/an-old-hope' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/an-old-hope" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/androidstudio' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/androidstudio" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/arduino-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/arduino-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/arta' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/arta" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/ascetic' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/ascetic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-cave-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-dune-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-estuary-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-forest-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-heath-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-lakeside-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-plateau-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-savanna-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-seaside-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atelier-sulphurpool-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark-reasonable' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark-reasonable" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/brown-paper' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/brown-paper" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/codepen-embed' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/codepen-embed" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/color-brewer' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/color-brewer" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/darcula' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/darcula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/darkula' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/darkula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/default-style' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/default-style" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/docco' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/docco" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/dracula' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/dracula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/far' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/far" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/foundation' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/foundation" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/github-gist' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/github-gist" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/github' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/github" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/gml' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/gml" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/googlecode' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/googlecode" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/gradient-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/gradient-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/grayscale' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/grayscale" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/gruvbox-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/hopscotch' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/hopscotch" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/hybrid' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/hybrid" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/idea' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/idea" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/ir-black' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/ir-black" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/isbl-editor-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/kimbie.dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/kimbie.dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/kimbie.light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/kimbie.light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/lightfair' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/lightfair" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/lioshi' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/lioshi" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/magula' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/magula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/mono-blue' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/mono-blue" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/monokai-sublime' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/monokai-sublime" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/monokai' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/monokai" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/night-owl' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/night-owl" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/nnfx-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/nnfx-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/nnfx' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/nnfx" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/nord' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/nord" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/obsidian' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/obsidian" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/ocean' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/ocean" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/paraiso-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/paraiso-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/paraiso-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/paraiso-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/pojoaque' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/pojoaque" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/purebasic' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/purebasic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/qtcreator_light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/railscasts' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/railscasts" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/rainbow' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/rainbow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/routeros' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/routeros" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/school-book' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/school-book" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/shades-of-purple' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/shades-of-purple" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/solarized-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/srcery' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/srcery" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/stackoverflow-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/sunburst' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/sunburst" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-blue' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-blue" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-bright' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-bright" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-eighties' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night-eighties" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/tomorrow' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/vs' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/vs" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/vs2015' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/vs2015" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/xcode' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/xcode" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/xt256' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/xt256" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/hljs/zenburn' {
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/zenburn" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism' {
-    export { default as a11yDark } from 'react-syntax-highlighter/dist/esm/styles/prism/a11y-dark';
-    export { default as atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism/atom-dark';
-    export { default as base16AteliersulphurpoolLight } from 'react-syntax-highlighter/dist/esm/styles/prism/base16-ateliersulphurpool.light';
-    export { default as cb } from 'react-syntax-highlighter/dist/esm/styles/prism/cb';
-    export { default as coldarkCold } from 'react-syntax-highlighter/dist/esm/styles/prism/coldark-cold';
-    export { default as coldarkDark } from 'react-syntax-highlighter/dist/esm/styles/prism/coldark-dark';
-    export { default as coy } from 'react-syntax-highlighter/dist/esm/styles/prism/coy';
-    export { default as darcula } from 'react-syntax-highlighter/dist/esm/styles/prism/darcula';
-    export { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/dark';
-    export { default as dracula } from 'react-syntax-highlighter/dist/esm/styles/prism/dracula';
-    export { default as duotoneDark } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-dark';
-    export { default as duotoneEarth } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-earth';
-    export { default as duotoneForest } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-forest';
-    export { default as duotoneLight } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-light';
-    export { default as duotoneSea } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-sea';
-    export { default as duotoneSpace } from 'react-syntax-highlighter/dist/esm/styles/prism/duotone-space';
-    export { default as funky } from 'react-syntax-highlighter/dist/esm/styles/prism/funky';
-    export { default as ghcolors } from 'react-syntax-highlighter/dist/esm/styles/prism/ghcolors';
-    export { default as gruvboxDark } from 'react-syntax-highlighter/dist/esm/styles/prism/gruvbox-dark';
-    export { default as gruvboxLight } from 'react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light';
-    export { default as hopscotch } from 'react-syntax-highlighter/dist/esm/styles/prism/hopscotch';
-    export { default as materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism/material-dark';
-    export { default as materialLight } from 'react-syntax-highlighter/dist/esm/styles/prism/material-light';
-    export { default as materialOceanic } from 'react-syntax-highlighter/dist/esm/styles/prism/material-oceanic';
-    export { default as nord } from 'react-syntax-highlighter/dist/esm/styles/prism/nord';
-    export { default as okaidia } from 'react-syntax-highlighter/dist/esm/styles/prism/okaidia';
-    export { default as oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism/one-dark';
-    export { default as oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism/one-light';
-    export { default as pojoaque } from 'react-syntax-highlighter/dist/esm/styles/prism/pojoaque';
-    export { default as prism } from 'react-syntax-highlighter/dist/esm/styles/prism/prism';
-    export { default as shadesOfPurple } from 'react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple';
-    export { default as solarizedlight } from 'react-syntax-highlighter/dist/esm/styles/prism/solarizedlight';
-    export { default as synthwave84 } from 'react-syntax-highlighter/dist/esm/styles/prism/synthwave84';
-    export { default as tomorrow } from 'react-syntax-highlighter/dist/esm/styles/prism/tomorrow';
-    export { default as twilight } from 'react-syntax-highlighter/dist/esm/styles/prism/twilight';
-    export { default as vs } from 'react-syntax-highlighter/dist/esm/styles/prism/vs';
-    export { default as vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
-    export { default as xonokai } from 'react-syntax-highlighter/dist/esm/styles/prism/xonokai';
+declare module "react-syntax-highlighter/dist/esm/styles/prism" {
+    export { default as a11yDark } from "react-syntax-highlighter/dist/esm/styles/prism/a11y-dark";
+    export { default as atomDark } from "react-syntax-highlighter/dist/esm/styles/prism/atom-dark";
+    export { default as base16AteliersulphurpoolLight } from "react-syntax-highlighter/dist/esm/styles/prism/base16-ateliersulphurpool.light";
+    export { default as cb } from "react-syntax-highlighter/dist/esm/styles/prism/cb";
+    export { default as coldarkCold } from "react-syntax-highlighter/dist/esm/styles/prism/coldark-cold";
+    export { default as coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism/coldark-dark";
+    export { default as coy } from "react-syntax-highlighter/dist/esm/styles/prism/coy";
+    export { default as darcula } from "react-syntax-highlighter/dist/esm/styles/prism/darcula";
+    export { default as dark } from "react-syntax-highlighter/dist/esm/styles/prism/dark";
+    export { default as dracula } from "react-syntax-highlighter/dist/esm/styles/prism/dracula";
+    export { default as duotoneDark } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-dark";
+    export { default as duotoneEarth } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-earth";
+    export { default as duotoneForest } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-forest";
+    export { default as duotoneLight } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-light";
+    export { default as duotoneSea } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-sea";
+    export { default as duotoneSpace } from "react-syntax-highlighter/dist/esm/styles/prism/duotone-space";
+    export { default as funky } from "react-syntax-highlighter/dist/esm/styles/prism/funky";
+    export { default as ghcolors } from "react-syntax-highlighter/dist/esm/styles/prism/ghcolors";
+    export { default as gruvboxDark } from "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-dark";
+    export { default as gruvboxLight } from "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light";
+    export { default as hopscotch } from "react-syntax-highlighter/dist/esm/styles/prism/hopscotch";
+    export { default as materialDark } from "react-syntax-highlighter/dist/esm/styles/prism/material-dark";
+    export { default as materialLight } from "react-syntax-highlighter/dist/esm/styles/prism/material-light";
+    export { default as materialOceanic } from "react-syntax-highlighter/dist/esm/styles/prism/material-oceanic";
+    export { default as nord } from "react-syntax-highlighter/dist/esm/styles/prism/nord";
+    export { default as okaidia } from "react-syntax-highlighter/dist/esm/styles/prism/okaidia";
+    export { default as oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
+    export { default as oneLight } from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
+    export { default as pojoaque } from "react-syntax-highlighter/dist/esm/styles/prism/pojoaque";
+    export { default as prism } from "react-syntax-highlighter/dist/esm/styles/prism/prism";
+    export { default as shadesOfPurple } from "react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple";
+    export { default as solarizedlight } from "react-syntax-highlighter/dist/esm/styles/prism/solarizedlight";
+    export { default as synthwave84 } from "react-syntax-highlighter/dist/esm/styles/prism/synthwave84";
+    export { default as tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism/tomorrow";
+    export { default as twilight } from "react-syntax-highlighter/dist/esm/styles/prism/twilight";
+    export { default as vs } from "react-syntax-highlighter/dist/esm/styles/prism/vs";
+    export { default as vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus";
+    export { default as xonokai } from "react-syntax-highlighter/dist/esm/styles/prism/xonokai";
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/a11y-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/a11y-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/atom-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/atom-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/base16-ateliersulphurpool.light' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/base16-ateliersulphurpool.light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/cb' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/cb" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/coldark-cold' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/coldark-cold" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/coldark-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/coldark-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/coy' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/coy" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/darcula' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/darcula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/dracula' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/dracula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-earth' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-earth" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-forest' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-forest" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-sea' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-sea" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/duotone-space' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/duotone-space" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/funky' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/funky" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/ghcolors' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/ghcolors" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/gruvbox-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/hopscotch' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/hopscotch" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/material-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/material-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/material-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/material-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/material-oceanic' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/material-oceanic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/nord' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/nord" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/okaidia' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/okaidia" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/one-light' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/one-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/one-dark' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/one-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/pojoaque' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/pojoaque" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/prism' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/prism" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/solarizedlight' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/solarizedlight" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/synthwave84' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/synthwave84" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/tomorrow' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/tomorrow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/twilight' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/twilight" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/vs' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/vs" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/styles/prism/xonokai' {
+declare module "react-syntax-highlighter/dist/esm/styles/prism/xonokai" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/1c' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/1c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/abnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/abnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/accesslog' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/accesslog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/actionscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/actionscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ada' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ada" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/angelscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/angelscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/apache' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/apache" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/applescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/applescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/arcade' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/arcade" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/arduino' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/arduino" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/armasm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/armasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/asciidoc' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/asciidoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/aspectj' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/aspectj" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/autohotkey' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/autohotkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/autoit' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/autoit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/avrasm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/avrasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/awk' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/awk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/axapta' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/axapta" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/bash' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/bash" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/basic' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/bnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/bnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/brainfuck' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/brainfuck" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/c-like' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/c-like" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/c' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/cal' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/cal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/capnproto' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/capnproto" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ceylon' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ceylon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/clean' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/clean" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/clojure-repl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/clojure-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/clojure' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/clojure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/cmake' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/cmake" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/coffeescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/coffeescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/coq' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/coq" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/cos' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/cos" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/cpp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/cpp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/crmsh' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/crmsh" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/crystal' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/crystal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/cs' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/cs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/csharp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/csharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/csp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/csp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/css' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/css" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/d' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/d" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dart' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dart" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/delphi' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/delphi" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/diff' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/diff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/django' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/django" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dns' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dns" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dockerfile' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dockerfile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dos' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dos" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dsconfig' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dsconfig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dts' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dts" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/dust' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/dust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ebnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ebnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/elixir' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/elixir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/elm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/elm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/erb' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/erb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/erlang-repl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/erlang-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/erlang' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/erlang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/excel' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/excel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/fix' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/fix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/flix' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/flix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/fortran' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/fortran" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/fsharp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/fsharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gams' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gams" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gauss' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gauss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gcode' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gherkin' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gherkin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/glsl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/glsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/go' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/go" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/golo' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/golo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/gradle' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/gradle" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/groovy' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/groovy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/haml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/haml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/handlebars' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/handlebars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/haskell' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/haskell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/haxe' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/haxe" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/hsp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/hsp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/htmlbars' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/htmlbars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/http' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/http" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/hy' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/hy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/inform7' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/inform7" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ini' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ini" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/irpf90' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/irpf90" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/isbl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/isbl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/java' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/java" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/javascript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/javascript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/jboss-cli' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/jboss-cli" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/json' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/json" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/julia-repl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/julia-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/julia' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/julia" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/kotlin' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/kotlin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/lasso' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/lasso" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/latex' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/latex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ldif' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ldif" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/leaf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/leaf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/less' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/less" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/lisp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/lisp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/livecodeserver' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/livecodeserver" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/livescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/livescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/llvm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/llvm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/lsl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/lsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/lua' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/lua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/makefile' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/makefile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/markdown' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/markdown" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mathematica' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mathematica" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/matlab' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/matlab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/maxima' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/maxima" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mel' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mercury' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mercury" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mipsasm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mipsasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mizar' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mizar" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/mojolicious' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/mojolicious" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/monkey' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/monkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/moonscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/moonscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/n1ql' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/n1ql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/nginx' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/nginx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/nim' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/nim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/nimrod' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/nimrod" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/nix' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/nix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/nsis' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/nsis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/objectivec' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/objectivec" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ocaml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ocaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/openscad' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/openscad" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/oxygene' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/oxygene" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/parser3' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/parser3" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/perl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/perl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/pf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/pf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/pgsql' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/pgsql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/php-template' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/php-template" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/php' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/php" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/plaintext' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/plaintext" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/pony' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/pony" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/powershell' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/powershell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/processing' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/processing" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/profile' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/profile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/prolog' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/prolog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/properties' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/properties" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/protobuf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/protobuf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/puppet' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/puppet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/purebasic' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/purebasic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/python-repl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/python-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/python' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/python" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/q' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/q" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/qml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/qml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/r' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/r" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/reasonml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/reasonml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/rib' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/rib" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/roboconf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/roboconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/routeros' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/routeros" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/rsl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/rsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ruby' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ruby" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/ruleslanguage' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/ruleslanguage" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/rust' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/rust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/sas' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/sas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/scala' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/scala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/scheme' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/scheme" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/scilab' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/scilab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/scss' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/scss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/shell' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/shell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/smali' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/smali" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/smalltalk' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/smalltalk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/sml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/sml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/sqf' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/sqf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/sql' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/sql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/stan' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/stan" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/stata' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/stata" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/step21' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/step21" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/stylus' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/stylus" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/subunit' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/subunit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/swift' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/swift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/taggerscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/taggerscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/tap' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/tap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/tcl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/tcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/tex' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/tex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/thrift' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/thrift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/tp' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/tp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/twig' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/twig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/typescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/typescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vala' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vbnet' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vbnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vbscript-html' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vbscript-html" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vbscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vbscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/verilog' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/verilog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vhdl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vhdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/vim' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/vim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/x86asm' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/x86asm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/xl' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/xl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/xml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/xml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/xquery' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/xquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/yaml' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/yaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/hljs/zephir' {
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/zephir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/abap' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/abap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/abnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/abnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/actionscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/actionscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ada' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ada" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/agda' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/agda" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/al' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/al" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/antlr4' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/antlr4" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/apacheconf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/apacheconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/apl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/apl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/applescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/applescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/aql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/aql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/arduino' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/arduino" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/arff' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/arff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/asciidoc' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/asciidoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/asm6502' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/asm6502" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/aspnet' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/aspnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/autohotkey' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/autohotkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/autoit' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/autoit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/bash' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/bash" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/basic' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/batch' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/batch" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/bbcode' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/bbcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/bison' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/bison" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/bnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/bnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/brainfuck' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/brainfuck" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/brightscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/brightscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/bro' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/bro" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/c' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/cil' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/cil" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/clike' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/clike" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/clojure' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/clojure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/cmake' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/cmake" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/coffeescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/coffeescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/concurnas' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/concurnas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/core' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/core" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/cpp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/cpp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/crystal' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/crystal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/csharp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/csharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/csp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/csp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/css-extras' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/css-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/css' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/css" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/cypher' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/cypher" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/d' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/d" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/dart' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/dart" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/dax' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/dax" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/dhall' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/dhall" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/diff' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/diff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/django' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/django" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/dns-zone-file' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/dns-zone-file" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/docker' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/docker" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ebnf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ebnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/editorconfig' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/editorconfig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/eiffel' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/eiffel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ejs' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ejs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/elixir' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/elixir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/elm' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/elm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/erb' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/erb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/erlang' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/erlang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/etlua' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/etlua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/excel-formula' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/excel-formula" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/factor' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/factor" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/firestore-security-rules' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/firestore-security-rules" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/flow' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/flow" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/fortran' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/fortran" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/fsharp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/fsharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ftl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ftl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/gcode' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/gcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/gdscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/gdscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/gedcom' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/gedcom" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/gherkin' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/gherkin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/git' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/git" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/glsl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/glsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/gml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/gml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/go' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/go" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/graphql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/graphql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/groovy' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/groovy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/haml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/haml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/handlebars' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/handlebars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/haskell' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/haskell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/haxe' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/haxe" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/hcl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/hcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/hlsl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/hlsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/hpkp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/hpkp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/hsts' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/hsts" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/http' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/http" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ichigojam' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ichigojam" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/icon' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/icon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/iecst' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/iecst" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ignore' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ignore" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/inform7' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/inform7" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ini' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ini" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/io' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/io" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/j' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/j" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/java' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/java" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/javadoc' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/javadoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/javadoclike' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/javadoclike" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/javascript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/javascript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/javastacktrace' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/javastacktrace" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/jolie' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/jolie" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/jq' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/jq" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/js-extras' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/js-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/js-templates' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/js-templates" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/js-doc' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/js-doc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/json' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/json" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/json5' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/json5" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/jsonp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/jsonp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/jsstacktrace' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/jsstacktrace" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/jsx' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/jsx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/julia' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/julia" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/keyman' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/keyman" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/kotlin' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/kotlin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/latex' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/latex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/latte' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/latte" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/less' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/less" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/lilypond' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/lilypond" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/liquid' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/liquid" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/lisp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/lisp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/livescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/livescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/llvm' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/llvm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/lolcode' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/lolcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/lua' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/lua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/makefile' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/makefile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/markdown' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/markdown" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/markup-templating' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/markup-templating" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/markup' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/markup" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/matlab' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/matlab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/mel' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/mel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/mizar' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/mizar" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/monkey' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/monkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/moonscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/moonscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/n1ql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/n1ql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/n4js' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/n4js" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nand2tetris-hdl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nand2tetris-hdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nasm' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/neon' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/neon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nginx' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nginx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nim' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nix' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/nsis' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/nsis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/objectivec' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/objectivec" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ocaml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ocaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/opencl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/opencl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/oz' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/oz" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/parigp' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/parigp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/parser' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/parser" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/pascal' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/pascal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/pascaligo' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/pascaligo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/pcaxis' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/pcaxis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/peoplecode' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/peoplecode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/perl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/perl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/php-extras' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/php-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/php' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/php" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/plsql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/plsql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/powerquery' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/powerquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/powershell' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/powershell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/processing' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/processing" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/prolog' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/prolog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/properties' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/properties" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/protobuf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/protobuf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/pug' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/pug" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/puppet' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/puppet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/pure' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/pure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/purebasic' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/purebasic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/python' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/python" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/q' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/q" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/qml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/qml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/qore' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/qore" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/r' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/r" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/racket' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/racket" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/reason' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/reason" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/regex' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/regex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/renpy' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/renpy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/rest' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/rest" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/rip' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/rip" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/roboconf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/roboconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/robotframework' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/robotframework" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/ruby' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/ruby" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/rust' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/rust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/sas' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/sas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/sass' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/sass" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/scala' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/scala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/scheme' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/scheme" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/scss' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/scss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/shell-session' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/shell-session" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/smali' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/smali" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/smalltalk' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/smalltalk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/smarty' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/smarty" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/solidity' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/solidity" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/solution-file' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/solution-file" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/soy' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/soy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/sparql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/sparql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/splunk-spl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/splunk-spl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/sqf' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/sqf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/sql' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/sql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/stylus' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/stylus" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/swift' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/swift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/t4-cs' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/t4-cs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/t4-templating' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/t4-templating" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/t4-vb' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/t4-vb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/tap' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/tap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/tcl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/tcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/textile' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/textile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/toml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/toml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/tsx' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/tsx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/tt2' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/tt2" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/turtle' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/turtle" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/twig' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/twig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/typescript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/typescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/unrealscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/unrealscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/vala' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/vala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/vbnet' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/vbnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/velocity' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/velocity" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/verilog' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/verilog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/vhdl' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/vhdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/vim' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/vim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/visual-basic' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/visual-basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/warpscript' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/warpscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/wasm' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/wasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/wiki' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/wiki" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/xeora' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/xeora" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/xml-doc' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/xml-doc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/xojo' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/xojo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/xquery' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/xquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/yaml' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/yaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/yang' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/yang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/esm/languages/prism/zig' {
+declare module "react-syntax-highlighter/dist/esm/languages/prism/zig" {
     const language: any;
     export default language;
 }
 // esm end
 
 // cjs start
-declare module 'react-syntax-highlighter/dist/cjs/default-highlight' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/default-highlight" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static supportedLanguages: string[];
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/light-async' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/light-async" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/prism-async-light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/prism-async-light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/prism-async' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/prism-async" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {}
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/prism-light' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/prism-light" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static registerLanguage(name: string, func: any): void;
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/prism' {
-    import * as React from 'react';
-    import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/prism" {
+    import * as React from "react";
+    import { SyntaxHighlighterProps } from "react-syntax-highlighter";
     export default class SyntaxHighlighter extends React.Component<SyntaxHighlighterProps> {
         static supportedLanguages: string[];
     }
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/create-element' {
-    import * as React from 'react';
-    import { createElementProps } from 'react-syntax-highlighter';
+declare module "react-syntax-highlighter/dist/cjs/create-element" {
+    import * as React from "react";
+    import { createElementProps } from "react-syntax-highlighter";
     function createElement(props: createElementProps): React.ReactNode;
     export default createElement;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs' {
-    export { default as a11yDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/a11y-dark';
-    export { default as a11yLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/a11y-light';
-    export { default as agate } from 'react-syntax-highlighter/dist/cjs/styles/hljs/agate';
-    export { default as anOldHope } from 'react-syntax-highlighter/dist/cjs/styles/hljs/an-old-hope';
-    export { default as androidstudio } from 'react-syntax-highlighter/dist/cjs/styles/hljs/androidstudio';
-    export { default as arduinoLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/arduino-light';
-    export { default as arta } from 'react-syntax-highlighter/dist/cjs/styles/hljs/arta';
-    export { default as ascetic } from 'react-syntax-highlighter/dist/cjs/styles/hljs/ascetic';
-    export { default as atelierCaveDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-dark';
-    export { default as atelierCaveLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-light';
-    export { default as atelierDuneDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-dark';
-    export { default as atelierDuneLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-light';
-    export { default as atelierEstuaryDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-dark';
-    export { default as atelierEstuaryLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-light';
-    export { default as atelierForestDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-dark';
-    export { default as atelierForestLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-light';
-    export { default as atelierHeathDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-dark';
-    export { default as atelierHeathLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-light';
-    export { default as atelierLakesideDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-dark';
-    export { default as atelierLakesideLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-light';
-    export { default as atelierPlateauDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-dark';
-    export { default as atelierPlateauLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-light';
-    export { default as atelierSavannaDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-dark';
-    export { default as atelierSavannaLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-light';
-    export { default as atelierSeasideDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-dark';
-    export { default as atelierSeasideLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-light';
-    export { default as atelierSulphurpoolDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-dark';
-    export { default as atelierSulphurpoolLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-light';
-    export { default as atomOneDarkReasonable } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark-reasonable';
-    export { default as atomOneDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark';
-    export { default as atomOneLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light';
-    export { default as brownPaper } from 'react-syntax-highlighter/dist/cjs/styles/hljs/brown-paper';
-    export { default as codepenEmbed } from 'react-syntax-highlighter/dist/cjs/styles/hljs/codepen-embed';
-    export { default as colorBrewer } from 'react-syntax-highlighter/dist/cjs/styles/hljs/color-brewer';
-    export { default as darcula } from 'react-syntax-highlighter/dist/cjs/styles/hljs/darcula';
-    export { default as dark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/dark';
-    export { default as darkula } from 'react-syntax-highlighter/dist/cjs/styles/hljs/darkula';
-    export { default as defaultStyle } from 'react-syntax-highlighter/dist/cjs/styles/hljs/default-style';
-    export { default as docco } from 'react-syntax-highlighter/dist/cjs/styles/hljs/docco';
-    export { default as dracula } from 'react-syntax-highlighter/dist/cjs/styles/hljs/dracula';
-    export { default as far } from 'react-syntax-highlighter/dist/cjs/styles/hljs/far';
-    export { default as foundation } from 'react-syntax-highlighter/dist/cjs/styles/hljs/foundation';
-    export { default as githubGist } from 'react-syntax-highlighter/dist/cjs/styles/hljs/github-gist';
-    export { default as github } from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
-    export { default as gml } from 'react-syntax-highlighter/dist/cjs/styles/hljs/gml';
-    export { default as googlecode } from 'react-syntax-highlighter/dist/cjs/styles/hljs/googlecode';
-    export { default as gradientDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/gradient-dark';
-    export { default as grayscale } from 'react-syntax-highlighter/dist/cjs/styles/hljs/grayscale';
-    export { default as gruvboxDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-dark';
-    export { default as gruvboxLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-light';
-    export { default as hopscotch } from 'react-syntax-highlighter/dist/cjs/styles/hljs/hopscotch';
-    export { default as hybrid } from 'react-syntax-highlighter/dist/cjs/styles/hljs/hybrid';
-    export { default as idea } from 'react-syntax-highlighter/dist/cjs/styles/hljs/idea';
-    export { default as irBlack } from 'react-syntax-highlighter/dist/cjs/styles/hljs/ir-black';
-    export { default as isblEditorDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-dark';
-    export { default as isblEditorLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-light';
-    export { default as kimbieDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.dark';
-    export { default as kimbieLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.light';
-    export { default as lightfair } from 'react-syntax-highlighter/dist/cjs/styles/hljs/lightfair';
-    export { default as lioshi } from 'react-syntax-highlighter/dist/cjs/styles/hljs/lioshi';
-    export { default as magula } from 'react-syntax-highlighter/dist/cjs/styles/hljs/magula';
-    export { default as monoBlue } from 'react-syntax-highlighter/dist/cjs/styles/hljs/mono-blue';
-    export { default as monokaiSublime } from 'react-syntax-highlighter/dist/cjs/styles/hljs/monokai-sublime';
-    export { default as monokai } from 'react-syntax-highlighter/dist/cjs/styles/hljs/monokai';
-    export { default as nightOwl } from 'react-syntax-highlighter/dist/cjs/styles/hljs/night-owl';
-    export { default as nnfxDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/nnfx-dark';
-    export { default as nnfx } from 'react-syntax-highlighter/dist/cjs/styles/hljs/nnfx';
-    export { default as nord } from 'react-syntax-highlighter/dist/cjs/styles/hljs/nord';
-    export { default as obsidian } from 'react-syntax-highlighter/dist/cjs/styles/hljs/obsidian';
-    export { default as ocean } from 'react-syntax-highlighter/dist/cjs/styles/hljs/ocean';
-    export { default as paraisoDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-dark';
-    export { default as paraisoLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-light';
-    export { default as pojoaque } from 'react-syntax-highlighter/dist/cjs/styles/hljs/pojoaque';
-    export { default as purebasic } from 'react-syntax-highlighter/dist/cjs/styles/hljs/purebasic';
-    export { default as qtcreatorDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_dark';
-    export { default as qtcreatorLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_light';
-    export { default as railscasts } from 'react-syntax-highlighter/dist/cjs/styles/hljs/railscasts';
-    export { default as rainbow } from 'react-syntax-highlighter/dist/cjs/styles/hljs/rainbow';
-    export { default as routeros } from 'react-syntax-highlighter/dist/cjs/styles/hljs/routeros';
-    export { default as schoolBook } from 'react-syntax-highlighter/dist/cjs/styles/hljs/school-book';
-    export { default as shadesOfPurple } from 'react-syntax-highlighter/dist/cjs/styles/hljs/shades-of-purple';
-    export { default as solarizedDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-dark';
-    export { default as solarizedLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light';
-    export { default as srcery } from 'react-syntax-highlighter/dist/cjs/styles/hljs/srcery';
-    export { default as stackoverflowDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark';
-    export { default as stackoverflowLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light';
-    export { default as sunburst } from 'react-syntax-highlighter/dist/cjs/styles/hljs/sunburst';
-    export { default as tomorrowNightBlue } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-blue';
-    export { default as tomorrowNightBright } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-bright';
-    export { default as tomorrowNightEighties } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-eighties';
-    export { default as tomorrowNight } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night';
-    export { default as tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow';
-    export { default as vs } from 'react-syntax-highlighter/dist/cjs/styles/hljs/vs';
-    export { default as vs2015 } from 'react-syntax-highlighter/dist/cjs/styles/hljs/vs2015';
-    export { default as xcode } from 'react-syntax-highlighter/dist/cjs/styles/hljs/xcode';
-    export { default as xt256 } from 'react-syntax-highlighter/dist/cjs/styles/hljs/xt256';
-    export { default as zenburn } from 'react-syntax-highlighter/dist/cjs/styles/hljs/zenburn';
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs" {
+    export { default as a11yDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/a11y-dark";
+    export { default as a11yLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/a11y-light";
+    export { default as agate } from "react-syntax-highlighter/dist/cjs/styles/hljs/agate";
+    export { default as anOldHope } from "react-syntax-highlighter/dist/cjs/styles/hljs/an-old-hope";
+    export { default as androidstudio } from "react-syntax-highlighter/dist/cjs/styles/hljs/androidstudio";
+    export { default as arduinoLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/arduino-light";
+    export { default as arta } from "react-syntax-highlighter/dist/cjs/styles/hljs/arta";
+    export { default as ascetic } from "react-syntax-highlighter/dist/cjs/styles/hljs/ascetic";
+    export { default as atelierCaveDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-dark";
+    export { default as atelierCaveLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-light";
+    export { default as atelierDuneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-dark";
+    export { default as atelierDuneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-light";
+    export { default as atelierEstuaryDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-dark";
+    export { default as atelierEstuaryLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-light";
+    export { default as atelierForestDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-dark";
+    export { default as atelierForestLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-light";
+    export { default as atelierHeathDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-dark";
+    export { default as atelierHeathLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-light";
+    export { default as atelierLakesideDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-dark";
+    export { default as atelierLakesideLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-light";
+    export { default as atelierPlateauDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-dark";
+    export { default as atelierPlateauLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-light";
+    export { default as atelierSavannaDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-dark";
+    export { default as atelierSavannaLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-light";
+    export { default as atelierSeasideDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-dark";
+    export { default as atelierSeasideLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-light";
+    export { default as atelierSulphurpoolDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-dark";
+    export { default as atelierSulphurpoolLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-light";
+    export { default as atomOneDarkReasonable } from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark-reasonable";
+    export { default as atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark";
+    export { default as atomOneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light";
+    export { default as brownPaper } from "react-syntax-highlighter/dist/cjs/styles/hljs/brown-paper";
+    export { default as codepenEmbed } from "react-syntax-highlighter/dist/cjs/styles/hljs/codepen-embed";
+    export { default as colorBrewer } from "react-syntax-highlighter/dist/cjs/styles/hljs/color-brewer";
+    export { default as darcula } from "react-syntax-highlighter/dist/cjs/styles/hljs/darcula";
+    export { default as dark } from "react-syntax-highlighter/dist/cjs/styles/hljs/dark";
+    export { default as darkula } from "react-syntax-highlighter/dist/cjs/styles/hljs/darkula";
+    export { default as defaultStyle } from "react-syntax-highlighter/dist/cjs/styles/hljs/default-style";
+    export { default as docco } from "react-syntax-highlighter/dist/cjs/styles/hljs/docco";
+    export { default as dracula } from "react-syntax-highlighter/dist/cjs/styles/hljs/dracula";
+    export { default as far } from "react-syntax-highlighter/dist/cjs/styles/hljs/far";
+    export { default as foundation } from "react-syntax-highlighter/dist/cjs/styles/hljs/foundation";
+    export { default as githubGist } from "react-syntax-highlighter/dist/cjs/styles/hljs/github-gist";
+    export { default as github } from "react-syntax-highlighter/dist/cjs/styles/hljs/github";
+    export { default as gml } from "react-syntax-highlighter/dist/cjs/styles/hljs/gml";
+    export { default as googlecode } from "react-syntax-highlighter/dist/cjs/styles/hljs/googlecode";
+    export { default as gradientDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/gradient-dark";
+    export { default as grayscale } from "react-syntax-highlighter/dist/cjs/styles/hljs/grayscale";
+    export { default as gruvboxDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-dark";
+    export { default as gruvboxLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-light";
+    export { default as hopscotch } from "react-syntax-highlighter/dist/cjs/styles/hljs/hopscotch";
+    export { default as hybrid } from "react-syntax-highlighter/dist/cjs/styles/hljs/hybrid";
+    export { default as idea } from "react-syntax-highlighter/dist/cjs/styles/hljs/idea";
+    export { default as irBlack } from "react-syntax-highlighter/dist/cjs/styles/hljs/ir-black";
+    export { default as isblEditorDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-dark";
+    export { default as isblEditorLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-light";
+    export { default as kimbieDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.dark";
+    export { default as kimbieLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.light";
+    export { default as lightfair } from "react-syntax-highlighter/dist/cjs/styles/hljs/lightfair";
+    export { default as lioshi } from "react-syntax-highlighter/dist/cjs/styles/hljs/lioshi";
+    export { default as magula } from "react-syntax-highlighter/dist/cjs/styles/hljs/magula";
+    export { default as monoBlue } from "react-syntax-highlighter/dist/cjs/styles/hljs/mono-blue";
+    export { default as monokaiSublime } from "react-syntax-highlighter/dist/cjs/styles/hljs/monokai-sublime";
+    export { default as monokai } from "react-syntax-highlighter/dist/cjs/styles/hljs/monokai";
+    export { default as nightOwl } from "react-syntax-highlighter/dist/cjs/styles/hljs/night-owl";
+    export { default as nnfxDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/nnfx-dark";
+    export { default as nnfx } from "react-syntax-highlighter/dist/cjs/styles/hljs/nnfx";
+    export { default as nord } from "react-syntax-highlighter/dist/cjs/styles/hljs/nord";
+    export { default as obsidian } from "react-syntax-highlighter/dist/cjs/styles/hljs/obsidian";
+    export { default as ocean } from "react-syntax-highlighter/dist/cjs/styles/hljs/ocean";
+    export { default as paraisoDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-dark";
+    export { default as paraisoLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-light";
+    export { default as pojoaque } from "react-syntax-highlighter/dist/cjs/styles/hljs/pojoaque";
+    export { default as purebasic } from "react-syntax-highlighter/dist/cjs/styles/hljs/purebasic";
+    export { default as qtcreatorDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_dark";
+    export { default as qtcreatorLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_light";
+    export { default as railscasts } from "react-syntax-highlighter/dist/cjs/styles/hljs/railscasts";
+    export { default as rainbow } from "react-syntax-highlighter/dist/cjs/styles/hljs/rainbow";
+    export { default as routeros } from "react-syntax-highlighter/dist/cjs/styles/hljs/routeros";
+    export { default as schoolBook } from "react-syntax-highlighter/dist/cjs/styles/hljs/school-book";
+    export { default as shadesOfPurple } from "react-syntax-highlighter/dist/cjs/styles/hljs/shades-of-purple";
+    export { default as solarizedDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/solarized-dark";
+    export { default as solarizedLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light";
+    export { default as srcery } from "react-syntax-highlighter/dist/cjs/styles/hljs/srcery";
+    export { default as stackoverflowDark } from "react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark";
+    export { default as stackoverflowLight } from "react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light";
+    export { default as sunburst } from "react-syntax-highlighter/dist/cjs/styles/hljs/sunburst";
+    export { default as tomorrowNightBlue } from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-blue";
+    export { default as tomorrowNightBright } from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-bright";
+    export { default as tomorrowNightEighties } from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-eighties";
+    export { default as tomorrowNight } from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night";
+    export { default as tomorrow } from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow";
+    export { default as vs } from "react-syntax-highlighter/dist/cjs/styles/hljs/vs";
+    export { default as vs2015 } from "react-syntax-highlighter/dist/cjs/styles/hljs/vs2015";
+    export { default as xcode } from "react-syntax-highlighter/dist/cjs/styles/hljs/xcode";
+    export { default as xt256 } from "react-syntax-highlighter/dist/cjs/styles/hljs/xt256";
+    export { default as zenburn } from "react-syntax-highlighter/dist/cjs/styles/hljs/zenburn";
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/a11y-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/a11y-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/a11y-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/a11y-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/agate' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/agate" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/an-old-hope' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/an-old-hope" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/androidstudio' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/androidstudio" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/arduino-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/arduino-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/arta' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/arta" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/ascetic' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/ascetic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-cave-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-dune-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-estuary-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-forest-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-heath-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-lakeside-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-plateau-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-savanna-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-seaside-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atelier-sulphurpool-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark-reasonable' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark-reasonable" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/brown-paper' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/brown-paper" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/codepen-embed' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/codepen-embed" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/color-brewer' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/color-brewer" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/darcula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/darcula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/darkula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/darkula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/default-style' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/default-style" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/docco' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/docco" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/dracula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/dracula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/far' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/far" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/foundation' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/foundation" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/github-gist' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/github-gist" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/github' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/github" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/gml' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/gml" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/googlecode' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/googlecode" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/gradient-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/gradient-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/grayscale' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/grayscale" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/gruvbox-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/hopscotch' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/hopscotch" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/hybrid' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/hybrid" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/idea' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/idea" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/ir-black' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/ir-black" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/isbl-editor-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/kimbie.light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/lightfair' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/lightfair" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/lioshi' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/lioshi" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/magula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/magula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/mono-blue' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/mono-blue" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/monokai-sublime' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/monokai-sublime" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/monokai' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/monokai" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/night-owl' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/night-owl" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/nnfx-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/nnfx-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/nnfx' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/nnfx" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/nord' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/nord" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/obsidian' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/obsidian" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/ocean' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/ocean" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/paraiso-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/pojoaque' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/pojoaque" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/purebasic' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/purebasic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/qtcreator_light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/railscasts' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/railscasts" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/rainbow' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/rainbow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/routeros' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/routeros" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/school-book' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/school-book" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/shades-of-purple' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/shades-of-purple" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/solarized-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/solarized-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/srcery' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/srcery" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/stackoverflow-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/sunburst' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/sunburst" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-blue' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-blue" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-bright' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-bright" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-eighties' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night-eighties" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/vs' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/vs" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/vs2015' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/vs2015" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/xcode' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/xcode" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/xt256' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/xt256" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/hljs/zenburn' {
+declare module "react-syntax-highlighter/dist/cjs/styles/hljs/zenburn" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism' {
-    export { default as a11yDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/a11y-dark';
-    export { default as atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark';
-    export { default as base16AteliersulphurpoolLight } from 'react-syntax-highlighter/dist/cjs/styles/prism/base16-ateliersulphurpool.light';
-    export { default as cb } from 'react-syntax-highlighter/dist/cjs/styles/prism/cb';
-    export { default as coldarkCold } from 'react-syntax-highlighter/dist/cjs/styles/prism/coldark-cold';
-    export { default as coldarkDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/coldark-dark';
-    export { default as coy } from 'react-syntax-highlighter/dist/cjs/styles/prism/coy';
-    export { default as darcula } from 'react-syntax-highlighter/dist/cjs/styles/prism/darcula';
-    export { default as dark } from 'react-syntax-highlighter/dist/cjs/styles/prism/dark';
-    export { default as dracula } from 'react-syntax-highlighter/dist/cjs/styles/prism/dracula';
-    export { default as duotoneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-dark';
-    export { default as duotoneEarth } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-earth';
-    export { default as duotoneForest } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-forest';
-    export { default as duotoneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-light';
-    export { default as duotoneSea } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-sea';
-    export { default as duotoneSpace } from 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-space';
-    export { default as funky } from 'react-syntax-highlighter/dist/cjs/styles/prism/funky';
-    export { default as ghcolors } from 'react-syntax-highlighter/dist/cjs/styles/prism/ghcolors';
-    export { default as hopscotch } from 'react-syntax-highlighter/dist/cjs/styles/prism/hopscotch';
-    export { default as materialDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/material-dark';
-    export { default as materialLight } from 'react-syntax-highlighter/dist/cjs/styles/prism/material-light';
-    export { default as materialOceanic } from 'react-syntax-highlighter/dist/cjs/styles/prism/material-oceanic';
-    export { default as nightOwl } from 'react-syntax-highlighter/dist/cjs/styles/prism/night-owl';
-    export { default as nord } from 'react-syntax-highlighter/dist/cjs/styles/prism/nord';
-    export { default as okaidia } from 'react-syntax-highlighter/dist/cjs/styles/prism/okaidia';
-    export { default as oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark';
-    export { default as oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism/one-light';
-    export { default as pojoaque } from 'react-syntax-highlighter/dist/cjs/styles/prism/pojoaque';
-    export { default as prism } from 'react-syntax-highlighter/dist/cjs/styles/prism/prism';
-    export { default as shadesOfPurple } from 'react-syntax-highlighter/dist/cjs/styles/prism/shades-of-purple';
-    export { default as solarizedlight } from 'react-syntax-highlighter/dist/cjs/styles/prism/solarizedlight';
-    export { default as synthwave84 } from 'react-syntax-highlighter/dist/cjs/styles/prism/synthwave84';
-    export { default as tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism/tomorrow';
-    export { default as twilight } from 'react-syntax-highlighter/dist/cjs/styles/prism/twilight';
-    export { default as vsDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/vs-dark';
-    export { default as vs } from 'react-syntax-highlighter/dist/cjs/styles/prism/vs';
-    export { default as vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus';
-    export { default as xonokai } from 'react-syntax-highlighter/dist/cjs/styles/prism/xonokai';
+declare module "react-syntax-highlighter/dist/cjs/styles/prism" {
+    export { default as a11yDark } from "react-syntax-highlighter/dist/cjs/styles/prism/a11y-dark";
+    export { default as atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism/atom-dark";
+    export { default as base16AteliersulphurpoolLight } from "react-syntax-highlighter/dist/cjs/styles/prism/base16-ateliersulphurpool.light";
+    export { default as cb } from "react-syntax-highlighter/dist/cjs/styles/prism/cb";
+    export { default as coldarkCold } from "react-syntax-highlighter/dist/cjs/styles/prism/coldark-cold";
+    export { default as coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism/coldark-dark";
+    export { default as coy } from "react-syntax-highlighter/dist/cjs/styles/prism/coy";
+    export { default as darcula } from "react-syntax-highlighter/dist/cjs/styles/prism/darcula";
+    export { default as dark } from "react-syntax-highlighter/dist/cjs/styles/prism/dark";
+    export { default as dracula } from "react-syntax-highlighter/dist/cjs/styles/prism/dracula";
+    export { default as duotoneDark } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-dark";
+    export { default as duotoneEarth } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-earth";
+    export { default as duotoneForest } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-forest";
+    export { default as duotoneLight } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-light";
+    export { default as duotoneSea } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-sea";
+    export { default as duotoneSpace } from "react-syntax-highlighter/dist/cjs/styles/prism/duotone-space";
+    export { default as funky } from "react-syntax-highlighter/dist/cjs/styles/prism/funky";
+    export { default as ghcolors } from "react-syntax-highlighter/dist/cjs/styles/prism/ghcolors";
+    export { default as hopscotch } from "react-syntax-highlighter/dist/cjs/styles/prism/hopscotch";
+    export { default as materialDark } from "react-syntax-highlighter/dist/cjs/styles/prism/material-dark";
+    export { default as materialLight } from "react-syntax-highlighter/dist/cjs/styles/prism/material-light";
+    export { default as materialOceanic } from "react-syntax-highlighter/dist/cjs/styles/prism/material-oceanic";
+    export { default as nightOwl } from "react-syntax-highlighter/dist/cjs/styles/prism/night-owl";
+    export { default as nord } from "react-syntax-highlighter/dist/cjs/styles/prism/nord";
+    export { default as okaidia } from "react-syntax-highlighter/dist/cjs/styles/prism/okaidia";
+    export { default as oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism/one-dark";
+    export { default as oneLight } from "react-syntax-highlighter/dist/cjs/styles/prism/one-light";
+    export { default as pojoaque } from "react-syntax-highlighter/dist/cjs/styles/prism/pojoaque";
+    export { default as prism } from "react-syntax-highlighter/dist/cjs/styles/prism/prism";
+    export { default as shadesOfPurple } from "react-syntax-highlighter/dist/cjs/styles/prism/shades-of-purple";
+    export { default as solarizedlight } from "react-syntax-highlighter/dist/cjs/styles/prism/solarizedlight";
+    export { default as synthwave84 } from "react-syntax-highlighter/dist/cjs/styles/prism/synthwave84";
+    export { default as tomorrow } from "react-syntax-highlighter/dist/cjs/styles/prism/tomorrow";
+    export { default as twilight } from "react-syntax-highlighter/dist/cjs/styles/prism/twilight";
+    export { default as vsDark } from "react-syntax-highlighter/dist/cjs/styles/prism/vs-dark";
+    export { default as vs } from "react-syntax-highlighter/dist/cjs/styles/prism/vs";
+    export { default as vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus";
+    export { default as xonokai } from "react-syntax-highlighter/dist/cjs/styles/prism/xonokai";
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/a11y-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/a11y-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/atom-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/base16-ateliersulphurpool.light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/base16-ateliersulphurpool.light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/cb' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/cb" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/coldark-cold' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/coldark-cold" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/coldark-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/coldark-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/coy' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/coy" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/darcula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/darcula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/dracula' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/dracula" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-earth' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-earth" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-forest' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-forest" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-sea' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-sea" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/duotone-space' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/duotone-space" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/funky' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/funky" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/ghcolors' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/ghcolors" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/hopscotch' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/hopscotch" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/material-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/material-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/material-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/material-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/material-oceanic' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/material-oceanic" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/night-owl' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/night-owl" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/nord' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/nord" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/okaidia' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/okaidia" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/one-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/one-light' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/one-light" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/pojoaque' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/pojoaque" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/prism' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/prism" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/shades-of-purple' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/shades-of-purple" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/solarizedlight' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/solarizedlight" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/synthwave84' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/synthwave84" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/tomorrow' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/tomorrow" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/twilight' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/twilight" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/vs-dark' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/vs-dark" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/vs' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/vs" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/styles/prism/xonokai' {
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/xonokai" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/1c' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/1c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/abnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/abnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/accesslog' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/accesslog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/actionscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/actionscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ada' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ada" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/angelscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/angelscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/apache' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/apache" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/applescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/applescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/arcade' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/arcade" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/arduino' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/arduino" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/armasm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/armasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/asciidoc' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/asciidoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/aspectj' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/aspectj" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/autohotkey' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/autohotkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/autoit' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/autoit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/avrasm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/avrasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/awk' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/awk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/axapta' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/axapta" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/bash' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/bash" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/basic' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/bnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/bnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/brainfuck' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/brainfuck" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/c-like' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/c-like" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/c' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/cal' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/cal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/capnproto' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/capnproto" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ceylon' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ceylon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/clean' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/clean" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/clojure-repl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/clojure-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/clojure' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/clojure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/cmake' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/cmake" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/coffeescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/coffeescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/coq' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/coq" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/cos' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/cos" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/cpp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/cpp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/crmsh' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/crmsh" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/crystal' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/crystal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/cs' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/cs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/csharp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/csharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/csp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/csp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/css' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/css" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/d' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/d" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dart' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dart" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/delphi' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/delphi" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/diff' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/diff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/django' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/django" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dns' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dns" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dockerfile' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dockerfile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dos' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dos" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dsconfig' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dsconfig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dts' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dts" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/dust' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/dust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ebnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ebnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/elixir' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/elixir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/elm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/elm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/erb' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/erb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/erlang-repl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/erlang-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/erlang' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/erlang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/excel' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/excel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/fix' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/fix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/flix' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/flix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/fortran' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/fortran" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/fsharp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/fsharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gams' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gams" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gauss' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gauss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gcode' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gherkin' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gherkin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/glsl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/glsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/go' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/go" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/golo' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/golo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/gradle' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/gradle" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/groovy' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/groovy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/haml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/haml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/handlebars' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/handlebars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/haskell' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/haskell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/haxe' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/haxe" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/hsp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/hsp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/htmlbars' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/htmlbars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/http' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/http" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/hy' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/hy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/inform7' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/inform7" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ini' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ini" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/irpf90' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/irpf90" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/isbl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/isbl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/java' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/java" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/javascript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/jboss-cli' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/jboss-cli" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/json' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/json" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/julia-repl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/julia-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/julia' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/julia" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/kotlin' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/kotlin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/lasso' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/lasso" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/latex' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/latex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ldif' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ldif" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/leaf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/leaf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/less' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/less" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/lisp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/lisp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/livecodeserver' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/livecodeserver" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/livescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/livescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/llvm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/llvm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/lsl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/lsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/lua' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/lua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/makefile' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/makefile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/markdown' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/markdown" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mathematica' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mathematica" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/matlab' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/matlab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/maxima' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/maxima" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mel' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mercury' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mercury" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mipsasm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mipsasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mizar' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mizar" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/mojolicious' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/mojolicious" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/monkey' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/monkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/moonscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/moonscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/n1ql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/n1ql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/nginx' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/nginx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/nim' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/nim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/nimrod' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/nimrod" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/nix' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/nix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/nsis' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/nsis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/objectivec' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/objectivec" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ocaml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ocaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/openscad' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/openscad" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/oxygene' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/oxygene" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/parser3' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/parser3" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/perl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/perl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/pf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/pf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/pgsql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/pgsql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/php-template' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/php-template" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/php' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/php" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/plaintext' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/plaintext" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/pony' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/pony" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/powershell' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/powershell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/processing' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/processing" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/profile' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/profile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/prolog' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/prolog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/properties' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/properties" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/protobuf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/protobuf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/puppet' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/puppet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/purebasic' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/purebasic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/python-repl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/python-repl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/python' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/python" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/q' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/q" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/qml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/qml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/r' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/r" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/reasonml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/reasonml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/rib' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/rib" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/roboconf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/roboconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/routeros' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/routeros" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/rsl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/rsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ruby' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ruby" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/ruleslanguage' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/ruleslanguage" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/rust' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/rust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/sas' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/sas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/scala' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/scala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/scheme' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/scheme" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/scilab' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/scilab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/scss' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/scss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/shell' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/shell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/smali' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/smali" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/smalltalk' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/smalltalk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/sml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/sml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/sqf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/sqf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/sql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/sql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/stan' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/stan" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/stata' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/stata" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/step21' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/step21" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/stylus' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/stylus" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/subunit' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/subunit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/swift' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/swift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/taggerscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/taggerscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/tap' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/tap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/tcl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/tcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/tex' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/tex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/thrift' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/thrift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/tp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/tp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/twig' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/twig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/typescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/typescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vala' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vbnet' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vbnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vbscript-html' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vbscript-html" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vbscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vbscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/verilog' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/verilog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vhdl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vhdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/vim' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/vim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/x86asm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/x86asm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/xl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/xl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/xml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/xml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/xquery' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/xquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/yaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/zephir' {
+declare module "react-syntax-highlighter/dist/cjs/languages/hljs/zephir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/abap' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/abap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/abnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/abnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/actionscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/actionscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ada' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ada" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/agda' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/agda" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/al' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/al" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/antlr4' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/antlr4" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/apacheconf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/apacheconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/apl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/apl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/applescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/applescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/aql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/aql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/arduino' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/arduino" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/arff' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/arff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/asciidoc' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/asciidoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/asm6502' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/asm6502" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/aspnet' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/aspnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/autohotkey' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/autohotkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/autoit' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/autoit" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/bash' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/bash" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/basic' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/batch' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/batch" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/bbcode' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/bbcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/bison' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/bison" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/bnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/bnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/brainfuck' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/brainfuck" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/brightscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/brightscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/bro' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/bro" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/c' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/c" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/cil' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/cil" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/clike' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/clike" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/clojure' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/clojure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/cmake' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/cmake" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/coffeescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/coffeescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/concurnas' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/concurnas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/core' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/core" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/cpp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/cpp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/crystal' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/crystal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/csharp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/csharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/csp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/csp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/css-extras' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/css-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/css' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/css" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/cypher' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/cypher" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/d' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/d" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/dart' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/dart" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/dax' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/dax" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/dhall' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/dhall" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/diff' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/diff" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/django' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/django" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/dns-zone-file' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/dns-zone-file" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/docker' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/docker" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ebnf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ebnf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/editorconfig' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/editorconfig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/eiffel' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/eiffel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ejs' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ejs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/elixir' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/elixir" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/elm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/elm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/erb' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/erb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/erlang' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/erlang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/etlua' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/etlua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/excel-formula' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/excel-formula" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/factor' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/factor" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/firestore-security-rules' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/firestore-security-rules" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/flow' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/flow" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/fortran' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/fortran" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/fsharp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/fsharp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ftl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ftl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/gcode' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/gcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/gdscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/gdscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/gedcom' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/gedcom" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/gherkin' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/gherkin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/git' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/git" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/glsl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/glsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/gml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/gml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/go' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/go" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/graphql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/graphql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/groovy' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/groovy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/haml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/haml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/handlebars' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/handlebars" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/haskell' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/haskell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/haxe' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/haxe" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/hcl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/hcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/hlsl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/hlsl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/hpkp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/hpkp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/hsts' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/hsts" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/http' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/http" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ichigojam' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ichigojam" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/icon' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/icon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/iecst' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/iecst" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ignore' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ignore" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/inform7' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/inform7" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ini' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ini" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/io' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/io" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/j' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/j" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/java' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/java" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/javadoc' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/javadoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/javadoclike' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/javadoclike" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/javascript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/javascript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/javastacktrace' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/javastacktrace" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jolie' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jolie" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jq' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jq" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/js-extras' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/js-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/js-templates' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/js-templates" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jsdoc' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jsdoc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/json' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/json" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/json5' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/json5" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jsonp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jsonp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jsstacktrace' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jsstacktrace" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/jsx' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/jsx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/julia' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/julia" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/keyman' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/keyman" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/kotlin' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/kotlin" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/latex' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/latex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/latte' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/latte" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/less' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/less" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/lilypond' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/lilypond" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/liquid' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/liquid" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/lisp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/lisp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/livescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/livescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/llvm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/llvm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/lolcode' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/lolcode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/lua' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/lua" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/makefile' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/makefile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/markdown' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/markdown" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/markup-templating' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/markup-templating" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/markup' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/markup" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/matlab' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/matlab" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/mel' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/mel" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/mizar' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/mizar" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/monkey' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/monkey" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/moonscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/moonscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/n1ql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/n1ql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/n4js' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/n4js" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nand2tetris-hdl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nand2tetris-hdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nasm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/neon' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/neon" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nginx' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nginx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nim' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nix' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nix" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/nsis' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/nsis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/objectivec' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/objectivec" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ocaml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ocaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/opencl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/opencl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/oz' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/oz" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/parigp' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/parigp" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/parser' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/parser" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/pascal' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/pascal" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/pascaligo' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/pascaligo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/pcaxis' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/pcaxis" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/peoplecode' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/peoplecode" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/perl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/perl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/php-extras' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/php-extras" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/php' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/php" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/plsql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/plsql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/powerquery' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/powerquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/powershell' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/powershell" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/processing' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/processing" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/prolog' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/prolog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/properties' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/properties" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/protobuf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/protobuf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/pug' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/pug" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/puppet' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/puppet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/pure' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/pure" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/purebasic' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/purebasic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/python' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/python" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/q' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/q" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/qml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/qml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/qore' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/qore" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/r' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/r" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/racket' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/racket" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/reason' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/reason" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/regex' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/regex" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/renpy' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/renpy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/rest' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/rest" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/rip' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/rip" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/roboconf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/roboconf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/robotframework' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/robotframework" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/ruby' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/ruby" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/rust' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/rust" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/sas' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/sas" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/sass' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/sass" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/scala' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/scala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/scheme' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/scheme" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/scss' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/scss" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/shell-session' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/shell-session" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/smali' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/smali" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/smalltalk' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/smalltalk" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/smarty' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/smarty" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/solidity' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/solidity" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/solution-file' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/solution-file" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/soy' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/soy" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/sparql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/sparql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/splunk-spl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/splunk-spl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/sqf' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/sqf" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/sql' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/sql" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/stylus' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/stylus" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/swift' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/swift" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/t4-cs' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/t4-cs" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/t4-templating' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/t4-templating" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/t4-vb' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/t4-vb" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/tap' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/tap" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/tcl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/tcl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/textile' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/textile" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/toml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/toml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/tsx' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/tsx" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/tt2' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/tt2" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/turtle' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/turtle" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/twig' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/twig" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/typescript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/typescript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/unrealscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/unrealscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/vala' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/vala" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/vbnet' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/vbnet" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/velocity' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/velocity" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/verilog' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/verilog" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/vhdl' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/vhdl" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/vim' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/vim" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/visual-basic' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/visual-basic" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/warpscript' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/warpscript" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/wasm' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/wasm" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/wiki' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/wiki" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/xeora' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/xeora" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/xml-doc' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/xml-doc" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/xojo' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/xojo" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/xquery' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/xquery" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/yaml' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/yaml" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/yang' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/yang" {
     const language: any;
     export default language;
 }
 
-declare module 'react-syntax-highlighter/dist/cjs/languages/prism/zig' {
+declare module "react-syntax-highlighter/dist/cjs/languages/prism/zig" {
     const language: any;
     export default language;
 }

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
-import SyntaxHighlighter, { Light as LightHighlighter, SyntaxHighlighterProps, createElementProps } from "react-syntax-highlighter";
-import PrismSyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
-import PrismLightHighlighter from "react-syntax-highlighter/dist/cjs/prism-light";
-import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
+import SyntaxHighlighter, {
+    createElementProps,
+    Light as LightHighlighter,
+    SyntaxHighlighterProps,
+} from "react-syntax-highlighter";
 import jsx from "react-syntax-highlighter/dist/cjs/languages/prism/jsx";
-import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
-import { oneLight as oneLightCjs, oneDark as oneDarkCjs } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import { coldarkCold, coldarkDark, oneLight, oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import PrismLightHighlighter from "react-syntax-highlighter/dist/cjs/prism-light";
+import { oneDark as oneDarkCjs, oneLight as oneLightCjs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import createElement from "react-syntax-highlighter/dist/esm/create-element";
+import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
+import PrismSyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
+import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { coldarkCold, coldarkDark, oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 const codeString = `class CPP {
     private year: number;
@@ -63,9 +67,9 @@ function codeTagProps() {
     const codeTagProps: SyntaxHighlighterProps["codeTagProps"] = {
         className: "some-classname",
         style: {
-            opacity: 0
+            opacity: 0,
         },
-        onMouseOver: (event: React.MouseEvent<HTMLElement>) => "foo"
+        onMouseOver: (event: React.MouseEvent<HTMLElement>) => "foo",
     };
 
     return (
@@ -79,9 +83,9 @@ function linePropsObject() {
     const lineProps: SyntaxHighlighterProps["lineProps"] = {
         className: "some-classname",
         style: {
-            opacity: 0
+            opacity: 0,
         },
-        onMouseOver: (event: React.MouseEvent<HTMLElement>) => "foo"
+        onMouseOver: (event: React.MouseEvent<HTMLElement>) => "foo",
     };
 
     return (
@@ -95,9 +99,9 @@ function lineTagPropsFunction() {
     const lineProps: lineTagPropsFunction = (lineNumber: number) => ({
         className: "some-classname",
         style: {
-            opacity: 0
+            opacity: 0,
         },
-        onMouseOver: (event: React.MouseEvent<HTMLElement>) => lineNumber * 5
+        onMouseOver: (event: React.MouseEvent<HTMLElement>) => lineNumber * 5,
     });
 
     return (
@@ -123,7 +127,7 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
 <PrismLightHighlighter style={oneLight}>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter style={oneDarkCjs}>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter style={oneLightCjs}>{codeString}</PrismLightHighlighter>;
-<PrismLightHighlighter style={{ keyword: { color: 'red' } }}>{codeString}</PrismLightHighlighter>;
+<PrismLightHighlighter style={{ keyword: { color: "red" } }}>{codeString}</PrismLightHighlighter>;
 // @ts-expect-error
 <PrismLightHighlighter style={{ color: "red" }}>{codeString}</PrismLightHighlighter>;
 
@@ -131,7 +135,9 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
 <PrismLightHighlighter>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter>{[codeString, "hello world"]}</PrismLightHighlighter>;
 // @ts-expect-error
-<PrismLightHighlighter><div>Hello world</div></PrismLightHighlighter>;
+<PrismLightHighlighter>
+    <div>Hello world</div>
+</PrismLightHighlighter>;
 // @ts-expect-error
 <PrismLightHighlighter />;
 
@@ -229,8 +235,8 @@ createElement({
     ...correctCreateElementProps,
     node: {
         ...correctCreateElementProps.node,
-        tagName: TestComponent
-    }
+        tagName: TestComponent,
+    },
 });
 createElement({ ...correctCreateElementProps, style: undefined });
 // @ts-expect-error
@@ -241,7 +247,7 @@ createElement({
         ...correctCreateElementProps.node,
         // @ts-expect-error
         properties: { className: "some-class" },
-    }
+    },
 });
 createElement({
     ...correctCreateElementProps,
@@ -249,7 +255,7 @@ createElement({
         ...correctCreateElementProps.node,
         // @ts-expect-error
         tagName: "mycomponent",
-    }
+    },
 });
 // @ts-expect-error
 createElement({ ...correctCreateElementProps, stylesheet: undefined });
@@ -269,7 +275,7 @@ createElement({ ...correctCreateElementProps, key: undefined });
             node,
             stylesheet,
             useInlineStyles,
-            key: `code-segement${i}`
+            key: `code-segement${i}`,
         })
     ))}
 >

--- a/types/righto/index.d.ts
+++ b/types/righto/index.d.ts
@@ -4,27 +4,27 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
 
-import { CPSFunction, Righto, RightoAfter } from '.';
+import { CPSFunction, Righto, RightoAfter } from ".";
 
 /** Represents a type as either the type itself, a righto of the type, or a promise of the type */
-type Flexible<T, ET = any> = T|Promise<T>|Righto<[T | undefined, ...any[]], ET>;
+type Flexible<T, ET = any> = T | Promise<T> | Righto<[T | undefined, ...any[]], ET>;
 /** Accepts an array of types and returns a array of each type OR'd with eventual representations (Righto and promise) */
 type ArgsAsFlexible<AT extends any[], ET> = {
-    [T in keyof AT]: Flexible<AT[T], ET>
+    [T in keyof AT]: Flexible<AT[T], ET>;
 };
 /** Transforms an object type to unwrap its Righto typed properties */
 type ResolvedObject<T> = {
-    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] : T[P]
+    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] : T[P];
 };
 /** Recursively transforms an object type to unwrap its Righto typed properties into "unknown" */
 type ResolvedObjectRecursive<T> = {
-    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] :
-                    T[P] extends object ? ResolvedObjectRecursive<T[P]> :
-                    T[P]
+    [P in keyof T]: T[P] extends Righto<infer X> ? X[0]
+        : T[P] extends object ? ResolvedObjectRecursive<T[P]>
+        : T[P];
 };
 /** Maps an array of types into their righto representations */
 type RightoArrayFrom<T extends any[], ET> = {
-    [P in keyof T]: Righto<[T[P]], ET>
+    [P in keyof T]: Righto<[T[P]], ET>;
 };
 
 /**
@@ -44,25 +44,39 @@ type RightoArrayFrom<T extends any[], ET> = {
  * let rResult2 = righto(divideNumbersAsync, 5, rResult); // A righto object that will eventually resolve to 2.5
  * rResult2((err, result) => console.log(result)); // Will print '2.5' to the console
  */
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, ...args: ArgsAsFlexible<AT, ET>): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    ...args: ArgsAsFlexible<AT, ET>
+): Righto<RT, ET>;
 // Righto constructor to allow for a single righto.after to appear before the function arguments
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, after: RightoAfter, ...args: ArgsAsFlexible<AT, ET>): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    after: RightoAfter,
+    ...args: ArgsAsFlexible<AT, ET>
+): Righto<RT, ET>;
 // Righto constructor to allow for a single righto.after to appear after the function arguments
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+): Righto<RT, ET>;
 // Righto constructor to allow for two righto.after statements to appear, once before the argument list and once after
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, after: RightoAfter, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    after: RightoAfter,
+    ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+): Righto<RT, ET>;
 
 // Library for function righto methods
 declare namespace righto {
     /** A callback function that accepts a single error argument, with any number of return arguments */
-    type ErrBack<RT extends any[] = [], ET = any> = (err?: ET, ...results: {[P in keyof RT]?: RT[P]}) => void;
+    type ErrBack<RT extends any[] = [], ET = any> = (err?: ET, ...results: { [P in keyof RT]?: RT[P] }) => void;
     /**  Usually an async function that accepts any number of parameters, then returns a result or error through an ErrBack method */
     type CPSFunction<AT extends any[], RT extends any[], ET> = (...args: [...AT, ErrBack<RT, ET>]) => void;
     /** A righto that does not resolve to any value, used for introducing delays in righto argument chains */
     type RightoAfter = Righto<[]>;
     /** Represents a constructed righto object */
     interface Righto<RT extends any[], ET = any> extends CPSFunction<[], RT, ET> {
-        get(prop: string|number|Righto<[string, ...any[]]>|Righto<[number, ...any[]]>): Righto<[any], ET>;
+        get(prop: string | number | Righto<[string, ...any[]]> | Righto<[number, ...any[]]>): Righto<[any], ET>;
         get<T>(fn: (x: RT[0]) => T): Righto<[T], ET>;
         /** You can force a righto task for run at any time without dealing with the results (or error) by calling it with no arguments */
         (): Righto<RT, ET>;
@@ -79,7 +93,9 @@ declare namespace righto {
      * @example
      * var somePromise = new Promise(righto.fork(someRighto));
      */
-    function fork<RT extends any[]>(righto: Righto<RT>): (resolve: (x: RT[0]) => void, reject: (x: any) => void) => void;
+    function fork<RT extends any[]>(
+        righto: Righto<RT>,
+    ): (resolve: (x: RT[0]) => void, reject: (x: any) => void) => void;
 
     /**
      * Righto supports running a generator (or any nextable iterator):
@@ -107,7 +123,9 @@ declare namespace righto {
      *     result === 'xyabc';
      * });
      */
-     function iterate<AT extends any[], RT, ET>(constructGenerator: (...args: AT) => Generator<Righto<[RT], ET>, RT, RT>): (...args: AT) => Righto<[RT], ET>;
+    function iterate<AT extends any[], RT, ET>(
+        constructGenerator: (...args: AT) => Generator<Righto<[RT], ET>, RT, RT>,
+    ): (...args: AT) => Righto<[RT], ET>;
 
     /**
      * You can pick and choose what results are used from a dependency like so:
@@ -119,7 +137,10 @@ declare namespace righto {
      *     result -> 'first third';
      * });
      */
-    function take<IDXS extends number[], ET>(righto: Righto<any[], ET>, ...args: IDXS): Righto<{[P in keyof IDXS]: any}, ET>;
+    function take<IDXS extends number[], ET>(
+        righto: Righto<any[], ET>,
+        ...args: IDXS
+    ): Righto<{ [P in keyof IDXS]: any }, ET>;
 
     /**
      * Righto.reduce takes an Array of values (an an eventual that resolves to an array) as the first argument, resolves them from left-to-right,
@@ -177,7 +198,11 @@ declare namespace righto {
      *     // finalResult === 7
      * });
      */
-    function reduce<RT, ET = any>(values: Array<CPSFunction<[RT], [RT], ET>>, reducer: (result: RT, next: CPSFunction<[RT], [RT], ET>) => Righto<[RT], ET>, seed?: RT): Righto<[RT], ET>;
+    function reduce<RT, ET = any>(
+        values: Array<CPSFunction<[RT], [RT], ET>>,
+        reducer: (result: RT, next: CPSFunction<[RT], [RT], ET>) => Righto<[RT], ET>,
+        seed?: RT,
+    ): Righto<[RT], ET>;
 
     /**
      * righto.all takes N tasks, or an Array of tasks as the first argument, resolves them all in parallel, and results in an Array of results.
@@ -229,9 +254,20 @@ declare namespace righto {
      *     result; // -> 10
      * });
      */
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, ...args: ArgsAsFlexible<AT, ET>): Righto<[RT], ET>;
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, after: RightoAfter, ...args: ArgsAsFlexible<AT, ET>): Righto<[RT], ET>;
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, after: RightoAfter, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        after: RightoAfter,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        after: RightoAfter,
+        ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+    ): Righto<[RT], ET>;
 
     /**
      * Anything can be converted to a righto with righto.from(anything);
@@ -241,7 +277,7 @@ declare namespace righto {
      * righto.from(somePromise); // Returns a new righto that resolves the promise
      * righto.from(5); // Returns a new righto that resolves 5
      */
-    function from<T, ET = any>(source: Righto<[T], ET>|Promise<T>): Righto<[T], ET>;
+    function from<T, ET = any>(source: Righto<[T], ET> | Promise<T>): Righto<[T], ET>;
     function from<T>(source: T): Righto<[T], undefined>;
 
     /**
@@ -265,7 +301,7 @@ declare namespace righto {
      *
      * righto2();
      */
-    function value<T, ET = any>(resolvable: Righto<[T], ET>|Promise<T>): Righto<[Righto<[T], ET>], ET>;
+    function value<T, ET = any>(resolvable: Righto<[T], ET> | Promise<T>): Righto<[Righto<[T], ET>], ET>;
 
     /**
      * You can resolve a task to an array containing either the error or results from a righto with righto.surely, which resolves to an array in the form of [error?, results...?].
@@ -291,7 +327,10 @@ declare namespace righto {
      *
      * z();
      */
-    function surely<AT extends any[], RT extends any[], ET>(fn: CPSFunction<AT, RT, ET>, ...args: ArgsAsFlexible<AT, ET>): Righto<[[ET, ...RT]], ET>;
+    function surely<AT extends any[], RT extends any[], ET>(
+        fn: CPSFunction<AT, RT, ET>,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[[ET, ...RT]], ET>;
 
     /**
      * Wrap a righto task with a handler that either forwards the successful result, or sends the rejected error through a handler to resolve the task.
@@ -354,7 +393,10 @@ declare namespace righto {
      *     bar; // -> {foo: {bar: 'foo'}}
      * });
      */
-    function resolve<T, B extends boolean>(obj: T, recursive: B): B extends true ? ResolvedObjectRecursive<T> : ResolvedObject<T>;
+    function resolve<T, B extends boolean>(
+        obj: T,
+        recursive: B,
+    ): B extends true ? ResolvedObjectRecursive<T> : ResolvedObject<T>;
     function resolve<T>(obj: T): ResolvedObject<T>;
 
     /**

--- a/types/righto/righto-tests.ts
+++ b/types/righto/righto-tests.ts
@@ -68,12 +68,12 @@ righto(
     rDivideNumbers2,
     righto.after(rDivideNumbers1),
 );
-// @ts-expect-error
 righto(
     divideNumbersCPS,
     righto.after(rDivideNumbers1),
     rDivideNumbers1,
     righto.after(rDivideNumbers1),
+    // @ts-expect-error
     rDivideNumbers2,
 );
 // #endregion

--- a/types/righto/righto-tests.ts
+++ b/types/righto/righto-tests.ts
@@ -10,193 +10,210 @@ function noArgsCPS(callback: ErrBack<[number], undefined>) {
 }
 
 function multiReturnCPS(a: number, callback: ErrBack<[number, string, boolean], Error>) {
-    if (a < 0)
+    if (a < 0) {
         callback(new Error("Cannot call this with an argument of 0!"));
-    else
+    } else {
         callback(void 0, a + 1, a.toString(), true);
+    }
 }
 
 function divideNumbersCPS(a: number, b: number, callback: ErrBack<[number], Error>) {
-    if (b === 0)
+    if (b === 0) {
         callback(new Error("Cannot divide by a negative number"));
-    else
+    } else {
         callback(void 0, a / b);
+    }
 }
 
 function divideNumbers(a: number, b: number) {
     return a / b;
 }
 
-//#region Test righto constructor
-    // $ExpectType Righto<[number], Error>
-    const rDivideNumbers1 = righto(divideNumbersCPS, 1, 1);
-    // $ExpectType Righto<[number], Error>
-    const rDivideNumbers2 = righto(divideNumbersCPS, 2, 1);
+// #region Test righto constructor
+// $ExpectType Righto<[number], Error>
+const rDivideNumbers1 = righto(divideNumbersCPS, 1, 1);
+// $ExpectType Righto<[number], Error>
+const rDivideNumbers2 = righto(divideNumbersCPS, 2, 1);
 
-    // $ExpectType Righto<[number], Error>
-    righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2);
-    // $ExpectType Righto<[number], Error>
-    righto(divideNumbersCPS, rDivideNumbers1, new Promise<number>(r => r(5)));
-    // $ExpectType Righto<[boolean], null>
-    const rBool = righto<[], [boolean], null>((fn) => fn(null, true));
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1, "");
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1);
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1, 2, 3);
-    // @ts-expect-error
-    righto(divideNumbers, 5, 6);
+// $ExpectType Righto<[number], Error>
+righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2);
+// $ExpectType Righto<[number], Error>
+righto(divideNumbersCPS, rDivideNumbers1, new Promise<number>(r => r(5)));
+// $ExpectType Righto<[boolean], null>
+const rBool = righto<[], [boolean], null>((fn) => fn(null, true));
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1, "");
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1);
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1, 2, 3);
+// @ts-expect-error
+righto(divideNumbers, 5, 6);
 
-    // $ExpectType Righto<[number, string, boolean], Error>
-    const rMultiReturn = righto(multiReturnCPS, 1);
-    // $ExpectType Righto<[], undefined>
-    const rNoReturn = righto(noReturnCPS);
-    // $ExpectType Righto<[number], undefined>
-    righto(noArgsCPS);
-    // @ts-expect-error
-    righto(noArgsCPS, 5);
+// $ExpectType Righto<[number, string, boolean], Error>
+const rMultiReturn = righto(multiReturnCPS, 1);
+// $ExpectType Righto<[], undefined>
+const rNoReturn = righto(noReturnCPS);
+// $ExpectType Righto<[number], undefined>
+righto(noArgsCPS);
+// @ts-expect-error
+righto(noArgsCPS, 5);
 
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2);
-    righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
-    // @ts-expect-error
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, righto.after(rDivideNumbers1), rDivideNumbers2);
-//#endregion
+righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2);
+righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
+righto(
+    divideNumbersCPS,
+    righto.after(rDivideNumbers1),
+    rDivideNumbers1,
+    rDivideNumbers2,
+    righto.after(rDivideNumbers1),
+);
+// @ts-expect-error
+righto(
+    divideNumbersCPS,
+    righto.after(rDivideNumbers1),
+    rDivideNumbers1,
+    righto.after(rDivideNumbers1),
+    rDivideNumbers2,
+);
+// #endregion
 
-//#region Test righto.fork
-    // $ExpectType Promise<number>
-    const promise = new Promise(righto.fork(rDivideNumbers1));
-    // $ExpectType Promise<undefined>
-    const promise2 = new Promise(righto.fork(rNoReturn));
-    // $ExpectType Promise<number>
-    const promise3 = new Promise(righto.fork(rMultiReturn));
-//#endregion
+// #region Test righto.fork
+// $ExpectType Promise<number>
+const promise = new Promise(righto.fork(rDivideNumbers1));
+// $ExpectType Promise<undefined>
+const promise2 = new Promise(righto.fork(rNoReturn));
+// $ExpectType Promise<number>
+const promise3 = new Promise(righto.fork(rMultiReturn));
+// #endregion
 
-//#region Test righto.iterate
-    const generated = righto.iterate(function*(a: string, b: string, c: string): Generator<Righto<[string], never>, string, string> {
+// #region Test righto.iterate
+const generated = righto.iterate(
+    function*(a: string, b: string, c: string): Generator<Righto<[string], never>, string, string> {
         const x = yield righto((done) => {
-            done(void 0, 'x');
+            done(void 0, "x");
         });
 
         const y = yield righto((done) => {
-            done(void 0, 'y');
+            done(void 0, "y");
         });
 
         return x + y + a + b + c;
-    });
+    },
+);
 
-    // $ExpectType Righto<[string], never>
-    const result = generated('a', 'b', 'c');
+// $ExpectType Righto<[string], never>
+const result = generated("a", "b", "c");
 
-    result((error, result) => {
-        result === 'xyabc';
-    });
-//#endregion
+result((error, result) => {
+    result === "xyabc";
+});
+// #endregion
 
-//#region Test immediate execution
-    rMultiReturn();
-    rMultiReturn((error, result) => {});
-//#endregion
+// #region Test immediate execution
+rMultiReturn();
+rMultiReturn((error, result) => {});
+// #endregion
 
-//#region Test righto.take
-    // $ExpectType Righto<[any, any], Error>
-    const taken = righto.take(rMultiReturn, 0, 1);
-//#endregion
+// #region Test righto.take
+// $ExpectType Righto<[any, any], Error>
+const taken = righto.take(rMultiReturn, 0, 1);
+// #endregion
 
-//#region Test righto.reduce
-    function reduceTestFunc1(callback: ErrBack<[number], null>) {
-        callback(null, 1);
-    }
-    function reduceTestFunc2(callback: ErrBack<[number], null>) {
-        callback(null, 2);
-    }
-    // $ExpectType Righto<[number], null>
-    const reduced1 = righto.reduce([righto(reduceTestFunc1), righto(reduceTestFunc2)]);
+// #region Test righto.reduce
+function reduceTestFunc1(callback: ErrBack<[number], null>) {
+    callback(null, 1);
+}
+function reduceTestFunc2(callback: ErrBack<[number], null>) {
+    callback(null, 2);
+}
+// $ExpectType Righto<[number], null>
+const reduced1 = righto.reduce([righto(reduceTestFunc1), righto(reduceTestFunc2)]);
 
-    function reduceTestFunc3(last: number, callback: ErrBack<[number], null>) {
-        callback(null, last);
-    }
+function reduceTestFunc3(last: number, callback: ErrBack<[number], null>) {
+    callback(null, last);
+}
 
-    function reduceTestFunc4(last: number, callback: ErrBack<[number], null>) {
-        callback(null, last + 2);
-    }
+function reduceTestFunc4(last: number, callback: ErrBack<[number], null>) {
+    callback(null, last + 2);
+}
 
-    // $ExpectType Righto<[number], null>
-    const reduced2 = righto.reduce(
-            [reduceTestFunc3, reduceTestFunc4],
-            (result, next) => { // Reducer
-                return righto(next, result);
-            },
-            5 // Seed
-        );
-//#endregion
+// $ExpectType Righto<[number], null>
+const reduced2 = righto.reduce(
+    [reduceTestFunc3, reduceTestFunc4],
+    (result, next) => { // Reducer
+        return righto(next, result);
+    },
+    5, // Seed
+);
+// #endregion
 
-//#region Test righto.all
-    // $ExpectType Righto<[number[]], Error>
-    const rAll1 = righto.all([rDivideNumbers1, rDivideNumbers2]);
-    // $ExpectType Righto<[any[]], any>
-    const rAll2 = righto.all([rDivideNumbers1, rBool]);
-//#endregion
+// #region Test righto.all
+// $ExpectType Righto<[number[]], Error>
+const rAll1 = righto.all([rDivideNumbers1, rDivideNumbers2]);
+// $ExpectType Righto<[any[]], any>
+const rAll2 = righto.all([rDivideNumbers1, rBool]);
+// #endregion
 
-//#region Test righto.sync
-    const someNumber = righto((done: ErrBack<[number], null>) => {
-        done(null, 5);
-    });
+// #region Test righto.sync
+const someNumber = righto((done: ErrBack<[number], null>) => {
+    done(null, 5);
+});
 
-    function numToString(value: number) {
-        return value.toString();
-    }
+function numToString(value: number) {
+    return value.toString();
+}
 
-    // $ExpectType Righto<[string], any>
-    const syncTask = righto.sync(numToString, someNumber);
-    righto.sync(numToString, 5);
-    // @ts-expect-error
-    righto.sync(numToString, rBool);
-//#endregion
+// $ExpectType Righto<[string], any>
+const syncTask = righto.sync(numToString, someNumber);
+righto.sync(numToString, 5);
+// @ts-expect-error
+righto.sync(numToString, rBool);
+// #endregion
 
-//#region Test righto.from
+// #region Test righto.from
+// $ExpectType Righto<[boolean], null>
+righto.from(rBool);
+// $ExpectType Righto<[number], any>
+righto.from(new Promise<number>(r => r(5)));
+// $ExpectType Righto<[string], undefined>
+righto.from("test");
+// $ExpectType Righto<[{ a: number; b: { a: number; }; }], undefined>
+righto.from({ a: 5, b: { a: 5 } });
+// #endregion
+
+// #region Test righto.value
+const rightoValue = righto.value(rBool);
+
+const rValIn = righto((value, callback) => {
     // $ExpectType Righto<[boolean], null>
-    righto.from(rBool);
-    // $ExpectType Righto<[number], any>
-    righto.from(new Promise<number>(r => r(5)));
-    // $ExpectType Righto<[string], undefined>
-    righto.from("test");
-    // $ExpectType Righto<[{ a: number; b: { a: number; }; }], undefined>
-    righto.from({a: 5, b: {a: 5}});
-//#endregion
+    value;
+}, rightoValue);
+// #endregion
 
-//#region Test righto.value
-    const rightoValue = righto.value(rBool);
+// #region Test righto.get
+const rGetObj = righto((cb: ErrBack<[{ a: number; b: number; c: number }], never>) => cb(void 0, { a: 1, b: 2, c: 3 }));
+// $ExpectType Righto<[number], never>
+rGetObj.get(x => x.a);
+// $ExpectType Righto<[any], never>
+rGetObj.get("a");
+// $ExpectType Righto<[any], never>
+rGetObj.get(rDivideNumbers1);
+// #endregion
 
-    const rValIn = righto((value, callback) => {
-        // $ExpectType Righto<[boolean], null>
-        value;
-    }, rightoValue);
-//#endregion
+// #region Test righto.surely
+// $ExpectType Righto<[[Error, string]], Error>
+const errorOrX = righto.surely((done: ErrBack<[string], Error>) => {
+    done(new Error("borked"));
+});
 
-//#region Test righto.get
-    const rGetObj = righto((cb: ErrBack<[{a: number, b: number, c: number}], never>) => cb(void 0, {a: 1, b: 2, c: 3}));
-    // $ExpectType Righto<[number], never>
-    rGetObj.get(x => x.a);
-    // $ExpectType Righto<[any], never>
-    rGetObj.get('a');
-    // $ExpectType Righto<[any], never>
-    rGetObj.get(rDivideNumbers1);
-//#endregion
+// $ExpectType Righto<[[Error, string]], Error>
+const errorOrY = righto.surely((done: ErrBack<[string], Error>) => {
+    done(void 0, "y");
+});
 
-//#region Test righto.surely
-    // $ExpectType Righto<[[Error, string]], Error>
-    const errorOrX = righto.surely((done: ErrBack<[string], Error>) => {
-        done(new Error('borked'));
-    });
-
-    // $ExpectType Righto<[[Error, string]], Error>
-    const errorOrY = righto.surely((done: ErrBack<[string], Error>) => {
-        done(void 0, 'y');
-    });
-
-    const z = righto(([xError, x], [yError, y]) => {
+const z = righto(
+    ([xError, x], [yError, y]) => {
         // $ExpectType Error
         xError;
         // $ExpectType string
@@ -205,110 +222,113 @@ function divideNumbers(a: number, b: number) {
         yError;
         // $ExpectType string
         y;
-    }, errorOrX, errorOrY);
-//#endregion
+    },
+    errorOrX,
+    errorOrY,
+);
+// #endregion
 
-//#region Test righto.handle
-    function mightFail(callback: ErrBack<[string], string>) {
-        if (Math.random() > 0.5) {
-            callback('borked');
-        } else {
-            callback(void 0, 'result');
-        }
+// #region Test righto.handle
+function mightFail(callback: ErrBack<[string], string>) {
+    if (Math.random() > 0.5) {
+        callback("borked");
+    } else {
+        callback(void 0, "result");
     }
+}
 
-    function defaultString(error: string, callback: ErrBack<[string], string>) {
-        callback(void 0, '');
-    }
+function defaultString(error: string, callback: ErrBack<[string], string>) {
+    callback(void 0, "");
+}
 
-    const maybeAString = righto(mightFail);
-    const aString = righto.handle(maybeAString, defaultString);
+const maybeAString = righto(mightFail);
+const aString = righto.handle(maybeAString, defaultString);
 
-    aString((error, result) => {
-        // $ExpectType string | undefined
-        error;
-        // $ExpectType string | undefined
-        result;
-    });
-//#endregion
+aString((error, result) => {
+    // $ExpectType string | undefined
+    error;
+    // $ExpectType string | undefined
+    result;
+});
+// #endregion
 
-//#region Test righto.resolve
-    const obj2Resolve = {
-        rNum: rDivideNumbers1,
-        str: "string",
+// #region Test righto.resolve
+const obj2Resolve = {
+    rNum: rDivideNumbers1,
+    str: "string",
+    obj: {
+        rBool,
         obj: {
-            rBool,
-            obj: {
-                rNum: rDivideNumbers1
-            }
-        }
-    };
+            rNum: rDivideNumbers1,
+        },
+    },
+};
 
-    const resolvedObj = righto.resolve(obj2Resolve, false);
-    // $ExpectType number
-    resolvedObj.rNum;
-    // $ExpectType Righto<[boolean], null>
-    resolvedObj.obj.rBool;
+const resolvedObj = righto.resolve(obj2Resolve, false);
+// $ExpectType number
+resolvedObj.rNum;
+// $ExpectType Righto<[boolean], null>
+resolvedObj.obj.rBool;
 
-    const resolvedObjRecursive = righto.resolve(obj2Resolve, true);
-    // $ExpectType number
-    resolvedObjRecursive.rNum;
-    // $ExpectType number
-    resolvedObjRecursive.obj.obj.rNum;
-//#endregion
+const resolvedObjRecursive = righto.resolve(obj2Resolve, true);
+// $ExpectType number
+resolvedObjRecursive.rNum;
+// $ExpectType number
+resolvedObjRecursive.obj.obj.rNum;
+// #endregion
 
-//#region Test righto.mate
-    // $ExpectType Righto<[number, number], Error>
-    const rMate = righto.mate<[number, number], Error>(rDivideNumbers1, rDivideNumbers2);
+// #region Test righto.mate
+// $ExpectType Righto<[number, number], Error>
+const rMate = righto.mate<[number, number], Error>(rDivideNumbers1, rDivideNumbers2);
 
-    rMate((error, stuff, otherStuff) => {
-        // $ExpectType Error | undefined
-        error;
-        // $ExpectType number | undefined
-        stuff;
-        // $ExpectType number | undefined
-        otherStuff;
+rMate((error, stuff, otherStuff) => {
+    // $ExpectType Error | undefined
+    error;
+    // $ExpectType number | undefined
+    stuff;
+    // $ExpectType number | undefined
+    otherStuff;
+});
+// #endregion
+
+// #region Test righto.fail
+const testFail = rDivideNumbers1.get((value) => {
+    if (!value) {
+        return righto.fail("was falsey");
+    }
+
+    return value;
+});
+// #endregion
+
+// #region Test righto.proxy
+const rightoProxy = righto.proxy;
+// $ExpectType any
+const foo = rightoProxy((done: ErrBack<[object], null>) => {
+    done(null, {
+        foo: {
+            bar: {
+                baz: "hello",
+            },
+        },
     });
-//#endregion
+});
+// #endregion
 
-//#region Test righto.fail
-    const testFail = rDivideNumbers1.get((value) => {
-        if (!value) {
-            return righto.fail('was falsey');
-        }
+// #region Test righto is functions
+// $ExpectType boolean
+righto.isRighto(rDivideNumbers1);
+// $ExpectType boolean
+righto.isThenable(rDivideNumbers1);
+// $ExpectType boolean
+righto.isResolvable(rDivideNumbers1);
+// #endregion
 
-        return value;
-    });
-//#endregion
+// #region Test righto debug features
+righto._debug = true;
+rDivideNumbers1();
+rDivideNumbers1._trace();
 
-//#region Test righto.proxy
-    const rightoProxy = righto.proxy;
-    // $ExpectType any
-    const foo = rightoProxy((done: ErrBack<[object], null>) => {
-            done(null, {
-                    foo: {
-                        bar: {
-                            baz: 'hello'
-                        }
-                    }
-                });
-        });
-//#endregion
-
-//#region Test righto is functions
-    // $ExpectType boolean
-    righto.isRighto(rDivideNumbers1);
-    // $ExpectType boolean
-    righto.isThenable(rDivideNumbers1);
-    // $ExpectType boolean
-    righto.isResolvable(rDivideNumbers1);
-//#endregion
-
-//#region Test righto debug features
-    righto._debug = true;
-    rDivideNumbers1();
-    rDivideNumbers1._trace();
-
-    rDivideNumbers1._traceOnError = true;
-    righto._autotraceOnError = true;
-//#endregion
+rDivideNumbers1._traceOnError = true;
+righto._autotraceOnError = true;
+// #endregion


### PR DESCRIPTION
> 👉 Partial implementation of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65993. If you're seeing this and are surprised it's happening, please read the discussion and give feedback! ❤️ 

We're splitting up the changes to make it a bit easier to apply & review them en masse - and, if we need later on, revert / bisect for issues.

This PR is split out from #66539. Implements the dprint formatting changes on packages that are seeing mysterious failures in CI:

- `react-blessed`
- `react-clipboardjs-copy`
- `react-map-gl`
- `react-native-awesome-card-io`
- `react-syntax-highlighter`
- `righto`
- `react-native-awesome-card-io`


