### PR TITLE
Reformat tizen-tv-webapis tests to work around swc bug

### DIFF
--- a/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.cjs.ts
+++ b/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.cjs.ts
@@ -24,9 +24,9 @@ widgetdata.getVersion(); // $ExpectType string
 
 avplay.setListener({
     onsubtitlechange: (duration, subtitles, type, attributes) => {
-        duration // $ExpectType string
-        subtitles // $ExpectType string
-        type // $ExpectType string
-        attributes // $ExpectType AVPlaySubtitleAttribute[]
-    }
-})
+        duration; // $ExpectType string
+        subtitles; // $ExpectType string
+        type; // $ExpectType string
+        attributes; // $ExpectType AVPlaySubtitleAttribute[]
+    },
+});

--- a/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.global.ts
+++ b/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.global.ts
@@ -11,10 +11,10 @@ tvinfo.getVersion(); // $ExpectType string
 widgetdata.getVersion(); // $ExpectType string
 
 avplay.setListener({
-  onsubtitlechange: (duration, subtitles, type, attributes) => {
-      duration // $ExpectType string
-      subtitles // $ExpectType string
-      type // $ExpectType string
-      attributes // $ExpectType AVPlaySubtitleAttribute[]
-  }
-})
+    onsubtitlechange: (duration, subtitles, type, attributes) => {
+        duration; // $ExpectType string
+        subtitles; // $ExpectType string
+        type; // $ExpectType string
+        attributes; // $ExpectType AVPlaySubtitleAttribute[]
+    },
+});


### PR DESCRIPTION
The dprint formatting is coming very shortly, but an SWC bug means that these newly added tests don't parse properly: https://github.com/swc-project/swc/issues/8073

To work around this, just preemptively reformat the code so when we merge #66235 things go fine.