### PR TITLE
[node] Add fetch to v18, update undici-types version

### DIFF
--- a/types/node/package.json
+++ b/types/node/package.json
@@ -16,7 +16,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -320,4 +320,62 @@ declare namespace NodeJS {
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
     }
+
+    namespace fetch {
+        type _Request = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Request;
+        type _Response = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Response;
+        type _FormData = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").FormData;
+        type _Headers = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Headers;
+        type _RequestInit = typeof globalThis extends { onmessage: any } ? {}
+            : import("undici-types").RequestInit;
+        type Request = globalThis.Request;
+        type Response = globalThis.Response;
+        type Headers = globalThis.Headers;
+        type FormData = globalThis.FormData;
+        type RequestInit = globalThis.RequestInit;
+        type RequestInfo = import("undici-types").RequestInfo;
+        type HeadersInit = import("undici-types").HeadersInit;
+        type BodyInit = import("undici-types").BodyInit;
+        type RequestRedirect = import("undici-types").RequestRedirect;
+        type RequestCredentials = import("undici-types").RequestCredentials;
+        type RequestMode = import("undici-types").RequestMode;
+        type ReferrerPolicy = import("undici-types").ReferrerPolicy;
+        type Dispatcher = import("undici-types").Dispatcher;
+        type RequestDuplex = import("undici-types").RequestDuplex;
+    }
 }
+
+interface RequestInit extends NodeJS.fetch._RequestInit {}
+
+declare function fetch(
+    input: NodeJS.fetch.RequestInfo,
+    init?: RequestInit,
+): Promise<Response>;
+
+interface Request extends NodeJS.fetch._Request {}
+declare var Request: typeof globalThis extends {
+    onmessage: any;
+    Request: infer T;
+} ? T
+    : typeof import("undici-types").Request;
+
+interface Response extends NodeJS.fetch._Response {}
+declare var Response: typeof globalThis extends {
+    onmessage: any;
+    Response: infer T;
+} ? T
+    : typeof import("undici-types").Response;
+
+interface FormData extends NodeJS.fetch._FormData {}
+declare var FormData: typeof globalThis extends {
+    onmessage: any;
+    FormData: infer T;
+} ? T
+    : typeof import("undici-types").FormData;
+
+interface Headers extends NodeJS.fetch._Headers {}
+declare var Headers: typeof globalThis extends {
+    onmessage: any;
+    Headers: infer T;
+} ? T
+    : typeof import("undici-types").Headers;

--- a/types/node/v18/package.json
+++ b/types/node/v18/package.json
@@ -15,6 +15,9 @@
             ]
         }
     },
+    "dependencies": {
+        "undici-types": "~5.26.4"
+    },
     "devDependencies": {
         "@types/node": "workspace:."
     },

--- a/types/node/v18/test/globals.ts
+++ b/types/node/v18/test/globals.ts
@@ -51,3 +51,35 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     x.reason; // $ExpectType any
     x.throwIfAborted(); // $ExpectType void
 }
+
+// fetch
+{
+    // This tsconfig.json references lib.dom.d.ts. The fetch
+    // types included in globals.d.ts are designed to be empty
+    // merges when lib.dom.d.ts is included. This test ensures
+    // the merge works, but the types observed are from lib.dom.d.ts.
+    fetch("https://example.com").then(response => {
+        response.arrayBuffer(); // $ExpectType Promise<ArrayBuffer>
+        response.blob(); // $ExpectType Promise<Blob>
+        response.formData(); // $ExpectType Promise<FormData>
+
+        // undici-types uses `Promise<unknown>` for `json()`
+        // This $ExpectType will change if tsconfig.json drops
+        // lib.dom.d.ts.
+        response.json(); // $ExpectType Promise<any>
+        response.text(); // $ExpectType Promise<string>
+    });
+    const fd = new FormData();
+    fd.append("foo", "bar");
+    const headers = new Headers();
+    headers.append("Accept", "application/json");
+    fetch("https://example.com", { body: fd });
+
+    fetch(new URL("https://example.com"), {
+        // @ts-expect-error this should not be available when lib.dom.d.ts is present
+        dispatcher: undefined,
+    });
+
+    // @ts-expect-error
+    NodeJS.fetch;
+}

--- a/types/node/v18/ts4.8/globals.d.ts
+++ b/types/node/v18/ts4.8/globals.d.ts
@@ -320,4 +320,62 @@ declare namespace NodeJS {
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
     }
+
+    namespace fetch {
+        type _Request = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Request;
+        type _Response = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Response;
+        type _FormData = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").FormData;
+        type _Headers = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Headers;
+        type _RequestInit = typeof globalThis extends { onmessage: any } ? {}
+            : import("undici-types").RequestInit;
+        type Request = globalThis.Request;
+        type Response = globalThis.Response;
+        type Headers = globalThis.Headers;
+        type FormData = globalThis.FormData;
+        type RequestInit = globalThis.RequestInit;
+        type RequestInfo = import("undici-types").RequestInfo;
+        type HeadersInit = import("undici-types").HeadersInit;
+        type BodyInit = import("undici-types").BodyInit;
+        type RequestRedirect = import("undici-types").RequestRedirect;
+        type RequestCredentials = import("undici-types").RequestCredentials;
+        type RequestMode = import("undici-types").RequestMode;
+        type ReferrerPolicy = import("undici-types").ReferrerPolicy;
+        type Dispatcher = import("undici-types").Dispatcher;
+        type RequestDuplex = import("undici-types").RequestDuplex;
+    }
 }
+
+interface RequestInit extends NodeJS.fetch._RequestInit {}
+
+declare function fetch(
+    input: NodeJS.fetch.RequestInfo,
+    init?: RequestInit,
+): Promise<Response>;
+
+interface Request extends NodeJS.fetch._Request {}
+declare var Request: typeof globalThis extends {
+    onmessage: any;
+    Request: infer T;
+} ? T
+    : typeof import("undici-types").Request;
+
+interface Response extends NodeJS.fetch._Response {}
+declare var Response: typeof globalThis extends {
+    onmessage: any;
+    Response: infer T;
+} ? T
+    : typeof import("undici-types").Response;
+
+interface FormData extends NodeJS.fetch._FormData {}
+declare var FormData: typeof globalThis extends {
+    onmessage: any;
+    FormData: infer T;
+} ? T
+    : typeof import("undici-types").FormData;
+
+interface Headers extends NodeJS.fetch._Headers {}
+declare var Headers: typeof globalThis extends {
+    onmessage: any;
+    Headers: infer T;
+} ? T
+    : typeof import("undici-types").Headers;

--- a/types/node/v18/ts4.8/test/globals.ts
+++ b/types/node/v18/ts4.8/test/globals.ts
@@ -43,3 +43,25 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     x.reason; // $ExpectType any
     x.throwIfAborted(); // $ExpectType void
 }
+
+// fetch
+{
+    fetch("https://example.com").then(response => {
+        response.arrayBuffer(); // $ExpectType Promise<ArrayBuffer>
+        response.blob(); // $ExpectType Promise<Blob>
+        response.formData(); // $ExpectType Promise<FormData>
+        response.json(); // $ExpectType Promise<unknown>
+        response.text(); // $ExpectType Promise<string>
+    });
+    const fd = new FormData();
+    fd.append("foo", "bar");
+    const headers = new Headers();
+    headers.append("Accept", "application/json");
+    fetch("https://example.com", { body: fd });
+    fetch(new URL("https://example.com"), {
+        dispatcher: undefined,
+    });
+
+    // @ts-expect-error
+    NodeJS.fetch;
+}


### PR DESCRIPTION
Follow-up to #66824, now possible thanks to #67085 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  ```
  ❯ node
  Welcome to Node.js v18.18.2.
  Type ".help" for more information.
  > process.versions.undici
  '5.26.3'

  ❯ node
  Welcome to Node.js v20.8.1.
  Type ".help" for more information.
  > process.versions.undici
  '5.26.3'
  ```
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
