### PR TITLE
[react] fix useMemo break when return undefined

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3274,7 +3274,7 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
     : P;
 
 // Exclude implicity return undefined
-type ExcludeVoidFn<T extends Function> = (() => void) extends T ? never : T;
+type ExcludeVoidFn<T extends () => unknown> = (() => void) extends T ? never : T;
 
 
 declare global {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1130,7 +1130,8 @@ declare namespace React {
      * @see https://react.dev/reference/react/useMemo
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => Exclude<T, void>, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: ExcludeVoidFn<() => T>, deps: DependencyList | undefined): T;
+
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *
@@ -3271,6 +3272,10 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
     : C extends { propTypes: infer T } ? MergePropTypes<P, PropTypes.InferProps<T>>
     : C extends { defaultProps: infer D } ? Defaultize<P, D>
     : P;
+
+// Exclude implicity return undefined
+type ExcludeVoidFn<T extends Function> = (() => void) extends T ? never : T;
+
 
 declare global {
     /**

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -239,6 +239,10 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useMemo(() => ({}), undefined);
     // allow explicit return null
     React.useMemo(() => null, undefined);
+    // allow explicit return undefined
+    React.useMemo(() => undefined, undefined);
+    // check explicit return type that might be undefined
+    React.useMemo(() => Math.random() < 0.5 ? "foo" : undefined, []);
     // but not allow factory function return void, prevent accidentally forget to return
     // @ts-expect-error
     React.useMemo(() => {});


### PR DESCRIPTION
This PR means to be to fix #67076. Sorry about the mess.

Thanks to @meyfa 's [solution](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67076#issuecomment-1771635702), this should fix **explicit return undefined** would brake.

And Thanks to @Hypnosphi @meyfa @kevinbailey25 @stephenzsy @miguelski @codeaid @jessemyers-lettuce to point out my mistake.
Special thanks to @meyfa for providing the solution, and @miguelski for explaining the reason why `Exclude<T, void>` won't work after typescript 5.1+.

Thanks to all future participants. You all make this library more robust and more comprehensive.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
