### PR TITLE
fix: add 'default' to Dialect

### DIFF
--- a/types/reserved-words/index.d.ts
+++ b/types/reserved-words/index.d.ts
@@ -14,6 +14,7 @@ export type Dialect =
     | "es7"
     | 7
     | "es6"
+    | "default"
     | "next";
 
 export interface Keywords {

--- a/types/reserved-words/reserved-words-tests.ts
+++ b/types/reserved-words/reserved-words-tests.ts
@@ -14,6 +14,12 @@ check("while", "es6", true);
 // $ExpectType boolean
 check("yield", 3);
 
+// $ExpectType boolean
+check("yield", dialect);
+
+// $ExpectType boolean
+check("yield", "default");
+
 // @ts-expect-error
 check("yield", 1);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: < https://github.com/mattiloh/kebabcase-keys#exclude >
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

※I have added `default` to the `type Dialect` in accordance with the JS library implementation. Please refer to the following code.
https://github.com/qfox/reserved-words/blob/v0.1.2/lib/reserved-words.js#L23
