### PR TITLE
Update dprint plugins, force no trailing commas in JSON

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -49,10 +49,13 @@
     },
     // NOTE: if extending this list, also update settings.template.json.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.88.1.wasm",
-        "https://plugins.dprint.dev/json-0.17.4.wasm",
+        "https://plugins.dprint.dev/typescript-0.88.2.wasm",
+        "https://plugins.dprint.dev/json-0.18.0.wasm",
         "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe"
     ],
     "indentWidth": 4,
-    "lineWidth": 120
+    "lineWidth": 120,
+    "json": {
+        "trailingCommas": "never" // Our tsconfig files must be parsable by JSON.parse.
+    }
 }


### PR DESCRIPTION
The newest version of the JSON plugin special cases `tsconfig.json` and `.vscode` dirs as being JSONC. But, our `tsconfig` files _must_ be parsable by `JSON.parse`, so I've changed the config to make sure that doesn't happen.

(This is a good reason to not auto-bump formatting plugins; this is a breaking change that if automatically applied would have broken the whole repo.)