### PR TITLE
Add style type declaration to react-native-simple-radio-button

### DIFF
--- a/types/react-native-simple-radio-button/index.d.ts
+++ b/types/react-native-simple-radio-button/index.d.ts
@@ -17,6 +17,7 @@ export interface ReactNativeRadioFormProps extends DefaultRadioFormProps {
     formHorizontal?: boolean | undefined;
     labelHorizontal?: boolean | undefined;
     animation?: boolean | undefined;
+    style?: StyleProp<ViewStyle> | undefined;
 }
 
 export interface RadioButtonProps {

--- a/types/react-native-simple-radio-button/react-native-simple-radio-button-tests.tsx
+++ b/types/react-native-simple-radio-button/react-native-simple-radio-button-tests.tsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
     render() {
         return (
             <React.Fragment>
-                <RadioForm radio_props={data} initial={0} onPress={value => console.log(value)} />
+                <RadioForm radio_props={data} initial={0} style={{backgroundColor: 'red'}}> onPress={value => console.log(value)} />
 
                 <RadioForm formHorizontal={false} animation={true}>
                     {data.map((obj, i) => (

--- a/types/react-native-simple-radio-button/react-native-simple-radio-button-tests.tsx
+++ b/types/react-native-simple-radio-button/react-native-simple-radio-button-tests.tsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
     render() {
         return (
             <React.Fragment>
-                <RadioForm radio_props={data} initial={0} style={{backgroundColor: 'red'}}> onPress={value => console.log(value)} />
+                <RadioForm radio_props={data} initial={0} style={{backgroundColor: 'red'}} onPress={value => console.log(value)} />
 
                 <RadioForm formHorizontal={false} animation={true}>
                     {data.map((obj, i) => (


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/moschan/react-native-simple-radio-button/blob/master/lib/SimpleRadioButton.js#L91C26-L91C26>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


As you can see, the RadioForm component has a style property, but the type is missing
