### PR TITLE
Set type definition to result param of Callback type

### DIFF
--- a/types/node-pushnotifications/index.d.ts
+++ b/types/node-pushnotifications/index.d.ts
@@ -192,6 +192,7 @@ declare namespace PushNotifications {
         /** ADM */
         consolidationKey?: string | undefined;
     }
+    type MethodValue = "apn" | "gcm" | "adm" | "wns" | "webPush" | "unknown" | "none";
     interface Message {
         regId: string;
         originalRegId?: string | undefined;
@@ -200,12 +201,12 @@ declare namespace PushNotifications {
         errorMsg?: string | undefined;
     }
     interface Result {
-        method: string;
+        method: MethodValue;
         success: number;
         failure: number;
         message: Message[];
     }
     type PushMethod = (regIds: string[], data: Data, settings: Settings) => void;
-    type Callback = (err: any, result: any) => void;
+    type Callback = (err: any, result: Result[]) => void;
     type RegistrationId = string | webPush.PushSubscription;
 }

--- a/types/node-pushnotifications/node-pushnotifications-tests.ts
+++ b/types/node-pushnotifications/node-pushnotifications-tests.ts
@@ -51,22 +51,63 @@ const data = {
     body: "Powered by AppFeel",
 };
 
+function assertResultTypes(result: PushNotifications.Result) {
+    // $ExpectType MethodValue
+    result.method;
+
+    result.method === "apn";
+    result.method === "gcm";
+    result.method === "adm";
+    result.method === "wns";
+    result.method === "webPush";
+    result.method === "unknown";
+    result.method === "none";
+    // @ts-expect-error
+    result.method === "any_other_string";
+
+    // $ExpectType number
+    result.success;
+
+    // $ExpectType number
+    result.failure;
+
+    // $ExpectType Message[]
+    result.message;
+
+    // $ExpectType string
+    result.message[0].regId;
+
+    // $ExpectType string | undefined
+    result.message[0].originalRegId;
+
+    // $ExpectType string | undefined
+    result.message[0].messageId;
+
+    // $ExpectType Error | null | undefined
+    result.message[0].error;
+
+    // $ExpectType string | undefined
+    result.message[0].errorMsg;
+}
+
 // You can use it in node callback style
-push.send(registrationIds, data, (err, result) => {
+push.send(registrationIds, data, (err, results) => {
     if (err) {
         console.log(err);
     } else {
-        console.log(result);
+        // $ExpectType Result[]
+        results;
+        results.forEach(assertResultTypes);
+        console.log(results);
     }
 });
 
 // Or you could use it as a promise and send only a single notifications:
 push.send(registrationIds[0], data)
     .then((results) => {
-        results.forEach((result) => {
-            console.log(result.success);
-            console.log(result.failure);
-        });
+        // $ExpectType Result[]
+        results;
+        results.forEach(assertResultTypes);
         console.log(results);
     })
     .catch((err) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

One of the overloads of the `send` function returns a `Promise<Result[]>`. The non-promise, callback-oriented version of that function should return the same type with the `result` value.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-pushnotifications/index.d.ts#L25