### PR TITLE
Don't format and commit on forks

### DIFF
--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   dprint-fmt:
     runs-on: ubuntu-latest
+    if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
I missed this in review. We don't want to run this on forks. Thankfully, the lack of a secret meant that this was just failing for everyone.