### PR TITLE
Ensure support window regularly updates, tweak workflow and script

### DIFF
--- a/.github/workflows/support-window.yml
+++ b/.github/workflows/support-window.yml
@@ -10,6 +10,9 @@ on:
   # Manually, when TypeScript is released
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
+  schedule:
+    # Weekly at 16:00 UTC on Monday 
+    - cron: '0 16 * * 1'
 permissions:
   contents: read
 
@@ -21,10 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      
       - uses: actions/setup-node@v3
         #with:
         #  cache: npm
+      
       - run: npm install
+      
       - name: Fetch TypeScript versions and release dates from npm
         run: |
           npm view --json typescript time |
@@ -38,14 +44,13 @@ jobs:
               | unique_by(.key)
               | from_entries
             ' > docs/support-window.json
+      
       - name: Make SVG diagram
         run: node --experimental-json-modules scripts/support-window > docs/support-window.svg
-      - run: git add docs/support-window.json docs/support-window.svg
-      - run: git config user.name .github/workflows/support-window.yml
-      - run: git config user.email bot@typescriptlang.org
-      - run: |
-          git diff --quiet --cached ||
-          git commit \
-            --message "[README] 🤖 Update support window diagram" \
-            --message "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-      - run: git push
+
+      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        with:
+          commit_author: "TypeScript Bot <typescriptbot@microsoft.com>"
+          commit_message: "🤖 Update support window"
+          commit_user_email: "typescriptbot@microsoft.com"
+          commit_user_name: "TypeScript Bot"

--- a/scripts/support-window.js
+++ b/scripts/support-window.js
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { max, min } from "d3-array";
 import { axisLeft, axisTop } from "d3-axis";
 import { scaleBand, scaleTime } from "d3-scale";
@@ -6,7 +7,9 @@ import { utcYear } from "d3-time";
 import { utcFormat } from "d3-time-format";
 import { JSDOM } from "jsdom";
 import serialize from "w3c-xmlserializer";
-import data from "../docs/support-window.json" assert { type: "json" };
+
+const dataPath = new URL('../docs/support-window.json', import.meta.url);
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
 
 const width = 640;
 const height = 250;


### PR DESCRIPTION
The support window hasn't been updated in a while; we didn't enable any sort of cron for this, and nobody ran it manually or triggered it otherwise.

This PR adds a cron for it, but also does some minor improvements like:

- Use the commit action the same as #66235
- Don't use Node's JSON import assertion (the syntax is dead and produces a warning; a file read is fine).

(I also have an alternative change which switches this to a GitHub/mermaid gantt diagram, but it looks significantly worse.)