### PR TITLE
fix(react-datepicker): export type HighlightDates

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -14,7 +14,7 @@ export function setDefaultLocale(localeName: string): void;
 export function getDefaultLocale(): string;
 export function CalendarContainer(props: CalendarContainerProps): React.ReactElement;
 
-interface HighlightDates {
+export interface HighlightDates {
     [className: string]: Date[];
 }
 


### PR DESCRIPTION
Hello, this is a short pull request to add some missing "export" clauses to some types.

Using a nx monorepo, one of my buildable modules fails to build with the following errors:

```
TS4023: Exported variable 'myVariable' has or is using name 'HighlightDates' from external module ".../node_modules/@types/react-datepicker/index" but cannot be named.
```

I tested it by first adding the export clause in my node_modules, then by using `yarn link + yarn link "@types/react-datepicker"` to test the present changes, and both resolved my build issues.

Also, I ran `pnpm -w run test react-datepicker` to make sure it was still green.

Thank you for considering this issue, and I hope you find this helpful. 

## Checklist

<!-- Please fill in this template. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**

