### PR TITLE
[dockerode] Fixed missing abortSignal property in ContainerStartOptions

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -111,9 +111,9 @@ container.inspect((err, data) => {
     // NOOP
 });
 
-container.start({abortSignal: new AbortController().signal}, (err, data) => {
+container.start({ abortSignal: new AbortController().signal }, (err, data) => {
     // NOOP
-})
+});
 
 container.start((err, data) => {
     // NOOP

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -111,6 +111,10 @@ container.inspect((err, data) => {
     // NOOP
 });
 
+container.start({abortSignal: new AbortController().signal}, (err, data) => {
+    // NOOP
+})
+
 container.start((err, data) => {
     // NOOP
 });
@@ -190,10 +194,9 @@ container.stats({ stream: true });
 // $ExpectType Promise<ContainerStats>
 container.stats({ stream: false });
 
-const abortController = new AbortController();
 container.wait({
     condition: "next-exit",
-    abortSignal: abortController.signal,
+    abortSignal: new AbortController().signal,
 });
 
 // $ExpectType Promise<ReadWriteStream>

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1163,6 +1163,7 @@ declare namespace Dockerode {
 
     interface ContainerStartOptions {
         detachKeys?: string;
+        abortSignal?: AbortSignal;
     }
 
     interface ContainerRemoveOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/dockerode/issues/745
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
