### PR TITLE
Enable formatting for inquirer and related packages

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -34,7 +34,7 @@
 
     // These files will be formatted soon, but are failing in CI for now.
     "./types/i18n*",
-    "./types/inquirer*",
+    "./types/inquirer",
     "./types/react-blessed",
     "./types/react-map-gl",
     "./types/react-syntax-highlighter"

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -34,7 +34,6 @@
 
     // These files will be formatted soon, but are failing in CI for now.
     "./types/i18n*",
-    "./types/inquirer",
     "./types/react-blessed",
     "./types/react-map-gl",
     "./types/react-syntax-highlighter"

--- a/types/inquirer-autocomplete-prompt/inquirer-autocomplete-prompt-tests.ts
+++ b/types/inquirer-autocomplete-prompt/inquirer-autocomplete-prompt-tests.ts
@@ -1,5 +1,5 @@
-import AutocompletePrompt from "inquirer-autocomplete-prompt";
 import inquirer, { Answers } from "inquirer";
+import AutocompletePrompt from "inquirer-autocomplete-prompt";
 
 inquirer.registerPrompt("autocomplete", AutocompletePrompt);
 

--- a/types/inquirer-fuzzy-path/index.d.ts
+++ b/types/inquirer-fuzzy-path/index.d.ts
@@ -4,10 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
-import { Answers, KeyUnion, QuestionCollection } from 'inquirer';
-import { AutocompleteQuestionOptions } from 'inquirer-autocomplete-prompt';
-import InquirerAutocomplete = require('inquirer-autocomplete-prompt');
-import { Interface as ReadlineInterface } from 'readline';
+import { Answers, KeyUnion, QuestionCollection } from "inquirer";
+import { AutocompleteQuestionOptions } from "inquirer-autocomplete-prompt";
+import InquirerAutocomplete = require("inquirer-autocomplete-prompt");
+import { Interface as ReadlineInterface } from "readline";
 
 export = InquirerFuzzyPath;
 
@@ -55,11 +55,12 @@ declare namespace InquirerFuzzyPath {
      * The type of the answers.
      */
     interface FuzzyPathQuestionOptions<T extends Answers = Answers>
-        extends Partial<Omit<AutocompleteQuestionOptions<T>, 'type'>> {
+        extends Partial<Omit<AutocompleteQuestionOptions<T>, "type">>
+    {
         /**
          * The key to save the answer to the answers-hash.
          */
-        type: 'fuzzypath';
+        type: "fuzzypath";
 
         /**
          * The key to save the answer to the answers-hash.
@@ -84,7 +85,7 @@ declare namespace InquirerFuzzyPath {
         /**
          * A string to specify the type of nodes to display, default to "any".
          */
-        itemType?: 'any' | 'directory' | 'file' | undefined;
+        itemType?: "any" | "directory" | "file" | undefined;
 
         /**
          * An integer (>= 0) to limit the depth of sub-folders to scan,

--- a/types/inquirer-fuzzy-path/inquirer-fuzzy-path-tests.ts
+++ b/types/inquirer-fuzzy-path/inquirer-fuzzy-path-tests.ts
@@ -21,5 +21,5 @@ inquirer.prompt([
         default: "inquirer-fuzzy-path/",
         suggestOnly: false,
         depthLimit: 5,
-    }
+    },
 ]);

--- a/types/inquirer-npm-name/index.d.ts
+++ b/types/inquirer-npm-name/index.d.ts
@@ -4,7 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
-import { Question, PromptFunction } from "inquirer";
+import { PromptFunction, Question } from "inquirer";
 
-declare function askName(name: string | Question, inquirer: { prompt: PromptFunction }): Promise<{ [key: string]: string }>;
+declare function askName(
+    name: string | Question,
+    inquirer: { prompt: PromptFunction },
+): Promise<{ [key: string]: string }>;
 export = askName;

--- a/types/inquirer-npm-name/inquirer-npm-name-tests.ts
+++ b/types/inquirer-npm-name/inquirer-npm-name-tests.ts
@@ -8,13 +8,16 @@ askName("moduleName", inquirer);
 askName(
     {
         name: "moduleName",
-        message: "What's the name of your module?"
+        message: "What's the name of your module?",
     },
-    inquirer);
+    inquirer,
+);
 
 askName(
-    "", {
-    prompt<T extends inquirer.Answers>(questions: inquirer.QuestionCollection<T>): Promise<T> {
-        return null as any;
-    }
-});
+    "",
+    {
+        prompt<T extends inquirer.Answers>(questions: inquirer.QuestionCollection<T>): Promise<T> {
+            return null as any;
+        },
+    },
+);

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -12,29 +12,29 @@
 //                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
-import { Interface as ReadlineInterface } from 'readline';
-import { Observable } from 'rxjs';
-import { ThroughStream } from 'through';
-import Choice from './lib/objects/choice.js';
-import Choices from './lib/objects/choices.js';
-import Separator from './lib/objects/separator.js';
-import './lib/prompts/base.js';
-import CheckboxPrompt from './lib/prompts/checkbox.js';
-import ConfirmPrompt from './lib/prompts/confirm.js';
-import EditorPrompt from './lib/prompts/editor.js';
-import ExpandPrompt from './lib/prompts/expand.js';
-import InputPrompt from './lib/prompts/input.js';
-import ListPrompt from './lib/prompts/list.js';
-import NumberPrompt from './lib/prompts/number.js';
-import PasswordPrompt from './lib/prompts/password.js';
-import RawListPrompt from './lib/prompts/rawlist.js';
-import UI from './lib/ui/baseUI.js';
-import './lib/ui/bottom-bar.js';
-import './lib/ui/prompt.js';
-import './lib/utils/events.js';
-import './lib/utils/paginator.js';
-import './lib/utils/readline.js';
-import './lib/utils/screen-manager.js';
+import { Interface as ReadlineInterface } from "readline";
+import { Observable } from "rxjs";
+import { ThroughStream } from "through";
+import Choice from "./lib/objects/choice.js";
+import Choices from "./lib/objects/choices.js";
+import Separator from "./lib/objects/separator.js";
+import "./lib/prompts/base.js";
+import CheckboxPrompt from "./lib/prompts/checkbox.js";
+import ConfirmPrompt from "./lib/prompts/confirm.js";
+import EditorPrompt from "./lib/prompts/editor.js";
+import ExpandPrompt from "./lib/prompts/expand.js";
+import InputPrompt from "./lib/prompts/input.js";
+import ListPrompt from "./lib/prompts/list.js";
+import NumberPrompt from "./lib/prompts/number.js";
+import PasswordPrompt from "./lib/prompts/password.js";
+import RawListPrompt from "./lib/prompts/rawlist.js";
+import UI from "./lib/ui/baseUI.js";
+import "./lib/ui/bottom-bar.js";
+import "./lib/ui/prompt.js";
+import "./lib/utils/events.js";
+import "./lib/utils/paginator.js";
+import "./lib/utils/readline.js";
+import "./lib/utils/screen-manager.js";
 
 /**
  * Represents a union which preserves autocompletion.
@@ -81,12 +81,12 @@ export interface PromptModuleBase extends PromptFunction {
 /**
  * Represents a function for registering a prompt.
  */
-type RegisterFunction = PromptModuleBase['registerPrompt'];
+type RegisterFunction = PromptModuleBase["registerPrompt"];
 
 /**
  * Represents a function for restoring a prompt.
  */
-type RestoreFunction = PromptModuleBase['restoreDefaultPrompts'];
+type RestoreFunction = PromptModuleBase["restoreDefaultPrompts"];
 
 /**
  * Represents a list-based question.
@@ -144,7 +144,7 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 /**
  * A set of answers.
  */
-export interface Answers extends Record<string, any> { }
+export interface Answers extends Record<string, any> {}
 
 /**
  * Provides the functionality to validate answers.
@@ -152,7 +152,7 @@ export interface Answers extends Record<string, any> { }
  * @template T
  * The type of the answers.
  */
-export type Validator<T extends Answers = Answers> = Question<T>['validate'];
+export type Validator<T extends Answers = Answers> = Question<T>["validate"];
 
 /**
  * Provides the functionality to transform an answer.
@@ -160,7 +160,7 @@ export type Validator<T extends Answers = Answers> = Question<T>['validate'];
  * @template T
  * The type of the answers.
  */
-export type Transformer<T extends Answers = Answers> = InputQuestionOptions<T>['transformer'];
+export type Transformer<T extends Answers = Answers> = InputQuestionOptions<T>["transformer"];
 
 /**
  * Represents a dynamic property for a question.
@@ -240,7 +240,7 @@ export interface SeparatorOptions extends ChoiceBase {
     /**
      * Gets the type of the choice.
      */
-    type: 'separator';
+    type: "separator";
 
     /**
      * Gets or sets the text of the separator.
@@ -255,7 +255,7 @@ export interface ChoiceOptions extends ChoiceBase {
     /**
      * @inheritdoc
      */
-    type?: 'choice' | undefined;
+    type?: "choice" | undefined;
 
     /**
      * The name of the choice to show to the user.
@@ -434,8 +434,8 @@ export interface Question<T extends Answers = Answers> {
 export type QuestionAnswer<T extends Answers = Answers> = {
     [K in keyof T]: {
         name: K;
-        answer: T[K]
-    }
+        answer: T[K];
+    };
 }[keyof T];
 
 /**
@@ -473,7 +473,7 @@ export interface InputQuestion<T extends Answers = Answers> extends InputQuestio
     /**
      * @inheritdoc
      */
-    type?: 'input' | undefined;
+    type?: "input" | undefined;
 }
 
 /**
@@ -482,7 +482,7 @@ export interface InputQuestion<T extends Answers = Answers> extends InputQuestio
  * @template T
  * The type of the answers.
  */
-export interface NumberQuestionOptions<T extends Answers = Answers> extends InputQuestionOptions<T> { }
+export interface NumberQuestionOptions<T extends Answers = Answers> extends InputQuestionOptions<T> {}
 
 /**
  * Provides options for a question for the {@link NumberPrompt `NumberPrompt<TQuestion>`}.
@@ -494,7 +494,7 @@ export interface NumberQuestion<T extends Answers = Answers> extends NumberQuest
     /**
      * @inheritdoc
      */
-    type: 'number';
+    type: "number";
 }
 
 /**
@@ -520,7 +520,7 @@ export interface PasswordQuestion<T extends Answers = Answers> extends PasswordQ
     /**
      * @inheritdoc
      */
-    type: 'password';
+    type: "password";
 }
 
 /**
@@ -532,7 +532,9 @@ export interface PasswordQuestion<T extends Answers = Answers> extends PasswordQ
  * @template TChoiceMap
  * The valid choices for the question.
  */
-interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap> extends ListQuestionOptionsBase<T, TChoiceMap> {
+interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap>
+    extends ListQuestionOptionsBase<T, TChoiceMap>
+{
     /**
      * A value indicating whether choices in a list should be looped.
      */
@@ -546,7 +548,8 @@ interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap> extends
  * The type of the answers.
  */
 export interface ListQuestionOptions<T extends Answers = Answers>
-    extends LoopableListQuestionOptionsBase<T, ListChoiceMap<T>> { }
+    extends LoopableListQuestionOptionsBase<T, ListChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link ListPrompt `ListPrompt<TQuestion>`}.
@@ -558,7 +561,7 @@ export interface ListQuestion<T extends Answers = Answers> extends ListQuestionO
     /**
      * @inheritdoc
      */
-    type: 'list';
+    type: "list";
 }
 
 /**
@@ -567,7 +570,7 @@ export interface ListQuestion<T extends Answers = Answers> extends ListQuestionO
  * @template T
  * The type of the answers.
  */
-export interface RawListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptions<T> { }
+export interface RawListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptions<T> {}
 
 /**
  * Provides options for a question for the {@link RawListPrompt `RawListPrompt<TQuestion>`}.
@@ -579,7 +582,7 @@ export interface RawListQuestion<T extends Answers = Answers> extends RawListQue
     /**
      * @inheritdoc
      */
-    type: 'rawlist';
+    type: "rawlist";
 }
 
 /**
@@ -589,7 +592,8 @@ export interface RawListQuestion<T extends Answers = Answers> extends RawListQue
  * The type of the answers.
  */
 export interface ExpandQuestionOptions<T extends Answers = Answers>
-    extends ListQuestionOptionsBase<T, ExpandChoiceMap<T>> { }
+    extends ListQuestionOptionsBase<T, ExpandChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link ExpandPrompt `ExpandPrompt<TQuestion>`}.
@@ -601,7 +605,7 @@ export interface ExpandQuestion<T extends Answers = Answers> extends ExpandQuest
     /**
      * @inheritdoc
      */
-    type: 'expand';
+    type: "expand";
 }
 
 /**
@@ -611,7 +615,8 @@ export interface ExpandQuestion<T extends Answers = Answers> extends ExpandQuest
  * The type of the answers.
  */
 export interface CheckboxQuestionOptions<T extends Answers = Answers>
-    extends LoopableListQuestionOptionsBase<T, CheckboxChoiceMap<T>> { }
+    extends LoopableListQuestionOptionsBase<T, CheckboxChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link CheckboxPrompt `CheckboxPrompt<TQuestion>`}.
@@ -623,7 +628,7 @@ export interface CheckboxQuestion<T extends Answers = Answers> extends CheckboxQ
     /**
      * @inheritdoc
      */
-    type: 'checkbox';
+    type: "checkbox";
 }
 
 /**
@@ -632,7 +637,7 @@ export interface CheckboxQuestion<T extends Answers = Answers> extends CheckboxQ
  * @template T
  * The type of the answers.
  */
-export interface ConfirmQuestionOptions<T extends Answers = Answers> extends Question<T> { }
+export interface ConfirmQuestionOptions<T extends Answers = Answers> extends Question<T> {}
 
 /**
  * Provides options for a question for the {@link ConfirmPrompt `ConfirmPrompt<TQuestion>`}.
@@ -644,7 +649,7 @@ export interface ConfirmQuestion<T extends Answers = Answers> extends ConfirmQue
     /**
      * @inheritdoc
      */
-    type: 'confirm';
+    type: "confirm";
 }
 
 /**
@@ -672,7 +677,7 @@ export interface EditorQuestion<T extends Answers = Answers> extends EditorQuest
     /**
      * @inheritdoc
      */
-    type: 'editor';
+    type: "editor";
 }
 
 /**
@@ -739,7 +744,7 @@ export type DistinctQuestion<T extends Answers = Answers> = QuestionMap<T>[keyof
 /**
  * Indicates the type of a question
  */
-export type QuestionTypeName = DistinctQuestion['type'];
+export type QuestionTypeName = DistinctQuestion["type"];
 
 /**
  * Represents a collection of questions.
@@ -785,7 +790,10 @@ export interface PromptModule extends PromptModuleBase {
     /**
      * Prompts the questions to the user.
      */
-    <T extends Answers = Answers>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T> & { ui: inquirer.ui.Prompt<T> };
+    <T extends Answers = Answers>(
+        questions: QuestionCollection<T>,
+        initialAnswers?: Partial<T>,
+    ): Promise<T> & { ui: inquirer.ui.Prompt<T> };
 
     /**
      * Registers a new prompt-type.
@@ -823,7 +831,7 @@ declare namespace inquirer {
         /**
          * Represents the state of a prompt.
          */
-        type PromptState = LiteralUnion<'pending' | 'idle' | 'loading' | 'answered' | 'done'>;
+        type PromptState = LiteralUnion<"pending" | "idle" | "loading" | "answered" | "done">;
 
         /**
          * Represents a prompt.
@@ -1148,7 +1156,7 @@ declare namespace inquirer {
         /**
          * @inheritdoc
          */
-        readonly type: 'separator';
+        readonly type: "separator";
 
         /**
          * @inheritdoc

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -1,25 +1,25 @@
-import { createInterface } from 'readline';
-import inquirer, { Answers, DistinctChoice, DistinctQuestion, InputQuestionOptions } from 'inquirer';
-import InputPrompt from 'inquirer/lib/prompts/input.js';
-import { fetchAsyncQuestionProperty } from 'inquirer/lib/utils/utils.js';
-import incrementListIndex from 'inquirer/lib/utils/incrementListIndex.js';
-import Choices from 'inquirer/lib/objects/choices.js';
-import Paginator from 'inquirer/lib/utils/paginator.js';
-import ScreenManager from 'inquirer/lib/utils/screen-manager.js';
-import { Subject } from 'rxjs';
+import inquirer, { Answers, DistinctChoice, DistinctQuestion, InputQuestionOptions } from "inquirer";
+import Choices from "inquirer/lib/objects/choices.js";
+import InputPrompt from "inquirer/lib/prompts/input.js";
+import incrementListIndex from "inquirer/lib/utils/incrementListIndex.js";
+import Paginator from "inquirer/lib/utils/paginator.js";
+import ScreenManager from "inquirer/lib/utils/screen-manager.js";
+import { fetchAsyncQuestionProperty } from "inquirer/lib/utils/utils.js";
+import { createInterface } from "readline";
+import { Subject } from "rxjs";
 {
-    new inquirer.Separator('');
+    new inquirer.Separator("");
     const promptModule = inquirer.createPromptModule();
-    promptModule.prompts['']; // $ExpectType PromptConstructor
-    promptModule.registerPrompt('', InputPrompt); // $ExpectType PromptModule
+    promptModule.prompts[""]; // $ExpectType PromptConstructor
+    promptModule.registerPrompt("", InputPrompt); // $ExpectType PromptModule
     promptModule.restoreDefaultPrompts();
     inquirer.createPromptModule({ skipTTYChecks: false });
 }
 {
     inquirer.prompt([
         {
-            message: '',
-            default: '',
+            message: "",
+            default: "",
         },
     ]);
 }
@@ -36,36 +36,38 @@ import { Subject } from 'rxjs';
         // @ts-expect-error
         {
             this: {
-                name: 'override-this',
-                message: '1st question'
+                name: "override-this",
+                message: "1st question",
             },
             is: {
-                message: '2nd question'
+                message: "2nd question",
             },
             a: {
-                message: '3rd question'
+                message: "3rd question",
             },
             test: {
-                message: '4th question'
-            }
-        });
+                message: "4th question",
+            },
+        },
+    );
 
     // Take note that the properties of the answer-hash `this`, `is`, `a` and `test` are showing up in the auto completion
     inquirer.prompt<AnswerHash>(
         {
             this: {
-                message: '1st question'
+                message: "1st question",
             },
             is: {
-                message: '2nd question'
+                message: "2nd question",
             },
             a: {
-                message: '3rd question'
+                message: "3rd question",
             },
             test: {
-                message: '4th question'
-            }
-        });
+                message: "4th question",
+            },
+        },
+    );
 }
 {
     new inquirer.ui.BottomBar();
@@ -73,22 +75,22 @@ import { Subject } from 'rxjs';
 }
 {
     const checkBoxQuestion: DistinctQuestion = {
-        type: 'checkbox',
+        type: "checkbox",
         askAnswered: true,
     };
 
     const listQuestion: DistinctQuestion = {
-        type: 'list',
+        type: "list",
         askAnswered: true,
     };
 
     const rawListQuestion: DistinctQuestion = {
-        type: 'rawlist',
+        type: "rawlist",
         askAnswered: true,
     };
 
     const expandQuestion: DistinctQuestion = {
-        type: 'expand',
+        type: "expand",
         askAnswered: true,
     };
 
@@ -117,11 +119,11 @@ import { Subject } from 'rxjs';
     let choice: DistinctChoice;
 
     choice = {
-        type: 'separator',
-        line: 'This is a test',
+        type: "separator",
+        line: "This is a test",
     };
 
-    if (choice.type === 'separator' && !(choice instanceof inquirer.Separator)) {
+    if (choice.type === "separator" && !(choice instanceof inquirer.Separator)) {
         // $ExpectType SeparatorOptions
         choice;
     }
@@ -132,7 +134,7 @@ interface ChalkQuestionOptions<T extends Answers = Answers> extends InputQuestio
 }
 
 interface ChalkQuestion<T extends Answers = Answers> extends ChalkQuestionOptions<T> {
-    type: 'chalk';
+    type: "chalk";
 }
 
 class ChalkPrompt extends InputPrompt {
@@ -141,9 +143,9 @@ class ChalkPrompt extends InputPrompt {
     protected onKeypress() {}
 }
 
-inquirer.registerPrompt('chalk', ChalkPrompt);
+inquirer.registerPrompt("chalk", ChalkPrompt);
 
-declare module 'inquirer' {
+declare module "inquirer" {
     interface QuestionMap<T> {
         chalk: ChalkQuestion<T>;
     }
@@ -151,7 +153,7 @@ declare module 'inquirer' {
 
 inquirer.prompt([
     {
-        type: 'chalk',
+        type: "chalk",
         previewColors: true,
     },
 ]);
@@ -159,21 +161,21 @@ inquirer.prompt([
 inquirer.prompt(
     [
         {
-            name: 'foo',
-            default: 'bar',
+            name: "foo",
+            default: "bar",
         },
     ],
     {
-        foo: 'baz',
+        foo: "baz",
     },
 );
 
 fetchAsyncQuestionProperty(
     {
-        name: 'foo',
-        default: 'bar',
+        name: "foo",
+        default: "bar",
     },
-    'message',
+    "message",
     {},
 ).pipe(source => {
     return source;
@@ -181,19 +183,19 @@ fetchAsyncQuestionProperty(
 
 {
     const options = {
-        name: 'foo',
+        name: "foo",
         loop: true,
-        choices: new Choices([{ name: 'foo' }], {}),
+        choices: new Choices([{ name: "foo" }], {}),
     };
 
     // $ExpectType number
-    incrementListIndex(0, 'up', options);
+    incrementListIndex(0, "up", options);
     // @ts-expect-error
-    incrementListIndex('notANumber', 'up', options);
+    incrementListIndex("notANumber", "up", options);
     // @ts-expect-error
-    incrementListIndex(0, 'left', options);
+    incrementListIndex(0, "left", options);
     // @ts-expect-error
-    incrementListIndex(0, 'up', {});
+    incrementListIndex(0, "up", {});
 }
 
 {
@@ -206,7 +208,7 @@ fetchAsyncQuestionProperty(
     new Paginator(screen);
     new Paginator(screen, { isInfinite: true });
     // @ts-expect-error
-    new Paginator(screen, { someUnsupportedOptions: 'foobar' });
+    new Paginator(screen, { someUnsupportedOptions: "foobar" });
 }
 
 {
@@ -217,18 +219,19 @@ fetchAsyncQuestionProperty(
     const screen = new ScreenManager(rl);
 
     const paginator = new Paginator(screen);
-    paginator.paginate('test', 0);
-    paginator.paginate('test', 0, 0);
+    paginator.paginate("test", 0);
+    paginator.paginate("test", 0, 0);
 }
 
 {
     const prompts = new Subject<DistinctQuestion>();
     const promptResult = inquirer.prompt(prompts);
     promptResult.ui.process.subscribe({
-        next: (value: {name: string, answer: any}) => {
+        next: (value: { name: string; answer: any }) => {
             // DO NOTHING
         },
     });
+    // dprint-ignore
     // @ts-expect-error
     promptResult.ui.process.subscribe({ next: (value: {name_: string, answer: number}) => {
             // DO NOTHING
@@ -238,10 +241,10 @@ fetchAsyncQuestionProperty(
 }
 
 {
-    const prompts = new Subject<DistinctQuestion<{str: string; num: number}>>();
+    const prompts = new Subject<DistinctQuestion<{ str: string; num: number }>>();
     const promptResult = inquirer.prompt(prompts);
     promptResult.ui.process.subscribe({
-        next: (value: {name: 'str', answer: string} | {name: 'num', answer: number}) => {
+        next: (value: { name: "str"; answer: string } | { name: "num"; answer: number }) => {
             // DO NOTHING
         },
     });
@@ -256,6 +259,7 @@ fetchAsyncQuestionProperty(
             }
         },
     });
+    // dprint-ignore
     // @ts-expect-error
     promptResult.ui.process.subscribe({ next: (value: {name: string, answer: number}) => {
             // DO NOTHING

--- a/types/inquirer/lib/objects/choice.d.ts
+++ b/types/inquirer/lib/objects/choice.d.ts
@@ -1,4 +1,4 @@
-import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from '../../index.js';
+import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from "../../index.js";
 
 /**
  * Represents a choice for several question-types.
@@ -7,11 +7,12 @@ import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions 
  * The type of the answers.
  */
 declare class Choice<T extends Answers = Answers>
-    implements ListChoiceOptions<T>, CheckboxChoiceOptions<T>, ExpandChoiceOptions {
+    implements ListChoiceOptions<T>, CheckboxChoiceOptions<T>, ExpandChoiceOptions
+{
     /**
      * @inheritdoc
      */
-    type?: 'choice' | undefined;
+    type?: "choice" | undefined;
 
     /**
      * @inheritdoc

--- a/types/inquirer/lib/objects/choices.d.ts
+++ b/types/inquirer/lib/objects/choices.d.ts
@@ -1,6 +1,6 @@
-import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from '../../index.js';
-import Choice from './choice.js';
-import Separator from './separator.js';
+import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from "../../index.js";
+import Choice from "./choice.js";
+import Separator from "./separator.js";
 
 /**
  * Represents a valid choice for the {@link Choices `Choices<T>`} class.
@@ -16,7 +16,7 @@ type DistinctChoice<T extends Answers> = AllChoiceMap<T>[keyof AllChoiceMap<T>];
  * @template T
  * The type of the answers.
  */
-type RealChoice<T extends Answers> = Exclude<DistinctChoice<T>, { type: Separator['type'] }>;
+type RealChoice<T extends Answers> = Exclude<DistinctChoice<T>, { type: Separator["type"] }>;
 
 /**
  * Represents a property-name of any choice-type.

--- a/types/inquirer/lib/prompts/base.d.ts
+++ b/types/inquirer/lib/prompts/base.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadLineInterface } from 'readline';
-import { Observable } from 'rxjs';
-import inquirer, { Answers, Question } from '../../index.js';
-import ScreenManager from '../utils/screen-manager.js';
+import { Interface as ReadLineInterface } from "readline";
+import { Observable } from "rxjs";
+import inquirer, { Answers, Question } from "../../index.js";
+import ScreenManager from "../utils/screen-manager.js";
 
 /**
  * Represents a prompt.

--- a/types/inquirer/lib/prompts/checkbox.d.ts
+++ b/types/inquirer/lib/prompts/checkbox.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadLineInterface } from 'readline';
-import inquirer, { Answers, CheckboxQuestionOptions } from '../../index.js';
-import Paginator from '../utils/paginator.js';
-import Prompt from './base.js';
+import { Interface as ReadLineInterface } from "readline";
+import inquirer, { Answers, CheckboxQuestionOptions } from "../../index.js";
+import Paginator from "../utils/paginator.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link CheckboxPrompt `CheckboxPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/confirm.d.ts
+++ b/types/inquirer/lib/prompts/confirm.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ConfirmQuestionOptions } from '../../index.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, ConfirmQuestionOptions } from "../../index.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link ConfirmPrompt `ConfirmPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/editor.d.ts
+++ b/types/inquirer/lib/prompts/editor.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Subject, Subscription } from 'rxjs';
-import inquirer, { Answers, EditorQuestionOptions } from '../../index.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import { Subject, Subscription } from "rxjs";
+import inquirer, { Answers, EditorQuestionOptions } from "../../index.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link EditorPrompt `EditorPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/expand.d.ts
+++ b/types/inquirer/lib/prompts/expand.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, ExpandQuestionOptions } from '../../index.js';
-import Paginator from '../utils/paginator.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import inquirer, { Answers, ExpandQuestionOptions } from "../../index.js";
+import Paginator from "../utils/paginator.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link ExpandPrompt `ExpandPrompt<TQuestion>`}.
@@ -118,7 +118,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @param choices
      * The choices to validate.
      */
-    protected validateChoices(choices: ExpandPrompt<TQuestion>['opt']['choices']): void;
+    protected validateChoices(choices: ExpandPrompt<TQuestion>["opt"]["choices"]): void;
 
     /**
      * Generates the string-representation of the choices.
@@ -132,7 +132,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @returns
      * The string-representations of the choices.
      */
-    protected generateChoicesString(choices: ExpandPrompt<TQuestion>['opt']['choices'], defaultChoice: any): string;
+    protected generateChoicesString(choices: ExpandPrompt<TQuestion>["opt"]["choices"], defaultChoice: any): string;
 
     /**
      * Renders the choices.
@@ -143,7 +143,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @param pointer
      * The value of the choice to select.
      */
-    protected renderChoices(choices: ExpandPrompt<TQuestion>['opt']['choices'], pointer: string): string;
+    protected renderChoices(choices: ExpandPrompt<TQuestion>["opt"]["choices"], pointer: string): string;
 }
 
 export default ExpandPrompt;

--- a/types/inquirer/lib/prompts/input.d.ts
+++ b/types/inquirer/lib/prompts/input.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, InputQuestionOptions } from '../../index.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import inquirer, { Answers, InputQuestionOptions } from "../../index.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link InputPrompt `InputPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/list.d.ts
+++ b/types/inquirer/lib/prompts/list.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ListQuestionOptions } from '../../index.js';
-import Paginator from '../utils/paginator.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, ListQuestionOptions } from "../../index.js";
+import Paginator from "../utils/paginator.js";
+import Prompt from "./base.js";
 
 /**
  * The question-options for the {@link ListPrompt `ListPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/number.d.ts
+++ b/types/inquirer/lib/prompts/number.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, NumberQuestionOptions } from '../../index.js';
-import InputPrompt from './input.js';
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, NumberQuestionOptions } from "../../index.js";
+import InputPrompt from "./input.js";
 
 /**
  * The question for the {@link NumberPrompt `NumberPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/password.d.ts
+++ b/types/inquirer/lib/prompts/password.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, PasswordQuestionOptions } from '../../index.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import inquirer, { Answers, PasswordQuestionOptions } from "../../index.js";
+import Prompt from "./base.js";
 
 /**
  * The question for the {@link PasswordPrompt `PasswordPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/rawlist.d.ts
+++ b/types/inquirer/lib/prompts/rawlist.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, RawListQuestionOptions } from '../../index.js';
-import Paginator from '../utils/paginator.js';
-import Prompt from './base.js';
+import { Interface as ReadlineInterface } from "readline";
+import inquirer, { Answers, RawListQuestionOptions } from "../../index.js";
+import Paginator from "../utils/paginator.js";
+import Prompt from "./base.js";
 
 /**
  * The question for the {@link RawListPrompt `RawListPrompt<TQuestion>`}.
@@ -89,7 +89,7 @@ declare class RawListPrompt<TQuestion extends Question = Question> extends Promp
      * @param type
      * A value indicating whether the up or the down-arrow is being pressed.
      */
-    protected onArrowKey(type: 'up' | 'down'): void;
+    protected onArrowKey(type: "up" | "down"): void;
 
     /**
      * Handles the `success`-event of the prompt.

--- a/types/inquirer/lib/ui/baseUI.d.ts
+++ b/types/inquirer/lib/ui/baseUI.d.ts
@@ -1,5 +1,5 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { StreamOptions } from '../../index.js';
+import { Interface as ReadlineInterface } from "readline";
+import inquirer, { StreamOptions } from "../../index.js";
 
 /**
  * Represents a ui.

--- a/types/inquirer/lib/ui/bottom-bar.d.ts
+++ b/types/inquirer/lib/ui/bottom-bar.d.ts
@@ -1,3 +1,3 @@
-import inquirer from '../../index.js';
+import inquirer from "../../index.js";
 
 export default inquirer.ui.BottomBar;

--- a/types/inquirer/lib/ui/prompt.d.ts
+++ b/types/inquirer/lib/ui/prompt.d.ts
@@ -1,3 +1,3 @@
-import inquirer from '../../index.js';
+import inquirer from "../../index.js";
 
 export default inquirer.ui.Prompt;

--- a/types/inquirer/lib/utils/events.d.ts
+++ b/types/inquirer/lib/utils/events.d.ts
@@ -1,5 +1,5 @@
-import { Interface as ReadlineInterface, Key } from 'readline';
-import { Observable } from 'rxjs';
+import { Interface as ReadlineInterface, Key } from "readline";
+import { Observable } from "rxjs";
 
 /**
  * Provides a description about a key.

--- a/types/inquirer/lib/utils/incrementListIndex.d.ts
+++ b/types/inquirer/lib/utils/incrementListIndex.d.ts
@@ -1,6 +1,6 @@
-import Choices from '../objects/choices.js';
+import Choices from "../objects/choices.js";
 
-type Direction = 'up' | 'down';
+type Direction = "up" | "down";
 interface Options {
     choices: Choices;
     loop?: boolean;

--- a/types/inquirer/lib/utils/paginator.d.ts
+++ b/types/inquirer/lib/utils/paginator.d.ts
@@ -1,4 +1,4 @@
-import ScreenManager from './screen-manager.js';
+import ScreenManager from "./screen-manager.js";
 
 interface PaginatorOptions {
     /**

--- a/types/inquirer/lib/utils/readline.d.ts
+++ b/types/inquirer/lib/utils/readline.d.ts
@@ -1,4 +1,4 @@
-import { Interface as ReadlineInterface } from 'readline';
+import { Interface as ReadlineInterface } from "readline";
 
 /**
  * Moves the cursor to the left.

--- a/types/inquirer/lib/utils/screen-manager.d.ts
+++ b/types/inquirer/lib/utils/screen-manager.d.ts
@@ -1,4 +1,4 @@
-import { Interface as ReadLineInterface } from 'readline';
+import { Interface as ReadLineInterface } from "readline";
 
 /**
  * Provides the functionality to manage the content of a console-screen.

--- a/types/inquirer/lib/utils/utils.d.ts
+++ b/types/inquirer/lib/utils/utils.d.ts
@@ -1,5 +1,5 @@
-import { Observable } from 'rxjs';
-import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from '../../index.js';
+import { Observable } from "rxjs";
+import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from "../../index.js";
 
 /**
  * Represents a property-name of any question-type.
@@ -24,6 +24,7 @@ type QuestionProperty = KeyUnion<UnionToIntersection<DistinctQuestion>>;
 export function fetchAsyncQuestionProperty(
     question: DistinctQuestion,
     prop: QuestionProperty,
-    answers: Answers): Observable<DistinctQuestion>;
+    answers: Answers,
+): Observable<DistinctQuestion>;
 
 export {};

--- a/types/inquirer/test/bottom-bar.ts
+++ b/types/inquirer/test/bottom-bar.ts
@@ -1,9 +1,9 @@
-import { spawn } from 'child_process';
-import BottomBar from 'inquirer/lib/ui/bottom-bar';
+import { spawn } from "child_process";
+import BottomBar from "inquirer/lib/ui/bottom-bar";
 // tslint:disable-next-line: no-var-requires
-const cmdify = require('cmdify');
+const cmdify = require("cmdify");
 
-const loader = ['/ Installing', '| Installing', '\\ Installing', '- Installing'];
+const loader = ["/ Installing", "| Installing", "\\ Installing", "- Installing"];
 let i = 4;
 const ui = new BottomBar({ bottomBar: loader[i % 4] });
 
@@ -11,9 +11,9 @@ setInterval(() => {
     ui.updateBottomBar(loader[i++ % 4]);
 }, 300);
 
-const cmd = spawn(cmdify('npm'), ['-g', 'install', 'inquirer'], { stdio: 'pipe' });
+const cmd = spawn(cmdify("npm"), ["-g", "install", "inquirer"], { stdio: "pipe" });
 cmd.stdout.pipe(ui.log);
-cmd.on('close', () => {
-    ui.updateBottomBar('Installation done!\n');
+cmd.on("close", () => {
+    ui.updateBottomBar("Installation done!\n");
     process.exit();
 });

--- a/types/inquirer/test/checkbox.ts
+++ b/types/inquirer/test/checkbox.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
 /**
  * Checkbox list examples
@@ -6,56 +6,56 @@ import inquirer from 'inquirer';
 inquirer
     .prompt([
         {
-            type: 'checkbox',
-            message: 'Select toppings',
-            name: 'toppings',
+            type: "checkbox",
+            message: "Select toppings",
+            name: "toppings",
             choices: [
-                new inquirer.Separator(' = The Meats = '),
+                new inquirer.Separator(" = The Meats = "),
                 {
-                    name: 'Pepperoni',
+                    name: "Pepperoni",
                 },
                 {
-                    name: 'Ham',
+                    name: "Ham",
                 },
                 {
-                    name: 'Ground Meat',
+                    name: "Ground Meat",
                 },
                 {
-                    name: 'Bacon',
+                    name: "Bacon",
                 },
-                new inquirer.Separator(' = The Cheeses = '),
+                new inquirer.Separator(" = The Cheeses = "),
                 {
-                    name: 'Mozzarella',
+                    name: "Mozzarella",
                     checked: true,
                 },
                 {
-                    name: 'Cheddar',
+                    name: "Cheddar",
                 },
                 {
-                    name: 'Parmesan',
+                    name: "Parmesan",
                 },
-                new inquirer.Separator(' = The usual ='),
+                new inquirer.Separator(" = The usual ="),
                 {
-                    name: 'Mushroom',
-                },
-                {
-                    name: 'Tomato',
-                },
-                new inquirer.Separator(' = The extras = '),
-                {
-                    name: 'Pineapple',
+                    name: "Mushroom",
                 },
                 {
-                    name: 'Olives',
-                    disabled: 'out of stock',
+                    name: "Tomato",
+                },
+                new inquirer.Separator(" = The extras = "),
+                {
+                    name: "Pineapple",
                 },
                 {
-                    name: 'Extra cheese',
+                    name: "Olives",
+                    disabled: "out of stock",
+                },
+                {
+                    name: "Extra cheese",
                 },
             ],
             validate(answer) {
                 if (answer.length < 1) {
-                    return 'You must choose at least one topping.';
+                    return "You must choose at least one topping.";
                 }
 
                 return true;
@@ -63,5 +63,5 @@ inquirer
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/test/editor.ts
+++ b/types/inquirer/test/editor.ts
@@ -1,16 +1,16 @@
-import inquirer, { QuestionCollection } from 'inquirer';
+import inquirer, { QuestionCollection } from "inquirer";
 
 /**
  * Editor prompt example
  */
 const questions: QuestionCollection = [
     {
-        type: 'editor',
-        name: 'bio',
-        message: 'Please write a short bio of at least 3 lines.',
+        type: "editor",
+        name: "bio",
+        message: "Please write a short bio of at least 3 lines.",
         validate(text) {
-            if (text.split('\n').length < 3) {
-                return 'Must be at least 3 lines.';
+            if (text.split("\n").length < 3) {
+                return "Must be at least 3 lines.";
             }
             return true;
         },
@@ -18,5 +18,5 @@ const questions: QuestionCollection = [
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/test/expand.ts
+++ b/types/inquirer/test/expand.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
 /**
  * Expand list examples
@@ -6,34 +6,34 @@ import inquirer from 'inquirer';
 inquirer
     .prompt([
         {
-            type: 'expand',
-            message: 'Conflict on `file.js`: ',
-            name: 'overwrite',
+            type: "expand",
+            message: "Conflict on `file.js`: ",
+            name: "overwrite",
             choices: [
                 {
-                    key: 'y',
-                    name: 'Overwrite',
-                    value: 'overwrite',
+                    key: "y",
+                    name: "Overwrite",
+                    value: "overwrite",
                 },
                 {
-                    key: 'a',
-                    name: 'Overwrite this one and all next',
-                    value: 'overwrite_all',
+                    key: "a",
+                    name: "Overwrite this one and all next",
+                    value: "overwrite_all",
                 },
                 {
-                    key: 'd',
-                    name: 'Show diff',
-                    value: 'diff',
+                    key: "d",
+                    name: "Show diff",
+                    value: "diff",
                 },
                 new inquirer.Separator(),
                 {
-                    key: 'x',
-                    name: 'Abort',
-                    value: 'abort',
+                    key: "x",
+                    name: "Abort",
+                    value: "abort",
                 },
             ],
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/test/hierarchical.ts
+++ b/types/inquirer/test/hierarchical.ts
@@ -1,4 +1,4 @@
-import inquirer, { DistinctQuestion } from 'inquirer';
+import inquirer, { DistinctQuestion } from "inquirer";
 
 /**
  * Represents answers provided by the user.
@@ -12,34 +12,34 @@ interface RPGAnswers {
     /**
      * The direction chosen by the user.
      */
-    direction: 'Forward' | 'Right' | 'Left' | 'Back';
+    direction: "Forward" | "Right" | "Left" | "Back";
 }
 
 /**
  * Heirarchical conversation example
  */
 const directionsPrompt: DistinctQuestion<RPGAnswers> = {
-    type: 'list',
-    name: 'direction',
-    message: 'Which direction would you like to go?',
-    choices: ['Forward', 'Right', 'Left', 'Back'],
+    type: "list",
+    name: "direction",
+    message: "Which direction would you like to go?",
+    choices: ["Forward", "Right", "Left", "Back"],
 };
 
 function main() {
-    console.log('You find youself in a small room, there is a door in front of you.');
+    console.log("You find youself in a small room, there is a door in front of you.");
     exitHouse();
 }
 
 function exitHouse() {
     inquirer.prompt(directionsPrompt).then(answers => {
-        if (answers.direction === 'Forward') {
-            console.log('You find yourself in a forest');
+        if (answers.direction === "Forward") {
+            console.log("You find yourself in a forest");
             console.log(
-                'There is a wolf in front of you; a friendly looking dwarf to the right and an impasse to the left.',
+                "There is a wolf in front of you; a friendly looking dwarf to the right and an impasse to the left.",
             );
             encounter1();
         } else {
-            console.log('You cannot go that way. Try again');
+            console.log("You cannot go that way. Try again");
             exitHouse();
         }
     });
@@ -48,16 +48,16 @@ function exitHouse() {
 function encounter1() {
     inquirer.prompt(directionsPrompt).then(answers => {
         const direction = answers.direction;
-        if (direction === 'Forward') {
-            console.log('You attempt to fight the wolf');
-            console.log('Theres a stick and some stones lying around you could use as a weapon');
+        if (direction === "Forward") {
+            console.log("You attempt to fight the wolf");
+            console.log("Theres a stick and some stones lying around you could use as a weapon");
             encounter2b();
-        } else if (direction === 'Right') {
-            console.log('You befriend the dwarf');
-            console.log('He helps you kill the wolf. You can now move forward');
+        } else if (direction === "Right") {
+            console.log("You befriend the dwarf");
+            console.log("He helps you kill the wolf. You can now move forward");
             encounter2a();
         } else {
-            console.log('You cannot go that way');
+            console.log("You cannot go that way");
             encounter1();
         }
     });
@@ -66,16 +66,16 @@ function encounter1() {
 function encounter2a() {
     inquirer.prompt(directionsPrompt).then(answers => {
         const direction = answers.direction;
-        if (direction === 'Forward') {
-            let output = 'You find a painted wooden sign that says:';
-            output += ' \n';
-            output += ' ____  _____  ____  _____ \n';
-            output += '(_  _)(  _  )(  _ \\(  _  ) \n';
-            output += '  )(   )(_)(  )(_) ))(_)(  \n';
-            output += ' (__) (_____)(____/(_____) \n';
+        if (direction === "Forward") {
+            let output = "You find a painted wooden sign that says:";
+            output += " \n";
+            output += " ____  _____  ____  _____ \n";
+            output += "(_  _)(  _  )(  _ \\(  _  ) \n";
+            output += "  )(   )(_)(  )(_) ))(_)(  \n";
+            output += " (__) (_____)(____/(_____) \n";
             console.log(output);
         } else {
-            console.log('You cannot go that way');
+            console.log("You cannot go that way");
             encounter2a();
         }
     });
@@ -84,13 +84,13 @@ function encounter2a() {
 function encounter2b() {
     inquirer
         .prompt<RPGAnswers>({
-            type: 'list',
-            name: 'weapon',
-            message: 'Pick one',
-            choices: ['Use the stick', 'Grab a large rock', 'Try and make a run for it', 'Attack the wolf unarmed'],
+            type: "list",
+            name: "weapon",
+            message: "Pick one",
+            choices: ["Use the stick", "Grab a large rock", "Try and make a run for it", "Attack the wolf unarmed"],
         })
         .then(() => {
-            console.log('The wolf mauls you. You die. The end.');
+            console.log("The wolf mauls you. You die. The end.");
         });
 }
 

--- a/types/inquirer/test/input.ts
+++ b/types/inquirer/test/input.ts
@@ -1,39 +1,39 @@
-import inquirer, { QuestionCollection } from 'inquirer';
-import chalkPipe = require('chalk-pipe');
+import inquirer, { QuestionCollection } from "inquirer";
+import chalkPipe = require("chalk-pipe");
 
 /**
  * Input prompt example
  */
 const questions: QuestionCollection = [
     {
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     },
     {
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     },
     {
-        type: 'input',
-        name: 'fav_color',
+        type: "input",
+        name: "fav_color",
         message: "What's your favorite color",
         transformer(color, answers, flags) {
             const text = chalkPipe(color)(color);
             if (flags.isFinal) {
-                return text + '!';
+                return text + "!";
             }
 
             return text;
         },
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -43,11 +43,11 @@ const questions: QuestionCollection = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/test/list.ts
+++ b/types/inquirer/test/list.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
 /**
  * List prompt example
@@ -6,31 +6,31 @@ import inquirer from 'inquirer';
 inquirer
     .prompt([
         {
-            type: 'list',
-            name: 'theme',
-            message: 'What do you want to do?',
+            type: "list",
+            name: "theme",
+            message: "What do you want to do?",
             choices: [
-                'Order a pizza',
-                'Make a reservation',
+                "Order a pizza",
+                "Make a reservation",
                 new inquirer.Separator(),
-                'Ask for opening hours',
+                "Ask for opening hours",
                 {
-                    name: 'Contact support',
-                    disabled: 'Unavailable at this time',
+                    name: "Contact support",
+                    disabled: "Unavailable at this time",
                 },
-                'Talk to the receptionist',
+                "Talk to the receptionist",
             ],
         },
         {
-            type: 'list',
-            name: 'size',
-            message: 'What size do you need?',
-            choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+            type: "list",
+            name: "size",
+            message: "What size do you need?",
+            choices: ["Jumbo", "Large", "Standard", "Medium", "Small", "Micro"],
             filter(val) {
                 return val.toLowerCase();
             },
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/test/long-list.ts
+++ b/types/inquirer/test/long-list.ts
@@ -1,32 +1,32 @@
-import inquirer, { ChoiceCollection } from 'inquirer';
+import inquirer, { ChoiceCollection } from "inquirer";
 
 /**
  * Paginated list
  */
 const choices: ChoiceCollection = new Array(26).fill(undefined).map((x, y) => String.fromCharCode(y + 65));
-choices.push('Multiline option \n  super cool feature');
+choices.push("Multiline option \n  super cool feature");
 choices.push({
     name:
-        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.',
-    value: 'foo',
-    short: 'The long option',
+        "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",
+    value: "foo",
+    short: "The long option",
 });
 
 inquirer
     .prompt([
         {
-            type: 'list',
-            name: 'letter',
+            type: "list",
+            name: "letter",
             message: "What's your favorite letter?",
             choices,
         },
         {
-            type: 'checkbox',
-            name: 'name',
-            message: 'Select the letter contained in your name:',
+            type: "checkbox",
+            name: "name",
+            message: "Select the letter contained in your name:",
             choices,
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/test/nested-call.ts
+++ b/types/inquirer/test/nested-call.ts
@@ -1,20 +1,20 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
 /**
  * Nested Inquirer call
  */
 inquirer
     .prompt({
-        type: 'list',
-        name: 'chocolate',
+        type: "list",
+        name: "chocolate",
         message: "What's your favorite chocolate?",
-        choices: ['Mars', 'Oh Henry', 'Hershey'],
+        choices: ["Mars", "Oh Henry", "Hershey"],
     })
     .then(() => {
         inquirer.prompt({
-            type: 'list',
-            name: 'beverage',
-            message: 'And your favorite beverage?',
-            choices: ['Pepsi', 'Coke', '7up', 'Mountain Dew', 'Red Bull'],
+            type: "list",
+            name: "beverage",
+            message: "And your favorite beverage?",
+            choices: ["Pepsi", "Coke", "7up", "Mountain Dew", "Red Bull"],
         });
     });

--- a/types/inquirer/test/password.ts
+++ b/types/inquirer/test/password.ts
@@ -1,4 +1,4 @@
-import inquirer, { Validator } from 'inquirer';
+import inquirer, { Validator } from "inquirer";
 
 /**
  * Password prompt example
@@ -8,23 +8,23 @@ const requireLetterAndNumber: Validator = value => {
         return true;
     }
 
-    return 'Password need to have at least a letter and a number';
+    return "Password need to have at least a letter and a number";
 };
 
 inquirer
     .prompt([
         {
-            type: 'password',
-            message: 'Enter a password',
-            name: 'password1',
+            type: "password",
+            message: "Enter a password",
+            name: "password1",
             validate: requireLetterAndNumber,
         },
         {
-            type: 'password',
-            message: 'Enter a masked password',
-            name: 'password2',
-            mask: '*',
+            type: "password",
+            message: "Enter a masked password",
+            name: "password2",
+            mask: "*",
             validate: requireLetterAndNumber,
         },
     ])
-    .then(answers => console.log(JSON.stringify(answers, null, '  ')));
+    .then(answers => console.log(JSON.stringify(answers, null, "  ")));

--- a/types/inquirer/test/pizza.ts
+++ b/types/inquirer/test/pizza.ts
@@ -1,21 +1,21 @@
-import inquirer, { DistinctQuestion } from 'inquirer';
+import inquirer, { DistinctQuestion } from "inquirer";
 
 /**
  * Pizza delivery prompt example
  * run example by writing `node pizza.js` in your console
  */
-console.log('Hi, welcome to Node Pizza');
+console.log("Hi, welcome to Node Pizza");
 
 const questions: DistinctQuestion[] = [
     {
-        type: 'confirm',
-        name: 'toBeDelivered',
-        message: 'Is this for delivery?',
+        type: "confirm",
+        name: "toBeDelivered",
+        message: "Is this for delivery?",
         default: false,
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number?",
         validate(value) {
             const pass = value.match(
@@ -25,74 +25,74 @@ const questions: DistinctQuestion[] = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
     {
-        type: 'list',
-        name: 'size',
-        message: 'What size do you need?',
-        choices: ['Large', 'Medium', 'Small'],
+        type: "list",
+        name: "size",
+        message: "What size do you need?",
+        choices: ["Large", "Medium", "Small"],
         filter(val) {
             return val.toLowerCase();
         },
     },
     {
-        type: 'input',
-        name: 'quantity',
-        message: 'How many do you need?',
+        type: "input",
+        name: "quantity",
+        message: "How many do you need?",
         validate(value) {
             const valid = !isNaN(parseFloat(value));
-            return valid || 'Please enter a number';
+            return valid || "Please enter a number";
         },
         filter: Number,
     },
     {
-        type: 'expand',
-        name: 'toppings',
-        message: 'What about the toppings?',
+        type: "expand",
+        name: "toppings",
+        message: "What about the toppings?",
         choices: [
             {
-                key: 'p',
-                name: 'Pepperoni and cheese',
-                value: 'PepperoniCheese',
+                key: "p",
+                name: "Pepperoni and cheese",
+                value: "PepperoniCheese",
             },
             {
-                key: 'a',
-                name: 'All dressed',
-                value: 'alldressed',
+                key: "a",
+                name: "All dressed",
+                value: "alldressed",
             },
             {
-                key: 'w',
-                name: 'Hawaiian',
-                value: 'hawaiian',
+                key: "w",
+                name: "Hawaiian",
+                value: "hawaiian",
             },
         ],
     },
     {
-        type: 'rawlist',
-        name: 'beverage',
-        message: 'You also get a free 2L beverage',
-        choices: ['Pepsi', '7up', 'Coke'],
+        type: "rawlist",
+        name: "beverage",
+        message: "You also get a free 2L beverage",
+        choices: ["Pepsi", "7up", "Coke"],
     },
     {
-        type: 'input',
-        name: 'comments',
-        message: 'Any comments on your purchase experience?',
-        default: 'Nope, all good!',
+        type: "input",
+        name: "comments",
+        message: "Any comments on your purchase experience?",
+        default: "Nope, all good!",
     },
     {
-        type: 'list',
-        name: 'prize',
-        message: 'For leaving a comment, you get a freebie',
-        choices: ['cake', 'fries'],
+        type: "list",
+        name: "prize",
+        message: "For leaving a comment, you get a freebie",
+        choices: ["cake", "fries"],
         when(answers) {
-            return answers.comments !== 'Nope, all good!';
+            return answers.comments !== "Nope, all good!";
         },
     },
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log('\nOrder receipt:');
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log("\nOrder receipt:");
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/test/rawlist.ts
+++ b/types/inquirer/test/rawlist.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
 /**
  * Raw List prompt example
@@ -6,27 +6,27 @@ import inquirer from 'inquirer';
 inquirer
     .prompt([
         {
-            type: 'rawlist',
-            name: 'theme',
-            message: 'What do you want to do?',
+            type: "rawlist",
+            name: "theme",
+            message: "What do you want to do?",
             choices: [
-                'Order a pizza',
-                'Make a reservation',
+                "Order a pizza",
+                "Make a reservation",
                 new inquirer.Separator(),
-                'Ask opening hours',
-                'Talk to the receptionist',
+                "Ask opening hours",
+                "Talk to the receptionist",
             ],
         },
         {
-            type: 'rawlist',
-            name: 'size',
-            message: 'What size do you need',
-            choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+            type: "rawlist",
+            name: "size",
+            message: "What size do you need",
+            choices: ["Jumbo", "Large", "Standard", "Medium", "Small", "Micro"],
             filter(val) {
                 return val.toLowerCase();
             },
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/test/recursive.ts
+++ b/types/inquirer/test/recursive.ts
@@ -1,4 +1,4 @@
-import inquirer, { QuestionCollection } from 'inquirer';
+import inquirer, { QuestionCollection } from "inquirer";
 
 /**
  * Recursive prompt example
@@ -8,14 +8,14 @@ const output: any[] = [];
 
 const questions: QuestionCollection = [
     {
-        type: 'input',
-        name: 'tvShow',
+        type: "input",
+        name: "tvShow",
         message: "What's your favorite TV show?",
     },
     {
-        type: 'confirm',
-        name: 'askAgain',
-        message: 'Want to enter another TV show favorite (just hit enter for YES)?',
+        type: "confirm",
+        name: "askAgain",
+        message: "Want to enter another TV show favorite (just hit enter for YES)?",
         default: true,
     },
 ];
@@ -26,7 +26,7 @@ function ask() {
         if (answers.askAgain) {
             ask();
         } else {
-            console.log('Your favorite TV Shows:', output.join(', '));
+            console.log("Your favorite TV Shows:", output.join(", "));
         }
     });
 }

--- a/types/inquirer/test/rx-observable-array.ts
+++ b/types/inquirer/test/rx-observable-array.ts
@@ -1,23 +1,23 @@
-import inquirer, { DistinctQuestion } from 'inquirer';
-import { from } from 'rxjs';
+import inquirer, { DistinctQuestion } from "inquirer";
+import { from } from "rxjs";
 
 const questions: DistinctQuestion[] = [
     {
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     },
     {
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -27,7 +27,7 @@ const questions: DistinctQuestion[] = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
 ];
@@ -36,12 +36,12 @@ const observable = from(questions);
 
 inquirer.prompt(observable).ui.process.subscribe(
     ans => {
-        console.log('Answer is: ', ans);
+        console.log("Answer is: ", ans);
     },
     err => {
-        console.log('Error: ', err);
+        console.log("Error: ", err);
     },
     () => {
-        console.log('Completed');
+        console.log("Completed");
     },
 );

--- a/types/inquirer/test/rx-observable-create.ts
+++ b/types/inquirer/test/rx-observable-create.ts
@@ -1,25 +1,25 @@
-import inquirer, { DistinctQuestion } from 'inquirer';
-import { Observable, Observer } from 'rxjs';
+import inquirer, { DistinctQuestion } from "inquirer";
+import { Observable, Observer } from "rxjs";
 
 const observe = Observable.create((obs: Observer<DistinctQuestion>) => {
     obs.next({
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     });
 
     obs.next({
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     });
 
     obs.next({
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -29,12 +29,12 @@ const observe = Observable.create((obs: Observer<DistinctQuestion>) => {
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     });
     obs.complete();
 });
 
 inquirer.prompt(observe).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/test/spawn.ts
+++ b/types/inquirer/test/spawn.ts
@@ -1,6 +1,6 @@
-import { spawn } from 'child_process';
+import { spawn } from "child_process";
 
-spawn('node', ['input.js'], {
+spawn("node", ["input.js"], {
     cwd: __dirname,
-    stdio: 'inherit',
+    stdio: "inherit",
 });

--- a/types/inquirer/test/when.ts
+++ b/types/inquirer/test/when.ts
@@ -1,35 +1,35 @@
-import inquirer, { Answers, QuestionCollection } from 'inquirer';
+import inquirer, { Answers, QuestionCollection } from "inquirer";
 
 /**
  * When example
  */
 const questions: QuestionCollection = [
     {
-        type: 'confirm',
-        name: 'bacon',
-        message: 'Do you like bacon?',
+        type: "confirm",
+        name: "bacon",
+        message: "Do you like bacon?",
     },
     {
-        type: 'input',
-        name: 'favorite',
-        message: 'Bacon lover, what is your favorite type of bacon?',
+        type: "input",
+        name: "favorite",
+        message: "Bacon lover, what is your favorite type of bacon?",
         when(answers) {
             return answers.bacon;
         },
     },
     {
-        type: 'confirm',
-        name: 'pizza',
-        message: 'Ok... Do you like pizza?',
+        type: "confirm",
+        name: "pizza",
+        message: "Ok... Do you like pizza?",
         when(answers) {
-            return !likesFood('bacon')(answers);
+            return !likesFood("bacon")(answers);
         },
     },
     {
-        type: 'input',
-        name: 'favorite',
-        message: 'Whew! What is your favorite type of pizza?',
-        when: likesFood('pizza'),
+        type: "input",
+        name: "favorite",
+        message: "Whew! What is your favorite type of pizza?",
+        when: likesFood("pizza"),
     },
 ];
 
@@ -40,5 +40,5 @@ function likesFood(aFood: string) {
 }
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/v8/index.d.ts
+++ b/types/inquirer/v8/index.d.ts
@@ -12,29 +12,29 @@
 //                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
-import { Interface as ReadlineInterface } from 'readline';
-import { Observable } from 'rxjs';
-import { ThroughStream } from 'through';
-import Choice = require('./lib/objects/choice');
-import Choices = require('./lib/objects/choices');
-import './lib/objects/separator';
-import './lib/prompts/base';
-import CheckboxPrompt = require('./lib/prompts/checkbox');
-import ConfirmPrompt = require('./lib/prompts/confirm');
-import EditorPrompt = require('./lib/prompts/editor');
-import ExpandPrompt = require('./lib/prompts/expand');
-import InputPrompt = require('./lib/prompts/input');
-import ListPrompt = require('./lib/prompts/list');
-import NumberPrompt = require('./lib/prompts/number');
-import PasswordPrompt = require('./lib/prompts/password');
-import RawListPrompt = require('./lib/prompts/rawlist');
-import UI = require('./lib/ui/baseUI');
-import './lib/ui/bottom-bar';
-import './lib/ui/prompt';
-import './lib/utils/events';
-import './lib/utils/paginator';
-import './lib/utils/readline';
-import './lib/utils/screen-manager';
+import { Interface as ReadlineInterface } from "readline";
+import { Observable } from "rxjs";
+import { ThroughStream } from "through";
+import Choice = require("./lib/objects/choice");
+import Choices = require("./lib/objects/choices");
+import "./lib/objects/separator";
+import "./lib/prompts/base";
+import CheckboxPrompt = require("./lib/prompts/checkbox");
+import ConfirmPrompt = require("./lib/prompts/confirm");
+import EditorPrompt = require("./lib/prompts/editor");
+import ExpandPrompt = require("./lib/prompts/expand");
+import InputPrompt = require("./lib/prompts/input");
+import ListPrompt = require("./lib/prompts/list");
+import NumberPrompt = require("./lib/prompts/number");
+import PasswordPrompt = require("./lib/prompts/password");
+import RawListPrompt = require("./lib/prompts/rawlist");
+import UI = require("./lib/ui/baseUI");
+import "./lib/ui/bottom-bar";
+import "./lib/ui/prompt";
+import "./lib/utils/events";
+import "./lib/utils/paginator";
+import "./lib/utils/readline";
+import "./lib/utils/screen-manager";
 
 /**
  * Represents a union which preserves autocompletion.
@@ -81,12 +81,12 @@ export interface PromptModuleBase extends PromptFunction {
 /**
  * Represents a function for registering a prompt.
  */
-type RegisterFunction = PromptModuleBase['registerPrompt'];
+type RegisterFunction = PromptModuleBase["registerPrompt"];
 
 /**
  * Represents a function for restoring a prompt.
  */
-type RestoreFunction = PromptModuleBase['restoreDefaultPrompts'];
+type RestoreFunction = PromptModuleBase["restoreDefaultPrompts"];
 
 /**
  * Represents a list-based question.
@@ -123,12 +123,13 @@ export type KeyUnion<T> = LiteralUnion<Extract<keyof T, string>>;
  * @template U
  * The union to convert to an intersection.
  */
-export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I
+    : never;
 
 /**
  * A set of answers.
  */
-export interface Answers extends Record<string, any> { }
+export interface Answers extends Record<string, any> {}
 
 /**
  * Provides the functionality to validate answers.
@@ -136,7 +137,7 @@ export interface Answers extends Record<string, any> { }
  * @template T
  * The type of the answers.
  */
-export type Validator<T extends Answers = Answers> = Question<T>['validate'];
+export type Validator<T extends Answers = Answers> = Question<T>["validate"];
 
 /**
  * Provides the functionality to transform an answer.
@@ -144,7 +145,7 @@ export type Validator<T extends Answers = Answers> = Question<T>['validate'];
  * @template T
  * The type of the answers.
  */
-export type Transformer<T extends Answers = Answers> = InputQuestionOptions<T>['transformer'];
+export type Transformer<T extends Answers = Answers> = InputQuestionOptions<T>["transformer"];
 
 /**
  * Represents a dynamic property for a question.
@@ -224,7 +225,7 @@ export interface SeparatorOptions extends ChoiceBase {
     /**
      * Gets the type of the choice.
      */
-    type: 'separator';
+    type: "separator";
 
     /**
      * Gets or sets the text of the separator.
@@ -239,7 +240,7 @@ export interface ChoiceOptions extends ChoiceBase {
     /**
      * @inheritdoc
      */
-    type?: 'choice' | undefined;
+    type?: "choice" | undefined;
 
     /**
      * The name of the choice to show to the user.
@@ -418,8 +419,8 @@ export interface Question<T extends Answers = Answers> {
 export type QuestionAnswer<T extends Answers = Answers> = {
     [K in keyof T]: {
         name: K;
-        answer: T[K]
-    }
+        answer: T[K];
+    };
 }[keyof T];
 
 /**
@@ -457,7 +458,7 @@ export interface InputQuestion<T extends Answers = Answers> extends InputQuestio
     /**
      * @inheritdoc
      */
-    type?: 'input' | undefined;
+    type?: "input" | undefined;
 }
 
 /**
@@ -466,7 +467,7 @@ export interface InputQuestion<T extends Answers = Answers> extends InputQuestio
  * @template T
  * The type of the answers.
  */
-export interface NumberQuestionOptions<T extends Answers = Answers> extends InputQuestionOptions<T> { }
+export interface NumberQuestionOptions<T extends Answers = Answers> extends InputQuestionOptions<T> {}
 
 /**
  * Provides options for a question for the {@link NumberPrompt `NumberPrompt<TQuestion>`}.
@@ -478,7 +479,7 @@ export interface NumberQuestion<T extends Answers = Answers> extends NumberQuest
     /**
      * @inheritdoc
      */
-    type: 'number';
+    type: "number";
 }
 
 /**
@@ -504,7 +505,7 @@ export interface PasswordQuestion<T extends Answers = Answers> extends PasswordQ
     /**
      * @inheritdoc
      */
-    type: 'password';
+    type: "password";
 }
 
 /**
@@ -516,7 +517,9 @@ export interface PasswordQuestion<T extends Answers = Answers> extends PasswordQ
  * @template TChoiceMap
  * The valid choices for the question.
  */
-export interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap> extends ListQuestionOptionsBase<T, TChoiceMap> {
+export interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap>
+    extends ListQuestionOptionsBase<T, TChoiceMap>
+{
     /**
      * A value indicating whether choices in a list should be looped.
      */
@@ -530,7 +533,8 @@ export interface LoopableListQuestionOptionsBase<T extends Answers, TChoiceMap> 
  * The type of the answers.
  */
 export interface ListQuestionOptions<T extends Answers = Answers>
-    extends LoopableListQuestionOptionsBase<T, ListChoiceMap<T>> { }
+    extends LoopableListQuestionOptionsBase<T, ListChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link ListPrompt `ListPrompt<TQuestion>`}.
@@ -542,7 +546,7 @@ export interface ListQuestion<T extends Answers = Answers> extends ListQuestionO
     /**
      * @inheritdoc
      */
-    type: 'list';
+    type: "list";
 }
 
 /**
@@ -551,7 +555,7 @@ export interface ListQuestion<T extends Answers = Answers> extends ListQuestionO
  * @template T
  * The type of the answers.
  */
-export interface RawListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptions<T> { }
+export interface RawListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptions<T> {}
 
 /**
  * Provides options for a question for the {@link RawListPrompt `RawListPrompt<TQuestion>`}.
@@ -563,7 +567,7 @@ export interface RawListQuestion<T extends Answers = Answers> extends RawListQue
     /**
      * @inheritdoc
      */
-    type: 'rawlist';
+    type: "rawlist";
 }
 
 /**
@@ -573,7 +577,8 @@ export interface RawListQuestion<T extends Answers = Answers> extends RawListQue
  * The type of the answers.
  */
 export interface ExpandQuestionOptions<T extends Answers = Answers>
-    extends ListQuestionOptionsBase<T, ExpandChoiceMap<T>> { }
+    extends ListQuestionOptionsBase<T, ExpandChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link ExpandPrompt `ExpandPrompt<TQuestion>`}.
@@ -585,7 +590,7 @@ export interface ExpandQuestion<T extends Answers = Answers> extends ExpandQuest
     /**
      * @inheritdoc
      */
-    type: 'expand';
+    type: "expand";
 }
 
 /**
@@ -595,7 +600,8 @@ export interface ExpandQuestion<T extends Answers = Answers> extends ExpandQuest
  * The type of the answers.
  */
 export interface CheckboxQuestionOptions<T extends Answers = Answers>
-    extends LoopableListQuestionOptionsBase<T, CheckboxChoiceMap<T>> { }
+    extends LoopableListQuestionOptionsBase<T, CheckboxChoiceMap<T>>
+{}
 
 /**
  * Provides options for a question for the {@link CheckboxPrompt `CheckboxPrompt<TQuestion>`}.
@@ -607,7 +613,7 @@ export interface CheckboxQuestion<T extends Answers = Answers> extends CheckboxQ
     /**
      * @inheritdoc
      */
-    type: 'checkbox';
+    type: "checkbox";
 }
 
 /**
@@ -616,7 +622,7 @@ export interface CheckboxQuestion<T extends Answers = Answers> extends CheckboxQ
  * @template T
  * The type of the answers.
  */
-export interface ConfirmQuestionOptions<T extends Answers = Answers> extends Question<T> { }
+export interface ConfirmQuestionOptions<T extends Answers = Answers> extends Question<T> {}
 
 /**
  * Provides options for a question for the {@link ConfirmPrompt `ConfirmPrompt<TQuestion>`}.
@@ -628,7 +634,7 @@ export interface ConfirmQuestion<T extends Answers = Answers> extends ConfirmQue
     /**
      * @inheritdoc
      */
-    type: 'confirm';
+    type: "confirm";
 }
 
 /**
@@ -656,7 +662,7 @@ export interface EditorQuestion<T extends Answers = Answers> extends EditorQuest
     /**
      * @inheritdoc
      */
-    type: 'editor';
+    type: "editor";
 }
 
 /**
@@ -723,7 +729,7 @@ export type DistinctQuestion<T extends Answers = Answers> = QuestionMap<T>[keyof
 /**
  * Indicates the type of a question
  */
-export type QuestionTypeName = DistinctQuestion['type'];
+export type QuestionTypeName = DistinctQuestion["type"];
 
 /**
  * Represents a collection of questions.
@@ -769,7 +775,10 @@ export interface PromptModule extends PromptModuleBase {
     /**
      * Prompts the questions to the user.
      */
-    <T extends Answers = Answers>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T> & { ui: ui.Prompt<T> };
+    <T extends Answers = Answers>(
+        questions: QuestionCollection<T>,
+        initialAnswers?: Partial<T>,
+    ): Promise<T> & { ui: ui.Prompt<T> };
 
     /**
      * Registers a new prompt-type.
@@ -803,7 +812,7 @@ export namespace prompts {
     /**
      * Represents the state of a prompt.
      */
-    type PromptState = LiteralUnion<'pending' | 'idle' | 'loading' | 'answered' | 'done'>;
+    type PromptState = LiteralUnion<"pending" | "idle" | "loading" | "answered" | "done">;
 
     /**
      * Represents a prompt.
@@ -1128,7 +1137,7 @@ export class Separator implements SeparatorOptions {
     /**
      * @inheritdoc
      */
-    readonly type: 'separator';
+    readonly type: "separator";
 
     /**
      * @inheritdoc

--- a/types/inquirer/v8/inquirer-tests.ts
+++ b/types/inquirer/v8/inquirer-tests.ts
@@ -1,27 +1,27 @@
-import { createInterface } from 'readline';
-import { DistinctQuestion, Separator } from 'inquirer';
-import inquirer = require('inquirer');
-import InputPrompt = require('inquirer/lib/prompts/input');
-import { fetchAsyncQuestionProperty } from 'inquirer/lib/utils/utils';
-import incrementListIndex = require('inquirer/lib/utils/incrementListIndex');
-import Choices = require('inquirer/lib/objects/choices');
-import Paginator = require('inquirer/lib/utils/paginator');
-import ScreenManager = require('inquirer/lib/utils/screen-manager');
-import { Subject } from 'rxjs';
+import { DistinctQuestion, Separator } from "inquirer";
+import { createInterface } from "readline";
+import inquirer = require("inquirer");
+import InputPrompt = require("inquirer/lib/prompts/input");
+import { fetchAsyncQuestionProperty } from "inquirer/lib/utils/utils";
+import incrementListIndex = require("inquirer/lib/utils/incrementListIndex");
+import Choices = require("inquirer/lib/objects/choices");
+import Paginator = require("inquirer/lib/utils/paginator");
+import ScreenManager = require("inquirer/lib/utils/screen-manager");
+import { Subject } from "rxjs";
 
 {
-    new inquirer.Separator('');
+    new inquirer.Separator("");
     const promptModule = inquirer.createPromptModule();
-    promptModule.prompts['']; // $ExpectType PromptConstructor
-    promptModule.registerPrompt('', InputPrompt); // $ExpectType PromptModule
+    promptModule.prompts[""]; // $ExpectType PromptConstructor
+    promptModule.registerPrompt("", InputPrompt); // $ExpectType PromptModule
     promptModule.restoreDefaultPrompts();
     inquirer.createPromptModule({ skipTTYChecks: false });
 }
 {
     inquirer.prompt([
         {
-            message: '',
-            default: '',
+            message: "",
+            default: "",
         },
     ]);
 }
@@ -38,36 +38,38 @@ import { Subject } from 'rxjs';
         // @ts-expect-error
         {
             this: {
-                name: 'override-this',
-                message: '1st question'
+                name: "override-this",
+                message: "1st question",
             },
             is: {
-                message: '2nd question'
+                message: "2nd question",
             },
             a: {
-                message: '3rd question'
+                message: "3rd question",
             },
             test: {
-                message: '4th question'
-            }
-        });
+                message: "4th question",
+            },
+        },
+    );
 
     // Take note that the properties of the answer-hash `this`, `is`, `a` and `test` are showing up in the auto completion
     inquirer.prompt<AnswerHash>(
         {
             this: {
-                message: '1st question'
+                message: "1st question",
             },
             is: {
-                message: '2nd question'
+                message: "2nd question",
             },
             a: {
-                message: '3rd question'
+                message: "3rd question",
             },
             test: {
-                message: '4th question'
-            }
-        });
+                message: "4th question",
+            },
+        },
+    );
 }
 {
     new inquirer.ui.BottomBar();
@@ -75,22 +77,22 @@ import { Subject } from 'rxjs';
 }
 {
     const checkBoxQuestion: inquirer.DistinctQuestion = {
-        type: 'checkbox',
+        type: "checkbox",
         askAnswered: true,
     };
 
     const listQuestion: inquirer.DistinctQuestion = {
-        type: 'list',
+        type: "list",
         askAnswered: true,
     };
 
     const rawListQuestion: inquirer.DistinctQuestion = {
-        type: 'rawlist',
+        type: "rawlist",
         askAnswered: true,
     };
 
     const expandQuestion: inquirer.DistinctQuestion = {
-        type: 'expand',
+        type: "expand",
         askAnswered: true,
     };
 
@@ -119,11 +121,11 @@ import { Subject } from 'rxjs';
     let choice: inquirer.DistinctChoice;
 
     choice = {
-        type: 'separator',
-        line: 'This is a test',
+        type: "separator",
+        line: "This is a test",
     };
 
-    if (choice.type === 'separator' && !(choice instanceof Separator)) {
+    if (choice.type === "separator" && !(choice instanceof Separator)) {
         // $ExpectType SeparatorOptions
         choice;
     }
@@ -134,7 +136,7 @@ interface ChalkQuestionOptions<T extends inquirer.Answers = inquirer.Answers> ex
 }
 
 interface ChalkQuestion<T extends inquirer.Answers = inquirer.Answers> extends ChalkQuestionOptions<T> {
-    type: 'chalk';
+    type: "chalk";
 }
 
 class ChalkPrompt extends InputPrompt {
@@ -143,9 +145,9 @@ class ChalkPrompt extends InputPrompt {
     protected onKeypress() {}
 }
 
-inquirer.registerPrompt('chalk', ChalkPrompt);
+inquirer.registerPrompt("chalk", ChalkPrompt);
 
-declare module 'inquirer' {
+declare module "inquirer" {
     interface QuestionMap<T> {
         chalk: ChalkQuestion<T>;
     }
@@ -153,7 +155,7 @@ declare module 'inquirer' {
 
 inquirer.prompt([
     {
-        type: 'chalk',
+        type: "chalk",
         previewColors: true,
     },
 ]);
@@ -161,21 +163,21 @@ inquirer.prompt([
 inquirer.prompt(
     [
         {
-            name: 'foo',
-            default: 'bar',
+            name: "foo",
+            default: "bar",
         },
     ],
     {
-        foo: 'baz',
+        foo: "baz",
     },
 );
 
 fetchAsyncQuestionProperty(
     {
-        name: 'foo',
-        default: 'bar',
+        name: "foo",
+        default: "bar",
     },
-    'message',
+    "message",
     {},
 ).pipe(source => {
     return source;
@@ -183,19 +185,19 @@ fetchAsyncQuestionProperty(
 
 {
     const options = {
-        name: 'foo',
+        name: "foo",
         loop: true,
-        choices: new Choices([{ name: 'foo' }], {}),
+        choices: new Choices([{ name: "foo" }], {}),
     };
 
     // $ExpectType number
-    incrementListIndex(0, 'up', options);
+    incrementListIndex(0, "up", options);
     // @ts-expect-error
-    incrementListIndex('notANumber', 'up', options);
+    incrementListIndex("notANumber", "up", options);
     // @ts-expect-error
-    incrementListIndex(0, 'left', options);
+    incrementListIndex(0, "left", options);
     // @ts-expect-error
-    incrementListIndex(0, 'up', {});
+    incrementListIndex(0, "up", {});
 }
 
 {
@@ -208,7 +210,7 @@ fetchAsyncQuestionProperty(
     new Paginator(screen);
     new Paginator(screen, { isInfinite: true });
     // @ts-expect-error
-    new Paginator(screen, { someUnsupportedOptions: 'foobar' });
+    new Paginator(screen, { someUnsupportedOptions: "foobar" });
 }
 
 {
@@ -219,31 +221,32 @@ fetchAsyncQuestionProperty(
     const screen = new ScreenManager(rl);
 
     const paginator = new Paginator(screen);
-    paginator.paginate('test', 0);
-    paginator.paginate('test', 0, 0);
+    paginator.paginate("test", 0);
+    paginator.paginate("test", 0, 0);
 }
 
 {
     const prompts = new Subject<DistinctQuestion>();
     const promptResult = inquirer.prompt(prompts);
     promptResult.ui.process.subscribe({
-        next: (value: {name: string, answer: any}) => {
+        next: (value: { name: string; answer: any }) => {
             // DO NOTHING
         },
     });
+    // dprint-ignore
     // @ts-expect-error
     promptResult.ui.process.subscribe({ next: (value: {name_: string, answer: number}) => {
-            // DO NOTHING
-        },
-    });
+        // DO NOTHING
+    },
+});
     prompts.complete();
 }
 
 {
-    const prompts = new Subject<DistinctQuestion<{str: string; num: number}>>();
+    const prompts = new Subject<DistinctQuestion<{ str: string; num: number }>>();
     const promptResult = inquirer.prompt(prompts);
     promptResult.ui.process.subscribe({
-        next: (value: {name: 'str', answer: string} | {name: 'num', answer: number}) => {
+        next: (value: { name: "str"; answer: string } | { name: "num"; answer: number }) => {
             // DO NOTHING
         },
     });
@@ -258,6 +261,7 @@ fetchAsyncQuestionProperty(
             }
         },
     });
+    // dprint-ignore
     // @ts-expect-error
     promptResult.ui.process.subscribe({ next: (value: {name: string, answer: number}) => {
             // DO NOTHING

--- a/types/inquirer/v8/lib/objects/choice.d.ts
+++ b/types/inquirer/v8/lib/objects/choice.d.ts
@@ -1,4 +1,4 @@
-import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from '../..';
+import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from "../..";
 
 /**
  * Represents a choice for several question-types.
@@ -7,11 +7,12 @@ import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions 
  * The type of the answers.
  */
 declare class Choice<T extends Answers = Answers>
-    implements ListChoiceOptions<T>, CheckboxChoiceOptions<T>, ExpandChoiceOptions {
+    implements ListChoiceOptions<T>, CheckboxChoiceOptions<T>, ExpandChoiceOptions
+{
     /**
      * @inheritdoc
      */
-    type?: 'choice' | undefined;
+    type?: "choice" | undefined;
 
     /**
      * @inheritdoc

--- a/types/inquirer/v8/lib/objects/choices.d.ts
+++ b/types/inquirer/v8/lib/objects/choices.d.ts
@@ -1,6 +1,6 @@
-import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from '../..';
-import Choice = require('./choice');
-import Separator = require('./separator');
+import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from "../..";
+import Choice = require("./choice");
+import Separator = require("./separator");
 
 /**
  * Represents a valid choice for the {@link Choices `Choices<T>`} class.
@@ -16,7 +16,7 @@ type DistinctChoice<T extends Answers> = AllChoiceMap<T>[keyof AllChoiceMap<T>];
  * @template T
  * The type of the answers.
  */
-type RealChoice<T extends Answers> = Exclude<DistinctChoice<T>, { type: Separator['type'] }>;
+type RealChoice<T extends Answers> = Exclude<DistinctChoice<T>, { type: Separator["type"] }>;
 
 /**
  * Represents a property-name of any choice-type.

--- a/types/inquirer/v8/lib/prompts/base.d.ts
+++ b/types/inquirer/v8/lib/prompts/base.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadLineInterface } from 'readline';
-import { Observable } from 'rxjs';
-import inquirer = require('../..');
-import ScreenManager = require('../utils/screen-manager');
+import { Interface as ReadLineInterface } from "readline";
+import { Observable } from "rxjs";
+import inquirer = require("../..");
+import ScreenManager = require("../utils/screen-manager");
 
 /**
  * The question-options for the {@link Prompt `Prompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/checkbox.d.ts
+++ b/types/inquirer/v8/lib/prompts/checkbox.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadLineInterface } from 'readline';
-import inquirer = require('../..');
-import Paginator = require('../utils/paginator');
-import Prompt = require('./base');
+import { Interface as ReadLineInterface } from "readline";
+import inquirer = require("../..");
+import Paginator = require("../utils/paginator");
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link CheckboxPrompt `CheckboxPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/confirm.d.ts
+++ b/types/inquirer/v8/lib/prompts/confirm.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ConfirmQuestionOptions } from '../..';
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, ConfirmQuestionOptions } from "../..";
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link ConfirmPrompt `ConfirmPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/editor.d.ts
+++ b/types/inquirer/v8/lib/prompts/editor.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Subject, Subscription } from 'rxjs';
-import inquirer = require('../..');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import { Subject, Subscription } from "rxjs";
+import inquirer = require("../..");
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link EditorPrompt `EditorPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/expand.d.ts
+++ b/types/inquirer/v8/lib/prompts/expand.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer = require('../..');
-import Paginator = require('../utils/paginator');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import inquirer = require("../..");
+import Paginator = require("../utils/paginator");
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link ExpandPrompt `ExpandPrompt<TQuestion>`}.
@@ -118,7 +118,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @param choices
      * The choices to validate.
      */
-    protected validateChoices(choices: ExpandPrompt<TQuestion>['opt']['choices']): void;
+    protected validateChoices(choices: ExpandPrompt<TQuestion>["opt"]["choices"]): void;
 
     /**
      * Generates the string-representation of the choices.
@@ -132,7 +132,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @returns
      * The string-representations of the choices.
      */
-    protected generateChoicesString(choices: ExpandPrompt<TQuestion>['opt']['choices'], defaultChoice: any): string;
+    protected generateChoicesString(choices: ExpandPrompt<TQuestion>["opt"]["choices"], defaultChoice: any): string;
 
     /**
      * Renders the choices.
@@ -143,7 +143,7 @@ declare class ExpandPrompt<TQuestion extends Question = Question> extends Prompt
      * @param pointer
      * The value of the choice to select.
      */
-    protected renderChoices(choices: ExpandPrompt<TQuestion>['opt']['choices'], pointer: string): string;
+    protected renderChoices(choices: ExpandPrompt<TQuestion>["opt"]["choices"], pointer: string): string;
 }
 
 export = ExpandPrompt;

--- a/types/inquirer/v8/lib/prompts/input.d.ts
+++ b/types/inquirer/v8/lib/prompts/input.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer = require('../..');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import inquirer = require("../..");
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link InputPrompt `InputPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/list.d.ts
+++ b/types/inquirer/v8/lib/prompts/list.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ListQuestionOptions } from '../..';
-import Paginator = require('../utils/paginator');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, ListQuestionOptions } from "../..";
+import Paginator = require("../utils/paginator");
+import Prompt = require("./base");
 
 /**
  * The question-options for the {@link ListPrompt `ListPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/number.d.ts
+++ b/types/inquirer/v8/lib/prompts/number.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import { Answers, NumberQuestionOptions } from '../..';
-import InputPrompt = require('./input');
+import { Interface as ReadlineInterface } from "readline";
+import { Answers, NumberQuestionOptions } from "../..";
+import InputPrompt = require("./input");
 
 /**
  * The question for the {@link NumberPrompt `NumberPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/password.d.ts
+++ b/types/inquirer/v8/lib/prompts/password.d.ts
@@ -1,6 +1,6 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer = require('../..');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import inquirer = require("../..");
+import Prompt = require("./base");
 
 /**
  * The question for the {@link PasswordPrompt `PasswordPrompt<TQuestion>`}.

--- a/types/inquirer/v8/lib/prompts/rawlist.d.ts
+++ b/types/inquirer/v8/lib/prompts/rawlist.d.ts
@@ -1,7 +1,7 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer = require('../..');
-import Paginator = require('../utils/paginator');
-import Prompt = require('./base');
+import { Interface as ReadlineInterface } from "readline";
+import inquirer = require("../..");
+import Paginator = require("../utils/paginator");
+import Prompt = require("./base");
 
 /**
  * The question for the {@link RawListPrompt `RawListPrompt<TQuestion>`}.
@@ -89,7 +89,7 @@ declare class RawListPrompt<TQuestion extends Question = Question> extends Promp
      * @param type
      * A value indicating whether the up or the down-arrow is being pressed.
      */
-    protected onArrowKey(type: 'up' | 'down'): void;
+    protected onArrowKey(type: "up" | "down"): void;
 
     /**
      * Handles the `success`-event of the prompt.

--- a/types/inquirer/v8/lib/ui/baseUI.d.ts
+++ b/types/inquirer/v8/lib/ui/baseUI.d.ts
@@ -1,5 +1,5 @@
-import { Interface as ReadlineInterface } from 'readline';
-import inquirer = require('../..');
+import { Interface as ReadlineInterface } from "readline";
+import inquirer = require("../..");
 
 /**
  * Represents a ui.

--- a/types/inquirer/v8/lib/ui/bottom-bar.d.ts
+++ b/types/inquirer/v8/lib/ui/bottom-bar.d.ts
@@ -1,3 +1,3 @@
-import { ui } from '../..';
+import { ui } from "../..";
 
 export = ui.BottomBar;

--- a/types/inquirer/v8/lib/ui/prompt.d.ts
+++ b/types/inquirer/v8/lib/ui/prompt.d.ts
@@ -1,3 +1,3 @@
-import { ui } from '../..';
+import { ui } from "../..";
 
 export = ui.Prompt;

--- a/types/inquirer/v8/lib/utils/events.d.ts
+++ b/types/inquirer/v8/lib/utils/events.d.ts
@@ -1,5 +1,5 @@
-import { Interface as ReadlineInterface, Key } from 'readline';
-import { Observable } from 'rxjs';
+import { Interface as ReadlineInterface, Key } from "readline";
+import { Observable } from "rxjs";
 
 /**
  * Provides a description about a key.

--- a/types/inquirer/v8/lib/utils/incrementListIndex.d.ts
+++ b/types/inquirer/v8/lib/utils/incrementListIndex.d.ts
@@ -1,6 +1,6 @@
-import Choices = require('../objects/choices');
+import Choices = require("../objects/choices");
 
-type Direction = 'up' | 'down';
+type Direction = "up" | "down";
 interface Options {
     choices: Choices;
     loop?: boolean;

--- a/types/inquirer/v8/lib/utils/paginator.d.ts
+++ b/types/inquirer/v8/lib/utils/paginator.d.ts
@@ -1,4 +1,4 @@
-import ScreenManager = require('./screen-manager');
+import ScreenManager = require("./screen-manager");
 
 interface PaginatorOptions {
     /**

--- a/types/inquirer/v8/lib/utils/readline.d.ts
+++ b/types/inquirer/v8/lib/utils/readline.d.ts
@@ -1,4 +1,4 @@
-import { Interface as ReadlineInterface } from 'readline';
+import { Interface as ReadlineInterface } from "readline";
 
 /**
  * Moves the cursor to the left.

--- a/types/inquirer/v8/lib/utils/screen-manager.d.ts
+++ b/types/inquirer/v8/lib/utils/screen-manager.d.ts
@@ -1,4 +1,4 @@
-import { Interface as ReadLineInterface } from 'readline';
+import { Interface as ReadLineInterface } from "readline";
 
 /**
  * Provides the functionality to manage the content of a console-screen.

--- a/types/inquirer/v8/lib/utils/utils.d.ts
+++ b/types/inquirer/v8/lib/utils/utils.d.ts
@@ -1,5 +1,5 @@
-import { Observable } from 'rxjs';
-import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from '../..';
+import { Observable } from "rxjs";
+import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from "../..";
 
 /**
  * Represents a property-name of any question-type.

--- a/types/inquirer/v8/test/bottom-bar.ts
+++ b/types/inquirer/v8/test/bottom-bar.ts
@@ -1,9 +1,9 @@
-import { spawn } from 'child_process';
-import BottomBar = require('inquirer/lib/ui/bottom-bar');
+import { spawn } from "child_process";
+import BottomBar = require("inquirer/lib/ui/bottom-bar");
 // tslint:disable-next-line: no-var-requires
-const cmdify = require('cmdify');
+const cmdify = require("cmdify");
 
-const loader = ['/ Installing', '| Installing', '\\ Installing', '- Installing'];
+const loader = ["/ Installing", "| Installing", "\\ Installing", "- Installing"];
 let i = 4;
 const ui = new BottomBar({ bottomBar: loader[i % 4] });
 
@@ -11,9 +11,9 @@ setInterval(() => {
     ui.updateBottomBar(loader[i++ % 4]);
 }, 300);
 
-const cmd = spawn(cmdify('npm'), ['-g', 'install', 'inquirer'], { stdio: 'pipe' });
+const cmd = spawn(cmdify("npm"), ["-g", "install", "inquirer"], { stdio: "pipe" });
 cmd.stdout.pipe(ui.log);
-cmd.on('close', () => {
-    ui.updateBottomBar('Installation done!\n');
+cmd.on("close", () => {
+    ui.updateBottomBar("Installation done!\n");
     process.exit();
 });

--- a/types/inquirer/v8/test/checkbox.ts
+++ b/types/inquirer/v8/test/checkbox.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Checkbox list examples
@@ -6,56 +6,56 @@ import inquirer = require('inquirer');
 inquirer
     .prompt([
         {
-            type: 'checkbox',
-            message: 'Select toppings',
-            name: 'toppings',
+            type: "checkbox",
+            message: "Select toppings",
+            name: "toppings",
             choices: [
-                new inquirer.Separator(' = The Meats = '),
+                new inquirer.Separator(" = The Meats = "),
                 {
-                    name: 'Pepperoni',
+                    name: "Pepperoni",
                 },
                 {
-                    name: 'Ham',
+                    name: "Ham",
                 },
                 {
-                    name: 'Ground Meat',
+                    name: "Ground Meat",
                 },
                 {
-                    name: 'Bacon',
+                    name: "Bacon",
                 },
-                new inquirer.Separator(' = The Cheeses = '),
+                new inquirer.Separator(" = The Cheeses = "),
                 {
-                    name: 'Mozzarella',
+                    name: "Mozzarella",
                     checked: true,
                 },
                 {
-                    name: 'Cheddar',
+                    name: "Cheddar",
                 },
                 {
-                    name: 'Parmesan',
+                    name: "Parmesan",
                 },
-                new inquirer.Separator(' = The usual ='),
+                new inquirer.Separator(" = The usual ="),
                 {
-                    name: 'Mushroom',
-                },
-                {
-                    name: 'Tomato',
-                },
-                new inquirer.Separator(' = The extras = '),
-                {
-                    name: 'Pineapple',
+                    name: "Mushroom",
                 },
                 {
-                    name: 'Olives',
-                    disabled: 'out of stock',
+                    name: "Tomato",
+                },
+                new inquirer.Separator(" = The extras = "),
+                {
+                    name: "Pineapple",
                 },
                 {
-                    name: 'Extra cheese',
+                    name: "Olives",
+                    disabled: "out of stock",
+                },
+                {
+                    name: "Extra cheese",
                 },
             ],
             validate(answer) {
                 if (answer.length < 1) {
-                    return 'You must choose at least one topping.';
+                    return "You must choose at least one topping.";
                 }
 
                 return true;
@@ -63,5 +63,5 @@ inquirer
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/v8/test/editor.ts
+++ b/types/inquirer/v8/test/editor.ts
@@ -1,16 +1,16 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Editor prompt example
  */
 const questions: inquirer.QuestionCollection = [
     {
-        type: 'editor',
-        name: 'bio',
-        message: 'Please write a short bio of at least 3 lines.',
+        type: "editor",
+        name: "bio",
+        message: "Please write a short bio of at least 3 lines.",
         validate(text) {
-            if (text.split('\n').length < 3) {
-                return 'Must be at least 3 lines.';
+            if (text.split("\n").length < 3) {
+                return "Must be at least 3 lines.";
             }
             return true;
         },
@@ -18,5 +18,5 @@ const questions: inquirer.QuestionCollection = [
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/v8/test/expand.ts
+++ b/types/inquirer/v8/test/expand.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Expand list examples
@@ -6,34 +6,34 @@ import inquirer = require('inquirer');
 inquirer
     .prompt([
         {
-            type: 'expand',
-            message: 'Conflict on `file.js`: ',
-            name: 'overwrite',
+            type: "expand",
+            message: "Conflict on `file.js`: ",
+            name: "overwrite",
             choices: [
                 {
-                    key: 'y',
-                    name: 'Overwrite',
-                    value: 'overwrite',
+                    key: "y",
+                    name: "Overwrite",
+                    value: "overwrite",
                 },
                 {
-                    key: 'a',
-                    name: 'Overwrite this one and all next',
-                    value: 'overwrite_all',
+                    key: "a",
+                    name: "Overwrite this one and all next",
+                    value: "overwrite_all",
                 },
                 {
-                    key: 'd',
-                    name: 'Show diff',
-                    value: 'diff',
+                    key: "d",
+                    name: "Show diff",
+                    value: "diff",
                 },
                 new inquirer.Separator(),
                 {
-                    key: 'x',
-                    name: 'Abort',
-                    value: 'abort',
+                    key: "x",
+                    name: "Abort",
+                    value: "abort",
                 },
             ],
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/v8/test/hierarchical.ts
+++ b/types/inquirer/v8/test/hierarchical.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Represents answers provided by the user.
@@ -12,34 +12,34 @@ interface RPGAnswers {
     /**
      * The direction chosen by the user.
      */
-    direction: 'Forward' | 'Right' | 'Left' | 'Back';
+    direction: "Forward" | "Right" | "Left" | "Back";
 }
 
 /**
  * Heirarchical conversation example
  */
 const directionsPrompt: inquirer.DistinctQuestion<RPGAnswers> = {
-    type: 'list',
-    name: 'direction',
-    message: 'Which direction would you like to go?',
-    choices: ['Forward', 'Right', 'Left', 'Back'],
+    type: "list",
+    name: "direction",
+    message: "Which direction would you like to go?",
+    choices: ["Forward", "Right", "Left", "Back"],
 };
 
 function main() {
-    console.log('You find youself in a small room, there is a door in front of you.');
+    console.log("You find youself in a small room, there is a door in front of you.");
     exitHouse();
 }
 
 function exitHouse() {
     inquirer.prompt(directionsPrompt).then(answers => {
-        if (answers.direction === 'Forward') {
-            console.log('You find yourself in a forest');
+        if (answers.direction === "Forward") {
+            console.log("You find yourself in a forest");
             console.log(
-                'There is a wolf in front of you; a friendly looking dwarf to the right and an impasse to the left.',
+                "There is a wolf in front of you; a friendly looking dwarf to the right and an impasse to the left.",
             );
             encounter1();
         } else {
-            console.log('You cannot go that way. Try again');
+            console.log("You cannot go that way. Try again");
             exitHouse();
         }
     });
@@ -48,16 +48,16 @@ function exitHouse() {
 function encounter1() {
     inquirer.prompt(directionsPrompt).then(answers => {
         const direction = answers.direction;
-        if (direction === 'Forward') {
-            console.log('You attempt to fight the wolf');
-            console.log('Theres a stick and some stones lying around you could use as a weapon');
+        if (direction === "Forward") {
+            console.log("You attempt to fight the wolf");
+            console.log("Theres a stick and some stones lying around you could use as a weapon");
             encounter2b();
-        } else if (direction === 'Right') {
-            console.log('You befriend the dwarf');
-            console.log('He helps you kill the wolf. You can now move forward');
+        } else if (direction === "Right") {
+            console.log("You befriend the dwarf");
+            console.log("He helps you kill the wolf. You can now move forward");
             encounter2a();
         } else {
-            console.log('You cannot go that way');
+            console.log("You cannot go that way");
             encounter1();
         }
     });
@@ -66,16 +66,16 @@ function encounter1() {
 function encounter2a() {
     inquirer.prompt(directionsPrompt).then(answers => {
         const direction = answers.direction;
-        if (direction === 'Forward') {
-            let output = 'You find a painted wooden sign that says:';
-            output += ' \n';
-            output += ' ____  _____  ____  _____ \n';
-            output += '(_  _)(  _  )(  _ \\(  _  ) \n';
-            output += '  )(   )(_)(  )(_) ))(_)(  \n';
-            output += ' (__) (_____)(____/(_____) \n';
+        if (direction === "Forward") {
+            let output = "You find a painted wooden sign that says:";
+            output += " \n";
+            output += " ____  _____  ____  _____ \n";
+            output += "(_  _)(  _  )(  _ \\(  _  ) \n";
+            output += "  )(   )(_)(  )(_) ))(_)(  \n";
+            output += " (__) (_____)(____/(_____) \n";
             console.log(output);
         } else {
-            console.log('You cannot go that way');
+            console.log("You cannot go that way");
             encounter2a();
         }
     });
@@ -84,13 +84,13 @@ function encounter2a() {
 function encounter2b() {
     inquirer
         .prompt<RPGAnswers>({
-            type: 'list',
-            name: 'weapon',
-            message: 'Pick one',
-            choices: ['Use the stick', 'Grab a large rock', 'Try and make a run for it', 'Attack the wolf unarmed'],
+            type: "list",
+            name: "weapon",
+            message: "Pick one",
+            choices: ["Use the stick", "Grab a large rock", "Try and make a run for it", "Attack the wolf unarmed"],
         })
         .then(() => {
-            console.log('The wolf mauls you. You die. The end.');
+            console.log("The wolf mauls you. You die. The end.");
         });
 }
 

--- a/types/inquirer/v8/test/input.ts
+++ b/types/inquirer/v8/test/input.ts
@@ -1,39 +1,39 @@
-import inquirer = require('inquirer');
-import chalkPipe = require('chalk-pipe');
+import inquirer = require("inquirer");
+import chalkPipe = require("chalk-pipe");
 
 /**
  * Input prompt example
  */
 const questions: inquirer.QuestionCollection = [
     {
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     },
     {
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     },
     {
-        type: 'input',
-        name: 'fav_color',
+        type: "input",
+        name: "fav_color",
         message: "What's your favorite color",
         transformer(color, answers, flags) {
             const text = chalkPipe(color)(color);
             if (flags.isFinal) {
-                return text + '!';
+                return text + "!";
             }
 
             return text;
         },
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -43,11 +43,11 @@ const questions: inquirer.QuestionCollection = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/v8/test/list.ts
+++ b/types/inquirer/v8/test/list.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * List prompt example
@@ -6,31 +6,31 @@ import inquirer = require('inquirer');
 inquirer
     .prompt([
         {
-            type: 'list',
-            name: 'theme',
-            message: 'What do you want to do?',
+            type: "list",
+            name: "theme",
+            message: "What do you want to do?",
             choices: [
-                'Order a pizza',
-                'Make a reservation',
+                "Order a pizza",
+                "Make a reservation",
                 new inquirer.Separator(),
-                'Ask for opening hours',
+                "Ask for opening hours",
                 {
-                    name: 'Contact support',
-                    disabled: 'Unavailable at this time',
+                    name: "Contact support",
+                    disabled: "Unavailable at this time",
                 },
-                'Talk to the receptionist',
+                "Talk to the receptionist",
             ],
         },
         {
-            type: 'list',
-            name: 'size',
-            message: 'What size do you need?',
-            choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+            type: "list",
+            name: "size",
+            message: "What size do you need?",
+            choices: ["Jumbo", "Large", "Standard", "Medium", "Small", "Micro"],
             filter(val) {
                 return val.toLowerCase();
             },
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/v8/test/long-list.ts
+++ b/types/inquirer/v8/test/long-list.ts
@@ -1,32 +1,32 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Paginated list
  */
 const choices: inquirer.ChoiceCollection = new Array(26).fill(undefined).map((x, y) => String.fromCharCode(y + 65));
-choices.push('Multiline option \n  super cool feature');
+choices.push("Multiline option \n  super cool feature");
 choices.push({
     name:
-        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.',
-    value: 'foo',
-    short: 'The long option',
+        "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",
+    value: "foo",
+    short: "The long option",
 });
 
 inquirer
     .prompt([
         {
-            type: 'list',
-            name: 'letter',
+            type: "list",
+            name: "letter",
             message: "What's your favorite letter?",
             choices,
         },
         {
-            type: 'checkbox',
-            name: 'name',
-            message: 'Select the letter contained in your name:',
+            type: "checkbox",
+            name: "name",
+            message: "Select the letter contained in your name:",
             choices,
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/v8/test/nested-call.ts
+++ b/types/inquirer/v8/test/nested-call.ts
@@ -1,20 +1,20 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Nested Inquirer call
  */
 inquirer
     .prompt({
-        type: 'list',
-        name: 'chocolate',
+        type: "list",
+        name: "chocolate",
         message: "What's your favorite chocolate?",
-        choices: ['Mars', 'Oh Henry', 'Hershey'],
+        choices: ["Mars", "Oh Henry", "Hershey"],
     })
     .then(() => {
         inquirer.prompt({
-            type: 'list',
-            name: 'beverage',
-            message: 'And your favorite beverage?',
-            choices: ['Pepsi', 'Coke', '7up', 'Mountain Dew', 'Red Bull'],
+            type: "list",
+            name: "beverage",
+            message: "And your favorite beverage?",
+            choices: ["Pepsi", "Coke", "7up", "Mountain Dew", "Red Bull"],
         });
     });

--- a/types/inquirer/v8/test/password.ts
+++ b/types/inquirer/v8/test/password.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Password prompt example
@@ -8,23 +8,23 @@ const requireLetterAndNumber: inquirer.Validator = value => {
         return true;
     }
 
-    return 'Password need to have at least a letter and a number';
+    return "Password need to have at least a letter and a number";
 };
 
 inquirer
     .prompt([
         {
-            type: 'password',
-            message: 'Enter a password',
-            name: 'password1',
+            type: "password",
+            message: "Enter a password",
+            name: "password1",
             validate: requireLetterAndNumber,
         },
         {
-            type: 'password',
-            message: 'Enter a masked password',
-            name: 'password2',
-            mask: '*',
+            type: "password",
+            message: "Enter a masked password",
+            name: "password2",
+            mask: "*",
             validate: requireLetterAndNumber,
         },
     ])
-    .then(answers => console.log(JSON.stringify(answers, null, '  ')));
+    .then(answers => console.log(JSON.stringify(answers, null, "  ")));

--- a/types/inquirer/v8/test/pizza.ts
+++ b/types/inquirer/v8/test/pizza.ts
@@ -1,21 +1,21 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Pizza delivery prompt example
  * run example by writing `node pizza.js` in your console
  */
-console.log('Hi, welcome to Node Pizza');
+console.log("Hi, welcome to Node Pizza");
 
 const questions: inquirer.DistinctQuestion[] = [
     {
-        type: 'confirm',
-        name: 'toBeDelivered',
-        message: 'Is this for delivery?',
+        type: "confirm",
+        name: "toBeDelivered",
+        message: "Is this for delivery?",
         default: false,
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number?",
         validate(value) {
             const pass = value.match(
@@ -25,74 +25,74 @@ const questions: inquirer.DistinctQuestion[] = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
     {
-        type: 'list',
-        name: 'size',
-        message: 'What size do you need?',
-        choices: ['Large', 'Medium', 'Small'],
+        type: "list",
+        name: "size",
+        message: "What size do you need?",
+        choices: ["Large", "Medium", "Small"],
         filter(val) {
             return val.toLowerCase();
         },
     },
     {
-        type: 'input',
-        name: 'quantity',
-        message: 'How many do you need?',
+        type: "input",
+        name: "quantity",
+        message: "How many do you need?",
         validate(value) {
             const valid = !isNaN(parseFloat(value));
-            return valid || 'Please enter a number';
+            return valid || "Please enter a number";
         },
         filter: Number,
     },
     {
-        type: 'expand',
-        name: 'toppings',
-        message: 'What about the toppings?',
+        type: "expand",
+        name: "toppings",
+        message: "What about the toppings?",
         choices: [
             {
-                key: 'p',
-                name: 'Pepperoni and cheese',
-                value: 'PepperoniCheese',
+                key: "p",
+                name: "Pepperoni and cheese",
+                value: "PepperoniCheese",
             },
             {
-                key: 'a',
-                name: 'All dressed',
-                value: 'alldressed',
+                key: "a",
+                name: "All dressed",
+                value: "alldressed",
             },
             {
-                key: 'w',
-                name: 'Hawaiian',
-                value: 'hawaiian',
+                key: "w",
+                name: "Hawaiian",
+                value: "hawaiian",
             },
         ],
     },
     {
-        type: 'rawlist',
-        name: 'beverage',
-        message: 'You also get a free 2L beverage',
-        choices: ['Pepsi', '7up', 'Coke'],
+        type: "rawlist",
+        name: "beverage",
+        message: "You also get a free 2L beverage",
+        choices: ["Pepsi", "7up", "Coke"],
     },
     {
-        type: 'input',
-        name: 'comments',
-        message: 'Any comments on your purchase experience?',
-        default: 'Nope, all good!',
+        type: "input",
+        name: "comments",
+        message: "Any comments on your purchase experience?",
+        default: "Nope, all good!",
     },
     {
-        type: 'list',
-        name: 'prize',
-        message: 'For leaving a comment, you get a freebie',
-        choices: ['cake', 'fries'],
+        type: "list",
+        name: "prize",
+        message: "For leaving a comment, you get a freebie",
+        choices: ["cake", "fries"],
         when(answers) {
-            return answers.comments !== 'Nope, all good!';
+            return answers.comments !== "Nope, all good!";
         },
     },
 ];
 
 inquirer.prompt(questions).then(answers => {
-    console.log('\nOrder receipt:');
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log("\nOrder receipt:");
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/v8/test/rawlist.ts
+++ b/types/inquirer/v8/test/rawlist.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Raw List prompt example
@@ -6,27 +6,27 @@ import inquirer = require('inquirer');
 inquirer
     .prompt([
         {
-            type: 'rawlist',
-            name: 'theme',
-            message: 'What do you want to do?',
+            type: "rawlist",
+            name: "theme",
+            message: "What do you want to do?",
             choices: [
-                'Order a pizza',
-                'Make a reservation',
+                "Order a pizza",
+                "Make a reservation",
                 new inquirer.Separator(),
-                'Ask opening hours',
-                'Talk to the receptionist',
+                "Ask opening hours",
+                "Talk to the receptionist",
             ],
         },
         {
-            type: 'rawlist',
-            name: 'size',
-            message: 'What size do you need',
-            choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+            type: "rawlist",
+            name: "size",
+            message: "What size do you need",
+            choices: ["Jumbo", "Large", "Standard", "Medium", "Small", "Micro"],
             filter(val) {
                 return val.toLowerCase();
             },
         },
     ])
     .then(answers => {
-        console.log(JSON.stringify(answers, null, '  '));
+        console.log(JSON.stringify(answers, null, "  "));
     });

--- a/types/inquirer/v8/test/recursive.ts
+++ b/types/inquirer/v8/test/recursive.ts
@@ -1,4 +1,4 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * Recursive prompt example
@@ -8,14 +8,14 @@ const output: any[] = [];
 
 const questions: inquirer.QuestionCollection = [
     {
-        type: 'input',
-        name: 'tvShow',
+        type: "input",
+        name: "tvShow",
         message: "What's your favorite TV show?",
     },
     {
-        type: 'confirm',
-        name: 'askAgain',
-        message: 'Want to enter another TV show favorite (just hit enter for YES)?',
+        type: "confirm",
+        name: "askAgain",
+        message: "Want to enter another TV show favorite (just hit enter for YES)?",
         default: true,
     },
 ];
@@ -26,7 +26,7 @@ function ask() {
         if (answers.askAgain) {
             ask();
         } else {
-            console.log('Your favorite TV Shows:', output.join(', '));
+            console.log("Your favorite TV Shows:", output.join(", "));
         }
     });
 }

--- a/types/inquirer/v8/test/rx-observable-array.ts
+++ b/types/inquirer/v8/test/rx-observable-array.ts
@@ -1,23 +1,23 @@
-import inquirer = require('inquirer');
-import { from } from 'rxjs';
+import inquirer = require("inquirer");
+import { from } from "rxjs";
 
 const questions: inquirer.DistinctQuestion[] = [
     {
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     },
     {
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     },
     {
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -27,7 +27,7 @@ const questions: inquirer.DistinctQuestion[] = [
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     },
 ];
@@ -36,12 +36,12 @@ const observable = from(questions);
 
 inquirer.prompt(observable).ui.process.subscribe(
     ans => {
-        console.log('Answer is: ', ans);
+        console.log("Answer is: ", ans);
     },
     err => {
-        console.log('Error: ', err);
+        console.log("Error: ", err);
     },
     () => {
-        console.log('Completed');
+        console.log("Completed");
     },
 );

--- a/types/inquirer/v8/test/rx-observable-create.ts
+++ b/types/inquirer/v8/test/rx-observable-create.ts
@@ -1,25 +1,25 @@
-import inquirer = require('inquirer');
-import { Observable, Observer } from 'rxjs';
+import inquirer = require("inquirer");
+import { Observable, Observer } from "rxjs";
 
 const observe = Observable.create((obs: Observer<inquirer.DistinctQuestion>) => {
     obs.next({
-        type: 'input',
-        name: 'first_name',
+        type: "input",
+        name: "first_name",
         message: "What's your first name",
     });
 
     obs.next({
-        type: 'input',
-        name: 'last_name',
+        type: "input",
+        name: "last_name",
         message: "What's your last name",
         default() {
-            return 'Doe';
+            return "Doe";
         },
     });
 
     obs.next({
-        type: 'input',
-        name: 'phone',
+        type: "input",
+        name: "phone",
         message: "What's your phone number",
         validate(value) {
             const pass = value.match(
@@ -29,12 +29,12 @@ const observe = Observable.create((obs: Observer<inquirer.DistinctQuestion>) => 
                 return true;
             }
 
-            return 'Please enter a valid phone number';
+            return "Please enter a valid phone number";
         },
     });
     obs.complete();
 });
 
 inquirer.prompt(observe).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });

--- a/types/inquirer/v8/test/spawn.ts
+++ b/types/inquirer/v8/test/spawn.ts
@@ -1,6 +1,6 @@
-import { spawn } from 'child_process';
+import { spawn } from "child_process";
 
-spawn('node', ['input.js'], {
+spawn("node", ["input.js"], {
     cwd: __dirname,
-    stdio: 'inherit',
+    stdio: "inherit",
 });

--- a/types/inquirer/v8/test/when.ts
+++ b/types/inquirer/v8/test/when.ts
@@ -1,35 +1,35 @@
-import inquirer = require('inquirer');
+import inquirer = require("inquirer");
 
 /**
  * When example
  */
 const questions: inquirer.QuestionCollection = [
     {
-        type: 'confirm',
-        name: 'bacon',
-        message: 'Do you like bacon?',
+        type: "confirm",
+        name: "bacon",
+        message: "Do you like bacon?",
     },
     {
-        type: 'input',
-        name: 'favorite',
-        message: 'Bacon lover, what is your favorite type of bacon?',
+        type: "input",
+        name: "favorite",
+        message: "Bacon lover, what is your favorite type of bacon?",
         when(answers) {
             return answers.bacon;
         },
     },
     {
-        type: 'confirm',
-        name: 'pizza',
-        message: 'Ok... Do you like pizza?',
+        type: "confirm",
+        name: "pizza",
+        message: "Ok... Do you like pizza?",
         when(answers) {
-            return !likesFood('bacon')(answers);
+            return !likesFood("bacon")(answers);
         },
     },
     {
-        type: 'input',
-        name: 'favorite',
-        message: 'Whew! What is your favorite type of pizza?',
-        when: likesFood('pizza'),
+        type: "input",
+        name: "favorite",
+        message: "Whew! What is your favorite type of pizza?",
+        when: likesFood("pizza"),
     },
 ];
 
@@ -40,5 +40,5 @@ function likesFood(aFood: string) {
 }
 
 inquirer.prompt(questions).then(answers => {
-    console.log(JSON.stringify(answers, null, '  '));
+    console.log(JSON.stringify(answers, null, "  "));
 });


### PR DESCRIPTION
After #66235, this repo is now formatted with dprint. This PR removes the temporary exception for a few packages. This required a few `// dprint-ignore` to deal with different TS versions having different error spans.