### PR TITLE
Add extras to loginoptions

### DIFF
--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -113,7 +113,7 @@ declare namespace facebook {
                 gender?: TParam extends "gender" ? string : never | undefined | undefined;
                 hometown?: TParam extends "hometown" ? Page : never | undefined | undefined;
                 inspirational_people?: TParam extends "inspirational_people" ? Experience[]
-                    : never | undefined | undefined;
+                : never | undefined | undefined;
                 install_type?: TParam extends "install_type" ? any : never | undefined | undefined;
                 is_guest_user?: TParam extends "is_guest_user" ? boolean : never | undefined | undefined;
                 languages?: TParam extends "languages" ? Experience[] : never | undefined | undefined;
@@ -125,21 +125,21 @@ declare namespace facebook {
                 name?: TParam extends "name" ? string : never | undefined | undefined;
                 name_format?: TParam extends "name_format" ? string : never | undefined | undefined;
                 payment_pricepoints?: TParam extends "payment_pricepoints" ? PaymentPricepoints
-                    : never | undefined | undefined;
+                : never | undefined | undefined;
                 name_political?: TParam extends "political" ? string : never | undefined | undefined;
                 profile_pic?: TParam extends "profile_pic" ? string : never | undefined | undefined;
                 quotes?: TParam extends "quotes" ? string : never | undefined | undefined;
                 relationship_status?: TParam extends "relationship_status" ? string : never | undefined | undefined;
                 religion?: TParam extends "religion" ? string : never | undefined | undefined;
                 shared_login_upgrade_required_by?: TParam extends "shared_login_upgrade_required_by" ? any
-                    : never | undefined | undefined;
+                : never | undefined | undefined;
                 short_name?: TParam extends "short_name" ? any : never | undefined | undefined;
                 significant_other?: TParam extends "significant_other" ? User : never | undefined | undefined;
                 sports?: TParam extends "sports" ? Experience[] : never | undefined | undefined;
                 supports_donate_button_in_live_video?: TParam extends "supports_donate_button_in_live_video" ? boolean
-                    : never | undefined | undefined;
+                : never | undefined | undefined;
                 token_for_business?: TParam extends "token_for_business" ? VideoUploadLimits
-                    : never | undefined | undefined;
+                : never | undefined | undefined;
                 video_upload_limits?: TParam extends "video_upload_limits" ? string : never | undefined | undefined;
                 website?: TParam extends "website" ? string : never | undefined | undefined;
             }) => void,
@@ -342,6 +342,32 @@ declare namespace facebook {
         config_id?: string | undefined;
         response_type?: string | undefined;
         override_default_response_type?: boolean | undefined;
+        extras?: {
+            setup: {
+                business: {
+                    name: string | undefined;
+                    email: string | undefined;
+                    phone: {
+                        code: number | undefined;
+                        number: string | undefined;
+                    }
+                    website: string | undefined;
+                    address: {
+                        streetAddress1: string | undefined;
+                        city: string | undefined;
+                        state: string | undefined;
+                        zipPostal: string | undefined;
+                        country: string | undefined;
+                    }
+                    timezone: string | undefined;
+                }
+                phone: {
+                    displayName: string | undefined;
+                    category: string | undefined;
+                    description: string | undefined;
+                }
+            }
+        }
     }
 
     ////////////////////////
@@ -386,10 +412,10 @@ declare namespace facebook {
         data?: string | undefined;
         exclude_ids?: string[] | undefined;
         filters?:
-            | "app_users"
-            | "app_non_users"
-            | Array<{ name: string; user_ids: string[] }>
-            | undefined;
+        | "app_users"
+        | "app_non_users"
+        | Array<{ name: string; user_ids: string[] }>
+        | undefined;
         max_recipients?: number | undefined;
         object_id?: string | undefined;
         suggestions?: string[] | undefined;
@@ -435,12 +461,12 @@ declare namespace facebook {
         display: "popup";
         method: "create_offer";
         objective:
-            | "APP_INSTALLS"
-            | "CONVERSIONS"
-            | "LINK_CLICKS"
-            | "OFFER_CLAIMS"
-            | "PRODUCT_CATALOG_SALES"
-            | "STORE_VISITS";
+        | "APP_INSTALLS"
+        | "CONVERSIONS"
+        | "LINK_CLICKS"
+        | "OFFER_CLAIMS"
+        | "PRODUCT_CATALOG_SALES"
+        | "STORE_VISITS";
         page_id: string;
     }
 
@@ -554,5 +580,5 @@ declare namespace facebook {
         success: boolean;
     }
 
-    interface CollectionAdsDialogResponse extends InstantExperiencesAdsDialogResponse {}
+    interface CollectionAdsDialogResponse extends InstantExperiencesAdsDialogResponse { }
 }

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -342,32 +342,7 @@ declare namespace facebook {
         config_id?: string | undefined;
         response_type?: string | undefined;
         override_default_response_type?: boolean | undefined;
-        extras?: {
-            setup: {
-                business: {
-                    name: string | undefined;
-                    email: string | undefined;
-                    phone: {
-                        code: number | undefined;
-                        number: string | undefined;
-                    }
-                    website: string | undefined;
-                    address: {
-                        streetAddress1: string | undefined;
-                        city: string | undefined;
-                        state: string | undefined;
-                        zipPostal: string | undefined;
-                        country: string | undefined;
-                    }
-                    timezone: string | undefined;
-                }
-                phone: {
-                    displayName: string | undefined;
-                    category: string | undefined;
-                    description: string | undefined;
-                }
-            }
-        }
+        extras?: { [key: string]: any } | undefined;
     }
 
     ////////////////////////


### PR DESCRIPTION
This pull request extends the `LoginOptions` interface in the `@types/facebook-js-sdk` package to include the `extras` object. The `extras` object is a critical part of the Facebook JavaScript SDK's authentication process and configuration.

**Motivation and Background**

The `LoginOptions` interface is an integral part of the Facebook JavaScript SDK, which provides methods for user authentication and interaction with Facebook's social platform. The `LoginOptions` interface specifies various options for the login process, such as `auth_type`, `scope`, and `response_type`. However, there are situations where additional configuration parameters are required to customize the authentication process further.

The `extras` object is one such parameter, enabling developers to provide additional configuration settings to the Facebook JavaScript SDK, allowing more fine-grained control and customization. This change is essential for developers who need to pass specific parameters during the login process, as it enables the SDK to recognize and utilize these additional settings.

**Proposed Changes**

I have added the `extras` object to the `LoginOptions` interface within the `index.d.ts` file. The `extras` object is an optional parameter and allows developers to include custom configuration settings during the login process.

Here's how the `LoginOptions` interface looks after this change:

```typescript
interface LoginOptions {
    auth_type?: "reauthenticate" | "reauthorize" | "rerequest" | undefined;
    scope?: string | undefined;
    return_scopes?: boolean | undefined;
    enable_profile_selector?: boolean | undefined;
    profile_selector_ids?: string | undefined;
    config_id?: string | undefined;
    response_type?: string | undefined;
    override_default_response_type?: boolean | undefined;
    extras?: { [key: string]: any } | undefined;  // Added extras object definition
}
