### PR TITLE
[node] Update types to v20.8.0

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -71,7 +71,7 @@ declare module "buffer" {
         MAX_LENGTH: number;
         MAX_STRING_LENGTH: number;
     };
-    export type TranscodeEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "latin1" | "binary";
+    export type TranscodeEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "latin1" | "binary";
     /**
      * Re-encodes the given `Buffer` or `Uint8Array` instance from one character
      * encoding to another. Returns a new `Buffer` instance.
@@ -225,6 +225,7 @@ declare module "buffer" {
             | "utf8"
             | "utf-8"
             | "utf16le"
+            | "utf-16le"
             | "ucs2"
             | "ucs-2"
             | "base64"

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -260,7 +260,7 @@ declare module "crypto" {
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
     // https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
     type BinaryToTextEncoding = "base64" | "base64url" | "hex" | "binary";
-    type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "latin1";
+    type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "utf-16le" | "latin1";
     type LegacyCharacterEncoding = "ascii" | "binary" | "ucs2" | "ucs-2";
     type Encoding = BinaryToTextEncoding | CharacterEncoding | LegacyCharacterEncoding;
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 20.7
+// Type definitions for non-npm package Node.js 20.8
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -142,13 +142,13 @@ declare module "module" {
          */
         type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
         /**
-         * The `initialize` hook provides a way to define a custom function that runs in the loader's thread
-         * when the loader is initialized. Initialization happens when the loader is registered via `register`
-         * or registered via the `--experimental-loader` command line option.
+         * The `initialize` hook provides a way to define a custom function that runs in the hooks thread
+         * when the hooks module is initialized. Initialization happens when the hooks module is registered via `register`.
          *
-         * This hook can send and receive data from a `register` invocation, including ports and other transferrable objects.
+         * This hook can receive data from a `register` invocation, including ports and other transferrable objects.
+         * The return value of `initialize` can be a `Promise`, in which case it will be awaited before the main application thread execution resumes.
          */
-        type InitializeHook<Data = any, ReturnType = any> = (data: Data) => ReturnType;
+        type InitializeHook<Data = any> = (data: Data) => void | Promise<void>;
         interface ResolveHookContext {
             /**
              * Export conditions of the relevant `package.json`
@@ -240,7 +240,7 @@ declare module "module" {
         ) => LoadFnOutput | Promise<LoadFnOutput>;
     }
     interface RegisterOptions<Data> {
-        parentURL: string;
+        parentURL: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }
@@ -252,12 +252,12 @@ declare module "module" {
         static builtinModules: string[];
         static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
-        static register<Data = any, ReturnType = any>(
-            specifier: string,
-            parentURL?: string,
+        static register<Data = any>(
+            specifier: string | URL,
+            parentURL?: string | URL,
             options?: RegisterOptions<Data>,
-        ): ReturnType;
-        static register<Data = any, ReturnType = any>(specifier: string, options?: RegisterOptions<Data>): ReturnType;
+        ): void;
+        static register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
         constructor(id: string, parent?: Module);
     }
     global {

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -240,6 +240,7 @@ declare module "net" {
          *
          * Each address is a string in the form of `$IP:$PORT`.
          * If the connection was successful, then the last address is the one that the socket is currently connected to.
+         * @since v19.4.0
          */
         readonly autoSelectFamilyAttemptedAddresses: string[];
         /**
@@ -832,9 +833,27 @@ declare module "net" {
     function createConnection(options: NetConnectOpts, connectionListener?: () => void): Socket;
     function createConnection(port: number, host?: string, connectionListener?: () => void): Socket;
     function createConnection(path: string, connectionListener?: () => void): Socket;
+    /**
+     * Gets the current default value of the `autoSelectFamily` option of `socket.connect(options)`.
+     * The initial default value is `true`, unless the command line option`--no-network-family-autoselection` is provided.
+     * @since v19.4.0
+     */
     function getDefaultAutoSelectFamily(): boolean;
+    /**
+     * Sets the default value of the `autoSelectFamily` option of `socket.connect(options)`.
+     * @since v19.4.0
+     */
     function setDefaultAutoSelectFamily(value: boolean): void;
+    /**
+     * Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+     * The initial default value is `250`.
+     * @since v19.8.0
+     */
     function getDefaultAutoSelectFamilyAttemptTimeout(): number;
+    /**
+     * Sets the default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+     * @since v19.8.0
+     */
     function setDefaultAutoSelectFamilyAttemptTimeout(value: number): void;
     /**
      * Returns `6` if `input` is an IPv6 address. Returns `4` if `input` is an IPv4

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -400,7 +400,7 @@ declare module "os" {
     const EOL: string;
     /**
      * Returns the operating system CPU architecture for which the Node.js binary was
-     * compiled. Possible values are `'arm'`, `'arm64'`, `'ia32'`, `'mips'`,`'mipsel'`, `'ppc'`, `'ppc64'`, `'s390'`, `'s390x'`, and `'x64'`.
+     * compiled. Possible values are `'arm'`, `'arm64'`, `'ia32'`, `'mips'`,`'mipsel'`, `'ppc'`, `'ppc64'`, `'riscv64'`, `'s390'`, `'s390x'`, and `'x64'`.
      *
      * The return value is equivalent to `process.arch`.
      * @since v0.5.0

--- a/types/node/scripts/generate-docs/docs.ts
+++ b/types/node/scripts/generate-docs/docs.ts
@@ -109,10 +109,11 @@ async function main() {
         writeFileSync(
             fileName,
             format(printer.printBundle(factory.createBundle(transformRes.transformed as SourceFile[])), {
-                printWidth: 200,
+                printWidth: 120,
                 parser: "typescript",
                 tabWidth: 4,
-                singleQuote: true,
+                singleQuote: false,
+                trailingComma: "all",
             }),
         );
     }

--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -77,6 +77,15 @@ declare module "stream/web" {
     type ReadableStreamDefaultReadResult<T> =
         | ReadableStreamDefaultReadValueResult<T>
         | ReadableStreamDefaultReadDoneResult;
+    interface ReadableStreamReadValueResult<T> {
+        done: false;
+        value: T;
+    }
+    interface ReadableStreamReadDoneResult<T> {
+        done: true;
+        value?: T;
+    }
+    type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {
         (controller: ReadableByteStreamController): void | PromiseLike<void>;
     }
@@ -138,6 +147,7 @@ declare module "stream/web" {
         readonly locked: boolean;
         cancel(reason?: any): Promise<void>;
         getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -151,6 +161,10 @@ declare module "stream/web" {
     };
     interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericReader {
         read(): Promise<ReadableStreamDefaultReadResult<R>>;
+        releaseLock(): void;
+    }
+    interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
+        read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
         releaseLock(): void;
     }
     const ReadableStreamDefaultReader: {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -84,7 +84,9 @@ declare module "node:test" {
     /**
      * ```js
      * import { tap } from 'node:test/reporters';
+     * import { run } from 'node:test';
      * import process from 'node:process';
+     * import path from 'node:path';
      *
      * run({ files: [path.resolve('./tests/test.js')] })
      *   .compose(tap)
@@ -292,6 +294,10 @@ declare module "node:test" {
          * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
+         * If truthy, the test context will only run tests that have the `only` option set
+         */
+        only?: boolean;
         /**
          * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
          */
@@ -1368,5 +1374,9 @@ declare module "node:test/reporters" {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, Spec as spec, tap, TestEvent };
+    /**
+     * The `junit` reporter outputs test results in a jUnit XML format
+     */
+    function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
+    export { dot, Spec as spec, tap, junit, TestEvent };
 }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -117,28 +117,27 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
     const parentURL = "some-url"; // import.meta.url
     Module.register(specifier);
     Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL('data:') });
     Module.register(specifier, parentURL);
+    Module.register(specifier, new URL('data:'));
 
     const someArrayBuffer = new ArrayBuffer(100);
-    const registerResult1 = Module.register(specifier, {
+    Module.register(specifier, {
         parentURL,
         data: someArrayBuffer,
         transferList: [someArrayBuffer],
     });
-    registerResult1; // $ExpectType any
 
     interface TransferableData {
         number: number;
     }
-    const registerResult2 = Module.register<TransferableData, "ok" | "fail">(specifier, {
+    Module.register<TransferableData>(specifier, {
         parentURL,
         data: { number: 1 },
     });
-    registerResult2; // $ExpectType "ok" | "fail" || "fail" | "ok"
 
-    type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
-    const initializeHook: MyInitializeHook = ({ number }) => {
+    type MyInitializeHook = Module.InitializeHook<TransferableData>;
+    const initializeHook: MyInitializeHook = async ({ number }) => {
         number; // $ExpectType number
-        return "ok";
     };
 }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -21,6 +21,7 @@ import { pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every } from "node:timers/promises";
 import { MessageChannel as NodeMC } from "node:worker_threads";
+import { Blob } from "node:buffer";
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -734,4 +735,8 @@ async function testTransferringStreamWithPostMessage() {
         // $ExpectType Error
         err;
     });
+}
+
+{
+    new Blob(['1', '2']).stream().getReader({ mode: 'byob' })
 }

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "node:stream";
 import { after, afterEach, before, beforeEach, describe, it, only, run, skip, test, todo, mock, Mock } from "node:test";
-import { dot, spec, tap, TestEvent } from "node:test/reporters";
+import { dot, spec, tap, junit, TestEvent } from "node:test/reporters";
 
 // run without options
 // $ExpectType TestsStream
@@ -21,6 +21,7 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ["executed"],
+    only: true,
     setup: (root) => {},
     watch: true,
     shard: {
@@ -652,6 +653,10 @@ tap();
 tap("" as any);
 // $ExpectType Spec
 new spec();
+// @ts-expect-error
+junit();
+// $ExpectType AsyncGenerator<string, void, unknown>
+junit("" as any);
 
 describe("Mock Timers Test Suite", () => {
     it((t) => {

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -71,7 +71,7 @@ declare module "buffer" {
         MAX_LENGTH: number;
         MAX_STRING_LENGTH: number;
     };
-    export type TranscodeEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "latin1" | "binary";
+    export type TranscodeEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "latin1" | "binary";
     /**
      * Re-encodes the given `Buffer` or `Uint8Array` instance from one character
      * encoding to another. Returns a new `Buffer` instance.
@@ -225,6 +225,7 @@ declare module "buffer" {
             | "utf8"
             | "utf-8"
             | "utf16le"
+            | "utf-16le"
             | "ucs2"
             | "ucs-2"
             | "base64"
@@ -529,7 +530,7 @@ declare module "buffer" {
              * @param [fill=0] A value to pre-fill the new `Buffer` with.
              * @param [encoding='utf8'] If `fill` is a string, this is its encoding.
              */
-            alloc(size: number, fill?: string | Buffer | number, encoding?: BufferEncoding): Buffer;
+            alloc(size: number, fill?: string | Uint8Array | number, encoding?: BufferEncoding): Buffer;
             /**
              * Allocates a new `Buffer` of `size` bytes. If `size` is larger than {@link constants.MAX_LENGTH} or smaller than 0, `ERR_OUT_OF_RANGE` is thrown.
              *

--- a/types/node/ts4.8/crypto.d.ts
+++ b/types/node/ts4.8/crypto.d.ts
@@ -260,7 +260,7 @@ declare module "crypto" {
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
     // https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
     type BinaryToTextEncoding = "base64" | "base64url" | "hex" | "binary";
-    type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "latin1";
+    type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "utf-16le" | "latin1";
     type LegacyCharacterEncoding = "ascii" | "binary" | "ucs2" | "ucs-2";
     type Encoding = BinaryToTextEncoding | CharacterEncoding | LegacyCharacterEncoding;
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -65,6 +65,24 @@ declare module "module" {
             originalLine: number;
             originalColumn: number;
         }
+        interface SourceOrigin {
+            /**
+             * The name of the range in the source map, if one was provided
+             */
+            name?: string;
+            /**
+             * The file name of the original source, as reported in the SourceMap
+             */
+            fileName: string;
+            /**
+             * The 1-indexed lineNumber of the corresponding call site in the original source
+             */
+            lineNumber: number;
+            /**
+             * The 1-indexed columnNumber of the corresponding call site in the original source
+             */
+            columnNumber: number;
+        }
         /**
          * @since v13.7.0, v12.17.0
          */
@@ -93,6 +111,16 @@ declare module "module" {
              * @param columnOffset The zero-indexed column number offset in the generated source
              */
             findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            /**
+             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
+             * find the corresponding call site location in the original source.
+             *
+             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
+             * then an empty object is returned.
+             * @param lineNumber The 1-indexed line number of the call site in the generated source
+             * @param columnNumber The 1-indexed column number of the call site in the generated source
+             */
+            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
         }
         interface ImportAssertions extends NodeJS.Dict<string> {
             type?: string | undefined;
@@ -114,13 +142,13 @@ declare module "module" {
          */
         type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
         /**
-         * The `initialize` hook provides a way to define a custom function that runs in the loader's thread
-         * when the loader is initialized. Initialization happens when the loader is registered via `register`
-         * or registered via the `--experimental-loader` command line option.
+         * The `initialize` hook provides a way to define a custom function that runs in the hooks thread
+         * when the hooks module is initialized. Initialization happens when the hooks module is registered via `register`.
          *
-         * This hook can send and receive data from a `register` invocation, including ports and other transferrable objects.
+         * This hook can receive data from a `register` invocation, including ports and other transferrable objects.
+         * The return value of `initialize` can be a `Promise`, in which case it will be awaited before the main application thread execution resumes.
          */
-        type InitializeHook<Data = any, ReturnType = any> = (data: Data) => ReturnType;
+        type InitializeHook<Data = any> = (data: Data) => void | Promise<void>;
         interface ResolveHookContext {
             /**
              * Export conditions of the relevant `package.json`
@@ -212,7 +240,7 @@ declare module "module" {
         ) => LoadFnOutput | Promise<LoadFnOutput>;
     }
     interface RegisterOptions<Data> {
-        parentURL: string;
+        parentURL: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }
@@ -224,12 +252,12 @@ declare module "module" {
         static builtinModules: string[];
         static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
-        static register<Data = any, ReturnType = any>(
-            specifier: string,
-            parentURL?: string,
+        static register<Data = any>(
+            specifier: string | URL,
+            parentURL?: string | URL,
             options?: RegisterOptions<Data>,
-        ): ReturnType;
-        static register<Data = any, ReturnType = any>(specifier: string, options?: RegisterOptions<Data>): ReturnType;
+        ): void;
+        static register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
         constructor(id: string, parent?: Module);
     }
     global {

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -235,6 +235,15 @@ declare module "net" {
          */
         ref(): this;
         /**
+         * This property is only present if the family autoselection algorithm is enabled in `socket.connect(options)`
+         * and it is an array of the addresses that have been attempted.
+         *
+         * Each address is a string in the form of `$IP:$PORT`.
+         * If the connection was successful, then the last address is the one that the socket is currently connected to.
+         * @since v19.4.0
+         */
+        readonly autoSelectFamilyAttemptedAddresses: string[];
+        /**
          * This property shows the number of characters buffered for writing. The buffer
          * may contain strings whose length after encoding is not yet known. So this number
          * is only an approximation of the number of bytes in the buffer.
@@ -824,6 +833,28 @@ declare module "net" {
     function createConnection(options: NetConnectOpts, connectionListener?: () => void): Socket;
     function createConnection(port: number, host?: string, connectionListener?: () => void): Socket;
     function createConnection(path: string, connectionListener?: () => void): Socket;
+    /**
+     * Gets the current default value of the `autoSelectFamily` option of `socket.connect(options)`.
+     * The initial default value is `true`, unless the command line option`--no-network-family-autoselection` is provided.
+     * @since v19.4.0
+     */
+    function getDefaultAutoSelectFamily(): boolean;
+    /**
+     * Sets the default value of the `autoSelectFamily` option of `socket.connect(options)`.
+     * @since v19.4.0
+     */
+    function setDefaultAutoSelectFamily(value: boolean): void;
+    /**
+     * Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+     * The initial default value is `250`.
+     * @since v19.8.0
+     */
+    function getDefaultAutoSelectFamilyAttemptTimeout(): number;
+    /**
+     * Sets the default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+     * @since v19.8.0
+     */
+    function setDefaultAutoSelectFamilyAttemptTimeout(value: number): void;
     /**
      * Returns `6` if `input` is an IPv6 address. Returns `4` if `input` is an IPv4
      * address in [dot-decimal notation](https://en.wikipedia.org/wiki/Dot-decimal_notation) with no leading zeroes. Otherwise, returns`0`.

--- a/types/node/ts4.8/os.d.ts
+++ b/types/node/ts4.8/os.d.ts
@@ -400,7 +400,7 @@ declare module "os" {
     const EOL: string;
     /**
      * Returns the operating system CPU architecture for which the Node.js binary was
-     * compiled. Possible values are `'arm'`, `'arm64'`, `'ia32'`, `'mips'`,`'mipsel'`, `'ppc'`, `'ppc64'`, `'s390'`, `'s390x'`, and `'x64'`.
+     * compiled. Possible values are `'arm'`, `'arm64'`, `'ia32'`, `'mips'`,`'mipsel'`, `'ppc'`, `'ppc64'`, `'riscv64'`, `'s390'`, `'s390x'`, and `'x64'`.
      *
      * The return value is equivalent to `process.arch`.
      * @since v0.5.0

--- a/types/node/ts4.8/stream.d.ts
+++ b/types/node/ts4.8/stream.d.ts
@@ -40,6 +40,12 @@ declare module "stream" {
     import Stream = internal.Stream;
     import Readable = internal.Readable;
     import ReadableOptions = internal.ReadableOptions;
+    interface ArrayOptions {
+        /** the maximum concurrent invocations of `fn` to call on the stream at once. **Default: 1**. */
+        concurrency?: number;
+        /** allows destroying the stream if the signal is aborted. */
+        signal?: AbortSignal;
+    }
     class ReadableBase extends Stream implements NodeJS.ReadableStream {
         /**
          * A utility method for creating Readable Streams out of iterators.
@@ -399,6 +405,164 @@ declare module "stream" {
          */
         wrap(stream: NodeJS.ReadableStream): this;
         push(chunk: any, encoding?: BufferEncoding): boolean;
+        /**
+         * The iterator created by this method gives users the option to cancel the destruction
+         * of the stream if the `for await...of` loop is exited by `return`, `break`, or `throw`,
+         * or if the iterator should destroy the stream if the stream emitted an error during iteration.
+         * @since v16.3.0
+         * @param options.destroyOnReturn When set to `false`, calling `return` on the async iterator,
+         * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
+         * **Default: `true`**.
+         */
+        iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+        /**
+         * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
+         * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
+         * @since v17.4.0, v16.14.0
+         * @param fn a function to map over every chunk in the stream. Async or not.
+         * @returns a stream mapped with the function *fn*.
+         */
+        map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+        /**
+         * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
+         * and if it returns a truthy value, the chunk will be passed to the result stream.
+         * If the *fn* function returns a promise - that promise will be `await`ed.
+         * @since v17.4.0, v16.14.0
+         * @param fn a function to filter chunks from the stream. Async or not.
+         * @returns a stream filtered with the predicate *fn*.
+         */
+        filter(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            options?: ArrayOptions,
+        ): Readable;
+        /**
+         * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
+         * If the *fn* function returns a promise - that promise will be `await`ed.
+         *
+         * This method is different from `for await...of` loops in that it can optionally process chunks concurrently.
+         * In addition, a `forEach` iteration can only be stopped by having passed a `signal` option
+         * and aborting the related AbortController while `for await...of` can be stopped with `break` or `return`.
+         * In either case the stream will be destroyed.
+         *
+         * This method is different from listening to the `'data'` event in that it uses the `readable` event
+         * in the underlying machinary and can limit the number of concurrent *fn* calls.
+         * @since v17.5.0
+         * @param fn a function to call on each chunk of the stream. Async or not.
+         * @returns a promise for when the stream has finished.
+         */
+        forEach(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+            options?: ArrayOptions,
+        ): Promise<void>;
+        /**
+         * This method allows easily obtaining the contents of a stream.
+         *
+         * As this method reads the entire stream into memory, it negates the benefits of streams. It's intended
+         * for interoperability and convenience, not as the primary way to consume streams.
+         * @since v17.5.0
+         * @returns a promise containing an array with the contents of the stream.
+         */
+        toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+        /**
+         * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
+         * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
+         * `await`ed return value is truthy, the stream is destroyed and the promise is fulfilled with `true`.
+         * If none of the *fn* calls on the chunks return a truthy value, the promise is fulfilled with `false`.
+         * @since v17.5.0
+         * @param fn a function to call on each chunk of the stream. Async or not.
+         * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
+         */
+        some(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            options?: ArrayOptions,
+        ): Promise<boolean>;
+        /**
+         * This method is similar to `Array.prototype.find` and calls *fn* on each chunk in the stream
+         * to find a chunk with a truthy value for *fn*. Once an *fn* call's awaited return value is truthy,
+         * the stream is destroyed and the promise is fulfilled with value for which *fn* returned a truthy value.
+         * If all of the *fn* calls on the chunks return a falsy value, the promise is fulfilled with `undefined`.
+         * @since v17.5.0
+         * @param fn a function to call on each chunk of the stream. Async or not.
+         * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
+         * or `undefined` if no element was found.
+         */
+        find<T>(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+            options?: ArrayOptions,
+        ): Promise<T | undefined>;
+        find(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            options?: ArrayOptions,
+        ): Promise<any>;
+        /**
+         * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
+         * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
+         * `await`ed return value is falsy, the stream is destroyed and the promise is fulfilled with `false`.
+         * If all of the *fn* calls on the chunks return a truthy value, the promise is fulfilled with `true`.
+         * @since v17.5.0
+         * @param fn a function to call on each chunk of the stream. Async or not.
+         * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
+         */
+        every(
+            fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            options?: ArrayOptions,
+        ): Promise<boolean>;
+        /**
+         * This method returns a new stream by applying the given callback to each chunk of the stream
+         * and then flattening the result.
+         *
+         * It is possible to return a stream or another iterable or async iterable from *fn* and the result streams
+         * will be merged (flattened) into the returned stream.
+         * @since v17.5.0
+         * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
+         * @returns a stream flat-mapped with the function *fn*.
+         */
+        flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+        /**
+         * This method returns a new stream with the first *limit* chunks dropped from the start.
+         * @since v17.5.0
+         * @param limit the number of chunks to drop from the readable.
+         * @returns a stream with *limit* chunks dropped from the start.
+         */
+        drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+        /**
+         * This method returns a new stream with the first *limit* chunks.
+         * @since v17.5.0
+         * @param limit the number of chunks to take from the readable.
+         * @returns a stream with *limit* chunks taken.
+         */
+        take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+        /**
+         * This method returns a new stream with chunks of the underlying stream paired with a counter
+         * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
+         * @since v17.5.0
+         * @returns a stream of indexed pairs.
+         */
+        asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+        /**
+         * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
+         * on the previous element. It returns a promise for the final value of the reduction.
+         *
+         * If no *initial* value is supplied the first chunk of the stream is used as the initial value.
+         * If the stream is empty, the promise is rejected with a `TypeError` with the `ERR_INVALID_ARGS` code property.
+         *
+         * The reducer function iterates the stream element-by-element which means that there is no *concurrency* parameter
+         * or parallelism. To perform a reduce concurrently, you can extract the async function to `readable.map` method.
+         * @since v17.5.0
+         * @param fn a reducer function to call over every chunk in the stream. Async or not.
+         * @param initial the initial value to use in the reduction.
+         * @returns a promise for the final value of the reduction.
+         */
+        reduce<T = any>(
+            fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            initial?: undefined,
+            options?: Pick<ArrayOptions, "signal">,
+        ): Promise<T>;
+        reduce<T = any>(
+            fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            initial: T,
+            options?: Pick<ArrayOptions, "signal">,
+        ): Promise<T>;
         _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
         /**
          * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the readable

--- a/types/node/ts4.8/stream/web.d.ts
+++ b/types/node/ts4.8/stream/web.d.ts
@@ -77,6 +77,15 @@ declare module "stream/web" {
     type ReadableStreamDefaultReadResult<T> =
         | ReadableStreamDefaultReadValueResult<T>
         | ReadableStreamDefaultReadDoneResult;
+    interface ReadableStreamReadValueResult<T> {
+        done: false;
+        value: T;
+    }
+    interface ReadableStreamReadDoneResult<T> {
+        done: true;
+        value?: T;
+    }
+    type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {
         (controller: ReadableByteStreamController): void | PromiseLike<void>;
     }
@@ -138,6 +147,7 @@ declare module "stream/web" {
         readonly locked: boolean;
         cancel(reason?: any): Promise<void>;
         getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -151,6 +161,10 @@ declare module "stream/web" {
     };
     interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericReader {
         read(): Promise<ReadableStreamDefaultReadResult<R>>;
+        releaseLock(): void;
+    }
+    interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
+        read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
         releaseLock(): void;
     }
     const ReadableStreamDefaultReader: {

--- a/types/node/ts4.8/test.d.ts
+++ b/types/node/ts4.8/test.d.ts
@@ -76,7 +76,7 @@
  *
  * If any tests fail, the process exit code is set to `1`.
  * @since v18.0.0, v16.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.2.0/lib/test.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.4.0/lib/test.js)
  */
 declare module "node:test" {
     import { Readable } from "node:stream";
@@ -84,7 +84,9 @@ declare module "node:test" {
     /**
      * ```js
      * import { tap } from 'node:test/reporters';
+     * import { run } from 'node:test';
      * import process from 'node:process';
+     * import path from 'node:path';
      *
      * run({ files: [path.resolve('./tests/test.js')] })
      *   .compose(tap)
@@ -292,6 +294,10 @@ declare module "node:test" {
          * For each test that is executed, any corresponding test hooks, such as `beforeEach()`, are also run.
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
+        /**
+         * If truthy, the test context will only run tests that have the `only` option set
+         */
+        only?: boolean;
         /**
          * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
          */
@@ -1146,7 +1152,22 @@ declare module "node:test" {
          */
         [Symbol.dispose](): void;
     }
-    export { after, afterEach, before, beforeEach, describe, it, mock, only, run, skip, test, test as default, todo, Mock };
+    export {
+        after,
+        afterEach,
+        before,
+        beforeEach,
+        describe,
+        it,
+        Mock,
+        mock,
+        only,
+        run,
+        skip,
+        test,
+        test as default,
+        todo,
+    };
 }
 
 interface TestLocationInfo {
@@ -1353,5 +1374,9 @@ declare module "node:test/reporters" {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, Spec as spec, tap, TestEvent };
+    /**
+     * The `junit` reporter outputs test results in a jUnit XML format
+     */
+    function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
+    export { dot, Spec as spec, tap, junit, TestEvent };
 }

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -117,28 +117,27 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
     const parentURL = "some-url"; // import.meta.url
     Module.register(specifier);
     Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL('data:') });
     Module.register(specifier, parentURL);
+    Module.register(specifier, new URL('data:'));
 
     const someArrayBuffer = new ArrayBuffer(100);
-    const registerResult1 = Module.register(specifier, {
+    Module.register(specifier, {
         parentURL,
         data: someArrayBuffer,
         transferList: [someArrayBuffer],
     });
-    registerResult1; // $ExpectType any
 
     interface TransferableData {
         number: number;
     }
-    const registerResult2 = Module.register<TransferableData, "ok" | "fail">(specifier, {
+    Module.register<TransferableData>(specifier, {
         parentURL,
         data: { number: 1 },
     });
-    registerResult2; // $ExpectType "ok" | "fail" || "fail" | "ok"
 
-    type MyInitializeHook = Module.InitializeHook<TransferableData, "ok" | "fail">;
-    const initializeHook: MyInitializeHook = ({ number }) => {
+    type MyInitializeHook = Module.InitializeHook<TransferableData>;
+    const initializeHook: MyInitializeHook = async ({ number }) => {
         number; // $ExpectType number
-        return "ok";
     };
 }

--- a/types/node/ts4.8/test/test.ts
+++ b/types/node/ts4.8/test/test.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "node:stream";
 import { after, afterEach, before, beforeEach, describe, it, only, run, skip, test, todo, mock, Mock } from "node:test";
-import { dot, spec, tap, TestEvent } from "node:test/reporters";
+import { dot, spec, tap, junit, TestEvent } from "node:test/reporters";
 
 // run without options
 // $ExpectType TestsStream
@@ -21,6 +21,7 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ["executed"],
+    only: true,
     setup: (root) => {},
     watch: true,
     shard: {
@@ -652,6 +653,10 @@ tap();
 tap("" as any);
 // $ExpectType Spec
 new spec();
+// @ts-expect-error
+junit();
+// $ExpectType AsyncGenerator<string, void, unknown>
+junit("" as any);
 
 describe("Mock Timers Test Suite", () => {
     it((t) => {

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -419,8 +419,14 @@ declare module "util" {
      * const bigNumber = 123_456_789n;
      * const bigDecimal = 1_234.123_45;
      *
-     * console.log(thousand, million, bigNumber, bigDecimal);
-     * // 1_000 1_000_000 123_456_789n 1_234.123_45
+     * console.log(inspect(thousand, { numericSeparator: true }));
+     * // 1_000
+     * console.log(inspect(million, { numericSeparator: true }));
+     * // 1_000_000
+     * console.log(inspect(bigNumber, { numericSeparator: true }));
+     * // 123_456_789n
+     * console.log(inspect(bigDecimal, { numericSeparator: true }));
+     * // 1_234.123_45
      * ```
      *
      * `util.inspect()` is a synchronous method intended for debugging. Its maximum
@@ -1087,6 +1093,8 @@ declare module "util" {
      *   const stats = await stat('.');
      *   console.log(`This directory is owned by ${stats.uid}`);
      * }
+     *
+     * callStat();
      * ```
      *
      * If there is an `original[util.promisify.custom]` property present, `promisify`will return its value, see `Custom promisified functions`.
@@ -1632,7 +1640,7 @@ declare module "util" {
          * params.set('foo', 'def');
          * params.set('baz', 'xyz');
          * console.log(params.toString());
-         * // Prints: foo=def&#x26;bar=1&#x26;baz=xyz
+         * // Prints: foo=def;bar=1;baz=xyz
          * ```
          */
         set(name: string, value: string): void;

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -419,8 +419,14 @@ declare module "util" {
      * const bigNumber = 123_456_789n;
      * const bigDecimal = 1_234.123_45;
      *
-     * console.log(thousand, million, bigNumber, bigDecimal);
-     * // 1_000 1_000_000 123_456_789n 1_234.123_45
+     * console.log(inspect(thousand, { numericSeparator: true }));
+     * // 1_000
+     * console.log(inspect(million, { numericSeparator: true }));
+     * // 1_000_000
+     * console.log(inspect(bigNumber, { numericSeparator: true }));
+     * // 123_456_789n
+     * console.log(inspect(bigDecimal, { numericSeparator: true }));
+     * // 1_234.123_45
      * ```
      *
      * `util.inspect()` is a synchronous method intended for debugging. Its maximum
@@ -1087,6 +1093,8 @@ declare module "util" {
      *   const stats = await stat('.');
      *   console.log(`This directory is owned by ${stats.uid}`);
      * }
+     *
+     * callStat();
      * ```
      *
      * If there is an `original[util.promisify.custom]` property present, `promisify`will return its value, see `Custom promisified functions`.
@@ -1632,7 +1640,7 @@ declare module "util" {
          * params.set('foo', 'def');
          * params.set('baz', 'xyz');
          * console.log(params.toString());
-         * // Prints: foo=def&#x26;bar=1&#x26;baz=xyz
+         * // Prints: foo=def;bar=1;baz=xyz
          * ```
          */
         set(name: string, value: string): void;


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.8.0

- esm: fix support for URL instances in register
- esm: remove return value for Module.register
- lib: allow byob reader for 'blob.stream()'
- test_runner: accept testOnly in run
- test_runner: add junit reporter

Also:
- add missed encoding aliases: "utf-8", "utf-16le", "ucs-2"
- add some missed types to `ts4.8` folder
