### PR TITLE
Add types for @eslint/eslintrc

### DIFF
--- a/types/eslint__eslintrc/eslint__eslintrc-tests.ts
+++ b/types/eslint__eslintrc/eslint__eslintrc-tests.ts
@@ -1,0 +1,38 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import { Linter } from "eslint";
+
+const __dirname = "/path/to/project";
+
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    resolvePluginsRelativeTo: __dirname,
+});
+
+const config: Linter.FlatConfig[] = [
+    // $ExpectType FlatConfig
+    ...compat.extends("standard", "example"),
+
+    // $ExpectType FlatConfig
+    ...compat.env({
+        es2020: true,
+        node: true,
+    }),
+
+    // $ExpectType FlatConfig
+    ...compat.plugins("airbnb", "react"),
+
+    // $ExpectType FlatConfig
+    ...compat.config({
+        plugins: ["airbnb", "react"],
+        extends: "standard",
+        env: {
+            es2020: true,
+            node: true,
+        },
+        rules: {
+            semi: "error",
+        },
+    }),
+];
+
+export default config;

--- a/types/eslint__eslintrc/index.d.ts
+++ b/types/eslint__eslintrc/index.d.ts
@@ -1,0 +1,49 @@
+import type { Linter } from "eslint";
+
+/**
+ * A compatibility class for working with configs.
+ */
+export class FlatCompat {
+    constructor({
+        baseDirectory,
+        resolvePluginsRelativeTo,
+        recommendedConfig,
+        allConfig,
+    }?: {
+        /**
+         * default: process.cwd()
+         */
+        baseDirectory?: string;
+        resolvePluginsRelativeTo?: string;
+        recommendedConfig?: Linter.Config;
+        allConfig?: Linter.Config;
+    });
+
+    /**
+     * Translates an ESLintRC-style config into a flag-config-style config.
+     * @param eslintrcConfig The ESLintRC-style config object.
+     * @returns A flag-config-style config object.
+     */
+    config(eslintrcConfig: Linter.Config): Linter.FlatConfig[];
+
+    /**
+     * Translates the `env` section of an ESLintRC-style config.
+     * @param envConfig The `env` section of an ESLintRC config.
+     * @returns An array of flag-config objects representing the environments.
+     */
+    env(envConfig: { [name: string]: boolean }): Linter.FlatConfig[];
+
+    /**
+     * Translates the `extends` section of an ESLintRC-style config.
+     * @param configsToExtend The names of the configs to load.
+     * @returns An array of flag-config objects representing the config.
+     */
+    extends(...configsToExtend: string[]): Linter.FlatConfig[];
+
+    /**
+     * Translates the `plugins` section of an ESLintRC-style config.
+     * @param plugins The names of the plugins to load.
+     * @returns An array of flag-config objects representing the plugins.
+     */
+    plugins(...plugins: string[]): Linter.FlatConfig[];
+}

--- a/types/eslint__eslintrc/package.json
+++ b/types/eslint__eslintrc/package.json
@@ -1,0 +1,21 @@
+{
+    "private": true,
+    "type": "module",
+    "name": "@types/eslint__eslintrc",
+    "version": "2.1.9999",
+    "projects": [
+        "https://github.com/eslint/eslintrc#readme"
+    ],
+    "dependencies": {
+        "@types/eslint": "*"
+    },
+    "devDependencies": {
+        "@types/eslint__eslintrc": "workspace:."
+    },
+    "owners": [
+        {
+            "name": "Gordon Ou",
+            "githubUsername": "gdlol"
+        }
+    ]
+}

--- a/types/eslint__eslintrc/tsconfig.json
+++ b/types/eslint__eslintrc/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "Node16",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "eslint__eslintrc-tests.ts"
+    ]
+}

--- a/types/eslint__eslintrc/tslint.json
+++ b/types/eslint__eslintrc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The `Legacy` property from the JavaScript source is omitted. According to the JavaScript repo README, the `Legacy` object should be for ESLint internal consumption, and the API surface of `Legacy` is significant larger than the primary class of the package `FlatCompat`. 

The `FlatCompact` class would be useful for providing type information in ESLint's new config file format: https://eslint.org/docs/latest/use/configure/migration-guide#using-eslintrc-configs-in-flat-config
