### PR TITLE
Fix misplaced no-unnecessary-generics in yargs after reformat

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -188,11 +188,10 @@ declare namespace yargs {
             middlewares?: Array<MiddlewareFunction<O>>,
             deprecated?: boolean | string,
         ): Argv<T>;
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         command<U = any>(
             command: string | ReadonlyArray<string>,
             description: string,
-            module: CommandModule<T, U>,
+            module: CommandModule<T, U>, // eslint-disable-line @definitelytyped/no-unnecessary-generics
         ): Argv<T>;
         command<U = T>(
             command: string | ReadonlyArray<string>,
@@ -208,11 +207,10 @@ declare namespace yargs {
             builder?: O,
             handler?: (args: ArgumentsCamelCase<InferredOptionTypes<O>>) => void | Promise<void>,
         ): Argv<T>;
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         command<U = any>(
             command: string | ReadonlyArray<string>,
             showInHelp: false,
-            module: CommandModule<T, U>,
+            module: CommandModule<T, U>, // eslint-disable-line @definitelytyped/no-unnecessary-generics
         ): Argv<T>;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         command<U = any>(module: CommandModule<T, U>): Argv<T>;


### PR DESCRIPTION
For some reason, this error is emitted at a singular _use_ rather than a declaration. The new formatting rules caused the line to wrap and for this ignore to not be matched. Replace it with one attached to the line we care about.