### PR TITLE
update(node): add 'Socket.destroySoon'

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -92,6 +92,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -67,6 +67,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -92,6 +92,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/ts4.8/test/net.ts
+++ b/types/node/ts4.8/test/net.ts
@@ -67,6 +67,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -84,6 +84,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -41,6 +41,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {

--- a/types/node/v16/ts4.8/net.d.ts
+++ b/types/node/v16/ts4.8/net.d.ts
@@ -84,6 +84,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/v16/ts4.8/test/net.ts
+++ b/types/node/v16/ts4.8/test/net.ts
@@ -41,6 +41,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {

--- a/types/node/v18/net.d.ts
+++ b/types/node/v18/net.d.ts
@@ -92,6 +92,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/v18/test/net.ts
+++ b/types/node/v18/test/net.ts
@@ -67,6 +67,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {

--- a/types/node/v18/ts4.8/net.d.ts
+++ b/types/node/v18/ts4.8/net.d.ts
@@ -92,6 +92,12 @@ declare module "net" {
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
         /**
+         * Destroys the socket after all data is written. If the `finish` event was already emitted the socket is destroyed immediately.
+         * If the socket is still writable it implicitly calls `socket.end()`.
+         * @since v0.3.4
+         */
+        destroySoon(): void;
+        /**
          * Sends data on the socket. The second parameter specifies the encoding in the
          * case of a string. It defaults to UTF8 encoding.
          *

--- a/types/node/v18/ts4.8/test/net.ts
+++ b/types/node/v18/ts4.8/test/net.ts
@@ -67,6 +67,7 @@ import * as net from "node:net";
 
     _socket = _socket.end();
     _socket = _socket.destroy();
+    _socket.destroySoon();
 }
 
 {


### PR DESCRIPTION
This adds missing `destroySoon` method  as pointed in #67147

https://nodejs.org/api/net.html#socketdestroysoon

Thanks!

/cc @byo-books

Closes #67147

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.