### PR TITLE
Fix filtered installs for non-PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,10 +53,11 @@ jobs:
           # If we're deleting packages, pnpm won't know what other unrelated packages
           # need to be reinstalled that may now be sourced from npm instead of the
           # local repo. Just pay the cost of the full install.
-          if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
+          # HEAD^1 is the merge base (typically master) in PRs, or the previous commit in pushes.
+          if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
             pnpm install
           else
-            pnpm install --filter . --filter '...[origin/master]'
+            pnpm install --filter . --filter '...[HEAD^1]'
           fi
         name: pnpm install
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,11 @@ jobs:
             pnpm install --filter . --filter '...[origin/master]'
           fi
         displayName: 'pnpm install'
+        if: eq(variables['Build.Reason'], 'PullRequest')
+
+      - script: pnpm install
+        displayName: 'pnpm install'
+        if: ne(variables['Build.Reason'], 'PullRequest')
 
       - script: |
           if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && pnpm run update-codeowners; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,17 +21,13 @@ jobs:
           # If we're deleting packages, pnpm won't know what other unrelated packages
           # need to be reinstalled that may now be sourced from npm instead of the
           # local repo. Just pay the cost of the full install.
-          if git diff --diff-filter=DR --name-only origin/master | grep -q 'package.json'; then
+          # HEAD^1 is the merge base (typically master) in PRs, or the previous commit in pushes.
+          if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
             pnpm install
           else
-            pnpm install --filter . --filter '...[origin/master]'
+            pnpm install --filter . --filter '...[HEAD^1]'
           fi
         displayName: 'pnpm install'
-        if: eq(variables['Build.Reason'], 'PullRequest')
-
-      - script: pnpm install
-        displayName: 'pnpm install'
-        if: ne(variables['Build.Reason'], 'PullRequest')
 
       - script: |
           if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && pnpm run update-codeowners; fi


### PR DESCRIPTION
#67219 was not fully correct; I also changed Pipelines, but that same pipeline is used for pushes to master, where the diff will turn out to be nothing because it already _is_ master.

Instead, use `HEAD^1`. This ref maps to the merge base for PRs (so, master), or the previous commit.