### PR TITLE
Reenable filtered pnpm install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,13 +53,11 @@ jobs:
           # If we're deleting packages, pnpm won't know what other unrelated packages
           # need to be reinstalled that may now be sourced from npm instead of the
           # local repo. Just pay the cost of the full install.
-          # TODO: enable this; see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67087#issuecomment-1767228131
-          # if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
-          #   pnpm install
-          # else
-          #   pnpm install --filter . --filter '...[origin/master]'
-          # fi
-          pnpm install
+          if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
+            pnpm install
+          else
+            pnpm install --filter . --filter '...[origin/master]'
+          fi
         name: pnpm install
 
       # Run tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,15 @@ jobs:
       - script: npm install -g pnpm
         displayName: 'Setup pnpm'
 
-      - script: pnpm install
+      - script: |
+          # If we're deleting packages, pnpm won't know what other unrelated packages
+          # need to be reinstalled that may now be sourced from npm instead of the
+          # local repo. Just pay the cost of the full install.
+          if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
+            pnpm install
+          else
+            pnpm install --filter . --filter '...[origin/master]'
+          fi
         displayName: 'pnpm install'
 
       - script: |


### PR DESCRIPTION
With https://github.com/microsoft/DefinitelyTyped-tools/pull/771 merged and released, the problem with partial installs busting DT loading in dt-tools should be fixed as we're no longer eagerly attempting to resolve files for unrelated packages.