### PR TITLE
[dygraphs] Use string instead of number for the color

### DIFF
--- a/types/dygraphs/dygraphs-tests.ts
+++ b/types/dygraphs/dygraphs-tests.ts
@@ -68,6 +68,7 @@ const d = new Dygraph(new HTMLDivElement(), "data", {
     labelsKMB: true,
     labelsSeparateLines: true,
     legend: "always",
+    rangeSelectorForegroundStrokeColor: "white",
     rollPeriod: 14,
     series: {
         y: {

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1032,7 +1032,7 @@ export namespace dygraphs {
          * form "#AABBCC" or "rgb(255,100,200)" or "yellow".
          * @default black
          */
-        rangeSelectorForegroundStrokeColor?: number | null | undefined;
+        rangeSelectorForegroundStrokeColor?: string | null | undefined;
 
         /**
          * The top color for the range selector mini plot fill color gradient. This can be of the form


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://dygraphs.com/options.html#rangeSelectorBackgroundStrokeColor (+ the source code itself in the JSDoc gives strings as examples)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.