### PR TITLE
[@types/node] Update the definition of `import.meta.resolve(…)` for `node` 20.6.

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -92,18 +92,12 @@ declare module 'module' {
         interface ImportMeta {
             url: string;
             /**
-             * @experimental
-             * This feature is only available with the `--experimental-import-meta-resolve`
-             * command flag enabled.
-             *
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
-             *
-             * @param specified The module specifier to resolve relative to `parent`.
-             * @param parent The absolute parent module URL to resolve from. If none
-             * is specified, the value of `import.meta.url` is used as the default.
+             * @since v20.6.0
+             * @param specifier The module specifier to resolve relative to the current module's URL (`import.meta.url`).
              */
-            resolve?(specified: string, parent?: string | URL): Promise<string>;
+            resolve(specifier: string): string;
         }
     }
     export = Module;

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -52,6 +52,6 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
     importmeta.url; // $ExpectType string
-    importmeta.resolve!('local', '/parent'); // $ExpectType Promise<string>
-    importmeta.resolve!('local', new URL('https://parent.module')); // $ExpectType Promise<string>
+    importmeta.resolve!('bare-specifier'); // $ExpectType string
+    importmeta.resolve!('./relative-specifier'); // $ExpectType string
 }


### PR DESCRIPTION
This was previously available:

- returning a `Promise`,
- behind a flag, and
- with an optional second `parent` parameter.

As of `node` v20.6.0 (https://nodejs.org/en/blog/release/v20.6.0), it is now:

- synchronous,
- unflagged without a parameter, and
- with the `parent` parameter only being supported behind the `--experimental-import-meta-resolve` flag.

To minimize the potential of confusion that would come from mixing the unflagged version with flagged parameter, this change only documents the unflagged version.

Note that there was a bug that sometimes returned a `URL` instead of a `string` in v20.6.0, but this was fixed in v20.8.0 (https://github.com/nodejs/node/issues/49695).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  - I tried, but this fails with: `Error: No ESLint configuration found in /Users/lgarron/Code/git/github.com/DefinitelyTyped/DefinitelyTyped/types/node.`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/en/blog/release/v20.6.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
