### PR TITLE
[@wordpress/components,next-pwa] Fix tests with TS 5.3

### DIFF
--- a/types/next-pwa/global.d.ts
+++ b/types/next-pwa/global.d.ts
@@ -1,0 +1,4 @@
+// Adding interfaces from webworker since we have to typecheck with DOM to get Next.js types
+// tslint:disable:no-empty-interface
+
+interface ExtendableEvent {}

--- a/types/next-pwa/index.d.ts
+++ b/types/next-pwa/index.d.ts
@@ -10,6 +10,28 @@
 import type { NextConfig } from "next";
 import type { GenerateSWOptions, InjectManifestOptions, RuntimeCaching } from "workbox-build";
 
+declare global {
+    interface PopStateEventInit extends EventInit {
+        state?: any;
+    }
+
+    /**
+     * PopStateEvent is an event handler for the popstate event on the window.
+     *
+     * Re-declare type to allow tsconfig `lib: ["es6", "webworker"]` to work.
+     * @see [DOM and WebWorker Should not be mutually exclusive](https://github.com/microsoft/TypeScript/issues/20595)
+     */
+    interface PopStateEvent extends Event {
+        /** Returns a copy of the information that was provided to pushState() or replaceState(). */
+        readonly state: any;
+    }
+
+    var PopStateEvent: {
+        prototype: PopStateEvent;
+        new(type: string, eventInitDict?: PopStateEventInit): PopStateEvent;
+    };
+}
+
 /**
  * The declaration type for the `withPWA` function.
  */

--- a/types/next-pwa/index.d.ts
+++ b/types/next-pwa/index.d.ts
@@ -4,32 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 5.1
 
+/// <reference path="global.d.ts" />
 /// <reference types="react"/>
 
 import type { NextConfig } from "next";
 import type { GenerateSWOptions, InjectManifestOptions, RuntimeCaching } from "workbox-build";
-
-declare global {
-    interface PopStateEventInit extends EventInit {
-        state?: unknown;
-    }
-
-    /**
-     * PopStateEvent is an event handler for the popstate event on the window.
-     *
-     * Re-declare type to allow tsconfig `lib: ["es6", "webworker"]` to work.
-     * @see [DOM and WebWorker Should not be mutually exclusive](https://github.com/microsoft/TypeScript/issues/20595)
-     */
-    interface PopStateEvent extends Event {
-        /** Returns a copy of the information that was provided to pushState() or replaceState(). */
-        readonly state: unknown;
-    }
-
-    var PopStateEvent: {
-        prototype: PopStateEvent;
-        new(type: string, eventInitDict?: PopStateEventInit): PopStateEvent;
-    };
-}
 
 /**
  * The declaration type for the `withPWA` function.

--- a/types/next-pwa/next-pwa-tests.ts
+++ b/types/next-pwa/next-pwa-tests.ts
@@ -2,6 +2,7 @@
 import nextPWA = require("next-pwa");
 import type { NextConfig } from "next";
 
+
 // $ExpectType (config: NextConfig) => NextConfig & PWAConfig
 const withPWA = nextPWA({
     dest: "public",

--- a/types/next-pwa/tsconfig.json
+++ b/types/next-pwa/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "webworker"
+            "DOM",
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -581,8 +581,7 @@ const kbshortcuts = {
             actions: [{ label: "Action One", url: "https://wordpress.org" }],
         },
     ]}
->
-</C.NoticeList>;
+/>;
 
 //
 // panel


### PR DESCRIPTION
Unblocks https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66897

Fixes

```
Error in next-pwa
Error: Errors in typescript@5.3 for external dependencies:
Error: node_modules/next/dist/client/components/router-reducer/router-reducer-types.d.ts(44,13): error TS2304: Cannot find name 'Location'.
Error: node_modules/next/dist/client/components/router-reducer/router-reducer-types.d.ts(50,13): error TS2304: Cannot find name 'Location'.
Error: node_modules/next/dist/client/components/router-reducer/router-reducer-types.d.ts(101,21): error TS2304: Cannot find name 'Location'.

Error in wordpress__components
Error: /home/runner/work/DefinitelyTyped/DefinitelyTyped/types/wordpress__components/wordpress__components-tests.tsx:575:2
ERROR: 575:2  expect  TypeScript@5.3 compile error:
Type '{ children: never[]; className: string; notices: { id: string; content: string; actions: { label: string; url: string; }[]; }[]; }' is not assignable to type 'IntrinsicAttributes & Props'.
  Property 'children' does not exist on type 'IntrinsicAttributes & Props'.

    at testTypesVersion (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint/src/index.ts:235:11)
    at runTests (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint/src/index.ts:176:5)
```