### PR TITLE
Add packageManager field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
     },
+    "packageManager": "pnpm@8.9.2",
     "engines": {
         "pnpm": ">=8.9.2",
         "node": ">=7.8.0"


### PR DESCRIPTION
This adds support for [corepack](https://nodejs.org/api/corepack.html). This means corepack users can just run `pnpm`, and corepack matches the version specified by the `packageManager` field.

This field is also respected by the [`pnpm/action-setup`](https://github.com/pnpm/action-setup) GitHub action. This is currently set to `latest`, but it may be better to remove that.

Arguably this makes the the `#/engines/pnpm` field in `package.json` redundant.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
