### PR TITLE
fix(bn.js): add missing second argument to setn

### DIFF
--- a/types/bn.js/bn.js-tests.ts
+++ b/types/bn.js/bn.js-tests.ts
@@ -10,6 +10,8 @@ function runTests(BN: typeof BN_esm) {
     bn = bn.add(bn);
     bn.isZero();
     bn.byteLength;
+    bn.setn(0, 1);
+    bn.setn(0, false);
 
     const endian: Endianness = "le";
     bn.toArrayLike(Buffer, endian, 2);

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -426,9 +426,9 @@ declare class BN {
     iuxor(b: BN): BN;
 
     /**
-     * @description set specified bit to 1
+     * @description set specified bit to value
      */
-    setn(b: number): BN;
+    setn(b: number, value: boolean | 0 | 1): BN;
 
     /**
      * @description shift left


### PR DESCRIPTION
bn.js in version 5.1 accepts two arguments for setn function (bit index and value to use), but README.md listed wrong signature for this function so this issue carried to this package. https://github.com/indutny/bn.js/commit/6ef485dc30b002ec8100602998763fec8a1a3897

bn.js only checks if value is truthy or not to decide what to do, so it could really be anything. I set it to boolean | 0 | 1 as those make sense for this function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/indutny/bn.js/commit/6ef485dc30b002ec8100602998763fec8a1a3897
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

