### PR TITLE
Markdown-It - Removed Typeof keyword for Type object

### DIFF
--- a/types/markdown-it/lib/index.d.ts
+++ b/types/markdown-it/lib/index.d.ts
@@ -9,7 +9,7 @@ import Renderer = require("./renderer");
 import Token = require("./token");
 
 declare namespace MarkdownIt {
-    type Token = typeof import("./token");
+    type Token = import("./token");
 
     /**
      * MarkdownIt provides named presets as a convenience to quickly


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```js
// Changed,
type Token = typeof import("./token");
// To,
type Token = import("./token");
// To allow the following import:
import MarkdownIt, { Token } from 'markdown-it'

// Normally, Token would be imported like that;
import Token from 'markdown-it/lib/token'
// But following definition:
type Token = typeof import("./token");
// leads IDE to suggest Token to import from main namespace, like that:
import MarkdownIt, { Token } from 'markdown-it'
// But, the usage above was not working because its definiton points to the type of a type.
// Although, It's worth mentioning that this usage has not been used in any way in the test codes.
// Following import is used in test files:
import Token from 'markdown-it/lib/token'

// In summary, when "Token" object included from the namespace, there is a bug as can be seen in the attachment I added. 
// And modifying the code does not cause any issues in the test codes. 
// What needs to be done is to either remove the unnecessary code or make it work. 
// Instead of removing it, I made the import work by removing the "typeof" keyword.
```

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

![error](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/46069238/f7739618-9f14-40d1-9516-912420971a79)
