### PR TITLE
[colab] fixed type of `Promise` in `pauseOutputUntil`

### DIFF
--- a/types/colab/colab-tests.ts
+++ b/types/colab/colab-tests.ts
@@ -33,5 +33,8 @@ google.colab.output.getDefaultOutputArea().appendChild(div);
 
 google.colab.output.pauseOutputUntil(fetch("http://example.com"));
 
+declare const someEmptyPromise: Promise<void>;
+google.colab.output.pauseOutputUntil(someEmptyPromise);
+
 google.colab.output.setIframeHeight(100, true, { interactive: true });
 google.colab.output.resizeIframeToContent();

--- a/types/colab/index.d.ts
+++ b/types/colab/index.d.ts
@@ -126,7 +126,7 @@ declare global {
              * outputframe will be paused until this promise is resolved. This can be used
              * to reduce layout jank while rendering complex outputs.
              */
-            function pauseOutputUntil(promise: Promise<{}>): void;
+            function pauseOutputUntil(promise: Promise<unknown>): void;
 
             interface ResizeOptions {
                 /** The maximum height that the outputframe is allowed to have. */


### PR DESCRIPTION
The original typings were `Promise<void>`.  When I upstreamed them to `@types`, I changed to `Promise<{}>` because I remembered reading that `{}` was the TS team's recommended way to express `unknown`.

When I went to include the `@types/colab` in Colab's codebase, I realized that `{}` doesn't include `undefined`, but `unknown` does.  We couldn't import `@types/colab` until I changed to `unknown`.

This change most correctly specifies that `pauseOutputUntil` doesn't care about the shape of the promise - it should work on `<void>`, `<undefined>`, or `<WhateverYouWant>`.

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
    (I've opened #67113 to track test failures cause by the LSC.  Since this is a minor type change that's already been tested in our codebase, I'm confident that it's okay.)