### PR TITLE
update(update-notifier): v7 bump and minor fixes

### DIFF
--- a/types/update-notifier/package.json
+++ b/types/update-notifier/package.json
@@ -8,7 +8,7 @@
     "type": "module",
     "dependencies": {
         "@types/configstore": "*",
-        "boxen": "^7.0.0"
+        "boxen": "^7.1.1"
     },
     "devDependencies": {
         "@types/update-notifier": "workspace:."

--- a/types/update-notifier/update-notifier-tests.ts
+++ b/types/update-notifier/update-notifier-tests.ts
@@ -47,8 +47,8 @@ if (notifier.update) {
     update.latest; // $ExpectType string
     update.name; // $ExpectType string
     update.type; // $ExpectType "latest" | "major" | "minor" | "patch" | "prerelease" | "build"
-    notifier.config.set("lastUpdateCheck", Date.now());
+    notifier.config?.set("lastUpdateCheck", Date.now());
     if (update.type && update.type !== "latest") {
-        notifier.config.set("update", update);
+        notifier.config?.set("update", update);
     }
 })();

--- a/types/update-notifier/update-notifier.d.ts
+++ b/types/update-notifier/update-notifier.d.ts
@@ -3,8 +3,8 @@ import ConfigStore from "configstore";
 import type { Options as BoxenOptions } from "boxen";
 
 export default class UpdateNotifier {
-    constructor(settings?: Settings);
-    readonly config: ConfigStore;
+    constructor(settings: Settings);
+    readonly config?: ConfigStore | undefined;
     readonly update?: UpdateInfo | undefined;
     check(): void;
     /**


### PR DESCRIPTION
- 'config' property can be undefined at runtime
- constructor always takes configuration object

https://github.com/yeoman/update-notifier/releases/tag/v7.0.0

```console
UpdateNotifier {
  config: undefined,
  update: undefined,
  _packageName: 'my-package',
  _shouldNotifyInNpmScript: undefined
}
```

The constructor now requires either `pkg` object with name, etc, or deprecated props, like `packageName`, otherwise constructor throws runtime exception.

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `pnpm test <package to test>`