### PR TITLE
Revert "[react] force useMemo factory function has an explicit return"

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1130,7 +1130,7 @@ declare namespace React {
      * @see https://react.dev/reference/react/useMemo
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => Exclude<T, void>, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -229,17 +229,9 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useDebugValue(id, value => value.toFixed());
     React.useDebugValue(id);
 
-    // allow passing an explicit undefined as dependency list
-    React.useMemo(() => ({}), undefined);
-    // but don't allow dependency list to be missing
-    // @ts-expect-error
-    React.useMemo(() => ({}));
-
-    // allow explicit return empty object
-    React.useMemo(() => ({}), undefined);
-    // allow explicit return null
-    React.useMemo(() => null, undefined);
-    // but not allow factory function return void, prevent accidentally forget to return
+    // allow passing an explicit undefined
+    React.useMemo(() => {}, undefined);
+    // but don't allow it to be missing
     // @ts-expect-error
     React.useMemo(() => {});
 


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#67076

This causes an unexpected breaking change, so we decided to revert it first.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67132 for further discussion.