### PR TITLE
[react-simple-maps] Add explicit types for children

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -14,6 +14,7 @@ export interface ProjectionConfig {
 export type ProjectionFunction = (width: number, height: number, config: ProjectionConfig) => GeoProjection;
 
 export interface ComposableMapProps extends React.SVGAttributes<SVGSVGElement> {
+    children?: React.ReactNode;
     /**
      * @default 800
      */
@@ -42,6 +43,7 @@ export interface Position {
 }
 
 export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
+    children?: React.ReactNode;
     /**
      * @default [0, 0]
      */
@@ -118,6 +120,7 @@ export interface GeographyProps
 export interface MarkerProps
     extends Pick<React.SVGProps<SVGPathElement>, Exclude<keyof React.SVGProps<SVGPathElement>, "style">>
 {
+    children?: React.ReactNode;
     coordinates?: Point | undefined;
     style?: {
         default?: React.CSSProperties | undefined;
@@ -133,6 +136,7 @@ export interface MarkerProps
 }
 
 export interface AnnotationProps extends React.SVGProps<SVGGElement> {
+    children?: React.ReactNode;
     subject?: Point | undefined;
     connectorProps: React.SVGProps<SVGPathElement>;
     /**


### PR DESCRIPTION
Some components that do implement children relied on their implicit declaration from React.FunctionComponent or React.Component. However, this implicit declaration was removed in `@types/react` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210).


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
