### PR TITLE
[colab] migrating typing from colabtools

### DIFF
--- a/types/colab/colab-tests.ts
+++ b/types/colab/colab-tests.ts
@@ -33,8 +33,7 @@ const div = document.createElement('div');
 google.colab.output.getActiveOutputArea().appendChild(div);
 google.colab.output.getDefaultOutputArea().appendChild(div);
 
-// will change type to Promise<{}> in next PR
-google.colab.output.pauseOutputUntil(fetch('http://example.com') as Promise<unknown> as Promise<void>);
+google.colab.output.pauseOutputUntil(fetch('http://example.com'));
 
 google.colab.output.setIframeHeight(100, true, { interactive: true });
 google.colab.output.resizeIframeToContent();

--- a/types/colab/colab-tests.ts
+++ b/types/colab/colab-tests.ts
@@ -1,0 +1,40 @@
+export const colabFunction =
+    (name: string) =>
+    async (...args: Array<{}>) => {
+        // stricter types are coming in the future.  for now, just importing from
+        // @googlecolab
+        const response = (await google.colab.kernel.invokeFunction(name, args)) as {
+            data: {
+                ['application/json']: [{}]; // eslint-disable-line @definitelytyped/no-single-element-tuple-type
+            };
+        };
+        return response.data['application/json'][0];
+    };
+
+if (google.colab.kernel.accessAllowed) {
+    let channel: google.colab.kernel.comms.Comm;
+
+    (async () => {
+        channel = await google.colab.kernel.comms.open('sample');
+
+        // sending messages to Python
+        setInterval(() => {
+            channel.send({ value: `hi from JavaScript at ${new Date()}` });
+        }, 1000);
+
+        // receiving messages from Python
+        for await (const message of channel.messages) {
+            console.log(message);
+        }
+    })();
+}
+
+const div = document.createElement('div');
+google.colab.output.getActiveOutputArea().appendChild(div);
+google.colab.output.getDefaultOutputArea().appendChild(div);
+
+// will change type to Promise<{}> in next PR
+google.colab.output.pauseOutputUntil(fetch('http://example.com') as Promise<unknown> as Promise<void>);
+
+google.colab.output.setIframeHeight(100, true, { interactive: true });
+google.colab.output.resizeIframeToContent();

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -1,0 +1,210 @@
+declare namespace google.colab.kernel {
+  /**
+   * Request that a registered method be invoked on the kernel.
+   * The method must have been registered via Python using
+   * `google.colab.output.register_callback`.
+   *
+   * @param functionName The name of the function registered on the kernel.
+   * @param args Array of args passed as the Python *args argument.
+   * @param kwargs Object of args passed as the Python **kwargs argument.
+   */
+  export function invokeFunction(
+      // tslint:disable-next-line:no-any intentionally allow any params.
+      functionName: string, args?: any[],
+      // tslint:disable-next-line:no-any intentionally allow any params.
+      kwargs?: {[key: string]: any}): Promise<unknown>;
+
+  /**
+   * Requests that the client start proxying content from the kernel's port
+   * `port` to be available from the user's browser. This returns a URL which
+   * can be used to access data on that port.
+   *
+   * @param port The TCP port number to be made available to the notebook
+   *     viewer. Must be accessible as http://localhost:{port}.
+   * @param cache True if the contents of HTTP GET requests should be cached in
+   *     the notebook for offline viewing.
+   * @return A promise resolved with a URL which can be used by the current
+   *     viewer of the notebook to access the port. This URL is only valid for
+   *     the current viewer while this notebook is open.
+   */
+  export function proxyPort(
+      port: number, {cache}?: {cache?: boolean}): Promise<string>;
+
+  /**
+   * True if this is a trusted output and can communicate with the kernel.
+   * Trusted outputs are outputs which were generated in the current browser
+   * session.
+   */
+  export const accessAllowed: boolean;
+}
+
+declare namespace google.colab.output {
+  /**
+   * Returns the current element which outputs go to for this outputframe.
+   * Unlike @getDefaultOutputArea when outputs are redirected to another element
+   * then this will return that redirected element.
+   */
+  export function getActiveOutputArea(): Element;
+
+  /**
+   * Returns the default element which outputs go to for this outputframe.
+   */
+  export function getDefaultOutputArea(): Element;
+
+  /**
+   * Pause processing of additional outputs until the provided promise has been
+   * resolved. This is used when asynchronous initialization must be performed.
+   *
+   * When outputs are initially being rendered then automatic resizing of the
+   * outputframe will be paused until this promise is resolved. This can be used
+   * to reduce layout jank while rendering complex outputs.
+   */
+  export function pauseOutputUntil(promise: Promise<void>): void;
+
+  interface ResizeOptions {
+    /** The maximum height that the outputframe is allowed to have. */
+    maxHeight?: number;
+
+    interactive?: boolean;
+  }
+
+  /**
+   * Request that the outputframe get resized to the specified height.
+   * @param height The height in pixels that the iframe height should be set to.
+   * @param autoResize False if automatic resizing should be disabled.
+   */
+  export function setIframeHeight(
+      height: number, autoResize?: boolean, options?: ResizeOptions): void;
+
+  /**
+   * Request that the outputframe get resized to the content height.
+   * Outputs should now be using the browser's ResizeObserver so this should
+   * now happen automatically.
+   */
+  export function resizeIframeToContent(): void;
+}
+
+/**
+ * APIs for leveraging Jupyter Comm channels within Colaboratory.
+ * For more information about comm channels see:
+ * https://jupyter-notebook.readthedocs.io/en/stable/comms.html
+ */
+declare namespace google.colab.kernel.comms {
+  /** Placeholder for any JSON serializable type. */
+  // tslint:disable-next-line:no-any
+  type JsonType = any;
+
+  export interface Message {
+    /** The JSON structured data of the message. */
+    readonly data: JsonType;
+    /** Optional binary buffers transferred with the message. */
+    readonly buffers?: ArrayBuffer[];
+  }
+
+  export interface Comm {
+    /**
+     * Send a comm message to the kernel.
+     * @param data The message data to be sent.
+     * @param opts Any binary buffers to be included in the message.
+     * @return Promise which will be resolved when the kernel successfully
+     *     receives the comm message.
+     */
+    send(data: JsonType, opts?: {buffers?: ArrayBuffer[]}): Promise<void>;
+    /**
+     * Closes the comm channel and notifies the kernel that the channel
+     * is closed.
+     */
+    close(): void;
+    /**
+     * An async iterator of the incoming messages from the kernel.
+     * The iterator will end when the comm channel is closed.
+     */
+    readonly messages: AsyncIterable<Message>;
+  }
+
+  /**
+   * Open a new comm channel to the kernel.
+   *
+   * The kernel should have registered a handler following the documentation
+   * at
+   * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend.
+   *
+   * @param targetName The name of the channel registered on the kernel.
+   * @param data Any data to be sent with the open message.
+   * @param buffers Any binary data to be sent with the open message.
+   * @return The established comm channel.
+   */
+  export function open(
+      targetName: string, data?: JsonType,
+      buffers?: ArrayBuffer[]): Promise<Comm>;
+
+  /**
+   * Listen comm channels opened by the kernel.
+   *
+   * See
+   * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-kernel.
+   *
+   * @param targetName The name used by the kernel to open a new comm channel.
+   * @param callback Function invoked with any new comm channels.
+   */
+  export function registerTarget(
+      targetName: string, callback: (comm: Comm) => void): void;
+}
+
+declare namespace google.colab.widgets {
+  /**
+   * @param url URL to an ES6 module exporting a WidgetManagerModule API.
+   * @param args custom arguments to `createWidgetManager`.
+   */
+  // tslint:disable-next-line:no-any
+  function installCustomManager(url: string, args: any): void;
+}
+
+/**
+ * The interface a custom widget manager ES6 module is expected to
+ * implement.
+ *
+ * In plain code this means that the module would export a method such as:
+ *
+ * ```
+ *    export function createWidgetManager(environment: WidgetEnvironment) {
+ *       ...
+ *    }
+ * ```
+ */
+ export declare interface WidgetManagerModule {
+  createWidgetManager(state: WidgetEnvironment, arguments?: unknown):
+      WidgetManager;
+}
+
+/**
+ * The host API of the widget manager.
+ */
+ export declare interface WidgetEnvironment {
+  /**
+   * @param modelId The ID of the model for which the model state is desired.
+   */
+  getModelState(modelId: string): Promise<ModelState|undefined>;
+}
+
+/** Custom widget manager. */
+export declare interface WidgetManager {
+  /**
+   * Render the model specified by modelId into the container element.
+   */
+  render(modelId: string, container: Element): Promise<void>;
+}
+
+/** Per-model state. */
+export declare interface ModelState {
+  modelName: string;
+  modelModule: string;
+  modelModuleVersion?: string;
+
+  state: {[key: string]: unknown};
+  /**
+   * If connected to a kernel then this is the comm channel to the kernel.
+   * This will only be set if currently connected to a kernel.
+   */
+  comm?: google.colab.kernel.comms.Comm;
+}

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -49,7 +49,7 @@ declare global {
             /**
              * APIs for leveraging Jupyter Comm channels within Colaboratory.
              * For more information about comm channels see:
-             * https://jupyter-notebook.readthedocs.io/en/stable/comms.html
+             * https://jupyter-notebook.readthedocs.io/en/v6.5.0/comms.html
              */
             namespace comms {
                 /** Placeholder for any JSON serializable type. */
@@ -89,7 +89,7 @@ declare global {
                  *
                  * The kernel should have registered a handler following the documentation
                  * at
-                 * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend.
+                 * https://jupyter-notebook.readthedocs.io/en/v6.5.0/comms.html#opening-a-comm-from-the-frontend.
                  *
                  * @param targetName The name of the channel registered on the kernel.
                  * @param data Any data to be sent with the open message.
@@ -102,7 +102,7 @@ declare global {
                  * Listen comm channels opened by the kernel.
                  *
                  * See
-                 * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-kernel.
+                 * https://jupyter-notebook.readthedocs.io/en/v6.5.0/comms.html#opening-a-comm-from-the-kernel.
                  *
                  * @param targetName The name used by the kernel to open a new comm channel.
                  * @param callback Function invoked with any new comm channels.

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for colab 388959523.0
+// Type definitions for colab 1.388959523
 // Project: https://github.com/googlecolab/colabtools
 // Definitions by: Google Colab team <https://github.com/googlecolab>
 //                 Brenton Simpson <https://github.com/appsforartists>

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -1,210 +1,221 @@
-declare namespace google.colab.kernel {
-  /**
-   * Request that a registered method be invoked on the kernel.
-   * The method must have been registered via Python using
-   * `google.colab.output.register_callback`.
-   *
-   * @param functionName The name of the function registered on the kernel.
-   * @param args Array of args passed as the Python *args argument.
-   * @param kwargs Object of args passed as the Python **kwargs argument.
-   */
-  export function invokeFunction(
-      // tslint:disable-next-line:no-any intentionally allow any params.
-      functionName: string, args?: any[],
-      // tslint:disable-next-line:no-any intentionally allow any params.
-      kwargs?: {[key: string]: any}): Promise<unknown>;
+// Type definitions for colab 388959523.0
+// Project: https://github.com/googlecolab/colabtools
+// Definitions by: Google Colab team <https://github.com/googlecolab>
+//                 Brenton Simpson <https://github.com/appsforartists>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-  /**
-   * Requests that the client start proxying content from the kernel's port
-   * `port` to be available from the user's browser. This returns a URL which
-   * can be used to access data on that port.
-   *
-   * @param port The TCP port number to be made available to the notebook
-   *     viewer. Must be accessible as http://localhost:{port}.
-   * @param cache True if the contents of HTTP GET requests should be cached in
-   *     the notebook for offline viewing.
-   * @return A promise resolved with a URL which can be used by the current
-   *     viewer of the notebook to access the port. This URL is only valid for
-   *     the current viewer while this notebook is open.
-   */
-  export function proxyPort(
-      port: number, {cache}?: {cache?: boolean}): Promise<string>;
+declare global {
+    namespace google.colab {
+        namespace kernel {
+            /**
+             * Request that a registered method be invoked on the kernel.
+             * The method must have been registered via Python using
+             * `google.colab.output.register_callback`.
+             *
+             * @param functionName The name of the function registered on the kernel.
+             * @param args Array of args passed as the Python *args argument.
+             * @param kwargs Object of args passed as the Python **kwargs argument.
+             */
+            function invokeFunction(
+                // tslint:disable-next-line:no-any intentionally allow any params.
+                functionName: string,
+                args?: any[],
+                // tslint:disable-next-line:no-any intentionally allow any params.
+                kwargs?: { [key: string]: any },
+            ): Promise<unknown>;
 
-  /**
-   * True if this is a trusted output and can communicate with the kernel.
-   * Trusted outputs are outputs which were generated in the current browser
-   * session.
-   */
-  export const accessAllowed: boolean;
+            /**
+             * Requests that the client start proxying content from the kernel's port
+             * `port` to be available from the user's browser. This returns a URL which
+             * can be used to access data on that port.
+             *
+             * @param port The TCP port number to be made available to the notebook
+             *     viewer. Must be accessible as http://localhost:{port}.
+             * @param cache True if the contents of HTTP GET requests should be cached in
+             *     the notebook for offline viewing.
+             * @return A promise resolved with a URL which can be used by the current
+             *     viewer of the notebook to access the port. This URL is only valid for
+             *     the current viewer while this notebook is open.
+             */
+            function proxyPort(port: number, { cache }?: { cache?: boolean }): Promise<string>;
+
+            /**
+             * True if this is a trusted output and can communicate with the kernel.
+             * Trusted outputs are outputs which were generated in the current browser
+             * session.
+             */
+            const accessAllowed: boolean;
+
+            /**
+             * APIs for leveraging Jupyter Comm channels within Colaboratory.
+             * For more information about comm channels see:
+             * https://jupyter-notebook.readthedocs.io/en/stable/comms.html
+             */
+            namespace comms {
+                /** Placeholder for any JSON serializable type. */
+                // tslint:disable-next-line:no-any
+                type JsonType = any;
+
+                interface Message {
+                    /** The JSON structured data of the message. */
+                    readonly data: JsonType;
+                    /** Optional binary buffers transferred with the message. */
+                    readonly buffers?: ArrayBuffer[];
+                }
+
+                interface Comm {
+                    /**
+                     * Send a comm message to the kernel.
+                     * @param data The message data to be sent.
+                     * @param opts Any binary buffers to be included in the message.
+                     * @return Promise which will be resolved when the kernel successfully
+                     *     receives the comm message.
+                     */
+                    send(data: JsonType, opts?: { buffers?: ArrayBuffer[] }): Promise<void>;
+                    /**
+                     * Closes the comm channel and notifies the kernel that the channel
+                     * is closed.
+                     */
+                    close(): void;
+                    /**
+                     * An async iterator of the incoming messages from the kernel.
+                     * The iterator will end when the comm channel is closed.
+                     */
+                    readonly messages: AsyncIterable<Message>;
+                }
+
+                /**
+                 * Open a new comm channel to the kernel.
+                 *
+                 * The kernel should have registered a handler following the documentation
+                 * at
+                 * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend.
+                 *
+                 * @param targetName The name of the channel registered on the kernel.
+                 * @param data Any data to be sent with the open message.
+                 * @param buffers Any binary data to be sent with the open message.
+                 * @return The established comm channel.
+                 */
+                function open(targetName: string, data?: JsonType, buffers?: ArrayBuffer[]): Promise<Comm>;
+
+                /**
+                 * Listen comm channels opened by the kernel.
+                 *
+                 * See
+                 * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-kernel.
+                 *
+                 * @param targetName The name used by the kernel to open a new comm channel.
+                 * @param callback Function invoked with any new comm channels.
+                 */
+                function registerTarget(targetName: string, callback: (comm: Comm) => void): void;
+            }
+
+        }
+
+        namespace output {
+            /**
+             * Returns the current element which outputs go to for this outputframe.
+             * Unlike @getDefaultOutputArea when outputs are redirected to another element
+             * then this will return that redirected element.
+             */
+            function getActiveOutputArea(): Element;
+
+            /**
+             * Returns the default element which outputs go to for this outputframe.
+             */
+            function getDefaultOutputArea(): Element;
+
+            /**
+             * Pause processing of additional outputs until the provided promise has been
+             * resolved. This is used when asynchronous initialization must be performed.
+             *
+             * When outputs are initially being rendered then automatic resizing of the
+             * outputframe will be paused until this promise is resolved. This can be used
+             * to reduce layout jank while rendering complex outputs.
+             */
+            function pauseOutputUntil(promise: Promise<void>): void;
+
+            interface ResizeOptions {
+                /** The maximum height that the outputframe is allowed to have. */
+                maxHeight?: number;
+
+                interactive?: boolean;
+            }
+
+            /**
+             * Request that the outputframe get resized to the specified height.
+             * @param height The height in pixels that the iframe height should be set to.
+             * @param autoResize False if automatic resizing should be disabled.
+             */
+            function setIframeHeight(height: number, autoResize?: boolean, options?: ResizeOptions): void;
+
+            /**
+             * Request that the outputframe get resized to the content height.
+             * Outputs should now be using the browser's ResizeObserver so this should
+             * now happen automatically.
+             */
+            function resizeIframeToContent(): void;
+        }
+
+        namespace widgets {
+            /**
+             * @param url URL to an ES6 module exporting a WidgetManagerModule API.
+             * @param args custom arguments to `createWidgetManager`.
+             */
+            // tslint:disable-next-line:no-any
+            function installCustomManager(url: string, args: any): void;
+        }
+
+        /**
+         * The interface a custom widget manager ES6 module is expected to
+         * implement.
+         *
+         * In plain code this means that the module would a method such as:
+         *
+         * ```
+         *    function createWidgetManager(environment: WidgetEnvironment) {
+         *       ...
+         *    }
+         * ```
+         */
+        interface WidgetManagerModule {
+            createWidgetManager(state: WidgetEnvironment, arguments?: unknown): WidgetManager;
+        }
+
+        /**
+         * The host API of the widget manager.
+         */
+        interface WidgetEnvironment {
+            /**
+             * @param modelId The ID of the model for which the model state is desired.
+             */
+            getModelState(modelId: string): Promise<ModelState | undefined>;
+        }
+
+        /** Custom widget manager. */
+        interface WidgetManager {
+            /**
+             * Render the model specified by modelId into the container element.
+             */
+            render(modelId: string, container: Element): Promise<void>;
+        }
+
+        /** Per-model state. */
+        interface ModelState {
+            modelName: string;
+            modelModule: string;
+            modelModuleVersion?: string;
+
+            state: { [key: string]: unknown };
+            /**
+             * If connected to a kernel then this is the comm channel to the kernel.
+             * This will only be set if currently connected to a kernel.
+             */
+            comm?: kernel.comms.Comm;
+        }
+    }
 }
 
-declare namespace google.colab.output {
-  /**
-   * Returns the current element which outputs go to for this outputframe.
-   * Unlike @getDefaultOutputArea when outputs are redirected to another element
-   * then this will return that redirected element.
-   */
-  export function getActiveOutputArea(): Element;
+// tells TypeScript that this is a module, which enables `declare global`
+export {};
 
-  /**
-   * Returns the default element which outputs go to for this outputframe.
-   */
-  export function getDefaultOutputArea(): Element;
-
-  /**
-   * Pause processing of additional outputs until the provided promise has been
-   * resolved. This is used when asynchronous initialization must be performed.
-   *
-   * When outputs are initially being rendered then automatic resizing of the
-   * outputframe will be paused until this promise is resolved. This can be used
-   * to reduce layout jank while rendering complex outputs.
-   */
-  export function pauseOutputUntil(promise: Promise<void>): void;
-
-  interface ResizeOptions {
-    /** The maximum height that the outputframe is allowed to have. */
-    maxHeight?: number;
-
-    interactive?: boolean;
-  }
-
-  /**
-   * Request that the outputframe get resized to the specified height.
-   * @param height The height in pixels that the iframe height should be set to.
-   * @param autoResize False if automatic resizing should be disabled.
-   */
-  export function setIframeHeight(
-      height: number, autoResize?: boolean, options?: ResizeOptions): void;
-
-  /**
-   * Request that the outputframe get resized to the content height.
-   * Outputs should now be using the browser's ResizeObserver so this should
-   * now happen automatically.
-   */
-  export function resizeIframeToContent(): void;
-}
-
-/**
- * APIs for leveraging Jupyter Comm channels within Colaboratory.
- * For more information about comm channels see:
- * https://jupyter-notebook.readthedocs.io/en/stable/comms.html
- */
-declare namespace google.colab.kernel.comms {
-  /** Placeholder for any JSON serializable type. */
-  // tslint:disable-next-line:no-any
-  type JsonType = any;
-
-  export interface Message {
-    /** The JSON structured data of the message. */
-    readonly data: JsonType;
-    /** Optional binary buffers transferred with the message. */
-    readonly buffers?: ArrayBuffer[];
-  }
-
-  export interface Comm {
-    /**
-     * Send a comm message to the kernel.
-     * @param data The message data to be sent.
-     * @param opts Any binary buffers to be included in the message.
-     * @return Promise which will be resolved when the kernel successfully
-     *     receives the comm message.
-     */
-    send(data: JsonType, opts?: {buffers?: ArrayBuffer[]}): Promise<void>;
-    /**
-     * Closes the comm channel and notifies the kernel that the channel
-     * is closed.
-     */
-    close(): void;
-    /**
-     * An async iterator of the incoming messages from the kernel.
-     * The iterator will end when the comm channel is closed.
-     */
-    readonly messages: AsyncIterable<Message>;
-  }
-
-  /**
-   * Open a new comm channel to the kernel.
-   *
-   * The kernel should have registered a handler following the documentation
-   * at
-   * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-frontend.
-   *
-   * @param targetName The name of the channel registered on the kernel.
-   * @param data Any data to be sent with the open message.
-   * @param buffers Any binary data to be sent with the open message.
-   * @return The established comm channel.
-   */
-  export function open(
-      targetName: string, data?: JsonType,
-      buffers?: ArrayBuffer[]): Promise<Comm>;
-
-  /**
-   * Listen comm channels opened by the kernel.
-   *
-   * See
-   * https://jupyter-notebook.readthedocs.io/en/stable/comms.html#opening-a-comm-from-the-kernel.
-   *
-   * @param targetName The name used by the kernel to open a new comm channel.
-   * @param callback Function invoked with any new comm channels.
-   */
-  export function registerTarget(
-      targetName: string, callback: (comm: Comm) => void): void;
-}
-
-declare namespace google.colab.widgets {
-  /**
-   * @param url URL to an ES6 module exporting a WidgetManagerModule API.
-   * @param args custom arguments to `createWidgetManager`.
-   */
-  // tslint:disable-next-line:no-any
-  function installCustomManager(url: string, args: any): void;
-}
-
-/**
- * The interface a custom widget manager ES6 module is expected to
- * implement.
- *
- * In plain code this means that the module would export a method such as:
- *
- * ```
- *    export function createWidgetManager(environment: WidgetEnvironment) {
- *       ...
- *    }
- * ```
- */
- export declare interface WidgetManagerModule {
-  createWidgetManager(state: WidgetEnvironment, arguments?: unknown):
-      WidgetManager;
-}
-
-/**
- * The host API of the widget manager.
- */
- export declare interface WidgetEnvironment {
-  /**
-   * @param modelId The ID of the model for which the model state is desired.
-   */
-  getModelState(modelId: string): Promise<ModelState|undefined>;
-}
-
-/** Custom widget manager. */
-export declare interface WidgetManager {
-  /**
-   * Render the model specified by modelId into the container element.
-   */
-  render(modelId: string, container: Element): Promise<void>;
-}
-
-/** Per-model state. */
-export declare interface ModelState {
-  modelName: string;
-  modelModule: string;
-  modelModuleVersion?: string;
-
-  state: {[key: string]: unknown};
-  /**
-   * If connected to a kernel then this is the comm channel to the kernel.
-   * This will only be set if currently connected to a kernel.
-   */
-  comm?: google.colab.kernel.comms.Comm;
-}

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -133,7 +133,7 @@ declare global {
              * outputframe will be paused until this promise is resolved. This can be used
              * to reduce layout jank while rendering complex outputs.
              */
-            function pauseOutputUntil(promise: Promise<void>): void;
+            function pauseOutputUntil(promise: Promise<{}>): void;
 
             interface ResizeOptions {
                 /** The maximum height that the outputframe is allowed to have. */

--- a/types/colab/tsconfig.json
+++ b/types/colab/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "esnext",
+        "target": "es6",
         "lib": [
             "dom",
             "es2018",

--- a/types/colab/tsconfig.json
+++ b/types/colab/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "node16",
+        "target": "esnext",
+        "lib": [
+            "dom",
+            "es2018",
+            "es2022"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "colab-tests.ts"
+    ]
+}

--- a/types/colab/tslint.json
+++ b/types/colab/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Colab is an environment that provides its own globals (like the DOM or Node).  The public/open-source API is written in Python; the only TypeScript in [that repo](https://github.com/googlecolab/colabtools/) is the typings file.  Because it is a loose file in the repo, it is not easily consumed by authors (except via copy/paste).  To avoid maintaining a types-only package on NPM, we're donating the types to DefinitelyTyped.

This PR has the equivalent typings to what's [currently found in colabtools](https://github.com/googlecolab/colabtools/blob/main/packages/outputframe/lib/index.d.ts), adapted to pass the DefinitelyTyped linter.  There is definite room for improvement.  That improvement should be done in future PRs; this is simply migrating the types from one org to another.

-----
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
-----

Note: as an ambient environment, these types are meant to be global.  I was able to achieve that by wrapping the namespace in 

```typescript
declare global {

}
export {}
```

As [they were originally written](https://github.com/googlecolab/colabtools/blob/main/packages/outputframe/lib/index.d.ts), TypeScript wasn't altering the global object.  With `declare global` the types now work as expected and the tests pass, but if this format doesn't pass the "Represents shape correctly" test, please let me know.