### PR TITLE
[http-signature] Fix typo in `writeDateHeader`

### DIFF
--- a/types/http-signature/http-signature-tests.ts
+++ b/types/http-signature/http-signature-tests.ts
@@ -34,12 +34,14 @@ httpSignature.sign(request, {
 // @ts-expect-error No options passed
 httpSignature.createSigner();
 // $ExpectType _RequestSigner
-httpSignature.createSigner({
+const signer = httpSignature.createSigner({
     keyId: "foo",
     key: "bar",
     algorithm: "foobar",
     keyPassphrase: "baz",
 });
+
+signer.writeDateHeader(); // $ExpectType string
 
 // --- utils.d.ts ---
 httpSignature.sshKeyToPEM("key"); // $ExpectType string

--- a/types/http-signature/lib/signer.d.ts
+++ b/types/http-signature/lib/signer.d.ts
@@ -34,7 +34,7 @@ declare class _RequestSigner {
 
     /** Adds a header to be signed alongside its value */
     writeHeader(header: string, value: string): string;
-    writeDataHeader(): string;
+    writeDateHeader(): string;
     /**
      * Add the request target to be signed
      * @param method HTTP mehod (i.e. `"get"`, `"post"`, `"put"`)


### PR DESCRIPTION
Related discussion: #67022
Closes #67023

Fixes a typo in `writeDateHeader` (said “Data”)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/TritonDataCenter/node-http-signature/blob/391fbe4864c2daef0c04345c987e5aa4d44c3ba1/lib/signer.js#L172>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
