### PR TITLE
[types/node] `import.meta.resolve(…)` updates: version, arg name, comment

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -267,22 +267,26 @@ declare module "module" {
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @param specified The module specifier to resolve relative to the current module.
+             * @since v20.6.0
+             *
+             * @param specifier The module specifier to resolve relative to the current module.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specified: string): string;
+            resolve(specifier: string): string;
             /**
-             * This feature is only available with the `--experimental-import-meta-resolve`
+             * This `parent` parameter is only used when the `--experimental-import-meta-resolve`
              * command flag enabled.
              *
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @param specified The module specifier to resolve relative to `parent`.
+             * @since v20.6.0
+             *
+             * @param specifier The module specifier to resolve relative to `parent`.
              * @param parent The absolute parent module URL to resolve from.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specified: string, parent: string | URL): string;
+            resolve(specifier: string, parent: string | URL): string;
         }
     }
     export = Module;

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -267,22 +267,26 @@ declare module "module" {
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @param specified The module specifier to resolve relative to the current module.
+             * @since v20.6.0
+             *
+             * @param specifier The module specifier to resolve relative to the current module.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specified: string): string;
+            resolve(specifier: string): string;
             /**
-             * This feature is only available with the `--experimental-import-meta-resolve`
+             * This `parent` parameter is only used when the `--experimental-import-meta-resolve`
              * command flag enabled.
              *
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @param specified The module specifier to resolve relative to `parent`.
+             * @since v20.6.0
+             *
+             * @param specifier The module specifier to resolve relative to `parent`.
              * @param parent The absolute parent module URL to resolve from.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specified: string, parent: string | URL): string;
+            resolve(specifier: string, parent: string | URL): string;
         }
     }
     export = Module;


### PR DESCRIPTION
This:

- Adds the version number for the latest relevant API changes (sync API in `node` v20.6.0).
- Updates the description for the flagged version to make it clear that the flag only affects whether `node` uses the second param. This is particularly valuable because *the flagged definition shows up in VS Code instead of the unflagged version*, giving the implication that the unflagged version is experimental as well.
- Change the first param name from `specified` to `specifier` (matching what [the spec](https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties) uses).

Changes I could not make:

- Mark only the flagged version as optional (`resolve?(…)`), since it has to match the unflagged version due to TypeScript constraints.

I'm still a bit uncomfortable with the fact that the flagged version will be ambiently available. When used in a mixed frontend + backend codebase (or any codebase with `node` types, which includes many codebases that simply contain `node` scripts for development purposes) this allows the second argument to type-check 100% of the time. Since the API is otherwise named and shaped exactly like the formally specced version in the other environments, this can easily give the impression that the `parent` arg is usable in browsers or other runtimes — **none of which support it, and all of which will ignore it**. To avoid the risk of misunderstandings or bugs, I'd personally advocate to remove the flagged version for now, but I didn't want that to block the other improvements in the PR — would certainly be happy to send another PR.

--------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  - This appears to fail for unrelated reasons (`Cannot find module 'undici-types' or its corresponding type declarations.`)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://nodejs.org/en/blog/release/v20.6.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.