### PR TITLE
feat(gh-pages): align types with v5.0.0

### DIFF
--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -53,8 +53,8 @@ export interface PublishOptions {
  *  Get the cache directory.
  */
 export function getCacheDir(optPath?: string): string;
-export function publish(basePath: string, callback: (err: any) => void): void;
-export function publish(basePath: string, config: PublishOptions, callback?: (err: any) => void): void;
+export function publish(basePath: string, callback: (err: any) => void): Promise<void>;
+export function publish(basePath: string, config: PublishOptions, callback?: (err: any) => void): Promise<void>;
 
 export function clean(): void;
 

--- a/types/gh-pages/package.json
+++ b/types/gh-pages/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/gh-pages",
-    "version": "3.2.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/tschaub/gh-pages"
     ],


### PR DESCRIPTION
`gh-pages` included breaking changes to the `publish` method in v5.0.0.

`publish` will now always return a promise.

- [v5.0.0 release notes](https://github.com/tschaub/gh-pages/releases/tag/v5.0.0)
- Relevant [PR and diff](https://github.com/tschaub/gh-pages/pull/452/files#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R97) of the breaking change

**Notes**

Note that both `gh-pages` v4.0.0 and v6.0.0 did not contain breaking changes to its API even though it was a major semver upgrade.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [v5.0.0 release notes](https://github.com/tschaub/gh-pages/releases/tag/v5.0.0) ([PR containing](https://github.com/tschaub/gh-pages/pull/452) the breaking changes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
