### PR TITLE
fix(react-datepicker): add missing calendarIconClassname type

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -49,6 +49,7 @@ export interface ReactDatePickerProps<
     autoFocus?: boolean | undefined;
     calendarClassName?: string | undefined;
     calendarContainer?(props: CalendarContainerProps): React.ReactNode;
+    calendarIconClassname?: string | undefined;
     calendarStartDay?: number | undefined;
     children?: React.ReactNode | undefined;
     chooseDayAriaLabelPrefix?: string | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -33,6 +33,7 @@ const topLogger: Modifier<"topLogger"> = {
     autoFocus
     calendarClassName=""
     calendarContainer={props => <div />}
+    calendarIconClassname=""
     calendarStartDay={0}
     className=""
     clearButtonClassName=""


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/pull/4295

In the react-datepicker PR linked above, the prop was called `calendarIconClassName` but in the code it's actually `calendarIconClassname`, so this PR matches the code. See the code here: https://github.com/Hacker0x01/react-datepicker/blob/32f1566954852aec6acbed6ea45b030f31d28fa7/src/index.jsx#L186
