### PR TITLE
[postcss-page-break] Add types for postcss-page-break

### DIFF
--- a/types/postcss-page-break/index.d.ts
+++ b/types/postcss-page-break/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import { PluginCreator } from "postcss";
 
-declare const pageBreak: PluginCreator<never>;
+declare const pageBreak: PluginCreator<{}>;
 
 export = pageBreak;

--- a/types/postcss-page-break/index.d.ts
+++ b/types/postcss-page-break/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for postcss-page-break 3.0
+// Project: https://github.com/shrpne/postcss-page-break#readme
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { PluginCreator } from "postcss";
+
+declare const pageBreak: PluginCreator<never>;
+
+export = pageBreak;

--- a/types/postcss-page-break/package.json
+++ b/types/postcss-page-break/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.1.0"
+    }
+}

--- a/types/postcss-page-break/postcss-page-break-tests.ts
+++ b/types/postcss-page-break/postcss-page-break-tests.ts
@@ -1,0 +1,5 @@
+import postcss = require("postcss");
+import pageBreak = require("postcss-page-break");
+
+postcss([pageBreak]);
+postcss([pageBreak()]);

--- a/types/postcss-page-break/tsconfig.json
+++ b/types/postcss-page-break/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-page-break-tests.ts"]
+}

--- a/types/postcss-page-break/tslint.json
+++ b/types/postcss-page-break/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package postcss-page-break (<https://www.npmjs.com/package/postcss-page-break>).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
