### PR TITLE
fix failing test in wordpress__components

### DIFF
--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -581,8 +581,7 @@ const kbshortcuts = {
             actions: [{ label: "Action One", url: "https://wordpress.org" }],
         },
     ]}
->
-</C.NoticeList>;
+/>;
 
 //
 // panel


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~~Test the change in your own code. (Compile and run.)~~
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This changes one of the tests to use a self-closing element since the component doesn't have a valid `children` property.