### PR TITLE
testing-library__cypress: move cypress to peerDependencies

### DIFF
--- a/types/testing-library__cypress/package.json
+++ b/types/testing-library__cypress/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "dependencies": {
         "@testing-library/dom": "^7.11.0",
+    },
+    "peerDependencies": {
         "cypress": "*"
-    }
+    }    
 }

--- a/types/testing-library__cypress/package.json
+++ b/types/testing-library__cypress/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@testing-library/dom": "^7.11.0",
+        "@testing-library/dom": "^7.11.0"
     },
     "peerDependencies": {
         "cypress": "*"


### PR DESCRIPTION
the way it's listed now leads to duplicate install 