### PR TITLE
sparqljs: accurate module representation

### DIFF
--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -1,303 +1,307 @@
 import * as RdfJs from "rdf-js";
+import Wildcard = require('./lib/Wildcard.js');
 
-export const Parser: {
-    new(options?: ParserOptions): SparqlParser;
-};
-
-export interface ParserOptions {
-    prefixes?: { [prefix: string]: string } | undefined;
-    baseIRI?: string | undefined;
-    factory?: RdfJs.DataFactory | undefined;
-    sparqlStar?: boolean | undefined;
+// tslint:disable-next-line:no-unnecessary-class
+declare class SparqlJs {
+    static Parser: {
+        new(options?: SparqlJs.ParserOptions): SparqlJs.SparqlParser;
+    };
+    static Generator: {
+        new(options?: SparqlJs.GeneratorOptions): SparqlJs.SparqlGenerator;
+    };
+    static Wildcard: typeof Wildcard;
 }
 
-export const Generator: {
-    new(options?: GeneratorOptions): SparqlGenerator;
-};
+declare namespace SparqlJs {
+    interface ParserOptions {
+        prefixes?: { [prefix: string]: string } | undefined;
+        baseIRI?: string | undefined;
+        factory?: RdfJs.DataFactory | undefined;
+        sparqlStar?: boolean | undefined;
+    }
 
-export interface GeneratorOptions {
-    allPrefixes?: boolean | undefined;
-    prefixes?: { [prefix: string]: string } | undefined;
-    indent?: string | undefined;
-    newline?: string | undefined;
-    sparqlStar?: boolean | undefined;
+    interface GeneratorOptions {
+        allPrefixes?: boolean | undefined;
+        prefixes?: { [prefix: string]: string } | undefined;
+        indent?: string | undefined;
+        newline?: string | undefined;
+        sparqlStar?: boolean | undefined;
+    }
+
+    interface SparqlParser {
+        parse(query: string): SparqlQuery;
+    }
+
+    interface SparqlGenerator {
+        stringify(query: SparqlQuery): string;
+
+        createGenerator(): any;
+    }
+
+    type Term = VariableTerm | IriTerm | LiteralTerm | BlankTerm | QuadTerm;
+
+    type VariableTerm = RdfJs.Variable;
+    type IriTerm = RdfJs.NamedNode;
+    type LiteralTerm = RdfJs.Literal;
+    type BlankTerm = RdfJs.BlankNode;
+    type QuadTerm = RdfJs.Quad;
+
+    type SparqlQuery = Query | Update;
+
+    type Query = SelectQuery | ConstructQuery | AskQuery | DescribeQuery;
+
+    interface BaseQuery {
+        type: "query";
+        base?: string | undefined;
+        prefixes: { [prefix: string]: string };
+        where?: Pattern[] | undefined;
+        values?: ValuePatternRow[] | undefined;
+    }
+
+    interface SelectQuery extends BaseQuery {
+        queryType: "SELECT";
+        variables: Variable[] | [Wildcard];
+        distinct?: boolean | undefined;
+        from?: {
+            default: IriTerm[];
+            named: IriTerm[];
+        } | undefined;
+        reduced?: boolean | undefined;
+        group?: Grouping[] | undefined;
+        having?: Expression[] | undefined;
+        order?: Ordering[] | undefined;
+        limit?: number | undefined;
+        offset?: number | undefined;
+    }
+
+    interface Grouping {
+        expression: Expression;
+    }
+
+    interface Ordering {
+        expression: Expression;
+        descending?: boolean | undefined;
+    }
+
+    interface ConstructQuery extends BaseQuery {
+        queryType: "CONSTRUCT";
+        template?: Triple[] | undefined;
+    }
+
+    interface AskQuery extends BaseQuery {
+        queryType: "ASK";
+    }
+
+    interface DescribeQuery extends BaseQuery {
+        queryType: "DESCRIBE";
+        variables: Variable[] | [Wildcard];
+    }
+
+    interface Update {
+        type: "update";
+        base?: string | undefined;
+        prefixes: { [prefix: string]: string };
+        updates: UpdateOperation[];
+    }
+
+    type UpdateOperation = InsertDeleteOperation | ManagementOperation;
+
+    interface InsertDeleteOperation {
+        updateType: "insert" | "delete" | "deletewhere" | "insertdelete";
+        graph?: IriTerm | undefined;
+        insert?: Quads[] | undefined;
+        delete?: Quads[] | undefined;
+        where?: Pattern[] | undefined;
+    }
+
+    type Quads = BgpPattern | GraphQuads;
+
+    type ManagementOperation =
+        | CopyMoveAddOperation
+        | LoadOperation
+        | CreateOperation
+        | ClearDropOperation;
+
+    interface CopyMoveAddOperation {
+        type: "copy" | "move" | "add";
+        silent: boolean;
+        source: GraphOrDefault;
+        destination: GraphOrDefault;
+    }
+
+    interface LoadOperation {
+        type: "load";
+        silent: boolean;
+        source: IriTerm;
+        destination: IriTerm | false;
+    }
+
+    interface CreateOperation {
+        type: "create";
+        silent: boolean;
+        graph: IriTerm;
+    }
+
+    interface ClearDropOperation {
+        type: "clear" | "drop";
+        silent: boolean;
+        graph: GraphReference;
+    }
+
+    interface GraphOrDefault {
+        type: "graph";
+        name?: IriTerm | undefined;
+        default?: boolean | undefined;
+    }
+
+    interface GraphReference extends GraphOrDefault {
+        named?: boolean | undefined;
+        all?: boolean | undefined;
+    }
+
+    /**
+     * Examples: '?var', '*',
+     *   SELECT (?a as ?b) ... ==> { expression: '?a', variable: '?b' }
+     */
+    type Variable = VariableExpression | VariableTerm;
+
+    interface VariableExpression {
+        expression: Expression;
+        variable: VariableTerm;
+    }
+
+    type Pattern =
+        | BgpPattern
+        | BlockPattern
+        | FilterPattern
+        | BindPattern
+        | ValuesPattern
+        | SelectQuery;
+
+    /**
+     * Basic Graph Pattern
+     */
+    interface BgpPattern {
+        type: "bgp";
+        triples: Triple[];
+    }
+
+    interface GraphQuads {
+        type: "graph";
+        name: IriTerm;
+        triples: Triple[];
+    }
+
+    type BlockPattern =
+        | OptionalPattern
+        | UnionPattern
+        | GroupPattern
+        | GraphPattern
+        | MinusPattern
+        | ServicePattern;
+
+    interface OptionalPattern {
+        type: "optional";
+        patterns: Pattern[];
+    }
+
+    interface UnionPattern {
+        type: "union";
+        patterns: Pattern[];
+    }
+
+    interface GroupPattern {
+        type: "group";
+        patterns: Pattern[];
+    }
+
+    interface GraphPattern {
+        type: "graph";
+        name: IriTerm;
+        patterns: Pattern[];
+    }
+
+    interface MinusPattern {
+        type: "minus";
+        patterns: Pattern[];
+    }
+
+    interface ServicePattern {
+        type: "service";
+        name: IriTerm;
+        silent: boolean;
+        patterns: Pattern[];
+    }
+
+    interface FilterPattern {
+        type: "filter";
+        expression: Expression;
+    }
+
+    interface BindPattern {
+        type: "bind";
+        expression: Expression;
+        variable: VariableTerm;
+    }
+
+    interface ValuesPattern {
+        type: "values";
+        values: ValuePatternRow[];
+    }
+
+    interface ValuePatternRow {
+        [variable: string]: IriTerm | BlankTerm | LiteralTerm | undefined;
+    }
+
+    interface Triple {
+        subject: IriTerm | BlankTerm | VariableTerm | QuadTerm;
+        predicate: IriTerm | VariableTerm | PropertyPath;
+        object: Term;
+    }
+
+    interface PropertyPath {
+        type: "path";
+        pathType: "|" | "/" | "^" | "+" | "*" | "!";
+        items: Array<IriTerm | PropertyPath>;
+    }
+
+    type Expression =
+        | OperationExpression
+        | FunctionCallExpression
+        | AggregateExpression
+        | BgpPattern
+        | GraphPattern
+        | GroupPattern
+        | Tuple
+        | Term;
+
+    // allow Expression circularly reference itself
+    interface Tuple extends Array<Expression> {
+    }
+
+    interface BaseExpression {
+        type: string;
+        distinct?: boolean | undefined;
+    }
+
+    interface OperationExpression extends BaseExpression {
+        type: "operation";
+        operator: string;
+        args: Expression[];
+    }
+
+    interface FunctionCallExpression extends BaseExpression {
+        type: "functionCall";
+        function: string;
+        args: Expression[];
+    }
+
+    interface AggregateExpression extends BaseExpression {
+        type: "aggregate";
+        expression: Expression;
+        aggregation: string;
+        separator?: string | undefined;
+    }
 }
 
-export interface SparqlParser {
-    parse(query: string): SparqlQuery;
-}
-
-export interface SparqlGenerator {
-    stringify(query: SparqlQuery): string;
-    createGenerator(): any;
-}
-
-export class Wildcard {
-    readonly termType: "Wildcard";
-    readonly value: "*";
-    equals(other: RdfJs.Term | null | undefined): boolean;
-}
-
-export type Term = VariableTerm | IriTerm | LiteralTerm | BlankTerm | QuadTerm;
-
-export type VariableTerm = RdfJs.Variable;
-export type IriTerm = RdfJs.NamedNode;
-export type LiteralTerm = RdfJs.Literal;
-export type BlankTerm = RdfJs.BlankNode;
-export type QuadTerm = RdfJs.Quad;
-
-export type SparqlQuery = Query | Update;
-
-export type Query = SelectQuery | ConstructQuery | AskQuery | DescribeQuery;
-
-export interface BaseQuery {
-    type: "query";
-    base?: string | undefined;
-    prefixes: { [prefix: string]: string };
-    where?: Pattern[] | undefined;
-    values?: ValuePatternRow[] | undefined;
-}
-
-export interface SelectQuery extends BaseQuery {
-    queryType: "SELECT";
-    variables: Variable[] | [Wildcard];
-    distinct?: boolean | undefined;
-    from?: {
-        default: IriTerm[];
-        named: IriTerm[];
-    } | undefined;
-    reduced?: boolean | undefined;
-    group?: Grouping[] | undefined;
-    having?: Expression[] | undefined;
-    order?: Ordering[] | undefined;
-    limit?: number | undefined;
-    offset?: number | undefined;
-}
-
-export interface Grouping {
-    expression: Expression;
-}
-
-export interface Ordering {
-    expression: Expression;
-    descending?: boolean | undefined;
-}
-
-export interface ConstructQuery extends BaseQuery {
-    queryType: "CONSTRUCT";
-    template?: Triple[] | undefined;
-}
-
-export interface AskQuery extends BaseQuery {
-    queryType: "ASK";
-}
-
-export interface DescribeQuery extends BaseQuery {
-    queryType: "DESCRIBE";
-    variables: Variable[] | [Wildcard];
-}
-
-export interface Update {
-    type: "update";
-    base?: string | undefined;
-    prefixes: { [prefix: string]: string };
-    updates: UpdateOperation[];
-}
-
-export type UpdateOperation = InsertDeleteOperation | ManagementOperation;
-
-export interface InsertDeleteOperation {
-    updateType: "insert" | "delete" | "deletewhere" | "insertdelete";
-    graph?: IriTerm | undefined;
-    insert?: Quads[] | undefined;
-    delete?: Quads[] | undefined;
-    where?: Pattern[] | undefined;
-}
-
-export type Quads = BgpPattern | GraphQuads;
-
-export type ManagementOperation =
-    | CopyMoveAddOperation
-    | LoadOperation
-    | CreateOperation
-    | ClearDropOperation;
-
-export interface CopyMoveAddOperation {
-    type: "copy" | "move" | "add";
-    silent: boolean;
-    source: GraphOrDefault;
-    destination: GraphOrDefault;
-}
-
-export interface LoadOperation {
-    type: "load";
-    silent: boolean;
-    source: IriTerm;
-    destination: IriTerm | false;
-}
-
-export interface CreateOperation {
-    type: "create";
-    silent: boolean;
-    graph: IriTerm;
-}
-
-export interface ClearDropOperation {
-    type: "clear" | "drop";
-    silent: boolean;
-    graph: GraphReference;
-}
-
-export interface GraphOrDefault {
-    type: "graph";
-    name?: IriTerm | undefined;
-    default?: boolean | undefined;
-}
-
-export interface GraphReference extends GraphOrDefault {
-    named?: boolean | undefined;
-    all?: boolean | undefined;
-}
-
-/**
- * Examples: '?var', '*',
- *   SELECT (?a as ?b) ... ==> { expression: '?a', variable: '?b' }
- */
-export type Variable = VariableExpression | VariableTerm;
-
-export interface VariableExpression {
-    expression: Expression;
-    variable: VariableTerm;
-}
-
-export type Pattern =
-    | BgpPattern
-    | BlockPattern
-    | FilterPattern
-    | BindPattern
-    | ValuesPattern
-    | SelectQuery;
-
-/**
- * Basic Graph Pattern
- */
-export interface BgpPattern {
-    type: "bgp";
-    triples: Triple[];
-}
-
-export interface GraphQuads {
-    type: "graph";
-    name: IriTerm;
-    triples: Triple[];
-}
-
-export type BlockPattern =
-    | OptionalPattern
-    | UnionPattern
-    | GroupPattern
-    | GraphPattern
-    | MinusPattern
-    | ServicePattern;
-
-export interface OptionalPattern {
-    type: "optional";
-    patterns: Pattern[];
-}
-
-export interface UnionPattern {
-    type: "union";
-    patterns: Pattern[];
-}
-
-export interface GroupPattern {
-    type: "group";
-    patterns: Pattern[];
-}
-
-export interface GraphPattern {
-    type: "graph";
-    name: IriTerm;
-    patterns: Pattern[];
-}
-
-export interface MinusPattern {
-    type: "minus";
-    patterns: Pattern[];
-}
-
-export interface ServicePattern {
-    type: "service";
-    name: IriTerm;
-    silent: boolean;
-    patterns: Pattern[];
-}
-
-export interface FilterPattern {
-    type: "filter";
-    expression: Expression;
-}
-
-export interface BindPattern {
-    type: "bind";
-    expression: Expression;
-    variable: VariableTerm;
-}
-
-export interface ValuesPattern {
-    type: "values";
-    values: ValuePatternRow[];
-}
-
-export interface ValuePatternRow {
-    [variable: string]: IriTerm | BlankTerm | LiteralTerm | undefined;
-}
-
-export interface Triple {
-    subject: IriTerm | BlankTerm | VariableTerm | QuadTerm;
-    predicate: IriTerm | VariableTerm | PropertyPath;
-    object: Term;
-}
-
-export interface PropertyPath {
-    type: "path";
-    pathType: "|" | "/" | "^" | "+" | "*" | "!";
-    items: Array<IriTerm | PropertyPath>;
-}
-
-export type Expression =
-    | OperationExpression
-    | FunctionCallExpression
-    | AggregateExpression
-    | BgpPattern
-    | GraphPattern
-    | GroupPattern
-    | Tuple
-    | Term;
-
-// allow Expression circularly reference itself
-export interface Tuple extends Array<Expression> {}
-
-export interface BaseExpression {
-    type: string;
-    distinct?: boolean | undefined;
-}
-
-export interface OperationExpression extends BaseExpression {
-    type: "operation";
-    operator: string;
-    args: Expression[];
-}
-
-export interface FunctionCallExpression extends BaseExpression {
-    type: "functionCall";
-    function: string;
-    args: Expression[];
-}
-
-export interface AggregateExpression extends BaseExpression {
-    type: "aggregate";
-    expression: Expression;
-    aggregation: string;
-    separator?: string | undefined;
-}
+export = SparqlJs;

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -1,5 +1,4 @@
 import * as RdfJs from "rdf-js";
-import Wildcard = require('./lib/Wildcard.js');
 
 // tslint:disable-next-line:no-unnecessary-class
 declare class SparqlJs {
@@ -9,7 +8,6 @@ declare class SparqlJs {
     static Generator: {
         new(options?: SparqlJs.GeneratorOptions): SparqlJs.SparqlGenerator;
     };
-    static Wildcard: typeof Wildcard;
 }
 
 declare namespace SparqlJs {
@@ -36,6 +34,12 @@ declare namespace SparqlJs {
         stringify(query: SparqlQuery): string;
 
         createGenerator(): any;
+    }
+
+    class Wildcard {
+        readonly termType: "Wildcard";
+        readonly value: "*";
+        equals(other: RdfJs.Term | null | undefined): boolean;
     }
 
     type Term = VariableTerm | IriTerm | LiteralTerm | BlankTerm | QuadTerm;

--- a/types/sparqljs/lib/Wildcard.d.ts
+++ b/types/sparqljs/lib/Wildcard.d.ts
@@ -1,0 +1,9 @@
+import * as RdfJs from "rdf-js";
+
+declare class Wildcard {
+    readonly termType: "Wildcard";
+    readonly value: "*";
+    equals(other: RdfJs.Term | null | undefined): boolean;
+}
+
+export = Wildcard;

--- a/types/sparqljs/lib/Wildcard.d.ts
+++ b/types/sparqljs/lib/Wildcard.d.ts
@@ -1,9 +1,0 @@
-import * as RdfJs from "rdf-js";
-
-declare class Wildcard {
-    readonly termType: "Wildcard";
-    readonly value: "*";
-    equals(other: RdfJs.Term | null | undefined): boolean;
-}
-
-export = Wildcard;

--- a/types/sparqljs/sparqljs-tests.ts
+++ b/types/sparqljs/sparqljs-tests.ts
@@ -1,5 +1,5 @@
 import * as RdfJs from "rdf-js";
-import * as SparqlJs from "sparqljs";
+import SparqlJs = require("sparqljs");
 
 // Declare RDF/JS factory implementation to create terms (IRIs, literals, variables, etc)
 declare const DataFactory: RdfJs.DataFactory;


### PR DESCRIPTION
`import * as Sparqljs from 'sparqljs'` is wrong because the package in CJS and default-import like `import Sparqljs from 'sparqljs'` must be used

In this PR I adjusted the index to reflect that> I only moved `Wildcard` to its own respective module because it is independent of the other types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
