### PR TITLE
[node-zookeeper-client] fix node-zookeeper-client Stat type

### DIFF
--- a/types/node-zookeeper-client/index.d.ts
+++ b/types/node-zookeeper-client/index.d.ts
@@ -31,17 +31,17 @@ export const Permission: {
 };
 
 export interface Stat {
-    czxid: number;
-    mzxid: number;
-    ctime: number;
-    mtime: number;
+    czxid: Buffer;
+    mzxid: Buffer;
+    ctime: Buffer;
+    mtime: Buffer;
     version: number;
     cversion: number;
     aversion: number;
-    ephemeralOwner: number;
+    ephemeralOwner: Buffer;
     dataLength: number;
     numChildren: number;
-    pzxid: number;
+    pzxid: Buffer;
 }
 
 export class State {

--- a/types/node-zookeeper-client/node-zookeeper-client-tests.ts
+++ b/types/node-zookeeper-client/node-zookeeper-client-tests.ts
@@ -96,6 +96,28 @@ const client = zookeeper.createClient(
 
         if (stat) {
             console.log("Node exists.");
+            // $ExpectType Buffer
+            stat.czxid;
+            // $ExpectType Buffer
+            stat.mzxid;
+            // $ExpectType Buffer
+            stat.ctime;
+            // $ExpectType Buffer
+            stat.mtime;
+            // $ExpectType number
+            stat.version;
+            // $ExpectType number
+            stat.cversion;
+            // $ExpectType number
+            stat.aversion;
+            // $ExpectType Buffer
+            stat.ephemeralOwner;
+            // $ExpectType number
+            stat.dataLength;
+            // $ExpectType number
+            stat.numChildren;
+            // $ExpectType Buffer
+            stat.pzxid;
         } else {
             console.log("Node does not exist.");
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

------

fix node-zookeeper-client stats.czxid, stats.ephemeralOwnerId, and others type.

* [A json file which Stat type property is described](https://github.com/alexguan/node-zookeeper-client/blob/master/lib/jute/specification.json#L11)
* [In this code, long is converted to Buffer](https://github.com/alexguan/node-zookeeper-client/blob/master/lib/jute/index.js#L84)

