### PR TITLE
Remove highlight.js as a dependency for remarkable types

### DIFF
--- a/types/remarkable/package.json
+++ b/types/remarkable/package.json
@@ -5,12 +5,11 @@
     "projects": [
         "https://github.com/jonschlinkert/remarkable"
     ],
-    "dependencies": {
-        "@types/highlight.js": "^9.7.0",
-        "highlight.js": "^9.7.0"
-    },
+    "dependencies": {},
     "devDependencies": {
-        "@types/remarkable": "workspace:."
+        "@types/highlight.js": "^9.7.0",
+        "@types/remarkable": "workspace:.",
+        "highlight.js": "^9.7.0"
     },
     "owners": [
         {


### PR DESCRIPTION
Highlight.js is only used for the test in this package. It shouldn't need to be marked as dependency. This results in everyone that uses the `@types/remarkable` package unnecessarily bringing in highlight.js as well.