### PR TITLE
[jsx-pdf] fix failing nightly test

### DIFF
--- a/types/jsx-pdf/jsx-pdf-tests.tsx
+++ b/types/jsx-pdf/jsx-pdf-tests.tsx
@@ -225,7 +225,7 @@ const doc12 = (
                 </text>
             )}
         </header>
-        <content>{/* ... */}</content>
+        <content>Hello, Bob!</content>
     </document>
 );
 


### PR DESCRIPTION
From the nightly:

```
Error in jsx-pdf
Error: /home/vsts/work/1/s/types/jsx-pdf/jsx-pdf-tests.tsx:228:10
ERROR: 228:10  expect  TypeScript@5.3 compile error: 
Property 'children' is missing in type '{}' but required in type 'ElementChildrenAttribute'.
```

This is the example from https://www.npmjs.com/package/jsx-pdf#dynamic-header-and-footer, but https://github.com/microsoft/TypeScript/pull/55981 broke it. @Andarist not sure if this was intentional or not but it's easy to fix.