### PR TITLE
fix(node): opaqueData arg is optional for http2 'goaway' handler

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -849,7 +849,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -859,7 +859,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -868,7 +868,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -877,7 +877,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -891,7 +891,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -906,7 +906,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});

--- a/types/node/ts4.8/http2.d.ts
+++ b/types/node/ts4.8/http2.d.ts
@@ -849,7 +849,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -859,7 +859,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -868,7 +868,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -877,7 +877,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -891,7 +891,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -906,7 +906,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/ts4.8/test/http2.ts
+++ b/types/node/ts4.8/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -850,7 +850,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -860,7 +860,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -869,7 +869,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -878,7 +878,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -892,7 +892,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -907,7 +907,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/v16/test/http2.ts
+++ b/types/node/v16/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});

--- a/types/node/v16/ts4.8/http2.d.ts
+++ b/types/node/v16/ts4.8/http2.d.ts
@@ -850,7 +850,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -860,7 +860,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -869,7 +869,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -878,7 +878,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -892,7 +892,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -907,7 +907,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/v16/ts4.8/test/http2.ts
+++ b/types/node/v16/ts4.8/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});

--- a/types/node/v18/http2.d.ts
+++ b/types/node/v18/http2.d.ts
@@ -850,7 +850,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -860,7 +860,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -869,7 +869,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -878,7 +878,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -892,7 +892,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -907,7 +907,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/v18/test/http2.ts
+++ b/types/node/v18/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});

--- a/types/node/v18/ts4.8/http2.d.ts
+++ b/types/node/v18/ts4.8/http2.d.ts
@@ -850,7 +850,7 @@ declare module "http2" {
         ): this;
         addListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "ping", listener: () => void): this;
@@ -860,7 +860,7 @@ declare module "http2" {
         emit(event: "close"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
-        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData?: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "ping"): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
@@ -869,7 +869,7 @@ declare module "http2" {
         on(event: "close", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "ping", listener: () => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -878,7 +878,7 @@ declare module "http2" {
         once(event: "close", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
-        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "ping", listener: () => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
@@ -892,7 +892,7 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "ping", listener: () => void): this;
@@ -907,7 +907,7 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "goaway",
-            listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void,
+            listener: (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void,
         ): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "ping", listener: () => void): this;

--- a/types/node/v18/ts4.8/test/http2.ts
+++ b/types/node/v18/ts4.8/test/http2.ts
@@ -67,7 +67,7 @@ import { URL } from "node:url";
     http2Session.on("connect", (session: Http2Session, socket: Socket) => {});
     http2Session.on("error", (err: Error) => {});
     http2Session.on("frameError", (frameType: number, errorCode: number, streamID: number) => {});
-    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+    http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
     http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [API Documentation](https://nodejs.org/docs/latest-v20.x/api/http2.html#event-goaway) | [Source Code](https://github.com/nodejs/node/blob/v20.9.0/src/node_http2.cc#L1438-L1455).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - Not applicable

---

I found that the TS definitions for the `'goaway'` event handlers do not capture the fact that the third argument of the handler (`opaqueData`) is optional and can be set to `undefined`.

Usage in the wild like [here](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/transport.ts#L203) in `@grpc/grpc-node` are not checking that the argument is defined before accessing it, which is a source of uncaught exception.