### PR TITLE
[node] Update v18 child_process.exec to accept buffer encoding

### DIFF
--- a/types/node/v18/child_process.d.ts
+++ b/types/node/v18/child_process.d.ts
@@ -891,7 +891,7 @@ declare module "child_process" {
         encoding: BufferEncoding;
     }
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: BufferEncoding | null; // specify `null`.
+        encoding: BufferEncoding | null | "buffer"; // specify `null`.
     }
     interface ExecException extends Error {
         cmd?: string | undefined;

--- a/types/node/v18/test/child_process.ts
+++ b/types/node/v18/test/child_process.ts
@@ -10,6 +10,13 @@ import { promisify } from "node:util";
     childProcess.exec("echo test");
     const abortController = new AbortController();
     childProcess.exec("echo test", { windowsHide: true, signal: abortController.signal });
+    childProcess.exec("echo test", { encoding: "buffer" }, (err, stdout, stderr) => {
+        assert(stdout instanceof Buffer);
+    });
+    const execOptions: childProcess.ExecOptionsWithBufferEncoding = { encoding: "buffer" };
+    childProcess.exec("echo test", execOptions, (err, stdout, stderr) => {
+        stdout; // $ExpectType Buffer
+    });
     childProcess.spawn("echo");
     childProcess.spawn("echo", { windowsHide: true, signal: new AbortSignal(), killSignal: "SIGABRT", timeout: 123 });
     childProcess.spawn("echo", ["test"], { windowsHide: true });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DOCS](https://nodejs.org/docs/latest-v18.x/api/child_process.html#child_processexeccommand-options-callback)

(edit) From docs:
>  If encoding is 'buffer', or an unrecognized character encoding, Buffer objects will be passed to the callback instead.

The docs explicitly mention that child_process.exec should accept `{ encoding: "buffer" }` as parameter, which is not reflected on the typings. It seems only `execFile` accepts `{ encoding: "buffer" }` as of now.

