### PR TITLE
Fix CreateDirectory in chrome.fileSystemProvider

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3912,7 +3912,10 @@ declare namespace chrome.fileSystemProvider {
         length: number;
     }
 
-    export interface DirectoryPathRecursiveRequestedEventOptions extends DirectoryPathRequestedEventOptions {
+    export interface CreateDirectoryRequestedEventOptions extends RequestedEventOptions {
+        /** The path of the directory to be created. */
+        directoryPath: string;
+
         /** Whether the operation is recursive (for directories only). */
         recursive: boolean;
     }
@@ -4002,10 +4005,10 @@ declare namespace chrome.fileSystemProvider {
         >
     {}
 
-    export interface DirectoryPathRecursiveRequestedEvent extends
+    export interface CreateDirectoryRequestedEvent extends
         chrome.events.Event<
             (
-                options: DirectoryPathRecursiveRequestedEventOptions,
+                options: CreateDirectoryRequestedEventOptions,
                 successCallback: Function,
                 errorCallback: (error: string) => void,
             ) => void
@@ -4144,7 +4147,7 @@ declare namespace chrome.fileSystemProvider {
     /** Raised when reading contents of a file opened previously with openRequestId is requested. The results must be returned in chunks by calling successCallback several times. In case of an error, errorCallback must be called. */
     export var onReadFileRequested: OpenedFileOffsetRequestedEvent;
     /** Raised when creating a directory is requested. The operation must fail with the EXISTS error if the target directory already exists. If recursive is true, then all of the missing directories on the directory path must be created. */
-    export var onCreateDirectoryRequested: DirectoryPathRecursiveRequestedEvent;
+    export var onCreateDirectoryRequested: CreateDirectoryRequestedEvent;
     /** Raised when deleting an entry is requested. If recursive is true, and the entry is a directory, then all of the entries inside must be recursively deleted as well. */
     export var onDeleteEntryRequested: EntryPathRecursiveRequestedEvent;
     /** Raised when creating a file is requested. If the file already exists, then errorCallback must be called with the "EXISTS" error code. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2077,6 +2077,14 @@ function testFileSystemProvider() {
             errorCallback: (error: string) => void,
         ) => {},
     );
+
+    chrome.fileSystemProvider.onCreateDirectoryRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.CreateDirectoryRequestedEventOptions,
+            successCallback: Function,
+            errorCallback: (error: string) => void,
+        ) => {},
+    );
 }
 
 // https://developer.chrome.com/docs/extensions/reference/sessions/


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/#type-CreateDirectoryRequestedOptions)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)

These definitions were not quite correct for the CreateDirectory event, which accepts 4 params (see [Documentation](https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/#type-CreateDirectoryRequestedOptions)).
This event's options were inheriting from `DirectoryPathRequestedEventOptions` which is an unrelated type, so I removed that and made this options type specific to CreateDirectory.

This API has very low usage so this has gone unnoticed for a while. I'm a maintainer of this API in Chrome.