### PR TITLE
Fix express-slow-down tests

### DIFF
--- a/types/express-slow-down/express-slow-down-tests.ts
+++ b/types/express-slow-down/express-slow-down-tests.ts
@@ -13,7 +13,7 @@ const slowerWithOptions = slowDown({
 });
 
 const slowerWithCallbacks = slowDown({
-    keyGenerator: (req, res) => req.ip,
+    keyGenerator: (req, res) => req.ip ?? "0.0.0.0",
     skip: (req, res) => false,
     onLimitReached: (req, res, opts) => {
         console.log(req.slowDown.current);


### PR DESCRIPTION
For new `ip: string | undefined` in express-serve-static-core. The old way of calculating dependencies missed express-slow-down or it would have failed tests and blocked merging the original PR.
