### PR TITLE
Fix node-geocoder depending on the wrong version of node-fetch

### DIFF
--- a/types/node-geocoder/package.json
+++ b/types/node-geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "node-fetch": "^3.3.0"
+    "@types/node-fetch": "^2"
   }
 }

--- a/types/node-geocoder/package.json
+++ b/types/node-geocoder/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "node-fetch": "^3.3.0"
+  }
+}

--- a/types/node-geocoder/package.json
+++ b/types/node-geocoder/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "dependencies": {
-    "node-fetch": "^3.3.0"
-  }
-}

--- a/types/node-geocoder/tslint.json
+++ b/types/node-geocoder/tslint.json
@@ -1,6 +1,3 @@
 { 
-  "extends": "@definitelytyped/dtslint/dt.json",
-  "rules": {
-    "no-outside-dependencies": false
-  }
+  "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/node-geocoder/tslint.json
+++ b/types/node-geocoder/tslint.json
@@ -1,3 +1,6 @@
 { 
-  "extends": "@definitelytyped/dtslint/dt.json"
+  "extends": "@definitelytyped/dtslint/dt.json",
+  "rules": {
+    "no-outside-dependencies": false
+  }
 }


### PR DESCRIPTION
This package actually depends on `node-fetch@2`. The only reason that this package is currently working is that `typesRoot` is remapping `node-fetch` back onto the local DT package.

This is technically equivalent to dropping `package.json` entirely, but I'm a little afraid of making the dep on `v2` implicit. We already allow `@types/node-fetch` as a dep, so it seemed okay and eventually we'll explicitly declare them anyhow.

Caught while working on the DT pnpm monorepo refactor.