### PR TITLE
Add some docs in Nova Editor types

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -5,7 +5,6 @@
 /// <reference no-default-lib="true"/>
 /// <reference lib="es2020" />
 /// <reference lib="WebWorker" />
-/// <reference types="vscode-languageserver-types" />
 
 /// https://docs.nova.app/api-reference/assistants-registry/
 

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -5,6 +5,7 @@
 /// <reference no-default-lib="true"/>
 /// <reference lib="es2020" />
 /// <reference lib="WebWorker" />
+/// <reference types="vscode-languageserver-types" />
 
 /// https://docs.nova.app/api-reference/assistants-registry/
 
@@ -51,8 +52,8 @@ type ResolvedTaskAction = TaskCommandAction | TaskProcessAction;
 
 interface TaskAssistant {
     provideTasks(): AssistantArray<Task>;
-    resolveTaskAction?<T extends Transferrable>(
-        context: TaskActionResolveContext<T>,
+    resolveTaskAction?(
+        context: TaskActionResolveContext<Transferrable>,
     ): ResolvedTaskAction | Promise<ResolvedTaskAction>;
 }
 
@@ -77,7 +78,7 @@ declare class Charset {
 
 /// https://docs.nova.app/api-reference/clipboard/
 
-declare interface Clipboard {
+interface Clipboard {
     readText(): Promise<string>;
     writeText(text: string): Promise<void>;
 }
@@ -543,13 +544,27 @@ declare class IssueParser {
 
 /// https://docs.nova.app/api-reference/language-client/
 
+/**
+ * A `LanguageClient` is an interface for adding a language server compatible
+ * with the Language Server Protocol specification. Creating an instance of a
+ * `LanguageClient` object sets up configuration for the server, at which point
+ * communication with the server is handed-off to the application.
+ *
+ * The `LanguageClient` class is not subclassable.
+ */
 declare class LanguageClient {
-    constructor(
-        identifier: string,
-        name: string,
-        serverOptions: ServerOptions,
-        clientOptions: { initializationOptions?: any; syntaxes: string[] },
-    );
+    /**
+     * @param identifier - a simple, unique string that can be used to identify
+     *   the server (such as `"typescript"`). It will not be displayed to the
+     *   user.
+     * @param name - the name of the server that can potentially be shown to the
+     *   user, to indicate that the server has been enabled and is in use.
+     * @param serverOptions - configuration settings for launching and
+     *   communicating with the server executable:
+     * @param clientOptions - defines configuration settings for how the editor
+     *   invokes the language client
+     */
+    constructor(identifier: string, name: string, serverOptions: ServerOptions, clientOptions: ClientOptions);
 
     readonly identifier: string;
     readonly name: string;
@@ -565,10 +580,27 @@ declare class LanguageClient {
 }
 
 interface ServerOptions {
+    /** The type of transport to use */
     type?: "stdio" | "socket" | "pipe";
+    /** The path to the server executable */
     path: string;
+    /** Additional arguments to pass (array) */
     args?: string[];
+    /** Additional environment variables to set (object) */
     env?: { [key: string]: string };
+}
+
+// Use `import()` rather than a normal module import to avoid throwing this
+// declaration file into module mode, since it provides globals when installed.
+type LSPAny = import("vscode-languageserver-types").LSPAny;
+
+interface ClientOptions {
+    /** Enable debug logging to the Extension Console */
+    debug?: boolean;
+    /** Custom options to send with the LSP initialize request (object) */
+    initializationOptions?: LSPAny;
+    /** Syntaxes for which the client is valid  */
+    syntaxes: string[];
 }
 
 /// https://docs.nova.app/api-reference/notification-center/
@@ -793,7 +825,7 @@ interface NovaSymbol {
 
 /// https://docs.nova.app/api-reference/task/
 
-declare type TaskName = string & { __type: "TaskName" };
+type TaskName = string & { __type: "TaskName" };
 
 declare class Task {
     static readonly Build: TaskName;
@@ -990,7 +1022,7 @@ declare class TreeView<E> extends Disposable {
 /// https://docs.nova.app/api-reference/workspace/
 
 // The line is optional, unless a column is specified
-declare type FileLocation =
+type FileLocation =
     | {
         line?: number;
         column?: never;

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -490,7 +490,7 @@ const tmpTaskName: any = "MyTask";
 tmpTaskName.__type = "TaskName";
 const taskName: TaskName = tmpTaskName;
 
-const taskActionResolveContext: TaskActionResolveContext<any> = {
+const taskActionResolveContext: TaskActionResolveContext<Transferrable> = {
     config: nova.config,
     action: taskName,
 };

--- a/types/nova-editor-node/package.json
+++ b/types/nova-editor-node/package.json
@@ -7,6 +7,9 @@
     "projects": [
         "https://docs.nova.app/api-reference/"
     ],
+    "dependencies": {
+        "vscode-languageserver-types": "*"
+    },
     "devDependencies": {
         "@types/nova-editor-node": "workspace:."
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.nova.app/api-reference/language-client/>

---

In addition to the primary change of adding docs, I fixed on type issue I spotted in the tests and also tackled a couple lint rules that were being flagged up.

Also, for the maintainer: It *looks* to me (but I have not double checked, so I could be wrong?) like Nova’s types here should actually just use the types for `LanguageClient` etc. straight from the LSP package?