### PR TITLE
feat(sinon): add define method to sandboxes

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1673,6 +1673,16 @@ declare namespace Sinon {
                     | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]);
             },
         ): SinonStubbedInstance<TType>;
+
+        /**
+         * Defines a property on the given object which will be torn down when
+         * the sandbox is restored
+         */
+        define(
+            obj: object,
+            key: PropertyKey,
+            value: unknown
+        ): void;
     }
 
     type SinonPromise<T> = Promise<T> & {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -135,6 +135,15 @@ function testSandbox() {
 
     // $ExpectType number
     objWithPrivateMembers.pubVar;
+
+    const objToDefine = {};
+
+    sb.define(objToDefine, 'someKey', 123);
+    sb.define(objToDefine, 100, 200);
+    sb.define(objToDefine, Symbol("abc"), 200);
+
+    // @ts-expect-error
+    sb.define(objToDefine, {}, 123);
 }
 
 function testFakeServer() {


### PR DESCRIPTION
This allows you to define an arbitrary property on an object for the lifetime of the sandbox.

Purposely doesn't use generics since you should be able to define properties the object's type doesn't have.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon/blob/main/CHANGES.md#1600
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
