### PR TITLE
Bump dprint and use new --list-different flag

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -49,8 +49,8 @@
     },
     // NOTE: if extending this list, also update settings.template.json.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.88.2.wasm",
-        "https://plugins.dprint.dev/json-0.18.0.wasm",
+        "https://plugins.dprint.dev/typescript-0.88.3.wasm",
+        "https://plugins.dprint.dev/json-0.19.0.wasm",
         "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe"
     ],
     "indentWidth": 4,

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -113,12 +113,17 @@ for (const files of chunked(allFiles, 50)) {
 if (dprintErrors.length > 0) {
     fail("dprint failed to execute");
 
+    // Try and make sure no reasonable error could ever close the code block.
+    // You can open a code block with as many backticks as you want, so long as
+    // you close it with the same string. Inside of the code block, any lower
+    // number of backticks cannot close the block.
+    const codeBlock = "``````````";
     const message = [
         "## Formatting errors",
         "",
-        "```",
+        codeBlock,
         ...dprintErrors.join("\n\n"),
-        "```",
+        codeBlock,
     ];
 
     markdown(message.join("\n"));

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -89,6 +89,7 @@ function chunked<T>(arr: T[], size: number): T[][] {
 }
 
 const unformatted = [];
+const dprintErrors = [];
 const allFiles = [...danger.git.created_files, ...danger.git.modified_files];
 // We batch this in chunks to avoid hitting max arg length issues.
 for (const files of chunked(allFiles, 50)) {
@@ -104,10 +105,24 @@ for (const files of chunked(allFiles, 50)) {
                 unformatted.push(path.relative(process.cwd(), line));
             }
         }
+    } else if (status !== 0) {
+        dprintErrors.push(result.stderr.trim());
     }
 }
 
-if (unformatted.length > 0) {
+if (dprintErrors.length > 0) {
+    fail("dprint failed to execute");
+
+    const message = [
+        "## Formatting errors",
+        "",
+        "```",
+        ...dprintErrors.join("\n\n"),
+        "```",
+    ];
+
+    markdown(message.join("\n"));
+} else if (unformatted.length > 0) {
     const message = [
         "## Formatting",
         "",

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -95,14 +95,14 @@ const allFiles = [...danger.git.created_files, ...danger.git.modified_files];
 for (const files of chunked(allFiles, 50)) {
     const result = cp.spawnSync(
         process.execPath,
-        ["node_modules/dprint/bin.js", "check", ...files],
+        ["node_modules/dprint/bin.js", "check", "--list-different" ...files],
         { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 },
     );
-    if (result.status !== 0) {
+    // https://dprint.dev/cli/#exit-codes
+    if (result.status === 20) {
         for (const line of result.stdout.split(/\r?\n/)) {
-            const match = stripAnsi(line).match(/^from (.*):$/);
-            if (match) {
-                unformatted.push(path.relative(process.cwd(), match[1]));
+            if (line) {
+                unformatted.push(path.relative(process.cwd(), line));
             }
         }
     }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -94,7 +94,7 @@ const allFiles = [...danger.git.created_files, ...danger.git.modified_files];
 for (const files of chunked(allFiles, 50)) {
     const result = cp.spawnSync(
         process.execPath,
-        ["node_modules/dprint/bin.js", "check", "--list-different" ...files],
+        ["node_modules/dprint/bin.js", "check", "--list-different", ...files],
         { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 },
     );
     // https://dprint.dev/cli/#exit-codes

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -2,7 +2,6 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 import cp = require("child_process");
-import stripAnsi = require("strip-ansi");
 import { danger, fail, markdown } from "danger";
 const suggestionsDir = [os.homedir(), ".dts", "suggestions"].join("/");
 const lines: string[] = [];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -105,7 +105,7 @@ for (const files of chunked(allFiles, 50)) {
                 unformatted.push(path.relative(process.cwd(), line));
             }
         }
-    } else if (status !== 0) {
+    } else if (result.status !== 0) {
         dprintErrors.push(result.stderr.trim());
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "d3-time": "^3.0.0",
         "d3-time-format": "^4.0.0",
         "danger": "^11.2.3",
-        "dprint": "^0.41.0",
+        "dprint": "^0.42.3",
         "eslint-plugin-jsdoc": "^44.2.7",
         "jsdom": "^17.0.0",
         "remark-cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "remark-validate-links": "^12.0.0",
         "shelljs": "^0.8.5",
         "source-map-support": "^0.5.21",
-        "strip-ansi": "^6.0.1",
         "typescript": "next",
         "w3c-xmlserializer": "^2.0.0",
         "yargs": "^17.1.1"


### PR DESCRIPTION
dprint now supports `--list-different`, simplifying this code to just reading out paths.