### PR TITLE
Disallow VariableDeclaration as declaration of ExportDefaultDeclaration in estree

### DIFF
--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -88,6 +88,8 @@ declare var importDefaultSpecifier: ESTree.ImportDefaultSpecifier;
 declare var importNamespaceSpecifier: ESTree.ImportNamespaceSpecifier;
 declare var exportNamedDeclaration: ESTree.ExportNamedDeclaration;
 declare var exportSpecifier: ESTree.ExportSpecifier;
+declare var maybeNamedClassDeclaration: ESTree.MaybeNamedClassDeclaration;
+declare var maybeNamedFunctionDeclaration: ESTree.MaybeNamedFunctionDeclaration;
 declare var exportDefaultDeclaration: ESTree.ExportDefaultDeclaration;
 declare var exportAllDeclaration: ESTree.ExportAllDeclaration;
 declare var awaitExpression: ESTree.AwaitExpression;
@@ -261,6 +263,7 @@ if (memberExpressionOrCallExpression.type === "MemberExpression") {
 // Declarations
 var functionDeclaration: ESTree.FunctionDeclaration;
 var identifierOrNull: ESTree.Identifier | null = functionDeclaration.id;
+// @ts-expect-error Use MaybeNamedFunctionDeclaration for default exports
 functionDeclaration.id = null;
 var params: ESTree.Pattern[] = functionDeclaration.params;
 blockStatement = functionDeclaration.body;
@@ -277,6 +280,7 @@ expressionMaybe = variableDeclarator.init;
 
 var classDeclaration: ESTree.ClassDeclaration;
 identifierOrNull = classDeclaration.id;
+// @ts-expect-error Use MaybeNamedClassDeclaration for default exports
 classDeclaration.id = null;
 
 // Clauses
@@ -797,7 +801,7 @@ switch (forOfStatement.left.type) {
         break;
 }
 
-switch(exportDefaultDeclaration.declaration.type) {
+switch (exportDefaultDeclaration.declaration.type) {
     case "Identifier":
         identifier = exportDefaultDeclaration.declaration;
         break;
@@ -810,10 +814,10 @@ switch(exportDefaultDeclaration.declaration.type) {
 
     // narrowing of Declaration
     case "FunctionDeclaration":
-        functionDeclaration = exportDefaultDeclaration.declaration;
+        maybeNamedFunctionDeclaration = exportDefaultDeclaration.declaration;
         break;
     case "ClassDeclaration":
-        classDeclaration = exportDefaultDeclaration.declaration;
+        maybeNamedClassDeclaration = exportDefaultDeclaration.declaration;
         break;
     // end narrowing of Declaration
 

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -796,3 +796,96 @@ switch (forOfStatement.left.type) {
         memberExpression = forOfStatement.left;
         break;
 }
+
+switch(exportDefaultDeclaration.declaration.type) {
+    case "Identifier":
+        identifier = exportDefaultDeclaration.declaration;
+        break;
+    case "Literal":
+        literal = exportDefaultDeclaration.declaration;
+        break;
+    case "FunctionExpression":
+        functionExpression = exportDefaultDeclaration.declaration;
+        break;
+
+    // narrowing of Declaration
+    case "FunctionDeclaration":
+        functionDeclaration = exportDefaultDeclaration.declaration;
+        break;
+    case "ClassDeclaration":
+        classDeclaration = exportDefaultDeclaration.declaration;
+        break;
+    // end narrowing of Declaration
+
+    // narrowing of Expression
+    case "ThisExpression":
+        thisExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ArrayExpression":
+        arrayExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ObjectExpression":
+        objectExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ArrowFunctionExpression":
+        arrowFunctionExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "YieldExpression":
+        yieldExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "UnaryExpression":
+        unaryExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "UpdateExpression":
+        updateExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "BinaryExpression":
+        binaryExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "AssignmentExpression":
+        assignmentExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "LogicalExpression":
+        logicalExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "MemberExpression":
+        memberExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ChainExpression":
+        chainExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ConditionalExpression":
+        conditionalExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "CallExpression":
+        callExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "NewExpression":
+        newExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "SequenceExpression":
+        sequenceExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "TemplateLiteral":
+        templateLiteral = exportDefaultDeclaration.declaration;
+        break;
+    case "TaggedTemplateExpression":
+        taggedTemplateExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ClassExpression":
+        classExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "MetaProperty":
+        metaProperty = exportDefaultDeclaration.declaration;
+        break;
+    case "AwaitExpression":
+        awaitExpression = exportDefaultDeclaration.declaration;
+        break;
+    case "ImportExpression":
+        importExpression = exportDefaultDeclaration.declaration;
+        break;
+    // end narrowing of Expression
+
+    default:
+        never = exportDefaultDeclaration.declaration;
+}

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -660,7 +660,7 @@ export interface ExportSpecifier extends BaseModuleSpecifier {
 
 export interface ExportDefaultDeclaration extends BaseModuleDeclaration {
     type: "ExportDefaultDeclaration";
-    declaration: Declaration | Expression;
+    declaration: FunctionDeclaration | ClassDeclaration | Expression;
 }
 
 export interface ExportAllDeclaration extends BaseModuleDeclaration {

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -233,11 +233,15 @@ export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDecla
 
 export interface BaseDeclaration extends BaseStatement {}
 
-export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
+export interface MaybeNamedFunctionDeclaration extends BaseFunction, BaseDeclaration {
     type: "FunctionDeclaration";
     /** It is null when a function declaration is a part of the `export default function` statement */
     id: Identifier | null;
     body: BlockStatement;
+}
+
+export interface FunctionDeclaration extends MaybeNamedFunctionDeclaration {
+    id: Identifier;
 }
 
 export interface VariableDeclaration extends BaseDeclaration {
@@ -593,10 +597,14 @@ export interface MethodDefinition extends BaseNode {
     static: boolean;
 }
 
-export interface ClassDeclaration extends BaseClass, BaseDeclaration {
+export interface MaybeNamedClassDeclaration extends BaseClass, BaseDeclaration {
     type: "ClassDeclaration";
     /** It is null when a class declaration is a part of the `export default class` statement */
     id: Identifier | null;
+}
+
+export interface ClassDeclaration extends MaybeNamedClassDeclaration {
+    id: Identifier;
 }
 
 export interface ClassExpression extends BaseClass, BaseExpression {
@@ -660,7 +668,7 @@ export interface ExportSpecifier extends BaseModuleSpecifier {
 
 export interface ExportDefaultDeclaration extends BaseModuleDeclaration {
     type: "ExportDefaultDeclaration";
-    declaration: FunctionDeclaration | ClassDeclaration | Expression;
+    declaration: MaybeNamedFunctionDeclaration | MaybeNamedClassDeclaration | Expression;
 }
 
 export interface ExportAllDeclaration extends BaseModuleDeclaration {


### PR DESCRIPTION
The following is not valid JavaScript:

```
export default var foo = 'bar'
```

This is also not valid according to the estree spec: https://github.com/estree/estree

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estree/estree/blob/7a0c8fb02a33a69fa16dbe3ca35beeaa8f58f1e3/es2015.md#exportdefaultdeclaration
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
