### PR TITLE
[@types/react-date-range] make `createStaticRanges` `isSelected` parameter optional

### DIFF
--- a/types/react-date-range/_util.d.ts
+++ b/types/react-date-range/_util.d.ts
@@ -1,0 +1,1 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>

--- a/types/react-date-range/_util.d.ts
+++ b/types/react-date-range/_util.d.ts
@@ -1,1 +1,1 @@
-export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -324,7 +324,7 @@ export class DefinedRange extends React.Component<DefinedRangeProps> {}
 export const defaultStaticRanges: StaticRange[];
 export const defaultInputRanges: InputRange[];
 
-export function createStaticRanges(ranges: Optional<StaticRange, "isSelected">[]): StaticRange[];
+export function createStaticRanges(ranges: Array<Optional<StaticRange, "isSelected">>): StaticRange[];
 
 // =============================================================================
 // DateRangePicker Component

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -6,9 +6,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Optional } from "./_util"
 import { Locale } from "date-fns";
 import * as React from "react";
+import { Optional } from "./_util";
 
 // =============================================================================
 // Helper Types/Interfaces

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -323,7 +323,8 @@ export class DefinedRange extends React.Component<DefinedRangeProps> {}
 export const defaultStaticRanges: StaticRange[];
 export const defaultInputRanges: InputRange[];
 
-export function createStaticRanges(ranges: StaticRange[]): StaticRange[];
+type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+export function createStaticRanges(ranges: Optional<StaticRange, "isSelected">[]): StaticRange[];
 
 // =============================================================================
 // DateRangePicker Component

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -6,6 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
+import { Optional } from "./_util"
 import { Locale } from "date-fns";
 import * as React from "react";
 
@@ -323,7 +324,6 @@ export class DefinedRange extends React.Component<DefinedRangeProps> {}
 export const defaultStaticRanges: StaticRange[];
 export const defaultInputRanges: InputRange[];
 
-type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export function createStaticRanges(ranges: Optional<StaticRange, "isSelected">[]): StaticRange[];
 
 // =============================================================================

--- a/types/react-date-range/react-date-range-tests.tsx
+++ b/types/react-date-range/react-date-range-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {
-    createStaticRanges,
     Calendar,
+    createStaticRanges,
     DateRange,
     DateRangePicker,
     defaultInputRanges,
@@ -166,9 +166,8 @@ const createdStaticRanges = createStaticRanges([
     {
         range: () => ({ startDate: new Date("2021-10-01"), endDate: new Date("2021-10-31") }),
         label: "Example created static range",
-    }
+    },
 ]);
-
 
 const inputRange: InputRange = {
     range: () => ({ startDate: new Date("2021-10-01"), endDate: new Date("2021-10-31") }),

--- a/types/react-date-range/react-date-range-tests.tsx
+++ b/types/react-date-range/react-date-range-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+    createStaticRanges,
     Calendar,
     DateRange,
     DateRangePicker,
@@ -161,6 +162,14 @@ const staticRange: StaticRange = {
     hasCustomRendering: true,
 };
 
+const createdStaticRanges = createsStaticRanges([
+    {
+        range: () => ({ startDate: new Date("2021-10-01"), endDate: new Date("2021-10-31") }),
+        label: "Example static range",
+    }
+]);
+
+
 const inputRange: InputRange = {
     range: () => ({ startDate: new Date("2021-10-01"), endDate: new Date("2021-10-31") }),
     getCurrentValue: range => range?.startDate?.getTime() || "",
@@ -190,7 +199,7 @@ class ReactDefinedDateRange extends React.Component<any, any> {
                     rangeColors={["red", "blue", "yellow"]}
                     ranges={[range]}
                     renderStaticRangeLabel={staticRange => <span>{staticRange?.label}</span>}
-                    staticRanges={[staticRange, defaultStaticRanges[0]]}
+                    staticRanges={[staticRange, defaultStaticRanges[0], ...createdStaticRanges]}
                 />
             </div>
         );
@@ -268,7 +277,7 @@ class ReactDateRangePicker extends React.Component<any, any> {
                     headerContent={<header>Header</header>}
                     inputRanges={[inputRange, defaultInputRanges[0]]}
                     renderStaticRangeLabel={staticRange => <span>{staticRange?.label}</span>}
-                    staticRanges={[staticRange, defaultStaticRanges[0]]}
+                    staticRanges={[staticRange, defaultStaticRanges[0], ...createdStaticRanges]}
                 />
             </div>
         );

--- a/types/react-date-range/react-date-range-tests.tsx
+++ b/types/react-date-range/react-date-range-tests.tsx
@@ -162,10 +162,10 @@ const staticRange: StaticRange = {
     hasCustomRendering: true,
 };
 
-const createdStaticRanges = createsStaticRanges([
+const createdStaticRanges = createStaticRanges([
     {
         range: () => ({ startDate: new Date("2021-10-01"), endDate: new Date("2021-10-31") }),
-        label: "Example static range",
+        label: "Example created static range",
     }
 ]);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/hypeserver/react-date-range/blob/master/src/defaultRanges.js#L29-L42>

----
The `createStaticRanges` function attaches an `isSelected` value automatically. So passing it is not needed. Have verified this by directly editing the file in `node_modules`.
