### PR TITLE
`ads-client`: Add type for `plcRuntimeState`

### DIFF
--- a/types/ads-client/ads-client-tests.ts
+++ b/types/ads-client/ads-client-tests.ts
@@ -177,4 +177,7 @@ async function usage() {
     client.on("plcRuntimeStateChange", state => {
         console.log("State is now:", state);
     });
+
+    const state = await client.readPlcRuntimeState();
+    console.log(state.adsStateStr, state.adsState, state.deviceState);
 }

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -40,7 +40,7 @@ export interface Metadata {
     routerState: object;
 }
 
-type ADSStateStr =
+export type ADSStateStr =
     'Invalid'
     | 'Idle'
     | 'Reset'

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -40,8 +40,7 @@ export interface Metadata {
     routerState: object;
 }
 
-export type ADSStateStr =
-    'Invalid'
+export type ADSStateStr = 'Invalid'
     | 'Idle'
     | 'Reset'
     | 'Initialize'

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -30,7 +30,7 @@ export interface Settings {
 export interface Metadata {
     deviceInfo: object;
     systemManagerState: object;
-    plcRuntimeState: object;
+    plcRuntimeState: PLCRuntimeState;
     uploadInfo: object;
     symbolVersion: number;
     allSymbolsCached: boolean;
@@ -38,6 +38,35 @@ export interface Metadata {
     allDataTypesCached: boolean;
     dataTypes: object;
     routerState: object;
+}
+
+type ADSStateStr =
+    'Invalid'
+    | 'Idle'
+    | 'Reset'
+    | 'Initialize'
+    | 'Start'
+    | 'Run'
+    | 'Stop'
+    | 'SaveConfig'
+    | 'LoadConfig'
+    | 'PowerFailure'
+    | 'PowerGood'
+    | 'Error'
+    | 'Shutdown'
+    | 'Susped' // Upstream typo
+    | 'Resume'
+    | 'Config'
+    | 'Reconfig'
+    | 'Stopping'
+    | 'Incompatible'
+    | 'Exception'
+    | 'UNKNOWN'
+
+export interface PLCRuntimeState {
+    adsState: number,
+    adsStateStr: ADSStateStr,
+    deviceState: number
 }
 
 export interface Connection {
@@ -218,7 +247,7 @@ export class Client extends EventEmitter {
 
     readSystemManagerState(): Promise<object>;
 
-    readPlcRuntimeState(adsPort?: number): Promise<object>;
+    readPlcRuntimeState(adsPort?: number): Promise<PLCRuntimeState>;
 
     readSymbolVersion(): Promise<number>;
 

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -60,7 +60,7 @@ export type ADSStateStr = 'Invalid'
     | 'Stopping'
     | 'Incompatible'
     | 'Exception'
-    | 'UNKNOWN'
+    | 'UNKNOWN';
 
 export interface PLCRuntimeState {
     adsState: number,


### PR DESCRIPTION
This adds type declaration for `plcRuntimeState` in `ads-client`.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jisotalo/ads-client/blob/1a88b8a02917ccf63874fe20cabb792b558b2dd1/src/ads-client-ads.js#L475
