### PR TITLE
[postcss-sorting] Add types for postcss-sorting

### DIFF
--- a/types/postcss-sorting/index.d.ts
+++ b/types/postcss-sorting/index.d.ts
@@ -1,0 +1,106 @@
+// Type definitions for postcss-sorting 8.0
+// Project: https://github.com/hudochenkov/postcss-sorting
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { PluginCreator } from "postcss";
+
+declare namespace sorting {
+    /**
+     * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/order/README.md#order>}
+     */
+    type OrderString =
+        | "custom-properties"
+        | "dollar-variables"
+        | "at-variables"
+        | "declarations"
+        | "rules"
+        | "at-rules";
+
+    /**
+     * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/order/README.md#extended-rule-objects>}
+     */
+    interface ExtendedRule {
+        type: "rule";
+        /**
+         * Selector pattern. Strings will be converted to {@link RegExp}
+         * (make sure to escape)
+         * @example
+         * // Matches simple pseudo-classes, such as &hover and &first-child
+         * { type: "rule", selector: /^&:[\w-]+$/ }
+         * @example
+         * // Matches pseudo-elements, such as &::before and &::placeholder
+         * { type: "rule", selector: /^&::[\w-]+$/ }
+         */
+        selector?: string | RegExp | undefined;
+    }
+
+    /**
+     * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/order/README.md#extended-at-rule-objects>}
+     */
+    interface ExtendedAtRule {
+        type: "at-rule";
+        name?: string | undefined;
+        /** Strings will be converted to {@link RegExp} */
+        parameter?: string | RegExp | undefined;
+        /**
+         * i.e. `true` for `@include icon { color: red; }`
+         * but `false` for `@include icon;`
+         */
+        hasBlock?: boolean | undefined;
+    }
+
+    interface Options {
+        /**
+         * Specify the order of content within declaration blocks.
+         * **Unlisted elements will be placed after all listed elements.**
+         * So if you specify an array and do not include declarations,
+         * that means that all declarations will be placed after any other element
+         * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/order/README.md>}
+         */
+        order?: ReadonlyArray<OrderString | ExtendedRule | ExtendedAtRule> | undefined;
+        /**
+         * Specify the order of properties within declaration blocks.
+         *
+         * This rule ignore prefixes to determine properties order,
+         * so `-moz-transform`, for example, is treated as `transform`.
+         * Shorthand properties will always precede their longhand forms
+         * (e.g. `border-style` will always be before `border-bottom-style`).
+         * Prefixed properties will always precede the unprefixed version
+         * e. g. `-moz-transform `will be always before `transform`).
+         *
+         * Recommended to use this rule only on source files.
+         * Some “non-standard” prefixes could be treated wrong,
+         * such as different flexbox implementations:
+         * `-ms-flex-align: center; align-items: center;` with alphabetical order
+         * will be sorted as `align-items: center; -ms-flex-align: center;`
+         * because alphabetically flex-align is after align-item.
+         *
+         * This rule ignores variables (`$sass`, `@less`, `--custom-property`)
+         * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/properties-order/README.md#properties-order>}
+         */
+        "properties-order"?: "alphabetical" | readonly string[] | undefined;
+        /**
+         * Specify position for properties not specified in {@link properties-order}.
+         * This option only works if you've defined your own _array_ of properties in {@link properties-order}.
+         *
+         * | Value              | Behaviour                                                                                                                          |
+         * | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+         * | bottom             | Unspecified properties will be placed _after_ any specified properties                                                             |
+         * | top                | Unspecified properties will be placed _before_ any specified properties                                                            |
+         * | bottomAlphabetical | Unspecified properties will be placed after any specified properties, and the unspecified properties will be in alphabetical order |
+         *
+         * @default "bottom"
+         * @see {@link <https://github.com/hudochenkov/postcss-sorting/blob/master/lib/properties-order/unspecified-properties-position.md#unspecified-properties-position>}
+         */
+        "unspecified-properties-position"?: "top" | "bottom" | "bottomAlphabetical" | undefined;
+        /**
+         * Throw config validation errors instead of showing and ignoring them
+         * @default false
+         */
+        "throw-validate-errors"?: boolean | undefined;
+    }
+}
+
+declare const sorting: PluginCreator<sorting.Options>;
+
+export = sorting;

--- a/types/postcss-sorting/package.json
+++ b/types/postcss-sorting/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.4.20"
+    }
+}

--- a/types/postcss-sorting/postcss-sorting-tests.ts
+++ b/types/postcss-sorting/postcss-sorting-tests.ts
@@ -14,17 +14,17 @@ postcss([
             "declarations",
             "dollar-variables",
             "rules",
-            { type: "at-rule" } as const,
-            { type: "rule" } as const,
-            { type: "at-rule", hasBlock: true, name: "foo" } as const,
-            { type: "rule", selector: /foo/ } as const,
-            { type: "rule", selector: "foo" } as const,
-        ] as const,
+            { type: "at-rule" },
+            { type: "rule" },
+            { type: "at-rule", hasBlock: true, name: "foo" },
+            { type: "rule", selector: /foo/ },
+            { type: "rule", selector: "foo" },
+        ],
     }),
 ]);
 
 postcss([sorting({ "properties-order": "alphabetical" })]);
-postcss([sorting({ "properties-order": ["a", "b", "c"] as const })]);
+postcss([sorting({ "properties-order": ["a", "b", "c"] })]);
 
 postcss([sorting({ "unspecified-properties-position": "top" })]);
 postcss([sorting({ "unspecified-properties-position": "bottom" })]);

--- a/types/postcss-sorting/postcss-sorting-tests.ts
+++ b/types/postcss-sorting/postcss-sorting-tests.ts
@@ -1,0 +1,33 @@
+import postcss = require("postcss");
+import sorting = require("postcss-sorting");
+
+postcss([sorting]);
+postcss([sorting()]);
+postcss([sorting({})]);
+
+postcss([
+    sorting({
+        order: [
+            "at-rules",
+            "at-variables",
+            "custom-properties",
+            "declarations",
+            "dollar-variables",
+            "rules",
+            { type: "at-rule" } as const,
+            { type: "rule" } as const,
+            { type: "at-rule", hasBlock: true, name: "foo" } as const,
+            { type: "rule", selector: /foo/ } as const,
+            { type: "rule", selector: "foo" } as const,
+        ] as const,
+    }),
+]);
+
+postcss([sorting({ "properties-order": "alphabetical" })]);
+postcss([sorting({ "properties-order": ["a", "b", "c"] as const })]);
+
+postcss([sorting({ "unspecified-properties-position": "top" })]);
+postcss([sorting({ "unspecified-properties-position": "bottom" })]);
+postcss([sorting({ "unspecified-properties-position": "bottomAlphabetical" })]);
+
+postcss([sorting({ "throw-validate-errors": true })]);

--- a/types/postcss-sorting/tsconfig.json
+++ b/types/postcss-sorting/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-sorting-tests.ts"]
+}

--- a/types/postcss-sorting/tsconfig.json
+++ b/types/postcss-sorting/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6", "ES2018.Promise"],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/postcss-sorting/tsconfig.json
+++ b/types/postcss-sorting/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": ["es6", "ES2018.Promise"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/postcss-sorting/tslint.json
+++ b/types/postcss-sorting/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package postcss-sorting (<https://www.npmjs.com/package/postcss-sorting>).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
