### PR TITLE
Post-pnpm workflow fixups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,8 +60,6 @@ jobs:
           fi
         name: pnpm install
 
-      - run: npm ls --all || true
-
       # Run tests
       - run: pnpm run test-all
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,11 +53,13 @@ jobs:
           # If we're deleting packages, pnpm won't know what other unrelated packages
           # need to be reinstalled that may now be sourced from npm instead of the
           # local repo. Just pay the cost of the full install.
-          if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
-            pnpm install
-          else
-            pnpm install --filter . --filter '...[origin/master]'
-          fi
+          # TODO: enable this; see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67087#issuecomment-1767228131
+          # if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
+          #   pnpm install
+          # else
+          #   pnpm install --filter . --filter '...[origin/master]'
+          # fi
+          pnpm install
         name: pnpm install
 
       # Run tests

--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -20,7 +20,12 @@ jobs:
           token: ${{ secrets.GH_DT_MERGEBOT_TOKEN }}
       - uses: actions/setup-node@v3
 
-      - run: npm install
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: |
+            - args: [--filter, .]
 
       - name: Get date
         id: date
@@ -40,7 +45,7 @@ jobs:
             ${{ runner.os }}-dprint-${{ hashFiles('package.json', '.dprint.jsonc') }}
             ${{ runner.os }}-dprint-
 
-      - run: npx dprint fmt
+      - run: pnpm dprint fmt
 
       - uses: stefanzweifel/git-auto-commit-action@v5.0.0
         with:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -128,7 +128,7 @@ if (unformatted.length > 0) {
 `);
     }
 
-    message.push("\nConsider running `npx dprint fmt` on these files to make review easier.");
+    message.push("\nConsider running `pnpm dprint fmt` on these files to make review easier.");
 
     markdown(message.join("\n"));
 }


### PR DESCRIPTION
I missed this new workflow in the rebase for #67085.

Also, no need to `ls` anymore; pnpm prints this on install so we don't have to do it.