### PR TITLE
[check-types] added, updated and grouped all search keys and values methods

### DIFF
--- a/types/check-types/check-types-tests.ts
+++ b/types/check-types/check-types-tests.ts
@@ -120,10 +120,44 @@ check.nonEmptyObject(Symbol(""));
 check.nonEmptyObject(0);
 check.nonEmptyObject([]);
 
-check.assert.containsKey({ key: "value" }, "key");
-check.assert.containsKey([], "key");
-check.assert.containsKey(new Map(), { k: "l" });
+check.containsKey(["a", "b", "c"], 1);
+check.containsKey({ key: "value" }, "key");
+check.containsKey({ [Symbol.for("key")]: "value" }, Symbol.for("key"));
+check.containsKey({ 1: "value" }, 1);
+check.containsKey(new Map([["key", "value"]]), "key");
+check.containsKey("string", "string".length - 1);
 
-check.assert.in("value", ["value"]);
-check.assert.in("value", { key: "value" });
-check.assert.in("string", "string");
+
+check.keyIn(1, ["a", "b", "c"]);
+check.keyIn("key", { key: "value" });
+check.keyIn(Symbol.for("key"), { [Symbol.for("key")]: "value" });
+check.keyIn(1, { 1: "value" });
+check.keyIn<number>(0, new Map([[0, "value"]]));
+check.keyIn("string".length - 1, "string");
+
+const iterableObject: Iterable<string> = new class implements Iterable<string> {
+    *[Symbol.iterator]() {
+        yield "something"
+        yield "value"
+        yield "another value"
+    }
+    // values function is required for check-types
+    values(this: Iterable<string>): Iterator<string> {
+        return this[Symbol.iterator]()
+    }
+}();
+
+check.in("value", ["value"]);
+check.in("value", { key: "value" });
+check.in("string", "str");
+check.in("value", new Map([["key", "value"]]));
+check.in("value", new Set(["value"]));
+check.in("value", iterableObject);
+
+check.contains(["value"], "value");
+check.contains({ key: "value" }, "value");
+check.contains("string", "str");
+check.contains<number>(new Map([["key", 42]]), 42);
+check.contains<string>(new Set(["value"]), "value");
+check.contains<string>(iterableObject, "value");
+

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for check-types 7.3
+// Type definitions for check-types 11.2
 // Project: https://gitlab.com/philbooth/check-types.js
 // Definitions by: idchlife <https://github.com/idchlife>
 //                 shov <https://github.com/shov>
@@ -97,14 +97,12 @@ interface CheckType {
     assigned(a: any): boolean;
     primitive(a: any): a is number | string | boolean | null | undefined | symbol;
     hasLength(a: any, length: number): boolean;
-    containsKey(a: any, key: any): boolean;
 
     /* String predicates */
 
     string(a: any): a is string;
     emptyString(a: any): boolean;
     nonEmptyString(a: any): boolean;
-    contains(a: string, substring: string): boolean;
     match(a: string, b: RegExp): boolean;
 
     /* Number predicates */
@@ -160,7 +158,6 @@ interface CheckType {
     arrayLike: ArrayLikeFunction;
     iterable: IterableFunction;
     includes(a: any[], value: any): boolean;
-    in(value: any, a: any[] | object | string): boolean;
 
     /* Date predicates */
 
@@ -194,6 +191,23 @@ interface CheckType {
     all(arr: boolean[] | { [k: string]: boolean }): boolean;
 
     any(arr: boolean[] | { [k: string]: boolean }): boolean;
+
+    /* Searching keys and values */
+    in(substring: string, a: string): boolean;
+    in(value: any, a: object): boolean;
+    in<T = any>(value: T, a: T[] | Set<T> | Map<any, T> | Iterable<T>): boolean;
+
+    contains(a: string, substring: string): boolean;
+    contains(a: object, value: any): boolean;
+    contains<T = any>(a: T[] | Set<T> | Map<any, T> | Iterable<T>, value: T): boolean;
+
+    keyIn(key: number | string, a: string | any[]): boolean;
+    keyIn(key: number | string | symbol, a: object): boolean;
+    keyIn<K = any>(key: K, a: Map<K, any>): boolean;
+
+    containsKey(a: string | any[], key: number | string): boolean;
+    containsKey(a: object, key: number | string | symbol): boolean;
+    containsKey<K = any>(a: Map<K, any>, key: K): boolean;
 }
 
 declare const check: CheckType;


### PR DESCRIPTION
Thanks to #66700 and #66800 PRs I found there are number of missing or not properly specified (with any) definitions. I arranged them out as Search keys and values methods. Tests have been updated. Version of package updated in the header. 
I decided to add some generics. They don't break anything and might prove to be useful.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [contains](https://gitlab.com/philbooth/check-types.js/-/blob/master/src/check-types.js#L575), [in](https://gitlab.com/philbooth/check-types.js/-/blob/master/src/check-types.js#L615), [containsKey](https://gitlab.com/philbooth/check-types.js/-/blob/master/src/check-types.js#L625), [keyIn](https://gitlab.com/philbooth/check-types.js/-/blob/master/src/check-types.js#L647)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
