### PR TITLE
mapbox__mapbox-sdk: Add missing DirectionsRequest optional parameters for driving profiles

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -429,6 +429,51 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
         voiceUnits?: DirectionsUnits | undefined;
     }
 
+    type DirectionsProfileInclusion = 
+     | {
+        profile: "walking" | "cycling";
+     } | {
+        profile: "driving";
+        /**
+         * The desired arrival time, formatted as a timestamp in ISO-8601 format in the local time at the route destination. The travel time, returned in duration, is a prediction for travel time based on historical travel data. The route is calculated in a time-dependent manner. For example, a trip that takes two hours will consider changing historic traffic conditions across the two-hour window. The route takes timed turn restrictions and conditional access restrictions into account based on the requested arrival time.
+         */
+        arriveBy?: string;
+        /**
+         * The departure time, formatted as a timestamp in ISO-8601 format in the local time at the route origin. The travel time, returned in duration, is a prediction for travel time based on historical travel data. The route is calculated in a time-dependent manner. For example, a trip that takes two hours will consider changing historic traffic conditions across the two-hour window, instead of only at the specified depart_at time. The route takes timed turn restrictions and conditional access restrictions into account based on the requested departure time.
+         */
+        departAt?: string;
+        /**
+         * The max vehicle height, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a height limit greater than or equal to the max vehicle height. max_height must be between 0 and 10 meters. The default value is 1.6 meters. Coverage for road height restriction may vary by region.
+         */
+        maxHeight?: number;
+        /**
+         * The max vehicle weight, in metric tons (1000 kg). If this parameter is provided, the Directions API will compute a route that includes only roads with a weight limit greater than or equal to the max vehicle weight. max_weight must be between 0 and 100 metric tons. The default value is 2.5 metric tons. Coverage for road weight restriction may vary by region.
+         */
+        maxWeight?: number;
+        /**
+         * The max vehicle width, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a width limit greater than or equal to the max vehicle width. max_width must be between 0 and 10 meters. The default value is 1.9 meters. Coverage for road width restriction may vary by region.
+         */
+        maxWidth?: number;
+     } | {
+        profile: "driving-traffic";
+        /**
+         * The departure time, formatted as a timestamp in ISO-8601 format in the local time at the route origin. The travel time, returned in duration, is a prediction for travel time based on historical travel data and live traffic. Live traffic is gently mixed with historical data when depart_at is set close to current time. The route takes timed turn restrictions and conditional access restrictions into account based on the requested arrival time.
+         */
+        departAt?: string;
+        /**
+         * The max vehicle height, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a height limit greater than or equal to the max vehicle height. max_height must be between 0 and 10 meters. The default value is 1.6 meters. Coverage for road height restriction may vary by region.
+         */
+        maxHeight?: number;
+        /**
+         * The max vehicle weight, in metric tons (1000 kg). If this parameter is provided, the Directions API will compute a route that includes only roads with a weight limit greater than or equal to the max vehicle weight. max_weight must be between 0 and 100 metric tons. The default value is 2.5 metric tons. Coverage for road weight restriction may vary by region.
+         */
+        maxWeight?: number;
+        /**
+         * The max vehicle width, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a width limit greater than or equal to the max vehicle width. max_width must be between 0 and 10 meters. The default value is 1.9 meters. Coverage for road width restriction may vary by region.
+         */
+        maxWidth?: number;
+     }
+
     type DirectionsProfileExclusion =
         | {
             profile: "walking";
@@ -445,7 +490,9 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
 
     type DirectionsRequest<T extends DirectionsGeometry = "polyline"> =
         & CommonDirectionsRequest<T>
-        & DirectionsProfileExclusion;
+        & DirectionsProfileInclusion
+        & DirectionsProfileExclusion
+
 
     interface Waypoint {
         /**

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -429,10 +429,9 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
         voiceUnits?: DirectionsUnits | undefined;
     }
 
-    type DirectionsProfileInclusion = 
-     | {
+    type DirectionsProfileInclusion = {
         profile: "walking" | "cycling";
-     } | {
+    } | {
         profile: "driving";
         /**
          * The desired arrival time, formatted as a timestamp in ISO-8601 format in the local time at the route destination. The travel time, returned in duration, is a prediction for travel time based on historical travel data. The route is calculated in a time-dependent manner. For example, a trip that takes two hours will consider changing historic traffic conditions across the two-hour window. The route takes timed turn restrictions and conditional access restrictions into account based on the requested arrival time.
@@ -454,7 +453,7 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
          * The max vehicle width, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a width limit greater than or equal to the max vehicle width. max_width must be between 0 and 10 meters. The default value is 1.9 meters. Coverage for road width restriction may vary by region.
          */
         maxWidth?: number;
-     } | {
+    } | {
         profile: "driving-traffic";
         /**
          * The departure time, formatted as a timestamp in ISO-8601 format in the local time at the route origin. The travel time, returned in duration, is a prediction for travel time based on historical travel data and live traffic. Live traffic is gently mixed with historical data when depart_at is set close to current time. The route takes timed turn restrictions and conditional access restrictions into account based on the requested arrival time.
@@ -472,7 +471,7 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
          * The max vehicle width, in meters. If this parameter is provided, the Directions API will compute a route that includes only roads with a width limit greater than or equal to the max vehicle width. max_width must be between 0 and 10 meters. The default value is 1.9 meters. Coverage for road width restriction may vary by region.
          */
         maxWidth?: number;
-     }
+    };
 
     type DirectionsProfileExclusion =
         | {
@@ -491,8 +490,7 @@ declare module "@mapbox/mapbox-sdk/services/directions" {
     type DirectionsRequest<T extends DirectionsGeometry = "polyline"> =
         & CommonDirectionsRequest<T>
         & DirectionsProfileInclusion
-        & DirectionsProfileExclusion
-
+        & DirectionsProfileExclusion;
 
     interface Waypoint {
         /**

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -55,6 +55,33 @@ mapiRequestGeoJSON.send().then((response: MapiResponse) => {
     const coordinates = routes[0].geometry.coordinates;
 });
 
+const drivingDirectionsRequest: MapiRequest = directionsService.getDirections({
+    profile: "driving",
+    waypoints: [],
+    arriveBy: '2023-10-24T10:43',
+    departAt: '2023-10-23T5:00',
+    maxHeight: 4.5,
+    maxWeight: 40,
+    maxWidth: 10,
+});
+
+drivingDirectionsRequest.send().then((response: MapiResponse) => {
+
+});
+
+const drivingTrafficDirectionsRequest: MapiRequest = directionsService.getDirections({
+    profile: "driving-traffic",
+    waypoints: [],
+    departAt: '2023-10-23T5:00',
+    maxHeight: 4.5,
+    maxWeight: 40,
+    maxWidth: 10,
+});
+
+drivingTrafficDirectionsRequest.send().then((response: MapiResponse) => {
+
+});
+
 const mapMatchingService: MapMatchingService = MapMatching(client);
 
 const mapMatchingRequest: MapiRequest = mapMatchingService.getMatch({

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -58,28 +58,26 @@ mapiRequestGeoJSON.send().then((response: MapiResponse) => {
 const drivingDirectionsRequest: MapiRequest = directionsService.getDirections({
     profile: "driving",
     waypoints: [],
-    arriveBy: '2023-10-24T10:43',
-    departAt: '2023-10-23T5:00',
+    arriveBy: "2023-10-24T10:43",
+    departAt: "2023-10-23T5:00",
     maxHeight: 4.5,
     maxWeight: 40,
     maxWidth: 10,
 });
 
 drivingDirectionsRequest.send().then((response: MapiResponse) => {
-
 });
 
 const drivingTrafficDirectionsRequest: MapiRequest = directionsService.getDirections({
     profile: "driving-traffic",
     waypoints: [],
-    departAt: '2023-10-23T5:00',
+    departAt: "2023-10-23T5:00",
     maxHeight: 4.5,
     maxWeight: 40,
     maxWidth: 10,
 });
 
 drivingTrafficDirectionsRequest.send().then((response: MapiResponse) => {
-
 });
 
 const mapMatchingService: MapMatchingService = MapMatching(client);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-profile
    - NOTE: Not including `alley_bias`, `snapping_include_closures`, or `snapping_include_static_closures` from the documentation as they don't seem to be supported in the JS SDK when testing. The optional parameters for the walking profile also did not seem to be supported.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
