### PR TITLE
[react-dom] Update types for latest state of Float

### DIFF
--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -44,7 +44,19 @@ declare module "." {
     }
     function preconnect(href: string, options?: PreconnectOptions): void;
 
-    type PreloadAs = "font" | "image" | "script" | "style";
+    type PreloadAs =
+        | "audio"
+        | "document"
+        | "embed"
+        | "fetch"
+        | "font"
+        | "image"
+        | "object"
+        | "track"
+        | "script"
+        | "style"
+        | "video"
+        | "worker";
     interface PreloadOptions {
         as: PreloadAs;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
@@ -67,6 +79,7 @@ declare module "." {
         as: PreloadModuleAs;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         integrity?: string | undefined;
+        nonce?: string | undefined;
     }
     function preloadModule(href: string, options?: PreloadModuleOptions): void;
 
@@ -90,6 +103,7 @@ declare module "." {
         as?: PreinitModuleAs;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         integrity?: string | undefined;
+        nonce?: string | undefined;
     }
     function preinitModule(href: string, options?: PreinitModuleOptions): void;
 }

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -38,16 +38,22 @@ declare module "." {
         // Don't create a helper type.
         // It would have to be in module scope to be inlined in TS tooltips.
         // But then it becomes part of the public API.
-        // TODO: Upstream to microsoft/TypeScript-DOM-lib-generator -> w3c/webref since the spec has a notion of a dedicated type: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
+        // TODO: Upstream to microsoft/TypeScript-DOM-lib-generator -> w3c/webref
+        // since the spec has a notion of a dedicated type: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
     }
     function preconnect(href: string, options?: PreconnectOptions): void;
 
-    type PreloadAs = "font" | "script" | "style";
+    type PreloadAs = "font" | "image" | "script" | "style";
     interface PreloadOptions {
         as: PreloadAs;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        fetchPriority?: "high" | "low" | "auto" | undefined;
+        // TODO: These should only be allowed with `as: 'image'` but it's not trivial to write tests against the full TS support matrix.
+        imageSizes?: string | undefined;
+        imageSrcSet?: string | undefined;
         integrity?: string | undefined;
+        nonce?: string | undefined;
     }
     function preload(href: string, options?: PreloadOptions): void;
 
@@ -67,6 +73,7 @@ declare module "." {
     interface PreinitOptions {
         as: PreinitAs;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        fetchPriority?: "high" | "low" | "auto" | undefined;
         precedence?: string | undefined;
         integrity?: string | undefined;
         nonce?: string | undefined;

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -38,7 +38,7 @@ declare module "." {
         // Don't create a helper type.
         // It would have to be in module scope to be inlined in TS tooltips.
         // But then it becomes part of the public API.
-        // Once we drop support for TS versions not shipping CrossOriginSettingsAttribute from lib.dom.d.ts, we can use that instead.
+        // TODO: Upstream to microsoft/TypeScript-DOM-lib-generator -> w3c/webref since the spec has a notion of a dedicated type: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
     }
     function preconnect(href: string, options?: PreconnectOptions): void;

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -54,6 +54,7 @@ declare module "." {
         imageSrcSet?: string | undefined;
         integrity?: string | undefined;
         nonce?: string | undefined;
+        referrerPolicy?: ReferrerPolicy | undefined;
     }
     function preload(href: string, options?: PreloadOptions): void;
 

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -32,21 +32,56 @@ import ReactDOM = require(".");
 export {};
 
 declare module "." {
+    function prefetchDNS(href: string): void;
+
+    interface PreconnectOptions {
+        // Don't create a helper type.
+        // It would have to be in module scope to be inlined in TS tooltips.
+        // But then it becomes part of the public API.
+        // Once we drop support for TS versions not shipping CrossOriginSettingsAttribute from lib.dom.d.ts, we can use that instead.
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    }
+    function preconnect(href: string, options?: PreconnectOptions): void;
+
     type PreloadAs = "font" | "script" | "style";
     interface PreloadOptions {
         as: PreloadAs;
-        crossOrigin?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         integrity?: string | undefined;
     }
     function preload(href: string, options?: PreloadOptions): void;
 
+    // https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+    type PreloadModuleAs = RequestDestination;
+    interface PreloadModuleOptions {
+        /**
+         * @default "script"
+         */
+        as: PreloadModuleAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        integrity?: string | undefined;
+    }
+    function preloadModule(href: string, options?: PreloadModuleOptions): void;
+
     type PreinitAs = "script" | "style";
     interface PreinitOptions {
         as: PreinitAs;
-        crossOrigin?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         precedence?: string | undefined;
         integrity?: string | undefined;
         nonce?: string | undefined;
     }
     function preinit(href: string, options?: PreinitOptions): void;
+
+    // Will be expanded to include all of https://github.com/tc39/proposal-import-attributes
+    type PreinitModuleAs = "script";
+    interface PreinitModuleOptions {
+        /**
+         * @default "script"
+         */
+        as?: PreinitModuleAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        integrity?: string | undefined;
+    }
+    function preinitModule(href: string, options?: PreinitModuleOptions): void;
 }

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -41,6 +41,7 @@ function preloadTest() {
             fetchPriority: "high",
             precedence: "high",
             integrity: "sad",
+            nonce: "0xeac1",
         });
         ReactDOM.preinit("bar", {
             // @ts-expect-error Only available in preload
@@ -76,7 +77,12 @@ function preloadTest() {
         // @ts-expect-error
         ReactDOM.preloadModule();
         ReactDOM.preloadModule("browserdefault");
-        ReactDOM.preloadModule("browserdefault", { as: "script", crossOrigin: "use-credentials", integrity: "0xeac1" });
+        ReactDOM.preloadModule("browserdefault", {
+            as: "script",
+            crossOrigin: "use-credentials",
+            integrity: "0xeac1",
+            nonce: "secret",
+        });
         ReactDOM.preloadModule("worker", { as: "worker" });
         ReactDOM.preloadModule("worker", {
             // @ts-expect-error Unknown request destination

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -2,8 +2,12 @@
 
 function preloadTest() {
     function Component() {
-        ReactDOM.preload("foo", { as: "style", integrity: "sad" });
-        ReactDOM.preload("bar", { as: "font" });
+        ReactDOM.preload("foo", { as: "style", fetchPriority: "high", integrity: "sad" });
+        ReactDOM.preload("bar", {
+            as: "font",
+            // @ts-expect-error Unknown fetch priority
+            fetchPriority: "unknown",
+        });
         ReactDOM.preload("baz", { as: "script", crossOrigin: "use-credentials" });
         ReactDOM.preload("baz", {
             // @ts-expect-error
@@ -11,13 +15,24 @@ function preloadTest() {
         });
         ReactDOM.preload("bar", {
             as: "font",
-            // @ts-expect-error -- Only allowed in preinit
             nonce: "0xeac1",
+        });
+        ReactDOM.preload("foo", {
+            as: "image",
+            imageSrcSet: "fooset",
+            imageSizes: "foosizes",
+        });
+        ReactDOM.preload("foo", {
+            as: "script",
+            // Undesired. Should not typecheck.
+            imageSrcSet: "fooset",
+            imageSizes: "foosizes",
         });
 
         ReactDOM.preinit("foo", {
             as: "style",
             crossOrigin: "anonymous",
+            fetchPriority: "high",
             precedence: "high",
             integrity: "sad",
         });
@@ -27,6 +42,8 @@ function preloadTest() {
         });
         ReactDOM.preinit("baz", {
             as: "script",
+            // @ts-expect-error Unknown fetch priority
+            fetchPriority: "unknown",
         });
         ReactDOM.preinit("baz", {
             // @ts-expect-error

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -21,6 +21,12 @@ function preloadTest() {
             as: "image",
             imageSrcSet: "fooset",
             imageSizes: "foosizes",
+            referrerPolicy: "no-referrer",
+        });
+        ReactDOM.preload("foo", {
+            as: "image",
+            // @ts-expect-error Not specified in https://w3c.github.io/webappsec-referrer-policy/#referrer-policy
+            referrerPolicy: "unknown-policy",
         });
         ReactDOM.preload("foo", {
             as: "script",

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -36,5 +36,37 @@ function preloadTest() {
             as: "script",
             nonce: "0xeac1",
         });
+
+        // @ts-expect-error
+        ReactDOM.preconnect();
+        ReactDOM.preconnect("foo");
+        ReactDOM.preconnect("bar", { crossOrigin: "anonymous" });
+
+        // @ts-expect-error
+        ReactDOM.prefetchDNS();
+        ReactDOM.prefetchDNS("foo");
+        ReactDOM.prefetchDNS(
+            "bar", // @ts-expect-error prefetchDNS does not accept any options at the moment
+            {},
+        );
+
+        // @ts-expect-error
+        ReactDOM.preloadModule();
+        ReactDOM.preloadModule("browserdefault");
+        ReactDOM.preloadModule("browserdefault", { as: "script", crossOrigin: "use-credentials", integrity: "0xeac1" });
+        ReactDOM.preloadModule("worker", { as: "worker" });
+        ReactDOM.preloadModule("worker", {
+            // @ts-expect-error Unknown request destination
+            as: "serviceworker",
+        });
+
+        // @ts-expect-error
+        ReactDOM.preinitModule();
+        ReactDOM.preinitModule("browserdefault");
+        ReactDOM.preinitModule("browserdefault", { as: "script", crossOrigin: "use-credentials", integrity: "0xeac1" });
+        ReactDOM.preinitModule("data", {
+            // @ts-expect-error Not supported (yet)
+            as: "json",
+        });
     }
 }


### PR DESCRIPTION
1. https://github.com/facebook/react/pull/26237
2. https://github.com/facebook/react/pull/27220
3. https://github.com/facebook/react/pull/26880
4. https://github.com/facebook/react/pull/26939
5. https://github.com/facebook/react/pull/26940
6. https://github.com/facebook/react/pull/27096
7. Concrete string literal for `crossOrigin`

@gnoff Could you review this one?