### PR TITLE
Fix git add when used on types dirs that look like ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ pnpm-debug.log
 
 # Output of 'npm pack'
 *.tgz
+
+# Package names containing dots may match any of the above.
+# Just allow any directory within the types directory directly.
+!/types/*/


### PR DESCRIPTION
Right now, if a package name matches one of the gitignored names, git will be unhappy when working with it. For example, `woosmap.map` matches the ignored pattern `*.map`, so git will skip adding files when this package is modified. I'm noticing this in an upcoming formatting change.

We know that any directory within the types directory is a types package; we should be able to just allow any subdirectory within `types` unconditionally.

A stronger version of this PR would instead say "ignore these extensions, but allow them when they're dirs", but that unfortunately is hard/impossible to achieve because while you can write `*.map,!*.map/`, that will then un-ignore all children of `*.map/` too.