### PR TITLE
Remove formatting exception for righto

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -40,7 +40,6 @@
     "./types/react-map-gl",
     "./types/react-native-awesome-card-io",
     "./types/react-syntax-highlighter",
-    "./types/righto",
     "./types/react-native-awesome-card-io"
   ],
   // NOTE: if extending this list, also update settings.template.json.

--- a/types/righto/index.d.ts
+++ b/types/righto/index.d.ts
@@ -4,27 +4,27 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
 
-import { CPSFunction, Righto, RightoAfter } from '.';
+import { CPSFunction, Righto, RightoAfter } from ".";
 
 /** Represents a type as either the type itself, a righto of the type, or a promise of the type */
-type Flexible<T, ET = any> = T|Promise<T>|Righto<[T | undefined, ...any[]], ET>;
+type Flexible<T, ET = any> = T | Promise<T> | Righto<[T | undefined, ...any[]], ET>;
 /** Accepts an array of types and returns a array of each type OR'd with eventual representations (Righto and promise) */
 type ArgsAsFlexible<AT extends any[], ET> = {
-    [T in keyof AT]: Flexible<AT[T], ET>
+    [T in keyof AT]: Flexible<AT[T], ET>;
 };
 /** Transforms an object type to unwrap its Righto typed properties */
 type ResolvedObject<T> = {
-    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] : T[P]
+    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] : T[P];
 };
 /** Recursively transforms an object type to unwrap its Righto typed properties into "unknown" */
 type ResolvedObjectRecursive<T> = {
-    [P in keyof T]: T[P] extends Righto<infer X> ? X[0] :
-                    T[P] extends object ? ResolvedObjectRecursive<T[P]> :
-                    T[P]
+    [P in keyof T]: T[P] extends Righto<infer X> ? X[0]
+        : T[P] extends object ? ResolvedObjectRecursive<T[P]>
+        : T[P];
 };
 /** Maps an array of types into their righto representations */
 type RightoArrayFrom<T extends any[], ET> = {
-    [P in keyof T]: Righto<[T[P]], ET>
+    [P in keyof T]: Righto<[T[P]], ET>;
 };
 
 /**
@@ -44,25 +44,39 @@ type RightoArrayFrom<T extends any[], ET> = {
  * let rResult2 = righto(divideNumbersAsync, 5, rResult); // A righto object that will eventually resolve to 2.5
  * rResult2((err, result) => console.log(result)); // Will print '2.5' to the console
  */
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, ...args: ArgsAsFlexible<AT, ET>): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    ...args: ArgsAsFlexible<AT, ET>
+): Righto<RT, ET>;
 // Righto constructor to allow for a single righto.after to appear before the function arguments
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, after: RightoAfter, ...args: ArgsAsFlexible<AT, ET>): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    after: RightoAfter,
+    ...args: ArgsAsFlexible<AT, ET>
+): Righto<RT, ET>;
 // Righto constructor to allow for a single righto.after to appear after the function arguments
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+): Righto<RT, ET>;
 // Righto constructor to allow for two righto.after statements to appear, once before the argument list and once after
-declare function righto<AT extends any[], RT extends any[], ET = any>(fn: CPSFunction<AT, RT, ET>, after: RightoAfter, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<RT, ET>;
+declare function righto<AT extends any[], RT extends any[], ET = any>(
+    fn: CPSFunction<AT, RT, ET>,
+    after: RightoAfter,
+    ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+): Righto<RT, ET>;
 
 // Library for function righto methods
 declare namespace righto {
     /** A callback function that accepts a single error argument, with any number of return arguments */
-    type ErrBack<RT extends any[] = [], ET = any> = (err?: ET, ...results: {[P in keyof RT]?: RT[P]}) => void;
+    type ErrBack<RT extends any[] = [], ET = any> = (err?: ET, ...results: { [P in keyof RT]?: RT[P] }) => void;
     /**  Usually an async function that accepts any number of parameters, then returns a result or error through an ErrBack method */
     type CPSFunction<AT extends any[], RT extends any[], ET> = (...args: [...AT, ErrBack<RT, ET>]) => void;
     /** A righto that does not resolve to any value, used for introducing delays in righto argument chains */
     type RightoAfter = Righto<[]>;
     /** Represents a constructed righto object */
     interface Righto<RT extends any[], ET = any> extends CPSFunction<[], RT, ET> {
-        get(prop: string|number|Righto<[string, ...any[]]>|Righto<[number, ...any[]]>): Righto<[any], ET>;
+        get(prop: string | number | Righto<[string, ...any[]]> | Righto<[number, ...any[]]>): Righto<[any], ET>;
         get<T>(fn: (x: RT[0]) => T): Righto<[T], ET>;
         /** You can force a righto task for run at any time without dealing with the results (or error) by calling it with no arguments */
         (): Righto<RT, ET>;
@@ -79,7 +93,9 @@ declare namespace righto {
      * @example
      * var somePromise = new Promise(righto.fork(someRighto));
      */
-    function fork<RT extends any[]>(righto: Righto<RT>): (resolve: (x: RT[0]) => void, reject: (x: any) => void) => void;
+    function fork<RT extends any[]>(
+        righto: Righto<RT>,
+    ): (resolve: (x: RT[0]) => void, reject: (x: any) => void) => void;
 
     /**
      * Righto supports running a generator (or any nextable iterator):
@@ -107,7 +123,9 @@ declare namespace righto {
      *     result === 'xyabc';
      * });
      */
-     function iterate<AT extends any[], RT, ET>(constructGenerator: (...args: AT) => Generator<Righto<[RT], ET>, RT, RT>): (...args: AT) => Righto<[RT], ET>;
+    function iterate<AT extends any[], RT, ET>(
+        constructGenerator: (...args: AT) => Generator<Righto<[RT], ET>, RT, RT>,
+    ): (...args: AT) => Righto<[RT], ET>;
 
     /**
      * You can pick and choose what results are used from a dependency like so:
@@ -119,7 +137,10 @@ declare namespace righto {
      *     result -> 'first third';
      * });
      */
-    function take<IDXS extends number[], ET>(righto: Righto<any[], ET>, ...args: IDXS): Righto<{[P in keyof IDXS]: any}, ET>;
+    function take<IDXS extends number[], ET>(
+        righto: Righto<any[], ET>,
+        ...args: IDXS
+    ): Righto<{ [P in keyof IDXS]: any }, ET>;
 
     /**
      * Righto.reduce takes an Array of values (an an eventual that resolves to an array) as the first argument, resolves them from left-to-right,
@@ -177,7 +198,11 @@ declare namespace righto {
      *     // finalResult === 7
      * });
      */
-    function reduce<RT, ET = any>(values: Array<CPSFunction<[RT], [RT], ET>>, reducer: (result: RT, next: CPSFunction<[RT], [RT], ET>) => Righto<[RT], ET>, seed?: RT): Righto<[RT], ET>;
+    function reduce<RT, ET = any>(
+        values: Array<CPSFunction<[RT], [RT], ET>>,
+        reducer: (result: RT, next: CPSFunction<[RT], [RT], ET>) => Righto<[RT], ET>,
+        seed?: RT,
+    ): Righto<[RT], ET>;
 
     /**
      * righto.all takes N tasks, or an Array of tasks as the first argument, resolves them all in parallel, and results in an Array of results.
@@ -229,9 +254,20 @@ declare namespace righto {
      *     result; // -> 10
      * });
      */
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, ...args: ArgsAsFlexible<AT, ET>): Righto<[RT], ET>;
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, after: RightoAfter, ...args: ArgsAsFlexible<AT, ET>): Righto<[RT], ET>;
-    function sync<AT extends any[], RT, ET = any>(fn: (...args: AT) => RT, after: RightoAfter, ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        after: RightoAfter,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[RT], ET>;
+    function sync<AT extends any[], RT, ET = any>(
+        fn: (...args: AT) => RT,
+        after: RightoAfter,
+        ...args: [...ArgsAsFlexible<AT, ET>, RightoAfter]
+    ): Righto<[RT], ET>;
 
     /**
      * Anything can be converted to a righto with righto.from(anything);
@@ -241,7 +277,7 @@ declare namespace righto {
      * righto.from(somePromise); // Returns a new righto that resolves the promise
      * righto.from(5); // Returns a new righto that resolves 5
      */
-    function from<T, ET = any>(source: Righto<[T], ET>|Promise<T>): Righto<[T], ET>;
+    function from<T, ET = any>(source: Righto<[T], ET> | Promise<T>): Righto<[T], ET>;
     function from<T>(source: T): Righto<[T], undefined>;
 
     /**
@@ -265,7 +301,7 @@ declare namespace righto {
      *
      * righto2();
      */
-    function value<T, ET = any>(resolvable: Righto<[T], ET>|Promise<T>): Righto<[Righto<[T], ET>], ET>;
+    function value<T, ET = any>(resolvable: Righto<[T], ET> | Promise<T>): Righto<[Righto<[T], ET>], ET>;
 
     /**
      * You can resolve a task to an array containing either the error or results from a righto with righto.surely, which resolves to an array in the form of [error?, results...?].
@@ -291,7 +327,10 @@ declare namespace righto {
      *
      * z();
      */
-    function surely<AT extends any[], RT extends any[], ET>(fn: CPSFunction<AT, RT, ET>, ...args: ArgsAsFlexible<AT, ET>): Righto<[[ET, ...RT]], ET>;
+    function surely<AT extends any[], RT extends any[], ET>(
+        fn: CPSFunction<AT, RT, ET>,
+        ...args: ArgsAsFlexible<AT, ET>
+    ): Righto<[[ET, ...RT]], ET>;
 
     /**
      * Wrap a righto task with a handler that either forwards the successful result, or sends the rejected error through a handler to resolve the task.
@@ -354,7 +393,10 @@ declare namespace righto {
      *     bar; // -> {foo: {bar: 'foo'}}
      * });
      */
-    function resolve<T, B extends boolean>(obj: T, recursive: B): B extends true ? ResolvedObjectRecursive<T> : ResolvedObject<T>;
+    function resolve<T, B extends boolean>(
+        obj: T,
+        recursive: B,
+    ): B extends true ? ResolvedObjectRecursive<T> : ResolvedObject<T>;
     function resolve<T>(obj: T): ResolvedObject<T>;
 
     /**

--- a/types/righto/righto-tests.ts
+++ b/types/righto/righto-tests.ts
@@ -10,193 +10,205 @@ function noArgsCPS(callback: ErrBack<[number], undefined>) {
 }
 
 function multiReturnCPS(a: number, callback: ErrBack<[number, string, boolean], Error>) {
-    if (a < 0)
+    if (a < 0) {
         callback(new Error("Cannot call this with an argument of 0!"));
-    else
+    } else {
         callback(void 0, a + 1, a.toString(), true);
+    }
 }
 
 function divideNumbersCPS(a: number, b: number, callback: ErrBack<[number], Error>) {
-    if (b === 0)
+    if (b === 0) {
         callback(new Error("Cannot divide by a negative number"));
-    else
+    } else {
         callback(void 0, a / b);
+    }
 }
 
 function divideNumbers(a: number, b: number) {
     return a / b;
 }
 
-//#region Test righto constructor
-    // $ExpectType Righto<[number], Error>
-    const rDivideNumbers1 = righto(divideNumbersCPS, 1, 1);
-    // $ExpectType Righto<[number], Error>
-    const rDivideNumbers2 = righto(divideNumbersCPS, 2, 1);
+// #region Test righto constructor
+// $ExpectType Righto<[number], Error>
+const rDivideNumbers1 = righto(divideNumbersCPS, 1, 1);
+// $ExpectType Righto<[number], Error>
+const rDivideNumbers2 = righto(divideNumbersCPS, 2, 1);
 
-    // $ExpectType Righto<[number], Error>
-    righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2);
-    // $ExpectType Righto<[number], Error>
-    righto(divideNumbersCPS, rDivideNumbers1, new Promise<number>(r => r(5)));
-    // $ExpectType Righto<[boolean], null>
-    const rBool = righto<[], [boolean], null>((fn) => fn(null, true));
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1, "");
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1);
-    // @ts-expect-error
-    righto(divideNumbersCPS, rDivideNumbers1, 2, 3);
-    // @ts-expect-error
-    righto(divideNumbers, 5, 6);
+// $ExpectType Righto<[number], Error>
+righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2);
+// $ExpectType Righto<[number], Error>
+righto(divideNumbersCPS, rDivideNumbers1, new Promise<number>(r => r(5)));
+// $ExpectType Righto<[boolean], null>
+const rBool = righto<[], [boolean], null>((fn) => fn(null, true));
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1, "");
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1);
+// @ts-expect-error
+righto(divideNumbersCPS, rDivideNumbers1, 2, 3);
+// @ts-expect-error
+righto(divideNumbers, 5, 6);
 
-    // $ExpectType Righto<[number, string, boolean], Error>
-    const rMultiReturn = righto(multiReturnCPS, 1);
-    // $ExpectType Righto<[], undefined>
-    const rNoReturn = righto(noReturnCPS);
-    // $ExpectType Righto<[number], undefined>
-    righto(noArgsCPS);
-    // @ts-expect-error
-    righto(noArgsCPS, 5);
+// $ExpectType Righto<[number, string, boolean], Error>
+const rMultiReturn = righto(multiReturnCPS, 1);
+// $ExpectType Righto<[], undefined>
+const rNoReturn = righto(noReturnCPS);
+// $ExpectType Righto<[number], undefined>
+righto(noArgsCPS);
+// @ts-expect-error
+righto(noArgsCPS, 5);
 
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2);
-    righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
-    // @ts-expect-error
-    righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, righto.after(rDivideNumbers1), rDivideNumbers2);
-//#endregion
+righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, rDivideNumbers2);
+righto(divideNumbersCPS, rDivideNumbers1, rDivideNumbers2, righto.after(rDivideNumbers1));
+righto(
+    divideNumbersCPS,
+    righto.after(rDivideNumbers1),
+    rDivideNumbers1,
+    rDivideNumbers2,
+    righto.after(rDivideNumbers1),
+);
+// dprint-ignore
+// @ts-expect-error
+righto(divideNumbersCPS, righto.after(rDivideNumbers1), rDivideNumbers1, righto.after(rDivideNumbers1), rDivideNumbers2);
+// #endregion
 
-//#region Test righto.fork
-    // $ExpectType Promise<number>
-    const promise = new Promise(righto.fork(rDivideNumbers1));
-    // $ExpectType Promise<undefined>
-    const promise2 = new Promise(righto.fork(rNoReturn));
-    // $ExpectType Promise<number>
-    const promise3 = new Promise(righto.fork(rMultiReturn));
-//#endregion
+// #region Test righto.fork
+// $ExpectType Promise<number>
+const promise = new Promise(righto.fork(rDivideNumbers1));
+// $ExpectType Promise<undefined>
+const promise2 = new Promise(righto.fork(rNoReturn));
+// $ExpectType Promise<number>
+const promise3 = new Promise(righto.fork(rMultiReturn));
+// #endregion
 
-//#region Test righto.iterate
-    const generated = righto.iterate(function*(a: string, b: string, c: string): Generator<Righto<[string], never>, string, string> {
+// #region Test righto.iterate
+const generated = righto.iterate(
+    function*(a: string, b: string, c: string): Generator<Righto<[string], never>, string, string> {
         const x = yield righto((done) => {
-            done(void 0, 'x');
+            done(void 0, "x");
         });
 
         const y = yield righto((done) => {
-            done(void 0, 'y');
+            done(void 0, "y");
         });
 
         return x + y + a + b + c;
-    });
+    },
+);
 
-    // $ExpectType Righto<[string], never>
-    const result = generated('a', 'b', 'c');
+// $ExpectType Righto<[string], never>
+const result = generated("a", "b", "c");
 
-    result((error, result) => {
-        result === 'xyabc';
-    });
-//#endregion
+result((error, result) => {
+    result === "xyabc";
+});
+// #endregion
 
-//#region Test immediate execution
-    rMultiReturn();
-    rMultiReturn((error, result) => {});
-//#endregion
+// #region Test immediate execution
+rMultiReturn();
+rMultiReturn((error, result) => {});
+// #endregion
 
-//#region Test righto.take
-    // $ExpectType Righto<[any, any], Error>
-    const taken = righto.take(rMultiReturn, 0, 1);
-//#endregion
+// #region Test righto.take
+// $ExpectType Righto<[any, any], Error>
+const taken = righto.take(rMultiReturn, 0, 1);
+// #endregion
 
-//#region Test righto.reduce
-    function reduceTestFunc1(callback: ErrBack<[number], null>) {
-        callback(null, 1);
-    }
-    function reduceTestFunc2(callback: ErrBack<[number], null>) {
-        callback(null, 2);
-    }
-    // $ExpectType Righto<[number], null>
-    const reduced1 = righto.reduce([righto(reduceTestFunc1), righto(reduceTestFunc2)]);
+// #region Test righto.reduce
+function reduceTestFunc1(callback: ErrBack<[number], null>) {
+    callback(null, 1);
+}
+function reduceTestFunc2(callback: ErrBack<[number], null>) {
+    callback(null, 2);
+}
+// $ExpectType Righto<[number], null>
+const reduced1 = righto.reduce([righto(reduceTestFunc1), righto(reduceTestFunc2)]);
 
-    function reduceTestFunc3(last: number, callback: ErrBack<[number], null>) {
-        callback(null, last);
-    }
+function reduceTestFunc3(last: number, callback: ErrBack<[number], null>) {
+    callback(null, last);
+}
 
-    function reduceTestFunc4(last: number, callback: ErrBack<[number], null>) {
-        callback(null, last + 2);
-    }
+function reduceTestFunc4(last: number, callback: ErrBack<[number], null>) {
+    callback(null, last + 2);
+}
 
-    // $ExpectType Righto<[number], null>
-    const reduced2 = righto.reduce(
-            [reduceTestFunc3, reduceTestFunc4],
-            (result, next) => { // Reducer
-                return righto(next, result);
-            },
-            5 // Seed
-        );
-//#endregion
+// $ExpectType Righto<[number], null>
+const reduced2 = righto.reduce(
+    [reduceTestFunc3, reduceTestFunc4],
+    (result, next) => { // Reducer
+        return righto(next, result);
+    },
+    5, // Seed
+);
+// #endregion
 
-//#region Test righto.all
-    // $ExpectType Righto<[number[]], Error>
-    const rAll1 = righto.all([rDivideNumbers1, rDivideNumbers2]);
-    // $ExpectType Righto<[any[]], any>
-    const rAll2 = righto.all([rDivideNumbers1, rBool]);
-//#endregion
+// #region Test righto.all
+// $ExpectType Righto<[number[]], Error>
+const rAll1 = righto.all([rDivideNumbers1, rDivideNumbers2]);
+// $ExpectType Righto<[any[]], any>
+const rAll2 = righto.all([rDivideNumbers1, rBool]);
+// #endregion
 
-//#region Test righto.sync
-    const someNumber = righto((done: ErrBack<[number], null>) => {
-        done(null, 5);
-    });
+// #region Test righto.sync
+const someNumber = righto((done: ErrBack<[number], null>) => {
+    done(null, 5);
+});
 
-    function numToString(value: number) {
-        return value.toString();
-    }
+function numToString(value: number) {
+    return value.toString();
+}
 
-    // $ExpectType Righto<[string], any>
-    const syncTask = righto.sync(numToString, someNumber);
-    righto.sync(numToString, 5);
-    // @ts-expect-error
-    righto.sync(numToString, rBool);
-//#endregion
+// $ExpectType Righto<[string], any>
+const syncTask = righto.sync(numToString, someNumber);
+righto.sync(numToString, 5);
+// @ts-expect-error
+righto.sync(numToString, rBool);
+// #endregion
 
-//#region Test righto.from
+// #region Test righto.from
+// $ExpectType Righto<[boolean], null>
+righto.from(rBool);
+// $ExpectType Righto<[number], any>
+righto.from(new Promise<number>(r => r(5)));
+// $ExpectType Righto<[string], undefined>
+righto.from("test");
+// $ExpectType Righto<[{ a: number; b: { a: number; }; }], undefined>
+righto.from({ a: 5, b: { a: 5 } });
+// #endregion
+
+// #region Test righto.value
+const rightoValue = righto.value(rBool);
+
+const rValIn = righto((value, callback) => {
     // $ExpectType Righto<[boolean], null>
-    righto.from(rBool);
-    // $ExpectType Righto<[number], any>
-    righto.from(new Promise<number>(r => r(5)));
-    // $ExpectType Righto<[string], undefined>
-    righto.from("test");
-    // $ExpectType Righto<[{ a: number; b: { a: number; }; }], undefined>
-    righto.from({a: 5, b: {a: 5}});
-//#endregion
+    value;
+}, rightoValue);
+// #endregion
 
-//#region Test righto.value
-    const rightoValue = righto.value(rBool);
+// #region Test righto.get
+const rGetObj = righto((cb: ErrBack<[{ a: number; b: number; c: number }], never>) => cb(void 0, { a: 1, b: 2, c: 3 }));
+// $ExpectType Righto<[number], never>
+rGetObj.get(x => x.a);
+// $ExpectType Righto<[any], never>
+rGetObj.get("a");
+// $ExpectType Righto<[any], never>
+rGetObj.get(rDivideNumbers1);
+// #endregion
 
-    const rValIn = righto((value, callback) => {
-        // $ExpectType Righto<[boolean], null>
-        value;
-    }, rightoValue);
-//#endregion
+// #region Test righto.surely
+// $ExpectType Righto<[[Error, string]], Error>
+const errorOrX = righto.surely((done: ErrBack<[string], Error>) => {
+    done(new Error("borked"));
+});
 
-//#region Test righto.get
-    const rGetObj = righto((cb: ErrBack<[{a: number, b: number, c: number}], never>) => cb(void 0, {a: 1, b: 2, c: 3}));
-    // $ExpectType Righto<[number], never>
-    rGetObj.get(x => x.a);
-    // $ExpectType Righto<[any], never>
-    rGetObj.get('a');
-    // $ExpectType Righto<[any], never>
-    rGetObj.get(rDivideNumbers1);
-//#endregion
+// $ExpectType Righto<[[Error, string]], Error>
+const errorOrY = righto.surely((done: ErrBack<[string], Error>) => {
+    done(void 0, "y");
+});
 
-//#region Test righto.surely
-    // $ExpectType Righto<[[Error, string]], Error>
-    const errorOrX = righto.surely((done: ErrBack<[string], Error>) => {
-        done(new Error('borked'));
-    });
-
-    // $ExpectType Righto<[[Error, string]], Error>
-    const errorOrY = righto.surely((done: ErrBack<[string], Error>) => {
-        done(void 0, 'y');
-    });
-
-    const z = righto(([xError, x], [yError, y]) => {
+const z = righto(
+    ([xError, x], [yError, y]) => {
         // $ExpectType Error
         xError;
         // $ExpectType string
@@ -205,110 +217,113 @@ function divideNumbers(a: number, b: number) {
         yError;
         // $ExpectType string
         y;
-    }, errorOrX, errorOrY);
-//#endregion
+    },
+    errorOrX,
+    errorOrY,
+);
+// #endregion
 
-//#region Test righto.handle
-    function mightFail(callback: ErrBack<[string], string>) {
-        if (Math.random() > 0.5) {
-            callback('borked');
-        } else {
-            callback(void 0, 'result');
-        }
+// #region Test righto.handle
+function mightFail(callback: ErrBack<[string], string>) {
+    if (Math.random() > 0.5) {
+        callback("borked");
+    } else {
+        callback(void 0, "result");
     }
+}
 
-    function defaultString(error: string, callback: ErrBack<[string], string>) {
-        callback(void 0, '');
-    }
+function defaultString(error: string, callback: ErrBack<[string], string>) {
+    callback(void 0, "");
+}
 
-    const maybeAString = righto(mightFail);
-    const aString = righto.handle(maybeAString, defaultString);
+const maybeAString = righto(mightFail);
+const aString = righto.handle(maybeAString, defaultString);
 
-    aString((error, result) => {
-        // $ExpectType string | undefined
-        error;
-        // $ExpectType string | undefined
-        result;
-    });
-//#endregion
+aString((error, result) => {
+    // $ExpectType string | undefined
+    error;
+    // $ExpectType string | undefined
+    result;
+});
+// #endregion
 
-//#region Test righto.resolve
-    const obj2Resolve = {
-        rNum: rDivideNumbers1,
-        str: "string",
+// #region Test righto.resolve
+const obj2Resolve = {
+    rNum: rDivideNumbers1,
+    str: "string",
+    obj: {
+        rBool,
         obj: {
-            rBool,
-            obj: {
-                rNum: rDivideNumbers1
-            }
-        }
-    };
+            rNum: rDivideNumbers1,
+        },
+    },
+};
 
-    const resolvedObj = righto.resolve(obj2Resolve, false);
-    // $ExpectType number
-    resolvedObj.rNum;
-    // $ExpectType Righto<[boolean], null>
-    resolvedObj.obj.rBool;
+const resolvedObj = righto.resolve(obj2Resolve, false);
+// $ExpectType number
+resolvedObj.rNum;
+// $ExpectType Righto<[boolean], null>
+resolvedObj.obj.rBool;
 
-    const resolvedObjRecursive = righto.resolve(obj2Resolve, true);
-    // $ExpectType number
-    resolvedObjRecursive.rNum;
-    // $ExpectType number
-    resolvedObjRecursive.obj.obj.rNum;
-//#endregion
+const resolvedObjRecursive = righto.resolve(obj2Resolve, true);
+// $ExpectType number
+resolvedObjRecursive.rNum;
+// $ExpectType number
+resolvedObjRecursive.obj.obj.rNum;
+// #endregion
 
-//#region Test righto.mate
-    // $ExpectType Righto<[number, number], Error>
-    const rMate = righto.mate<[number, number], Error>(rDivideNumbers1, rDivideNumbers2);
+// #region Test righto.mate
+// $ExpectType Righto<[number, number], Error>
+const rMate = righto.mate<[number, number], Error>(rDivideNumbers1, rDivideNumbers2);
 
-    rMate((error, stuff, otherStuff) => {
-        // $ExpectType Error | undefined
-        error;
-        // $ExpectType number | undefined
-        stuff;
-        // $ExpectType number | undefined
-        otherStuff;
+rMate((error, stuff, otherStuff) => {
+    // $ExpectType Error | undefined
+    error;
+    // $ExpectType number | undefined
+    stuff;
+    // $ExpectType number | undefined
+    otherStuff;
+});
+// #endregion
+
+// #region Test righto.fail
+const testFail = rDivideNumbers1.get((value) => {
+    if (!value) {
+        return righto.fail("was falsey");
+    }
+
+    return value;
+});
+// #endregion
+
+// #region Test righto.proxy
+const rightoProxy = righto.proxy;
+// $ExpectType any
+const foo = rightoProxy((done: ErrBack<[object], null>) => {
+    done(null, {
+        foo: {
+            bar: {
+                baz: "hello",
+            },
+        },
     });
-//#endregion
+});
+// #endregion
 
-//#region Test righto.fail
-    const testFail = rDivideNumbers1.get((value) => {
-        if (!value) {
-            return righto.fail('was falsey');
-        }
+// #region Test righto is functions
+// $ExpectType boolean
+righto.isRighto(rDivideNumbers1);
+// $ExpectType boolean
+righto.isThenable(rDivideNumbers1);
+// $ExpectType boolean
+righto.isResolvable(rDivideNumbers1);
+// #endregion
 
-        return value;
-    });
-//#endregion
+// #region Test righto debug features
+righto._debug = true;
+rDivideNumbers1();
+rDivideNumbers1._trace();
 
-//#region Test righto.proxy
-    const rightoProxy = righto.proxy;
-    // $ExpectType any
-    const foo = rightoProxy((done: ErrBack<[object], null>) => {
-            done(null, {
-                    foo: {
-                        bar: {
-                            baz: 'hello'
-                        }
-                    }
-                });
-        });
-//#endregion
-
-//#region Test righto is functions
-    // $ExpectType boolean
-    righto.isRighto(rDivideNumbers1);
-    // $ExpectType boolean
-    righto.isThenable(rDivideNumbers1);
-    // $ExpectType boolean
-    righto.isResolvable(rDivideNumbers1);
-//#endregion
-
-//#region Test righto debug features
-    righto._debug = true;
-    rDivideNumbers1();
-    rDivideNumbers1._trace();
-
-    rDivideNumbers1._traceOnError = true;
-    righto._autotraceOnError = true;
-//#endregion
+rDivideNumbers1._traceOnError = true;
+righto._autotraceOnError = true;
+// #endregion


### PR DESCRIPTION
After #66235, this repo is now formatted with dprint. This PR removes the temporary exception for `righto`, which required a `dprint-ignore` as the error span differs depending on the TS version.