### PR TITLE
fix(jest): mark alias matchers as deprecated

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -805,6 +805,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected arguments via a generic.
          * Note that the type must be either an array or a tuple.
+         *
+         * @deprecated in favor of `toHaveBeenLastCalledWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         lastCalledWith<E extends any[]>(...args: E): R;
@@ -813,6 +815,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected value via a generic.
          * This is particularly useful for ensuring expected objects have the right structure.
+         *
+         * @deprecated in favor of `toHaveLastReturnedWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         lastReturnedWith<E = any>(expected?: E): R;
@@ -821,6 +825,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected arguments via a generic.
          * Note that the type must be either an array or a tuple.
+         *
+         * @deprecated in favor of `toHaveBeenNthCalledWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         nthCalledWith<E extends any[]>(nthCall: number, ...params: E): R;
@@ -829,6 +835,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected value via a generic.
          * This is particularly useful for ensuring expected objects have the right structure.
+         *
+         * @deprecated in favor of `toHaveNthReturnedWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         nthReturnedWith<E = any>(n: number, expected?: E): R;
@@ -843,10 +851,14 @@ declare namespace jest {
         toBe<E = any>(expected: E): R;
         /**
          * Ensures that a mock function is called.
+         * 
+         * @deprecated in favor of `toHaveBeenCalled`
          */
         toBeCalled(): R;
         /**
          * Ensures that a mock function is called an exact number of times.
+         *
+         * @deprecated in favor of `toHaveBeenCalledTimes`
          */
         toBeCalledTimes(expected: number): R;
         /**
@@ -854,6 +866,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected arguments via a generic.
          * Note that the type must be either an array or a tuple.
+         *
+         * @deprecated in favor of `toHaveBeenCalledWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         toBeCalledWith<E extends any[]>(...args: E): R;
@@ -1087,10 +1101,14 @@ declare namespace jest {
         toMatchInlineSnapshot(snapshot?: string): R;
         /**
          * Ensure that a mock function has returned (as opposed to thrown) at least once.
+         *
+         * @deprecated in favor of `toHaveReturned`
          */
         toReturn(): R;
         /**
          * Ensure that a mock function has returned (as opposed to thrown) a specified number of times.
+         *
+         * @deprecated in favor of `toHaveReturnedTimes`
          */
         toReturnTimes(count: number): R;
         /**
@@ -1098,6 +1116,8 @@ declare namespace jest {
          *
          * Optionally, you can provide a type for the expected value via a generic.
          * This is particularly useful for ensuring expected objects have the right structure.
+         *
+         * @deprecated in favor of `toHaveReturnedWith`
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         toReturnWith<E = any>(value?: E): R;
@@ -1115,6 +1135,8 @@ declare namespace jest {
         toThrow(error?: string | Constructable | RegExp | Error): R;
         /**
          * If you want to test that a specific error is thrown inside a function.
+         *
+         * @deprecated in favor of `toThrow`
          */
         toThrowError(error?: string | Constructable | RegExp | Error): R;
         /**

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -851,7 +851,7 @@ declare namespace jest {
         toBe<E = any>(expected: E): R;
         /**
          * Ensures that a mock function is called.
-         * 
+         *
          * @deprecated in favor of `toHaveBeenCalled`
          */
         toBeCalled(): R;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -2020,3 +2020,16 @@ test("import.meta.jest replaces the global jest in ESM", () => {
 
     importMetaJest.fn();
 });
+
+// these are deprecated and will be removed in Jest v30
+expect('abc').toBeCalled();
+expect('abc').toBeCalledTimes(0);
+expect('abc').toBeCalledWith();
+expect('abc').lastCalledWith();
+expect('abc').nthCalledWith(0);
+expect('abc').toReturn();
+expect('abc').toReturnTimes(0);
+expect('abc').toReturnWith();
+expect('abc').lastReturnedWith();
+expect('abc').nthReturnedWith(0);
+expect('abc').toThrowError();

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -2022,14 +2022,14 @@ test("import.meta.jest replaces the global jest in ESM", () => {
 });
 
 // these are deprecated and will be removed in Jest v30
-expect('abc').toBeCalled();
-expect('abc').toBeCalledTimes(0);
-expect('abc').toBeCalledWith();
-expect('abc').lastCalledWith();
-expect('abc').nthCalledWith(0);
-expect('abc').toReturn();
-expect('abc').toReturnTimes(0);
-expect('abc').toReturnWith();
-expect('abc').lastReturnedWith();
-expect('abc').nthReturnedWith(0);
-expect('abc').toThrowError();
+expect("abc").toBeCalled();
+expect("abc").toBeCalledTimes(0);
+expect("abc").toBeCalledWith();
+expect("abc").lastCalledWith();
+expect("abc").nthCalledWith(0);
+expect("abc").toReturn();
+expect("abc").toReturnTimes(0);
+expect("abc").toReturnWith();
+expect("abc").lastReturnedWith();
+expect("abc").nthReturnedWith(0);
+expect("abc").toThrowError();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jestjs/jest/issues/13164
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

---

As far as I know there's no way to add tests for `@deprecated` but if that has changed let me know
