### PR TITLE
[colorguard] Add types for colorguard

### DIFF
--- a/types/colorguard/colorguard-tests.ts
+++ b/types/colorguard/colorguard-tests.ts
@@ -1,0 +1,17 @@
+import postcss = require('postcss');
+import colorguard = require('colorguard');
+
+postcss([colorguard]);
+postcss([colorguard()]);
+postcss([colorguard({})]);
+postcss([
+    colorguard({
+        ignore: ['#ffffff'] as const,
+        threshold: 3,
+        whitelist: [['#000000', '#010101']] as const,
+        allowEquivalentNotation: true,
+    }),
+]);
+
+colorguard.process('* {}'); // $ExpectType LazyResult
+colorguard.process('* {}', {}); // $ExpectType LazyResult

--- a/types/colorguard/index.d.ts
+++ b/types/colorguard/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for colorguard 1.2
+// Project: https://github.com/SlexAxton/css-colorguard
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Plugin } from 'postcss';
+
+declare namespace cologuard {
+    interface Options {
+        /** Colors of hex codes to ignore */
+        ignore?: readonly string[] | undefined;
+        /**
+         * Scale from 0-100.
+         * Lower values are more precise
+         * @default 3
+         */
+        threshold?: number | undefined;
+        /**
+         * An array of color pairs to ignore
+         * @example
+         * [['#000000', '#010101']]
+         */
+        whitelist?: ReadonlyArray<readonly [string, string]> | undefined;
+        /**
+         * By default, colorguard will complain
+         * if identical colors are represented with different notations.
+         * For example, `#000`, `#000000`, `rgba(0, 0, 0, 0)`, and `black`.
+         * If you want to permit these equivalent notations, set this option to `true`
+         * @default false
+         * @see {@link <https://github.com/SlexAxton/css-colorguard/tree/master#allowequivalentnotation>}
+         */
+        allowEquivalentNotation?: boolean | undefined;
+    }
+}
+
+declare const colorguard: Plugin<cologuard.Options>;
+
+export = colorguard;

--- a/types/colorguard/package.json
+++ b/types/colorguard/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^5.0.4"
+    }
+}

--- a/types/colorguard/tsconfig.json
+++ b/types/colorguard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "colorguard-tests.ts"]
+}

--- a/types/colorguard/tslint.json
+++ b/types/colorguard/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package colorguard (<https://www.npmjs.com/package/colorguard>).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
