### PR TITLE
[@types/node]: Fix typing of UserInfo.shell to be correct to behaviour and documentation

### DIFF
--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -38,7 +38,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;

--- a/types/node/ts4.8/os.d.ts
+++ b/types/node/ts4.8/os.d.ts
@@ -38,7 +38,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;

--- a/types/node/v16/os.d.ts
+++ b/types/node/v16/os.d.ts
@@ -37,7 +37,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;

--- a/types/node/v16/ts4.8/os.d.ts
+++ b/types/node/v16/ts4.8/os.d.ts
@@ -38,7 +38,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;

--- a/types/node/v18/os.d.ts
+++ b/types/node/v18/os.d.ts
@@ -38,7 +38,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;

--- a/types/node/v18/ts4.8/os.d.ts
+++ b/types/node/v18/ts4.8/os.d.ts
@@ -38,7 +38,7 @@ declare module "os" {
         username: T;
         uid: number;
         gid: number;
-        shell: T;
+        shell: T | null;
         homedir: T;
     }
     type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;


### PR DESCRIPTION
Quote from https://nodejs.org/docs/latest-v18.x/api/os.html#osuserinfooptions

> Returns information about the currently effective user. On POSIX platforms, this is typically a subset of the password file. The returned object includes the username, uid, gid, shell, and homedir. On Windows, the uid and gid fields are -1, and shell is null.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Versions:
- v20
- v18 (needs to be backported)