### PR TITLE
[sharedb] Add `doc.del()` overloads

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -178,7 +178,8 @@ export class Doc<T = any> extends TypedEmitter<DocEventMap<T>> {
     create(data: any, type?: string, callback?: Callback): void;
     create(data: any, type?: string, options?: ShareDBSourceOptions, callback?: Callback): void;
     submitOp(data: any, options?: ShareDBSourceOptions, callback?: Callback): void;
-    del(options: ShareDBSourceOptions, callback?: (err: Error) => void): void;
+    del(callback?: Callback): void;
+    del(options?: ShareDBSourceOptions, callback?: Callback): void;
     whenNothingPending(callback: () => void): void;
     hasPending(): boolean;
     hasWritePending(): boolean;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -418,6 +418,12 @@ function startClient(callback) {
     doc.on("error", (error: ShareDB.Error) => {});
     doc.on("destroy", () => {});
 
+    doc.del();
+    doc.del({source: true});
+    doc.del((error) => {
+        console.log(error);
+    });
+
     connection.fetchSnapshot("examples", "foo", 123, (error, snapshot: ShareDBClient.Snapshot) => {
         if (error) throw error;
         console.log(snapshot.data);


### PR DESCRIPTION
The `doc.del()` method allows calling:

 - [without `options`][1]
 - [without `callback`][2]

This change updates our types to reflect this.

[1]: https://github.com/share/sharedb/blob/6fd6bec140ab9d95e9cc433d529f13d4c1df074d/lib/client/doc.js#L902-L906
[2]: https://github.com/share/sharedb/blob/6fd6bec140ab9d95e9cc433d529f13d4c1df074d/lib/client/doc.js#L909

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
