### PR TITLE
[react] force useMemo factory function has an explicit return

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1162,7 +1162,7 @@ declare namespace React {
      * @see https://react.dev/reference/react/useMemo
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: () => Exclude<T, void>, deps: DependencyList | undefined): T;
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -236,9 +236,9 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useMemo(() => ({}));
 
     // allow explicit return empty object
-    React.useMemo(() => ({}), undefined)
+    React.useMemo(() => ({}), undefined);
     // allow explicit return null
-    React.useMemo(() => null, undefined)
+    React.useMemo(() => null, undefined);
     // but not allow factory function return void, prevent accidentally forget to return
     // @ts-expect-error
     React.useMemo(() => {});

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -229,9 +229,17 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useDebugValue(id, value => value.toFixed());
     React.useDebugValue(id);
 
-    // allow passing an explicit undefined
-    React.useMemo(() => {}, undefined);
-    // but don't allow it to be missing
+    // allow passing an explicit undefined as dependency list
+    React.useMemo(() => ({}), undefined);
+    // but don't allow dependency list to be missing
+    // @ts-expect-error
+    React.useMemo(() => ({}));
+
+    // allow explicit return empty object
+    React.useMemo(() => ({}), undefined)
+    // allow explicit return null
+    React.useMemo(() => null, undefined)
+    // but not allow factory function return void, prevent accidentally forget to return
     // @ts-expect-error
     React.useMemo(() => {});
 


### PR DESCRIPTION
according to React document:
> useMemo is a React Hook that lets you cache the result of a calculation between re-renders.

Type should be able to check that is there a return value in a factory function. This can prevent users from forgetting to return value when they write a long factory function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [useMemo](https://react.dev/reference/react/useMemo)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
