### PR TITLE
Exempt recurly__recurly-js from formatting enforcement

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -26,6 +26,7 @@
         "./types/openui5",
         "./types/p5",
         "./types/react-native",
+        "./types/recurly__recurly-js",
         "./types/sawtooth-sdk",
         "./types/three",
         "./types/webextension-polyfill",


### PR DESCRIPTION
See #67004; we missed this package as being generated.