### PR TITLE
[sharedb] stronger `doc.create()` typing

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -174,9 +174,9 @@ export class Doc<T = any> extends TypedEmitter<DocEventMap<T>> {
 
     ingestSnapshot(snapshot: Pick<Snapshot<T>, "v" | "type" | "data">, callback?: Callback): void;
     destroy(callback?: Callback): void;
-    create(data: any, callback?: Callback): void;
-    create(data: any, type?: string, callback?: Callback): void;
-    create(data: any, type?: string, options?: ShareDBSourceOptions, callback?: Callback): void;
+    create(data: T, callback?: Callback): void;
+    create(data: T, type?: string, callback?: Callback): void;
+    create(data: T, type?: string, options?: ShareDBSourceOptions, callback?: Callback): void;
     submitOp(data: any, options?: ShareDBSourceOptions, callback?: Callback): void;
     del(options: ShareDBSourceOptions, callback?: (err: Error) => void): void;
     whenNothingPending(callback: () => void): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -355,6 +355,9 @@ function startClient(callback) {
         bar: "abc",
     });
 
+    // @ts-expect-error :: invalid payload
+    typedDoc.create({bad: true});
+
     typedDoc.ingestSnapshot({
         v: 10,
         type: "json0",


### PR DESCRIPTION
`doc.create()` should be called with something the same shape as `doc.data` which already has type `T`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

