### PR TITLE
[react-map-gl] enable formatting

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -36,8 +36,7 @@
     "./types/i18next-ko",
     "./types/i18next-node-fs-backend",
     "./types/i18next-sprintf-postprocessor",
-    "./types/react-blessed",
-    "./types/react-map-gl"
+    "./types/react-blessed"
   ],
   // NOTE: if extending this list, also update settings.template.json.
   "plugins": [

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -13,12 +13,12 @@
 
 /// <reference lib='dom' />
 
-import * as React from 'react';
-import * as MapboxGL from 'mapbox-gl';
-import * as GeoJSON from 'geojson';
-import WebMercatorViewport from 'viewport-mercator-project';
+import * as GeoJSON from "geojson";
+import * as MapboxGL from "mapbox-gl";
+import * as React from "react";
+import WebMercatorViewport from "viewport-mercator-project";
 
-export { WebMercatorViewport } from 'viewport-mercator-project';
+export { WebMercatorViewport } from "viewport-mercator-project";
 
 export interface ViewState {
     latitude: number;
@@ -140,7 +140,7 @@ export interface ViewportProps {
     minZoom: number;
     maxPitch: number;
     minPitch: number;
-    transitionDuration?: number | 'auto' | undefined;
+    transitionDuration?: number | "auto" | undefined;
     transitionInterpolator?: TransitionInterpolator | undefined;
     transitionInterruption?: TRANSITION_EVENTS | undefined;
     transitionEasing?: EasingFunction | undefined;
@@ -272,7 +272,7 @@ export interface InteractiveMapProps extends StaticMapProps {
     onViewStateChange?: ContextViewStateChangeHandler | undefined;
     onViewportChange?: ContextViewportChangeHandler | undefined;
     onInteractionStateChange?: ((state: ExtraState) => void) | undefined;
-    transitionDuration?: number | 'auto' | undefined;
+    transitionDuration?: number | "auto" | undefined;
     transitionInterpolator?: TransitionInterpolator | undefined;
     transitionInterruption?: TRANSITION_EVENTS | undefined;
     transitionEasing?: EasingFunction | undefined;
@@ -409,7 +409,7 @@ export class GeolocateControl extends BaseControl<GeolocateControlProps, HTMLDiv
 
 export interface ScaleControlProps extends BaseControlProps {
     maxWidth?: number | undefined;
-    unit?: 'imperial' | 'metric' | 'nautical' | undefined;
+    unit?: "imperial" | "metric" | "nautical" | undefined;
 }
 
 export class ScaleControl extends BaseControl<ScaleControlProps, HTMLDivElement> {}
@@ -479,11 +479,11 @@ export interface SourceProps {
     tiles?: string[] | undefined;
     tileSize?: number | undefined;
     bounds?: number[] | undefined;
-    scheme?: 'xyz' | 'tms' | undefined;
+    scheme?: "xyz" | "tms" | undefined;
     minzoom?: number | undefined;
     maxzoom?: number | undefined;
     attribution?: string | undefined;
-    encoding?: 'terrarium' | 'mapbox' | undefined;
+    encoding?: "terrarium" | "mapbox" | undefined;
     data?: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | string | undefined;
     buffer?: number | undefined;
     tolerance?: number | undefined;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -1,5 +1,5 @@
-import * as MapboxGL from 'mapbox-gl';
-import * as React from 'react';
+import * as MapboxGL from "mapbox-gl";
+import * as React from "react";
 
 import {
     CanvasOverlay,
@@ -13,23 +13,23 @@ import {
     LinearInterpolator,
     Marker,
     Popup,
-    SVGOverlay,
-    SVGRedrawOptions,
     ScaleControl,
     Source,
     StaticMap,
+    SVGOverlay,
+    SVGRedrawOptions,
     ViewportProps,
-} from 'react-map-gl';
+} from "react-map-gl";
 
-import { FeatureCollection } from 'geojson';
+import { FeatureCollection } from "geojson";
 
 interface State {
     viewport: ViewportProps;
 }
 
 const geojson: FeatureCollection = {
-    type: 'FeatureCollection',
-    features: [{ type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [-122.4, 37.8] } }],
+    type: "FeatureCollection",
+    features: [{ type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [-122.4, 37.8] } }],
 };
 
 class MyMap extends React.Component<{}, State> {
@@ -72,11 +72,11 @@ class MyMap extends React.Component<{}, State> {
                         event.preventDefault();
                     }}
                 >
-                    <FullscreenControl className="test-class" container={document.querySelector('body')} />
+                    <FullscreenControl className="test-class" container={document.querySelector("body")} />
                     <GeolocateControl
                         auto={false}
                         className="test-class"
-                        style={{ marginTop: '8px' }}
+                        style={{ marginTop: "8px" }}
                         onGeolocate={options => {
                             console.log(options.enableHighAccuracy);
                         }}
@@ -114,7 +114,7 @@ class MyMap extends React.Component<{}, State> {
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         style={{
-                            border: '2px solid black',
+                            border: "2px solid black",
                         }}
                         captureScroll={true}
                         captureDrag={true}
@@ -126,10 +126,10 @@ class MyMap extends React.Component<{}, State> {
                         <Layer
                             type="point"
                             paint={{
-                                'circle-radius': 10,
-                                'circle-color': '#007cbf',
+                                "circle-radius": 10,
+                                "circle-color": "#007cbf",
                             }}
-                        ></Layer>
+                        />
                     </Source>
                     <Source
                         id="raster-tiles-source"
@@ -145,7 +145,7 @@ class MyMap extends React.Component<{}, State> {
                             paint={{}}
                             minzoom={0}
                             maxzoom={22}
-                        ></Layer>
+                        />
                     </Source>
                     <Marker
                         latitude={0}
@@ -191,8 +191,8 @@ class MyMap extends React.Component<{}, State> {
                         this.setState(prevState => ({
                             viewport: {
                                 ...prevState.viewport,
-                                width: '100vw',
-                                height: '100vh',
+                                width: "100vw",
+                                height: "100vh",
                             },
                         }));
                     }}
@@ -209,12 +209,12 @@ class MyMap extends React.Component<{}, State> {
         }
         this.map = el;
         this.mapboxMap = el.getMap();
-    }
+    };
 
     private readonly setRefStatic = (el: StaticMap | null) => {
         if (el === null) {
             return;
         }
         this.mapboxMap = el.getMap();
-    }
+    };
 }


### PR DESCRIPTION
After #66235, this repo is now formatted with dprint. This PR removes the temporary exception for `react-map-gl`. This exposed a bug in the tests for 5.3; `Layer` is self-closing and should not have children.

Though, #66961 just removes this package.