### PR TITLE
Fix item types for @types/steam-tradeoffer-manager

### DIFF
--- a/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
+++ b/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
@@ -1,21 +1,22 @@
 import TradeOfferManager = require("../../index");
 import SteamID = require("steamid");
 import CEconItem = require("steamcommunity/classes/CEconItem");
+import { appid, assetid, contextid } from "steamcommunity";
 
 interface BaseItem {
-    appid: number;
-    contextid: number;
+    appid: appid;
+    contextid: contextid;
     amount?: number | undefined;
 }
 
 interface ItemWithId extends BaseItem {
-    id: string;
-    assetid?: string | number | undefined;
+    id: assetid;
+    assetid?: assetid | undefined;
 }
 
 interface ItemWithAssetId extends BaseItem {
-    id?: string | undefined;
-    assetid: string | number;
+    id?: assetid | undefined;
+    assetid: assetid;
 }
 
 /**

--- a/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
+++ b/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
@@ -5,16 +5,16 @@ import CEconItem = require("steamcommunity/classes/CEconItem");
 interface BaseItem {
     appid: number;
     contextid: number;
-    amount?: number;
+    amount?: number | undefined;
 }
 
 interface ItemWithId extends BaseItem {
     id: string;
-    assetid?: string | number;
+    assetid?: string | number | undefined;
 }
 
 interface ItemWithAssetId extends BaseItem {
-    id?: string;
+    id?: string | undefined;
     assetid: string | number;
 }
 

--- a/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
+++ b/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
@@ -2,6 +2,31 @@ import TradeOfferManager = require("../../index");
 import SteamID = require("steamid");
 import CEconItem = require("steamcommunity/classes/CEconItem");
 
+interface BaseItem {
+    appid: number;
+    contextid: number;
+    amount?: number;
+}
+
+interface ItemWithId extends BaseItem {
+    id: string;
+    assetid?: string | number;
+}
+
+interface ItemWithAssetId extends BaseItem {
+    id?: string;
+    assetid: string | number;
+}
+
+/**
+ * The item object should be in the same format as is returned by the Steam inventory. That is, it should have the following properties:
+ * - `assetid` - The item's asset ID within its context (the property can also be named `id`)
+ * - `appid` - The ID of the app to which the item belongs
+ * - `contextid` - The ID of the context within the app to which the item belongs
+ * - `amount` - Default 1, if the item is stackable, this is how much of the stack will be added
+ */
+type Item = ItemWithId | ItemWithAssetId;
+
 export = TradeOffer;
 
 /**
@@ -40,13 +65,13 @@ declare class TradeOffer {
      * An array of items to be given from your account should this offer be accepted
      * - If this offer has not yet been sent or was just sent, object in this array will not contain `classid` or `instanceid` properties, as it would had you loaded a sent offer
      */
-    readonly itemsToGive: CEconItem[];
+    readonly itemsToGive: Array<Item | CEconItem>;
 
     /**
      * An array of items to be given from the other account and received by yours should this offer be accepted
      * - If this offer has not yet been sent or was just sent, object in this array will not contain `classid` or `instanceid` properties, as it would had you loaded a sent offer
      */
-    readonly itemsToReceive: CEconItem[];
+    readonly itemsToReceive: Array<Item | CEconItem>;
 
     /**
      * `true` if this offer was sent by you, `false` if you received it
@@ -169,14 +194,14 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    addMyItem(item: CEconItem): boolean;
+    addMyItem(item: Item): boolean;
 
     /**
      * Convenience method which simply calls addMyItem for each item in the array. Returns the number of items that were successfully added.
      *
      * @param items - An array of item objects
      */
-    addMyItems(items: CEconItem[]): number;
+    addMyItems(items: Item[]): number;
 
     /**
      * Removes an item from your side of the trade offer. Returns true if the item was found and removed successfully, or false if the item wasn't found in the offer.
@@ -185,28 +210,28 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    removeMyItem(item: CEconItem): boolean;
+    removeMyItem(item: Item): boolean;
 
     /**
      * Convenience method which simply calls removeMyItem for each item in the array. Returns the number of items that were successfully removed.
      *
      * @param items - An array of item objects
      */
-    removeMyItems(items: CEconItem[]): number;
+    removeMyItems(items: Item[]): number;
 
     /**
      * Same as addMyItem, but for the partner's side of the trade.
      *
      * @param item - An item object
      */
-    addTheirItem(item: CEconItem): boolean;
+    addTheirItem(item: Item): boolean;
 
     /**
      * Convenience method which simply calls addTheirItem for each item in the array. Returns the number of items that were successfully added.
      *
      * @param items - An array of item objects
      */
-    addTheirItems(items: CEconItem[]): number;
+    addTheirItems(items: Item[]): number;
 
     /**
      * Removes an item from the other side of the trade offer. Returns true if the item was found and removed successfully, or false if the item wasn't found in the offer.
@@ -215,21 +240,21 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    removeTheirItem(item: CEconItem): boolean;
+    removeTheirItem(item: Item): boolean;
 
     /**
      * Convenience method which simply calls removeTheirItem for each item in the array. Returns the number of items that were successfully removed.
      *
      * @param items - An array of item objects
      */
-    removeTheirItems(items: CEconItem[]): number;
+    removeTheirItems(items: Item[]): number;
 
     /**
      * Returns true if the given item is in this offer, or false if not.
      *
      * @param item - An item object containing `appid`, `contextid`, and `assetid`/`id` properties
      */
-    containsItem(item: CEconItem): boolean;
+    containsItem(item: Item): boolean;
 
     /**
      * Sets this unsent offer's message. Messages are limited by Steam to 128 characters.

--- a/types/steam-tradeoffer-manager/steam-tradeoffer-manager-tests.ts
+++ b/types/steam-tradeoffer-manager/steam-tradeoffer-manager-tests.ts
@@ -11,7 +11,12 @@ let manager = new TradeOfferManager();
 const user = new SteamUser();
 const steam = new Steam.SteamClient();
 const offer = manager.createOffer("123");
-const item = new CEconItem("a", "b", "c");
+const item1 = new CEconItem("a", "b", "c");
+const item2 = {
+    appid: 1234,
+    contextid: 1234,
+    assetid: "1234",
+};
 
 // ----- TradeOfferManager -----
 
@@ -86,10 +91,10 @@ manager.loadUserInventory("123", 440, 2, true, (err, inventory, currencies) => {
 manager.getOfferToken((err, token: string) => {
 });
 
-manager.getOffersContainingItem(item, true, (err, sent: TradeOffer[], received: TradeOffer[]) => {
+manager.getOffersContainingItem(item1, true, (err, sent: TradeOffer[], received: TradeOffer[]) => {
 });
 
-manager.getOffersContainingItem(item, (err, sent, received) => {
+manager.getOffersContainingItem(item1, (err, sent, received) => {
 });
 
 manager.doPoll();
@@ -109,31 +114,41 @@ offer.loadPartnerInventory(440, 2, (err, inventory, currencies) => {
 });
 
 // $ExpectType boolean
-offer.addMyItem(item);
+offer.addMyItem(item1);
+// $ExpectType boolean
+offer.addMyItem(item2);
 
 // $ExpectType number
-offer.addMyItems([item, item]);
+offer.addMyItems([item1, item2]);
 
 // $ExpectType boolean
-offer.removeMyItem(item);
+offer.removeMyItem(item1);
+// $ExpectType boolean
+offer.removeMyItem(item2);
 
 // $ExpectType number
-offer.removeMyItems([item, item]);
+offer.removeMyItems([item1, item2]);
 
 // $ExpectType boolean
-offer.addTheirItem(item);
+offer.addTheirItem(item1);
+// $ExpectType boolean
+offer.addTheirItem(item2);
 
 // $ExpectType number
-offer.addTheirItems([item, item]);
+offer.addTheirItems([item1, item2]);
 
 // $ExpectType boolean
-offer.removeTheirItem(item);
+offer.removeTheirItem(item1);
+// $ExpectType boolean
+offer.removeTheirItem(item2);
 
 // $ExpectType number
-offer.removeTheirItems([item, item]);
+offer.removeTheirItems([item1, item2]);
 
 // $ExpectType boolean
-offer.containsItem(item);
+offer.containsItem(item1);
+// $ExpectType boolean
+offer.containsItem(item2);
 
 offer.setMessage("a");
 


### PR DESCRIPTION
When adding items to an offer, only the properties `assetid` or `id`, `appid` and `contextid` are required, and `amount` is optional. You do not need to provide an entire CEconItem.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/TradeOffer#addmyitemitem https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/blob/3652b13b14988d9f954f38d744f2046307a682b6/lib/classes/TradeOffer.js#L249-L273 
