### PR TITLE
Update wicg-file-system-access types based on latest spec (2023/10)

### DIFF
--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package File System Access API 2020.09
+// Type definitions for non-npm package File System Access API 2023.10
 // Project: https://github.com/WICG/file-system-access
 // Definitions by: Ingvar Stepanyan <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,10 +8,6 @@ export {};
 
 declare global {
     interface FileSystemHandle {
-        readonly kind: "file" | "directory";
-        readonly name: string;
-
-        isSameEntry(other: FileSystemHandle): Promise<boolean>;
         queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
         requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
 
@@ -25,76 +21,77 @@ declare global {
          */
         readonly isDirectory: boolean;
     }
-    var FileSystemHandle: {
-        prototype: FileSystemHandle;
-        new(): FileSystemHandle;
-    };
-    type FileSystemHandleUnion = FileSystemFileHandle | FileSystemDirectoryHandle;
+
+    type FileExtension = `.${string}`
+    type MIMEType = `${string}/${string}`
 
     interface FilePickerAcceptType {
+        /**
+         * @default ""
+         */
         description?: string | undefined;
-        accept: Record<string, string | string[]>;
+        accept?: Record<MIMEType, FileExtension | FileExtension[]> | undefined;
     }
+
+    /**
+     * https://wicg.github.io/file-system-access/#enumdef-wellknowndirectory
+     */
+    type WellKnownDirectory = "desktop" | "documents" | "downloads" | "music" | "pictures" | "videos"
 
     interface FilePickerOptions {
         types?: FilePickerAcceptType[] | undefined;
+        /**
+         * @default false
+         */
         excludeAcceptAllOption?: boolean | undefined;
+        startIn?: WellKnownDirectory | FileSystemHandle | undefined;
+        id?: string | undefined;
     }
 
     interface OpenFilePickerOptions extends FilePickerOptions {
+        /**
+         * @default false
+         */
         multiple?: boolean | undefined;
     }
 
     interface SaveFilePickerOptions extends FilePickerOptions {
-        suggestedName?: string;
+        suggestedName?: string | undefined;
     }
 
-    // tslint:disable-next-line:no-empty-interface
-    interface DirectoryPickerOptions {}
+    type FileSystemPermissionMode = "read" | "readwrite"
 
-    type FileSystemPermissionMode = "read" | "readwrite";
+    interface DirectoryPickerOptions {
+        id?: string | undefined;
+        startIn?: WellKnownDirectory | FileSystemHandle | undefined;
+        /**
+         * @default "read"
+         */
+        mode?: FileSystemPermissionMode | undefined;
+    }
 
     interface FileSystemPermissionDescriptor extends PermissionDescriptor {
         handle: FileSystemHandle;
+        /**
+         * @default "read"
+         */
         mode?: FileSystemPermissionMode | undefined;
     }
 
     interface FileSystemHandlePermissionDescriptor {
+        /**
+         * @default "read"
+         */
         mode?: FileSystemPermissionMode | undefined;
     }
 
+    // TODO: Implemented natively in TS 5.1, remove
     interface FileSystemCreateWritableOptions {
-        keepExistingData?: boolean | undefined;
+        keepExistingData?: boolean;
     }
-
-    interface FileSystemGetFileOptions {
-        create?: boolean | undefined;
-    }
-
-    interface FileSystemGetDirectoryOptions {
-        create?: boolean | undefined;
-    }
-
-    interface FileSystemRemoveOptions {
-        recursive?: boolean | undefined;
-    }
-
-    // type WriteParams =
-    //     | { type: 'write'; position?: number | undefined; data: BufferSource | Blob | string }
-    //     | { type: 'seek'; position: number }
-    //     | { type: 'truncate'; size: number };
-
-    // type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
-
-    // class FileSystemWritableFileStream extends WritableStream {
-    //     write(data: FileSystemWriteChunkType): Promise<void>;
-    //     seek(position: number): Promise<void>;
-    //     truncate(size: number): Promise<void>;
-    // }
 
     interface FileSystemFileHandle extends FileSystemHandle {
-        readonly kind: "file";
-        getFile(): Promise<File>;
+        // TODO: Implemented natively in TS 5.1, remove
         createWritable(options?: FileSystemCreateWritableOptions): Promise<FileSystemWritableFileStream>;
         /**
          * @deprecated Old property just for Chromium <=85. Use `kind` property in the new API.
@@ -106,17 +103,7 @@ declare global {
         readonly isDirectory: false;
     }
 
-    var FileSystemFileHandle: {
-        prototype: FileSystemFileHandle;
-        new(): FileSystemFileHandle;
-    };
-
     interface FileSystemDirectoryHandle extends FileSystemHandle {
-        readonly kind: "directory";
-        getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
-        getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
-        removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
-        resolve(possibleDescendant: FileSystemHandle): Promise<string[] | null>;
         keys(): AsyncIterableIterator<string>;
         values(): AsyncIterableIterator<FileSystemDirectoryHandle | FileSystemFileHandle>;
         entries(): AsyncIterableIterator<[string, FileSystemDirectoryHandle | FileSystemFileHandle]>;
@@ -131,22 +118,11 @@ declare global {
         readonly isDirectory: true;
     }
 
-    var FileSystemDirectoryHandle: {
-        prototype: FileSystemDirectoryHandle;
-        new(): FileSystemDirectoryHandle;
-    };
-
     interface DataTransferItem {
         getAsFileSystemHandle(): Promise<FileSystemHandle | null>;
     }
 
-    interface StorageManager {
-        getDirectory(): Promise<FileSystemDirectoryHandle>;
-    }
-
-    function showOpenFilePicker(
-        options?: OpenFilePickerOptions & { multiple?: false | undefined },
-    ): Promise<[FileSystemFileHandle]>;
+    function showOpenFilePicker(options?: OpenFilePickerOptions & { multiple?: false | undefined }): Promise<[FileSystemFileHandle]>;
     function showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
     function showSaveFilePicker(options?: SaveFilePickerOptions): Promise<FileSystemFileHandle>;
     function showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;

--- a/types/wicg-file-system-access/wicg-file-system-access-tests.ts
+++ b/types/wicg-file-system-access/wicg-file-system-access-tests.ts
@@ -1,81 +1,118 @@
 (async () => {
-    let [fileHandle]: [FileSystemFileHandle] = await showOpenFilePicker();
-    [fileHandle] = await showOpenFilePicker({ multiple: false });
+    const filePickerOptions: FilePickerOptions = {
+        types: [{ description: "SVG images", accept: { "image/svg": ".svg" } }],
+        excludeAcceptAllOption: true,
+        startIn: "downloads",
+        id: "uniqueFileId"
+    };
+
+    const saveFilePickerOptions: SaveFilePickerOptions = {
+        suggestedName: "image.svg",
+    };
+
+    const openFilePickerOptions: OpenFilePickerOptions = {
+        multiple: true
+    }
+
+    const directoryPickerOptions: DirectoryPickerOptions = {
+        id: "uniqueDirId",
+        startIn: undefined,
+        mode: "readwrite",
+    }
+
+    // showOpenFilePicker
+
+    const [defaultFileHandle]: [FileSystemFileHandle] = await showOpenFilePicker();
+    const [fileHandleNoMultipleExplicit]: [FileSystemFileHandle] = await showOpenFilePicker({multiple: false});
+    const [fileHandleMultiple1, fileHandleMultiple2]: FileSystemFileHandle[] = await showOpenFilePicker({ multiple: true });
     const fileHandles: FileSystemFileHandle[] = await showOpenFilePicker({
         excludeAcceptAllOption: true,
         multiple: true,
         types: [{ accept: { "image/*": [".png", ".jpg"], "text/plain": ".txt" } }],
     });
-    let w: FileSystemWritableFileStream = await fileHandle.createWritable();
-    w = await fileHandle.createWritable({ keepExistingData: true });
-    await w.write("abc");
-    await w.write(new Uint8Array([1, 2, 3]));
-    await w.write({ type: "seek", position: 0 });
-    await w.seek(1);
-    await w.write(new Blob(["xyz"]));
-    await w.write({ type: "write", position: 3, data: new Uint8Array([4, 5, 6]) });
-    await w.write({ type: "truncate", size: 2 });
-    await w.truncate(1);
-    await w.close();
+    const [fileHandleFromFilePickerOptions]: [FileSystemFileHandle] = await showOpenFilePicker({...filePickerOptions})
+    const fileHandlesFromOpenFilePickerOptions: FileSystemFileHandle[] = await showOpenFilePicker({
+        ...openFilePickerOptions,
+        ...filePickerOptions
+    })
 
-    let permissionState: PermissionState = await fileHandle.queryPermission();
-    permissionState = await fileHandle.requestPermission({ mode: "read" });
-    permissionState = await fileHandle.requestPermission({ mode: "readwrite" });
+    // showSaveFilePicker
 
-    const saveFilePickerOptions = {
-        suggestedName: "image.svg",
-    };
-    const filePickerOptions = {
+    const defaultSaveFileHandle: FileSystemFileHandle = await showSaveFilePicker();
+    const saveFileHandle = await showSaveFilePicker({
         excludeAcceptAllOption: true,
-        types: [{ description: "SVG images", accept: { "image/svg": ["svg"] } }],
-    };
-
-    fileHandle = await showSaveFilePicker();
-    fileHandle = await showSaveFilePicker({
+        types: [{ description: "Any text", accept: { "text/*": [".txt", '.json'] } }],
+    });
+    const saveFileHandleFromFilePickerOptions: FileSystemFileHandle = await showSaveFilePicker({
         ...filePickerOptions,
     });
-    fileHandle = await showSaveFilePicker({
-        ...saveFilePickerOptions,
-    });
-    fileHandle = await showSaveFilePicker({
+    const saveFileHandlesFromSaveFilePickerOptions = await showSaveFilePicker({
         ...saveFilePickerOptions,
         ...filePickerOptions,
     });
 
-    const file: File = await fileHandle.getFile();
-    new ReadableStream().pipeTo(await fileHandle.createWritable());
 
-    let dirHandle: FileSystemDirectoryHandle = await showDirectoryPicker();
-    dirHandle = await showDirectoryPicker({});
+    // showDirectoryFilePicker
 
-    (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
-        // Disable due to a bug in TSLint https://github.com/palantir/tslint/issues/3997:
-        // tslint:disable-next-line await-promise
-        for await (const [name, handle] of dirHandle) {
-            if (handle.kind === "file") {
-                yield handle.getFile();
-            } else {
-                yield* recursivelyWalkDir(handle);
-            }
+    const defaultDirectoryHandle: FileSystemDirectoryHandle = await showDirectoryPicker();
+    const directoryHandleStartInDir: FileSystemDirectoryHandle = await showDirectoryPicker({
+        id: "uniqueDirIdManuaDir",
+        startIn: defaultDirectoryHandle,
+    });
+    const directoryHandleStartInFile: FileSystemDirectoryHandle = await showDirectoryPicker({
+        id: "uniqueDirIdManualFile",
+        startIn: defaultFileHandle,
+    });
+    const directoryHandleFromDirectoryPickerOptions: FileSystemDirectoryHandle = await showDirectoryPicker(directoryPickerOptions);
+
+    // permissions
+
+    const [permissionFileHandle] = await showOpenFilePicker();
+    const defaultPermissionState: PermissionState = await permissionFileHandle.queryPermission();
+    const permissionStateRead: PermissionState = await permissionFileHandle.requestPermission({ mode: "read" });
+    const permissionStateReadWrite: PermissionState = await permissionFileHandle.requestPermission({ mode: "readwrite" });
+
+    // reading, writing, deleting
+
+    const [rwFileHandle] = await showOpenFilePicker();
+    const file: File = await rwFileHandle.getFile();
+
+    new ReadableStream().pipeTo(await rwFileHandle.createWritable());
+
+    const fileStream: FileSystemWritableFileStream = await rwFileHandle.createWritable();
+    await fileStream.close();
+
+    const fileStreamCustom: FileSystemWritableFileStream = await rwFileHandle.createWritable({ keepExistingData: true });
+
+    await fileStreamCustom.write("abc");
+    await fileStreamCustom.write(new Uint8Array([1, 2, 3]));
+    await fileStreamCustom.write({ type: "seek", position: 0 });
+    await fileStreamCustom.seek(1);
+    await fileStreamCustom.write(new Blob(["xyz"]));
+    await fileStreamCustom.write({ type: "write", position: 3, data: new Uint8Array([4, 5, 6]) });
+    await fileStreamCustom.write({ type: "truncate", size: 2 });
+    await fileStreamCustom.truncate(1);
+    await fileStreamCustom.close();
+
+    // drag and drop
+
+    addEventListener('drop', async (e) => {
+        e.preventDefault();
+      
+        const dataTransferItemList: DataTransferItemList = e.dataTransfer!.items
+        const firstDataTranferItem: DataTransferItem = dataTransferItemList[0]
+        const maybeItemAsFileSystemHandle = await firstDataTranferItem.getAsFileSystemHandle()
+
+        if (maybeItemAsFileSystemHandle) {
+            const itemAsFileHandle: FileSystemHandle = maybeItemAsFileSystemHandle
         }
-    })(dirHandle);
-
-    const maybePath = await dirHandle.resolve(fileHandle);
-    if (maybePath) {
-        const pathItems: string[] = maybePath;
-    }
-
-    fileHandle = await dirHandle.getFileHandle("temp.txt");
-    fileHandle = await dirHandle.getFileHandle("temp.txt", { create: true });
-
-    dirHandle = await dirHandle.getDirectoryHandle("subdir", { create: false });
-
-    await dirHandle.removeEntry("temp.txt");
-    await dirHandle.removeEntry("nested-dir", { recursive: true });
-
-    dirHandle = await navigator.storage.getDirectory();
+    })
 
     // Testing Chromium <=85 methods, remove when all Chromium-based browsers have upgraded.
+
+    let fileHandle: FileSystemHandle;
+    let dirHandle: FileSystemDirectoryHandle;
+    let permissionState: PermissionState;
 
     fileHandle = await chooseFileSystemEntries();
     fileHandle = await chooseFileSystemEntries({


### PR DESCRIPTION
Template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [WICG File System Access Spec](https://wicg.github.io/file-system-access)

--- 

Hello!

As DefinitelyTyped is used downstream, we hit an issue with outdated types. For example, `id` in `FilePickerOptions` is now supported for quite some time in Chromium.

I took the liberty to:
* sync the types with the latest spec,
* add latest features as per latest Chromium release, 
* update and format the tests a bit 
* as well as remove many duplicated interface definitions that are already included since Typescript 4.6,
* and added TODO for future deduplications (TS 5.1+)

Code has been fully tested.

If @RReverser agrees, I'd like to put myself on the list of Definition Owners (not included in the PR currently).
We have been consuming these types on heavy scale internally at Google and I'd like to keep an eye on them and keep them in sync as much as possible to make sure there aren't huge gaps between upstream/downstream.