### PR TITLE
Enable formatting for a few working i18n* packages

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -33,7 +33,9 @@
     "./types/vscode",
 
     // These files will be formatted soon, but are failing in CI for now.
-    "./types/i18n*",
+    "./types/i18next-ko",
+    "./types/i18next-node-fs-backend",
+    "./types/i18next-sprintf-postprocessor",
     "./types/inquirer*",
     "./types/react-blessed",
     "./types/react-map-gl",

--- a/types/i18n-abide/i18n-abide-tests.ts
+++ b/types/i18n-abide/i18n-abide-tests.ts
@@ -1,13 +1,13 @@
-import * as i18n from 'i18n-abide';
+import * as i18n from "i18n-abide";
 
 const emptyAbideOptions: i18n.AbideOptions = {};
 const fullAbideOptions: i18n.AbideOptions = {
-    gettext_alias: 'gettext',
-    supported_languages: ['en-US'],
-    default_lang: 'en-US',
-    debug_lang: 'it-CH',
+    gettext_alias: "gettext",
+    supported_languages: ["en-US"],
+    default_lang: "en-US",
+    debug_lang: "it-CH",
     disable_locale_check: false,
-    translation_directory: 'l18n/',
+    translation_directory: "l18n/",
     logger: { warn(msg: string) {}, error(msg: string) {} },
 };
 
@@ -17,7 +17,7 @@ i18n.abide(fullAbideOptions); // $ExpectType RequestHandler<ParamsDictionary, an
 
 i18n.parseAcceptLanguage(""); // $ExpectType { lang: string; quality: number; }[]
 
-i18n.bestLanguage([{lang: 'en-US', quality: 1.0}], ['en-US'], 'en-US'); // $ExpectType string
+i18n.bestLanguage([{ lang: "en-US", quality: 1.0 }], ["en-US"], "en-US"); // $ExpectType string
 
 i18n.localeFrom(); // $ExpectType string
 i18n.localeFrom(""); // $ExpectType string

--- a/types/i18n-abide/index.d.ts
+++ b/types/i18n-abide/index.d.ts
@@ -4,11 +4,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { RequestHandler } from 'express';
+import { RequestHandler } from "express";
 
 export function abide(options?: AbideOptions): RequestHandler;
-export function parseAcceptLanguage(header?: string): Array<{ lang: string, quality: number }>;
-export function bestLanguage(languages: Array<{ lang: string, quality: number}>, supported_languages: string[], defaultLanguage: string): string;
+export function parseAcceptLanguage(header?: string): Array<{ lang: string; quality: number }>;
+export function bestLanguage(
+    languages: Array<{ lang: string; quality: number }>,
+    supported_languages: string[],
+    defaultLanguage: string,
+): string;
 export function localeFrom(language?: string): string;
 export function languageFrom(locale?: string): string;
 export function normalizeLanguage(language?: string): string;
@@ -23,5 +27,5 @@ export interface AbideOptions {
     debug_lang?: string | undefined;
     disable_locale_check?: boolean | undefined;
     translation_directory?: string | undefined;
-    logger?: { warn(msg: string): void, error(msg: string): void } | undefined;
+    logger?: { warn(msg: string): void; error(msg: string): void } | undefined;
 }

--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -16,9 +16,9 @@ I18n.t("some.missing.scope", { defaultValue: "A default message" });
 I18n.t("noun", { defaultValue: "I'm a {{noun}}", noun: "Mac" });
 I18n.t("some.missing.scope", { defaults: [{ scope: "some.existing.scope" }] });
 I18n.t("some.missing.scope", { defaults: [{ message: "Some message" }] });
-I18n.translate("message", {defaultValue: { one: "%{count} message", other: "%{count} messages"}, count: 1});
+I18n.translate("message", { defaultValue: { one: "%{count} message", other: "%{count} messages" }, count: 1 });
 I18n.translate("foo", {
-    defaults: [{scope: "bar"}],
+    defaults: [{ scope: "bar" }],
     defaultValue: (scope: string) => scope.toUpperCase(),
 });
 
@@ -26,7 +26,7 @@ I18n.fallbacks = true;
 I18n.fallbacks = "de";
 I18n.fallbacks = {
     de: "en",
-    "de-DE": [ "de", "en" ]
+    "de-DE": ["de", "en"],
 };
 I18n.locales.no = ["nb", "en"];
 I18n.locales.no = "nb";
@@ -45,14 +45,13 @@ I18n.missingTranslation = (scope, options) => undefined;
 
 I18n.t("inbox.counting", { count: 10 });
 I18n.pluralization["ru"] = count => {
-    const key =
-        count % 10 === 1 && count % 100 !== 11
-            ? "one"
-            : [2, 3, 4].indexOf(count % 10) >= 0 && [12, 13, 14].indexOf(count % 100) < 0
-            ? "few"
-            : count % 10 === 0 || [5, 6, 7, 8, 9].indexOf(count % 10) >= 0 || [11, 12, 13, 14].indexOf(count % 100) >= 0
-            ? "many"
-            : "other";
+    const key = count % 10 === 1 && count % 100 !== 11
+        ? "one"
+        : [2, 3, 4].indexOf(count % 10) >= 0 && [12, 13, 14].indexOf(count % 100) < 0
+        ? "few"
+        : count % 10 === 0 || [5, 6, 7, 8, 9].indexOf(count % 10) >= 0 || [11, 12, 13, 14].indexOf(count % 100) >= 0
+        ? "many"
+        : "other";
     return [key];
 };
 
@@ -75,7 +74,7 @@ I18n.toNumber(1000, { delimiter: ".", precision: 0 });
 I18n.toCurrency(1000, { precision: 0 });
 
 I18n.toHumanSize(1234);
-I18n.toHumanSize(1024 * 1024, {scope: "extended"});
+I18n.toHumanSize(1024 * 1024, { scope: "extended" });
 
 I18n.l("date.formats.short", "2009-09-18");
 I18n.l("time.formats.short", "2009-09-18 23:12:43");

--- a/types/i18n-js/index.d.ts
+++ b/types/i18n-js/index.d.ts
@@ -24,12 +24,23 @@ declare namespace I18n {
     // eslint-disable-next-line @definitelytyped/prefer-declare-function
     let missingTranslation: (scope: string, options?: TranslateOptions) => string | null | undefined;
     // eslint-disable-next-line @definitelytyped/prefer-declare-function
-    let missingPlaceholder: (placeholder: string, message: string, options?: InterpolateOptions) => string | null | undefined;
+    let missingPlaceholder: (
+        placeholder: string,
+        message: string,
+        options?: InterpolateOptions,
+    ) => string | null | undefined;
     // eslint-disable-next-line @definitelytyped/prefer-declare-function
-    let nullPlaceholder: (placeholder: string, message: string, options?: InterpolateOptions) => string | null | undefined;
+    let nullPlaceholder: (
+        placeholder: string,
+        message: string,
+        options?: InterpolateOptions,
+    ) => string | null | undefined;
 
     let translations: { [locale: string]: object };
-    let locales: { [key: string]: string | string[] | ((locale: string) => string | string[]), get: (locale: string) => string[] };
+    let locales: {
+        [key: string]: string | string[] | ((locale: string) => string | string[]);
+        get: (locale: string) => string[];
+    };
     let pluralization: { [locale: string]: (count: number) => string[] };
 
     function reset(): void;

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -8,8 +8,8 @@
 
 import express = require("express");
 import i18n = require("i18n");
-import { I18n } from "i18n";
 import { Request } from "express-serve-static-core";
+import { I18n } from "i18n";
 
 const app = express();
 declare const req: Express.Request & Request;
@@ -19,37 +19,37 @@ declare const req: Express.Request & Request;
  * https://github.com/mashpie/i18n-node#configure
  */
 i18n.configure({
-    locales: ['en', 'de'],
-    directory: __dirname + '/locales',
+    locales: ["en", "de"],
+    directory: __dirname + "/locales",
 });
 
 i18n.configure({
     // setup some locales - other locales default to en silently
-    locales: [ 'en', 'de' ],
+    locales: ["en", "de"],
 
     // fall back from Dutch to German
-    fallbacks: { nl: 'de' },
+    fallbacks: { nl: "de" },
 
     // you may alter a site wide default locale
-    defaultLocale: 'de',
+    defaultLocale: "de",
 
     // will return translation from defaultLocale in case current locale doesn't provide it
     retryInDefaultLocale: false,
 
     // sets a custom cookie name to parse locale settings from - defaults to NULL
-    cookie: 'yourcookiename',
+    cookie: "yourcookiename",
 
     // sets a custom header name to read the language preference from - accept-language header by default
-    header: 'accept-language',
+    header: "accept-language",
 
     // query parameter to switch locale (ie. /home?lang=ch) - defaults to NULL
-    queryParameter: 'lang',
+    queryParameter: "lang",
 
     // where to store json files - defaults to './locales' relative to modules directory
-    directory: './mylocales',
+    directory: "./mylocales",
 
     // control mode on directory creation - defaults to NULL which defaults to umask of process user. Setting has no effect on win.
-    directoryPermissions: '755',
+    directoryPermissions: "755",
 
     // watch for changes in JSON files to reload locale on updates - defaults to false
     autoReload: true,
@@ -64,27 +64,27 @@ i18n.configure({
     indent: "\t",
 
     // setting extension of json files - defaults to '.json' (you might want to set this to '.js' according to webtranslateit)
-    extension: '.js',
+    extension: ".js",
 
     // setting prefix of json files name - default to none '' (in case you use different locale files naming scheme (webapp-en.json), rather then just en.json)
-    prefix: 'webapp-',
+    prefix: "webapp-",
 
     // enable object notation
     objectNotation: false,
 
     // setting of log level DEBUG - default to require('debug')('i18n:debug')
     logDebugFn: (msg) => {
-        console.log('debug', msg);
+        console.log("debug", msg);
     },
 
     // setting of log level WARN - default to require('debug')('i18n:warn')
     logWarnFn: (msg) => {
-        console.log('warn', msg);
+        console.log("warn", msg);
     },
 
     // setting of log level ERROR - default to require('debug')('i18n:error')
     logErrorFn: (msg) => {
-        console.log('error', msg);
+        console.log("error", msg);
     },
 
     // Function to provide missing translations.
@@ -98,8 +98,8 @@ i18n.configure({
     // hash to specify different aliases for i18n's internal methods to apply on the request/response objects (method -> alias).
     // note that this will *not* overwrite existing properties with the same name
     api: {
-      __: 't',  // now req.__ becomes req.t
-      __n: 'tn' // and req.__n can be called as req.tn
+        __: "t", // now req.__ becomes req.t
+        __n: "tn", // and req.__n can be called as req.tn
     },
 
     // Downcase locale when passed on queryParam; e.g. lang=en-US becomes
@@ -109,21 +109,21 @@ i18n.configure({
 
     // Static translation catalog. Setting this option overrides `locales`
     staticCatalog: {
-        'en-US': {
-            no: 'No',
-            ok: 'Ok',
-            yes: 'Yes',
+        "en-US": {
+            no: "No",
+            ok: "Ok",
+            yes: "Yes",
         },
-        'nl-NL': {
-            no: 'Nee',
-            ok: 'Oké',
-            yes: 'Ja',
+        "nl-NL": {
+            no: "Nee",
+            ok: "Oké",
+            yes: "Ja",
         },
     },
 
     // use mustache with customTags (https://www.npmjs.com/package/mustache#custom-delimiters) or disable mustache entirely
     mustacheConfig: {
-        tags: ['{{', '}}'],
+        tags: ["{{", "}}"],
         disable: false,
     },
     // Set JSON as buildin object which is acceptable as an parser object.
@@ -134,7 +134,7 @@ i18n.configure({
  * Usage in global scope
  * https://github.com/mashpie/i18n-node#example-usage-in-global-scope
  */
-const greeting = i18n.__('Hello');
+const greeting = i18n.__("Hello");
 
 /**
  * Usage in Express
@@ -144,8 +144,8 @@ const greeting = i18n.__('Hello');
 // default: using 'accept-language' header to guess language settings
 app.use(i18n.init);
 
-app.get('/de', (_req: Express.Request, res: Express.Response) => {
-    const greeting = res.__('Hello');
+app.get("/de", (_req: Express.Request, res: Express.Response) => {
+    const greeting = res.__("Hello");
 });
 
 /**
@@ -153,19 +153,19 @@ app.get('/de', (_req: Express.Request, res: Express.Response) => {
  * https://github.com/mashpie/i18n-node#__
  */
 // global (this.locale == 'de')
-i18n.__('Hello'); // Hallo
-i18n.__('Hello %s', 'Marcus'); // Hallo Marcus
-i18n.__('Hello {{name}}', { name: 'Marcus' }); // Hallo Marcus
+i18n.__("Hello"); // Hallo
+i18n.__("Hello %s", "Marcus"); // Hallo Marcus
+i18n.__("Hello {{name}}", { name: "Marcus" }); // Hallo Marcus
 
 // scoped via req object (req.locale == 'de')
-req.__('Hello'); // Hallo
-req.__('Hello %s', 'Marcus'); // Hallo Marcus
-req.__('Hello {{name}}', { name: 'Marcus' }); // Hallo Marcus
+req.__("Hello"); // Hallo
+req.__("Hello %s", "Marcus"); // Hallo Marcus
+req.__("Hello {{name}}", { name: "Marcus" }); // Hallo Marcus
 
 // passing specific locale
-i18n.__({ phrase: 'Hello', locale: 'fr' }); // Salut
-i18n.__({ phrase: 'Hello %s', locale: 'fr' }, 'Marcus'); // Salut Marcus
-i18n.__({ phrase: 'Hello {{name}}', locale: 'fr' }, { name: 'Marcus' }); // Salut Marcus
+i18n.__({ phrase: "Hello", locale: "fr" }); // Salut
+i18n.__({ phrase: "Hello %s", locale: "fr" }, "Marcus"); // Salut Marcus
+i18n.__({ phrase: "Hello {{name}}", locale: "fr" }, { name: "Marcus" }); // Salut Marcus
 
 /**
  * __n()
@@ -196,60 +196,60 @@ i18n.__n({ singular: "%s cat", plural: "%s cats", locale: "fr", count: 1 }); // 
 i18n.__n({ singular: "%s cat", plural: "%s cats", locale: "fr", count: 3 }); // 3 chat
 
 // mustache plurals
-i18n.__n('example', 1, {me: 'marcus'}); // and a catchall rule for marcus
-i18n.__n('example', 2, {me: 'marcus'}); // two to five (included) for marcus
-i18n.__n('example', 5, {me: 'marcus'}); // two to five (included) for marcus
-i18n.__n('example', 3, {me: 'marcus'}); // two to five (included) for marcus
-i18n.__n('example', 6, {me: 'marcus'}); // and a catchall rule for marcus
+i18n.__n("example", 1, { me: "marcus" }); // and a catchall rule for marcus
+i18n.__n("example", 2, { me: "marcus" }); // two to five (included) for marcus
+i18n.__n("example", 5, { me: "marcus" }); // two to five (included) for marcus
+i18n.__n("example", 3, { me: "marcus" }); // two to five (included) for marcus
+i18n.__n("example", 6, { me: "marcus" }); // and a catchall rule for marcus
 
 /**
  * __mf()
  * https://github.com/mashpie/i18n-node#i18n__mf
  */
-app.get('/de', (_req: Express.Request, res: i18n.Response) => {
+app.get("/de", (_req: Express.Request, res: i18n.Response) => {
     // assume res is set to german
-    res.setLocale('de');
+    res.setLocale("de");
 
     // start simple
-    res.__mf('Hello'); // --> Hallo
+    res.__mf("Hello"); // --> Hallo
 
     // can replace too
-    res.__mf('Hello {name}', { name: 'Marcus' }); // --> Hallo Marcus
+    res.__mf("Hello {name}", { name: "Marcus" }); // --> Hallo Marcus
 
     // and combines with sprintf
-    res.__mf('Hello {name}, how was your %s?', 'test', { name: 'Marcus' }); // --> Hallo Marcus, wie war dein test?
+    res.__mf("Hello {name}, how was your %s?", "test", { name: "Marcus" }); // --> Hallo Marcus, wie war dein test?
 
     // now check out a plural rule
-    res.__mf('{N, plural, one{# cat} few{# cats} many{# cats} others{# cats}}', {N: 1});
+    res.__mf("{N, plural, one{# cat} few{# cats} many{# cats} others{# cats}}", { N: 1 });
 });
 
 /**
  * __l()
  * https://github.com/mashpie/i18n-node#i18n__l
  */
-i18n.__l('Hello'); // --> [ 'Hallo', 'Hello' ]
+i18n.__l("Hello"); // --> [ 'Hallo', 'Hello' ]
 
 /**
  * __h()
  * https://github.com/mashpie/i18n-node#i18n__h
  */
-i18n.__h('Hello'); // --> [ { de: 'Hallo' }, { en: 'Hello' } ]
+i18n.__h("Hello"); // --> [ { de: 'Hallo' }, { en: 'Hello' } ]
 
 /**
  * setLocale()
  * https://github.com/mashpie/i18n-node#setlocale
  */
-i18n.setLocale('de');
-i18n.setLocale(req, 'de');
-req.setLocale('de');
+i18n.setLocale("de");
+i18n.setLocale(req, "de");
+req.setLocale("de");
 
-app.get('/ar', (_req: Express.Request, res: i18n.Response) => {
-    i18n.setLocale(req, 'ar');
-    i18n.setLocale(res, 'ar');
-    i18n.setLocale(res.locals, 'ar');
+app.get("/ar", (_req: Express.Request, res: i18n.Response) => {
+    i18n.setLocale(req, "ar");
+    i18n.setLocale(res, "ar");
+    i18n.setLocale(res.locals, "ar");
 
     i18n.setLocale([req, res.locals], req.params.lang);
-    i18n.setLocale(res, 'ar', true);
+    i18n.setLocale(res, "ar", true);
 });
 
 /**
@@ -266,30 +266,30 @@ req.getLocale(); // --> de
  */
 i18n.getLocales(); // --> ['en', 'de', 'en-GB']
 
-i18n.addLocale('de'); // adds locale
-i18n.removeLocale('de'); // removes locale
+i18n.addLocale("de"); // adds locale
+i18n.removeLocale("de"); // removes locale
 
 /**
  * getCatalog()
  * https://github.com/mashpie/i18n-node#getcatalog
  */
 i18n.getCatalog(); // returns all locales
-i18n.getCatalog('de'); // returns just 'de'
+i18n.getCatalog("de"); // returns just 'de'
 
 i18n.getCatalog(req); // returns all locales
-i18n.getCatalog(req, 'de'); // returns just 'de'
+i18n.getCatalog(req, "de"); // returns just 'de'
 
 req.getCatalog(); // returns all locales
-req.getCatalog('de'); // returns just 'de'
+req.getCatalog("de"); // returns just 'de'
 
 const i18nInstance = new I18n(); // creates new instance of i18n
 
 i18nInstance.configure({
-    locales: ['en', 'de'],
-    directory: __dirname + '/locales'
+    locales: ["en", "de"],
+    directory: __dirname + "/locales",
 });
 
 const i18nInstanceWithConstructorOptions = new I18n({
-    locales: ['en', 'de'],
-    directory: __dirname + '/locales'
+    locales: ["en", "de"],
+    directory: __dirname + "/locales",
 });

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -232,7 +232,7 @@ declare namespace i18n {
      */
     function init(request: Express.Request, response: Express.Response, next?: () => void): void;
 
-    //#region __()
+    // #region __()
 
     /**
      * Translate the given phrase using locale configuration
@@ -248,9 +248,9 @@ declare namespace i18n {
      */
     function __(phraseOrOptions: string | TranslateOptions, replacements: Replacements): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __n()
+    // #region __n()
 
     /**
      * Translate with plural condition the given phrase and count using locale configuration
@@ -284,9 +284,9 @@ declare namespace i18n {
      */
     function __n(phrase: string, count: number | string, replacements: Replacements): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __mf()
+    // #region __mf()
 
     /**
      * Translate the given phrase using locale configuration and MessageFormat
@@ -302,9 +302,9 @@ declare namespace i18n {
      */
     function __mf(phraseOrOptions: string | TranslateOptions, replacements: Replacements): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __l()
+    // #region __l()
 
     /**
      * Returns a list of translations for a given phrase in each language.
@@ -313,9 +313,9 @@ declare namespace i18n {
      */
     function __l(phrase: string): string[];
 
-    //#endregion
+    // #endregion
 
-    //#region __h()
+    // #region __h()
 
     /**
      * Returns a hashed list of translations for a given phrase in each language.
@@ -324,9 +324,9 @@ declare namespace i18n {
      */
     function __h(phrase: string): HashedList[];
 
-    //#endregion
+    // #endregion
 
-    //#region Locale
+    // #region Locale
 
     /**
      * Change the current active locale
@@ -339,7 +339,11 @@ declare namespace i18n {
      * @param locale - The locale to set as default
      * @param [inheritance=false] - Disables inheritance if true
      */
-    function setLocale(requestOrResponse: Express.Request | Express.Response, locale: string, inheritance?: boolean): void;
+    function setLocale(
+        requestOrResponse: Express.Request | Express.Response,
+        locale: string,
+        inheritance?: boolean,
+    ): void;
     /**
      * Change the current active locale for specified response
      * @param objects - The object(s) to change locale on
@@ -365,9 +369,9 @@ declare namespace i18n {
 
     function removeLocale(locale: string): void;
 
-    //#endregion
+    // #endregion
 
-    //#region Catalog
+    // #region Catalog
 
     /**
      * Get the current global catalog
@@ -388,7 +392,7 @@ declare namespace i18n {
      */
     function getCatalog(request: Express.Request, locale?: string): LocaleCatalog;
 
-    //#endregion
+    // #endregion
 
     /**
      * Override the current request locale by using the query param (?locale=en)
@@ -457,7 +461,7 @@ declare namespace i18n {
 interface i18nAPI {
     locale: string;
 
-    //#region __()
+    // #region __()
 
     /**
      * Translate the given phrase using locale configuration
@@ -473,9 +477,9 @@ interface i18nAPI {
      */
     __(phraseOrOptions: string | i18n.TranslateOptions, replacements: i18n.Replacements): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __n()
+    // #region __n()
 
     /**
      * Translate with plural condition the given phrase and count using locale configuration
@@ -501,9 +505,9 @@ interface i18nAPI {
      */
     __n(singular: string, plural: string, count: number | string): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __mf()
+    // #region __mf()
 
     /**
      * Translate the given phrase using locale configuration and MessageFormat
@@ -519,9 +523,9 @@ interface i18nAPI {
      */
     __mf(phraseOrOptions: string | i18n.TranslateOptions, replacements: i18n.Replacements): string;
 
-    //#endregion
+    // #endregion
 
-    //#region __l()
+    // #region __l()
 
     /**
      * Returns a list of translations for a given phrase in each language.
@@ -530,9 +534,9 @@ interface i18nAPI {
      */
     __l(phrase: string): string[];
 
-    //#endregion
+    // #endregion
 
-    //#region __h()
+    // #region __h()
 
     /**
      * Returns a hashed list of translations for a given phrase in each language.
@@ -541,7 +545,7 @@ interface i18nAPI {
      */
     __h(phrase: string): i18n.HashedList[];
 
-    //#endregion
+    // #endregion
 
     /**
      * Get the current active locale

--- a/types/i18next-fs-backend/i18next-fs-backend-tests.ts
+++ b/types/i18next-fs-backend/i18next-fs-backend-tests.ts
@@ -1,12 +1,12 @@
-import i18next from 'i18next';
-import Backend, { i18nextFsBackend } from 'i18next-fs-backend';
+import i18next from "i18next";
+import Backend, { i18nextFsBackend } from "i18next-fs-backend";
 
-//#region Plain options
+// #region Plain options
 
 const plainOptions: { backend: i18nextFsBackend.i18nextFsBackendOptions; skipOnVariables: boolean } = {
     backend: {
-        loadPath: '/locales/{{lng}}/{{ns}}.json',
-        addPath: '/locales/{{lng}}/{{ns}}.missing.json',
+        loadPath: "/locales/{{lng}}/{{ns}}.json",
+        addPath: "/locales/{{lng}}/{{ns}}.missing.json",
         ident: 2,
         parse: JSON.parse,
         stringify: JSON.stringify,
@@ -17,36 +17,36 @@ const plainOptions: { backend: i18nextFsBackend.i18nextFsBackendOptions; skipOnV
 i18next.use(Backend).init(plainOptions);
 i18next.use(Backend).init({ backend: plainOptions.backend });
 
-//#endregion
-//#region Custom loadPath resolver
+// #endregion
+// #region Custom loadPath resolver
 
 const loadPathOptions: { backend: i18nextFsBackend.i18nextFsBackendOptions } = {
     backend: {
         loadPath: (lng: string, ns: string) => `/locales/${lng}/${ns}.json`,
-        addPath: '/locales/{{lng}}/{{ns}}.missing.json',
+        addPath: "/locales/{{lng}}/{{ns}}.missing.json",
         ident: 2,
         parse: JSON.parse,
-        stringify: JSON.stringify
-    }
+        stringify: JSON.stringify,
+    },
 };
 
 i18next.use(Backend).init(loadPathOptions);
 i18next.use(Backend).init({ backend: loadPathOptions.backend });
 
-//#endregion
-//#region Custom parse & stringify
+// #endregion
+// #region Custom parse & stringify
 
 const parseStringifyOptions: { backend: i18nextFsBackend.i18nextFsBackendOptions } = {
     backend: {
         loadPath: (lng: string, ns: string) => `/locales/${lng}/${ns}.json`,
-        addPath: '/locales/{{lng}}/{{ns}}.missing.json',
+        addPath: "/locales/{{lng}}/{{ns}}.missing.json",
         ident: 2,
         parse: (data: string) => JSON.parse(data),
-        stringify: (data: unknown) => JSON.stringify(data)
-    }
+        stringify: (data: unknown) => JSON.stringify(data),
+    },
 };
 
 i18next.use(Backend).init(parseStringifyOptions);
 i18next.use(Backend).init({ backend: parseStringifyOptions.backend });
 
-//#endregion
+// #endregion

--- a/types/i18next-fs-backend/index.d.ts
+++ b/types/i18next-fs-backend/index.d.ts
@@ -4,7 +4,7 @@
 //                 Jeroen "Favna" Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { BackendModule, InitOptions, Services, ReadCallback } from 'i18next';
+import { BackendModule, InitOptions, ReadCallback, Services } from "i18next";
 
 export namespace i18next {
     interface InitOptions {
@@ -25,9 +25,17 @@ export namespace i18nextFsBackend {
 }
 
 export default class Backend implements BackendModule<i18nextFsBackend.i18nextFsBackendOptions> {
-    type: 'backend';
-    constructor(services: Services, backendOptions: i18nextFsBackend.i18nextFsBackendOptions, i18nextOptions: InitOptions);
-    init(services: Services, backendOptions: i18nextFsBackend.i18nextFsBackendOptions, i18nextOptions: InitOptions): void;
+    type: "backend";
+    constructor(
+        services: Services,
+        backendOptions: i18nextFsBackend.i18nextFsBackendOptions,
+        i18nextOptions: InitOptions,
+    );
+    init(
+        services: Services,
+        backendOptions: i18nextFsBackend.i18nextFsBackendOptions,
+        i18nextOptions: InitOptions,
+    ): void;
     read(language: string, namespace: string, callback: ReadCallback): void;
     create(languages: string[], namespace: string, key: string, fallbackValue: string): void;
 
@@ -35,5 +43,5 @@ export default class Backend implements BackendModule<i18nextFsBackend.i18nextFs
     writeFile(lng: string, namespace: string): void;
     queue(lng: string, namespace: string, key: string, fallbackValue: string, callback: unknown): void;
 
-    static type: 'backend';
+    static type: "backend";
 }


### PR DESCRIPTION
After #66235, this repo is now formatted with dprint. This PR removes the temporary exception for a few packages.

The leftover packages fail on my machine; their `i18next` dependencies are wrong. For another PR.