### PR TITLE
Fixed type for StandardApiResponse.status

### DIFF
--- a/types/backblaze-b2/backblaze-b2-tests.ts
+++ b/types/backblaze-b2/backblaze-b2-tests.ts
@@ -342,3 +342,13 @@ b2.listKeys({
     axios: { someAxiosConfig: true },
     axiosOverride: { someOtherParam: "" },
 });
+
+(async () => {
+    const result = await b2.authorize({
+        axios: { someAxiosConfig: true },
+        axiosOverride: { someOtherParam: "" },
+    });
+
+    // $ExpectType number
+    const status = result.status;
+})();

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -22,7 +22,7 @@ interface CommonArgs {
 }
 
 interface StandardApiResponse {
-    status: string;
+    status: number;
     statusText: string;
     headers: any;
     config: any;


### PR DESCRIPTION
Docs on https://github.com/yakovkhalinsky/backblaze-b2 describe `status` as an integer, and I observe a `number` type on 1.7.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yakovkhalinsky/backblaze-b2
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

