### PR TITLE
Rewrite type definitions for react-tagcloud 2.x

### DIFF
--- a/types/react-tagcloud/index.d.ts
+++ b/types/react-tagcloud/index.d.ts
@@ -1,41 +1,86 @@
-/// <reference types="react"/>
+import * as React from "react";
 
-declare namespace ReactTagCloud {
-    interface TagCloudProps {
-        children?: React.ReactNode;
-        ref?: React.LegacyRef<void> | undefined;
-        tags: any[];
-        maxSize: number;
-        minSize: number;
-        shuffle?: boolean | undefined;
-        colorOptions?: object | undefined;
-        renderer?: Function | undefined;
-        className?: string | undefined;
-        onClick?: Function | undefined;
-        disableRandomColor?: boolean | undefined;
-    }
-    interface TagCloudClass extends React.ComponentClass<TagCloudProps> {}
+export class TagCloud extends React.Component<TagCloudProps> {}
 
-    interface DefaultRendererFactoryOptions {
-        tagRenderer?: Function | undefined;
-        colorOptions?: any;
-        props?: any;
-    }
-    interface RendererFunction {
-        (tag: any, size: number, key: string | number, handlers: any): any;
-    }
-    interface DefaultRendererFactory {
-        new(_ref?: DefaultRendererFactoryOptions): RendererFunction;
-        (_ref?: DefaultRendererFactoryOptions): RendererFunction;
-    }
+export interface TagCloudProps {
+    children?: React.ReactNode | undefined;
+    ref?: React.LegacyRef<void> | undefined;
+    className?: string | undefined;
+    /** Array of objects that represent tags */
+    tags: Tag[];
+    /** Maximal font size (in px) used in cloud */
+    maxSize: number;
+    /** Minimal font size (in px) used in cloud */
+    minSize: number;
+    /** If true, tags are shuffled. When tags are modified, cloud is re-shuffled. Default: true */
+    shuffle?: boolean | undefined;
+    /** Options passed to randomcolor library: https://github.com/davidmerfield/randomColor#options */
+    colorOptions?: ColorOptions | undefined;
+    /** Custom function to render a tag */
+    renderer?: RendererFunction | undefined;
+    /** If true, random color is not used */
+    disableRandomColor?: boolean | undefined;
+    /** Random seed used to shuffle tags and generate color */
+    randomSeed?: number | undefined;
+    /** @deprecated use randomSeed instead */
+    randomNumberGenerator?: Function | undefined;
+    /** Fired when a tag is clicked */
+    onClick?: TagEventHandler | undefined;
+    /** Fired when a tag is double-clicked */
+    onDoubleClick?: TagEventHandler | undefined;
+    /** Fired when mouse hovered over a tag */
+    onMouseMove?: TagEventHandler | undefined;
 }
 
-// export = TagCloud
-declare namespace reactTagCloud {
-    const TagCloud: ReactTagCloud.TagCloudClass;
-    const DefaultRenderer: ReactTagCloud.DefaultRendererFactory;
+export interface Tag {
+    /** String value to be displayed */
+    value: string;
+    /** Represents frequency of the tag that is used to calculate tag size */
+    count: number;
+    /**
+     * Tag element key.
+     * If it is not provided, value property will be used instead
+     * (however it can fail if you don't have unique tag values. It is highly recommeded to use key property)
+     */
+    key?: string | undefined;
+    /** Color of the tag. If not provided a random color will be used */
+    color?: string | undefined;
+    /** Additional props to be passed to a particular tag component */
+    props?: object | undefined;
 }
 
-declare module "react-tagcloud" {
-    export = reactTagCloud;
+export type TagEventHandler = (
+    tag: Tag,
+    event: React.MouseEvent<HTMLDivElement>,
+) => void;
+
+export type RendererFunction = (
+    tag: Tag,
+    size: number,
+    color: string,
+) => JSX.Element;
+
+export interface ColorOptions {
+    /**
+     * Controls the hue of the generated color.
+     * You can pass a string representing a color name:
+     * red, orange, yellow, green, blue, purple, pink and monochrome are currently supported.
+     * If you pass a hexidecimal color string such as #00FFFF,
+     * randomColor will extract its hue value and use that to generate colors.
+     */
+    hue?: string | undefined;
+    /** Controls the luminosity of the generated color. */
+    luminosity?: "bright" | "light" | "dark" | undefined;
+    /** An integer which specifies the number of colors to generate. */
+    count?: number | undefined;
+    /** An integer or string which when passed will cause randomColor to return the same color each time. */
+    seed?: number | string | undefined;
+    /** A string which specifies the format of the generated color. (Defaults to hex) */
+    format?: "rgb" | "rgba" | "rgbArray" | "hsl" | "hsla" | "hslArray" | "hex" | undefined;
+    /**
+     * A decimal between 0 and 1.
+     * Only relevant when using a format with an alpha channel (rgba and hsla).
+     * Defaults to a random value.
+     */
+    alpha?: number | undefined;
 }

--- a/types/react-tagcloud/package.json
+++ b/types/react-tagcloud/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-tagcloud": "workspace:."
     },
     "owners": [

--- a/types/react-tagcloud/package.json
+++ b/types/react-tagcloud/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-tagcloud",
-    "version": "1.1.9999",
+    "version": "2.3.9999",
     "projects": [
         "https://github.com/madox2/react-tagcloud"
     ],

--- a/types/react-tagcloud/react-tagcloud-tests.tsx
+++ b/types/react-tagcloud/react-tagcloud-tests.tsx
@@ -1,92 +1,49 @@
-// simple cloud
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { DefaultRenderer, TagCloud } from "react-tagcloud";
+import { RendererFunction, Tag, TagCloud } from "react-tagcloud";
 
-let data = [
+let data: Tag[] = [
     { value: "jQuery", count: 25 },
     { value: "MongoDB", count: 18 },
     { value: "JavaScript", count: 38 },
     { value: "React", count: 30 },
     { value: "Nodejs", count: 28 },
-    { value: "Express.js", count: 25 },
-    { value: "HTML5", count: 33 },
-    { value: "CSS3", count: 20 },
+    { value: "Express.js", count: 25, key: "expr" },
+    { value: "HTML5", count: 33, color: "blue" },
+    { value: "CSS3", count: 20, props: { style: { textDecoration: "underline" } } },
 ];
 
+const customRenderer: RendererFunction = (tag, size, color) => (
+    <span
+        key={tag.key ?? tag.value}
+        style={{
+            animation: "blinker 3s linear infinite",
+            animationDelay: `${Math.random() * 2}s`,
+            fontSize: `${size / 2}em`,
+            border: `2px solid ${color}`,
+            margin: "3px",
+            padding: "3px",
+            display: "inline-block",
+            color: "white",
+        }}
+    >
+        {tag.value}
+    </span>
+);
+
 ReactDOM.render(
-    // minSize, maxSize - font size in px
-    // tags - array of objects with properties value and count
-    // shuffle - indicates if data should be shuffled (true by default)
-    // onClick event handler has `tag` and `event` parameter
     <TagCloud
         minSize={12}
         maxSize={35}
         tags={data}
         shuffle={false}
         disableRandomColor={false}
-        onClick={(tag: string) => console.log("clicking on tag:", tag)}
+        randomSeed={123456}
+        colorOptions={{ hue: "green", luminosity: "bright", count: 100, seed: 123, format: "rgba", alpha: 0.9 }}
+        onClick={(tag, event) => console.log("click on:", tag.value, event.target)}
+        onDoubleClick={(tag, event) => console.log("dbl-click on:", tag.value, event.target)}
+        onMouseMove={(tag, event) => console.log("hover on:", tag.value, event.target)}
+        renderer={customRenderer}
     />,
     document.getElementById("simple-cloud"),
-);
-
-// default-renderer
-
-// DefaultRenderer creates default renderer implementation with custom options
-// usage of tagRenderer option is described in ./custom-tag-renderer.js
-
-// custom props will be applied on each tag component
-const props = {
-    style: { border: "1px solid silver", padding: "5px" },
-    className: "my-tag-class",
-};
-
-// custom random color options
-// see randomColor package: https://github.com/davidmerfield/randomColor
-const colorOptions = {
-    luminosity: "light",
-    hue: "blue",
-};
-
-let customizedDefaultRenderer = new DefaultRenderer({ props, colorOptions });
-
-ReactDOM.render(
-    <TagCloud minSize={12} maxSize={35} tags={data} renderer={customizedDefaultRenderer} />,
-    document.getElementById("default-renderer"),
-);
-//
-// custom-renderer.js
-// using custom renderer the default renderer will be overriden
-
-// custom renderer is function which takes tag, computed font size and
-// elemnt key as arguments, and returns react component
-let customRenderer2 = (tag: any, size: number, key: string | number) => {
-    return <span key={key} className={`tag-${size}`}>{tag.value}</span>;
-};
-
-ReactDOM.render(
-    <TagCloud tags={data} minSize={1} maxSize={5} renderer={customRenderer2} />,
-    document.getElementById("custom-renderer"),
-);
-
-// example from custom-tag-renderer.js
-let data2 = [
-    { value: { name: "google", link: "http://google.com" }, count: 25 },
-    { value: { name: "yahoo", link: "http://yahoo.com" }, count: 18 },
-    { value: { name: "facebook", link: "http://facebook.com" }, count: 38 },
-    { value: { name: "twitter", link: "http://twitter.com" }, count: 30 },
-    { value: { name: "github", link: "https://github.com" }, count: 28 },
-    { value: { name: "npmjs", link: "http://npmjs.com" }, count: 25 },
-    { value: { name: "stackoverflow", link: "https://stackoverflow.com" }, count: 33 },
-];
-
-// with tagRenderer option it is possible to customize rendering of each tag
-// tagRender is a function which takes tag as argument and returns react component or simple string
-const tagRenderer = (tag: any) => <a href={tag.value.link}>{tag.value.name}</a>;
-
-const customizedDefaultRenderer4 = new DefaultRenderer({ tagRenderer });
-
-ReactDOM.render(
-    <TagCloud minSize={12} maxSize={35} tags={data2} renderer={customizedDefaultRenderer4} />,
-    document.getElementById("custom-tag-renderer"),
 );

--- a/types/react-tagcloud/react-tagcloud-tests.tsx
+++ b/types/react-tagcloud/react-tagcloud-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { RendererFunction, Tag, TagCloud } from "react-tagcloud";
 
 let data: Tag[] = [
@@ -31,19 +30,20 @@ const customRenderer: RendererFunction = (tag, size, color) => (
     </span>
 );
 
-ReactDOM.render(
-    <TagCloud
-        minSize={12}
-        maxSize={35}
-        tags={data}
-        shuffle={false}
-        disableRandomColor={false}
-        randomSeed={123456}
-        colorOptions={{ hue: "green", luminosity: "bright", count: 100, seed: 123, format: "rgba", alpha: 0.9 }}
-        onClick={(tag, event) => console.log("click on:", tag.value, event.target)}
-        onDoubleClick={(tag, event) => console.log("dbl-click on:", tag.value, event.target)}
-        onMouseMove={(tag, event) => console.log("hover on:", tag.value, event.target)}
-        renderer={customRenderer}
-    />,
-    document.getElementById("simple-cloud"),
-);
+export function MyTagCloud() {
+    return (
+        <TagCloud
+            minSize={12}
+            maxSize={35}
+            tags={data}
+            shuffle={false}
+            disableRandomColor={false}
+            randomSeed={123456}
+            colorOptions={{ hue: "green", luminosity: "bright", count: 100, seed: 123, format: "rgba", alpha: 0.9 }}
+            onClick={(tag, event) => console.log("click on:", tag.value, event.target)}
+            onDoubleClick={(tag, event) => console.log("dbl-click on:", tag.value, event.target)}
+            onMouseMove={(tag, event) => console.log("hover on:", tag.value, event.target)}
+            renderer={customRenderer}
+        />
+    );
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/madox2/react-tagcloud
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is pretty much a complete rewrite of the type definitions because:

- the API in 2.x has changed significantly,
- the old type definitions contained lots of `any` and `Function` types.

Overview of the changes:

- Included `colorOptions` prop type definition based on https://github.com/davidmerfield/randomColor#options
- Defined `Tag` type for use in the `tags` prop and various functions.
- Defined function types for event callbacks and renderer.
- Included bunch of doc-comments.
- Marked `randomNumberGenerator` prop as deprecated.
- Replaced complex namespace declarations with plain exports.
- Included all the utility types also to exports (e.g. `Tag` and `RendererFunction`) in addition to the single `TagCloud` export (the only name exported by the 2.x version of the JS library).
- Removed `react-dom` from dev-dependencies.
- Simplified tests.