### PR TITLE
[server] engine option should accept an object

### DIFF
--- a/types/server/server-tests.ts
+++ b/types/server/server-tests.ts
@@ -72,3 +72,12 @@ server(
     },
     [get("/", ctx => "Hello, World!")],
 );
+
+server(
+    {
+        engine: {
+            md(filePath, locals, cb) { cb(null, "<h1>html</h1>") },
+        }
+    },
+    get("/", ctx => "Hello, World!"),
+);

--- a/types/server/typings/options.d.ts
+++ b/types/server/typings/options.d.ts
@@ -42,7 +42,7 @@ export interface CsurfOptions {
     sessionKey?: string | undefined;
 }
 
-export {}
+export {}  // This prevents EngineArgs being automatically exported
 type EngineArgs = Parameters<express.Application['engine']>
 
 export interface Options {

--- a/types/server/typings/options.d.ts
+++ b/types/server/typings/options.d.ts
@@ -42,12 +42,15 @@ export interface CsurfOptions {
     sessionKey?: string | undefined;
 }
 
+export {}
+type EngineArgs = Parameters<express.Application['engine']>
+
 export interface Options {
     port?: number | undefined;
     secret?: string | undefined;
     public?: string | undefined;
     views?: string | undefined;
-    engine?: string | undefined;
+    engine?: string | undefined | Record<EngineArgs[0], EngineArgs[1]>;
     env?: string | undefined;
     favicon?: string | undefined;
     parser?: {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

From [documentation on adding engines](https://serverjs.io/documentation/options/#writing-your-own-engine):
```js
const options = {
  engine: {
    // Register two keys for the same render function
    nunjucks,
    njk: nunjucks
  }
};

server(options, [...])
```

It has been this way since 2017 ([commit](https://github.com/franciscop/server/commit/bb329fd9bed9ec91bff333e55487566db2f2d592))
