### PR TITLE
[dns2] Add support for IPv6 UDP DNS servers

### DIFF
--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -60,6 +60,43 @@ server.on("request", (request, response, rinfo) => {
 
 server.listen({ udp: 5333 });
 
+const serverByType = DNS.createServer({
+    udp: { type: 'udp4' },
+    handle: (request, send, rinfo) => {
+        const response = Packet.createResponseFromRequest(request);
+        const [question] = request.questions;
+        const { name } = question;
+        response.answers.push({
+            name,
+            type: Packet.TYPE.A,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            address: "8.8.8.8",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.CNAME,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            domain: "another-name.example.com",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.TXT,
+            class: Packet.CLASS.IN,
+            ttl: 60,
+            data: "dnslink=/ipfs/123abc",
+        });
+        send(response);
+    },
+});
+
+serverByType.on("request", (request, response, rinfo) => {
+    console.log(request.header.id, request.questions[0]);
+});
+
+serverByType.listen({ udp: 5344 });
+
 const udpServer = new DNS.UDPServer((request, send, rinfo) => {
     const response = Packet.createResponseFromRequest(request);
     send(response);
@@ -73,3 +110,11 @@ const tcpServer = DNS.createTCPServer((request, send, rinfo) => {
 });
 
 tcpServer.listen(5454, "127.0.0.1");
+
+const udpServerByType = new DNS.UDPServer({type: 'udp4'})
+udpServerByType.on("request", (request, send, rinfo) => {
+    const response = Packet.createResponseFromRequest(request);
+    send(response);
+});
+
+udpServer.listen(5555, "127.0.0.1");

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -85,6 +85,10 @@ declare namespace DNS {
         data?: string;
     }
 
+    interface UdpDnsServerOptions {
+        type: string;
+    }
+
     type DnsHandler = (
         request: DnsRequest,
         sendResponse: (response: DnsResponse) => void,
@@ -108,8 +112,8 @@ declare class DnsServer extends EventEmitter {
 }
 
 declare class UdpDnsServer extends udp.Socket {
-    constructor(callback?: DNS.DnsHandler);
-    listen(port: number, address: string): Promise<void>;
+    constructor(arg?: DNS.UdpDnsServerOptions | DNS.DnsHandler);
+    listen(port: number, address?: string): Promise<void>;
 }
 
 declare class TcpDnsServer extends net.Server {
@@ -119,7 +123,12 @@ declare class TcpDnsServer extends net.Server {
 declare class DNS {
     constructor(options?: Partial<DNS.DnsClientOptions>);
 
-    static createServer(options: { udp?: boolean; tcp?: boolean; doh?: boolean; handle: DNS.DnsHandler }): DnsServer;
+    static createServer(options: {
+        udp?: boolean | DNS.UdpDnsServerOptions;
+        tcp?: boolean;
+        doh?: boolean;
+        handle: DNS.DnsHandler;
+    }): DnsServer;
 
     static Packet: typeof Packet;
 

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -86,7 +86,7 @@ declare namespace DNS {
     }
 
     interface UdpDnsServerOptions {
-        type: string;
+        type: 'udp4' | 'udp6';
     }
 
     type DnsHandler = (


### PR DESCRIPTION
To instantiate a UDP IPv6 DNS server, it is necessary to pass an object with type set as 'udp6' as a constructor argument. This will cause dns2 to open the right kind of socket.

See https://github.com/song940/node-dns/blob/master/server/udp.js

This commit updates the UDP objects to add this facility.

The address has been made optional in the UDP listen signature to allow the socket to choose the right all interface address.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/song940/node-dns/blob/master/server/udp.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
