### PR TITLE
fix(npmlog): use any type as message argument

### DIFF
--- a/types/npmlog/index.d.ts
+++ b/types/npmlog/index.d.ts
@@ -19,15 +19,15 @@ declare namespace npmlog {
          * Creates a log message
          * @param level
          * @param prefix
-         * @param message message of the lopg which will be formatted using utils.format()
-         * @param args additional arguments
+         * @param message message of the log which will be formatted using utils.format()
+         * @param args additional arguments appended to the log message also formatted using utils.format()
          */
         log(level: LogLevels | string, prefix: string, message: any, ...args: any[]): void;
 
         /**
          * @param prefix
          * @param message message of the log which will be formatted using utils.format()
-         * @param args additional arguments
+         * @param args additional arguments appended to the log message also formatted using utils.format()
          */
         silly(prefix: string, message: any, ...args: any[]): void;
         verbose(prefix: string, message: any, ...args: any[]): void;

--- a/types/npmlog/index.d.ts
+++ b/types/npmlog/index.d.ts
@@ -25,7 +25,6 @@ declare namespace npmlog {
         log(level: LogLevels | string, prefix: string, message: any, ...args: any[]): void;
 
         /**
-         *
          * @param prefix
          * @param message message of the log which will be formatted using utils.format()
          * @param args additional arguments

--- a/types/npmlog/index.d.ts
+++ b/types/npmlog/index.d.ts
@@ -15,17 +15,30 @@ declare namespace npmlog {
         heading: string;
         stream: any; // Defaults to process.stderr
 
-        log(level: LogLevels | string, prefix: string, message: string, ...args: any[]): void;
+        /**
+         * Creates a log message
+         * @param level
+         * @param prefix
+         * @param message message of the lopg which will be formatted using utils.format()
+         * @param args additional arguments
+         */
+        log(level: LogLevels | string, prefix: string, message: any, ...args: any[]): void;
 
-        silly(prefix: string, message: string, ...args: any[]): void;
-        verbose(prefix: string, message: string, ...args: any[]): void;
-        info(prefix: string, message: string, ...args: any[]): void;
-        timing(prefix: string, message: string, ...args: any[]): void;
-        http(prefix: string, message: string, ...args: any[]): void;
-        notice(prefix: string, message: string, ...args: any[]): void;
-        warn(prefix: string, message: string, ...args: any[]): void;
-        error(prefix: string, message: string, ...args: any[]): void;
-        silent(prefix: string, message: string, ...args: any[]): void;
+        /**
+         *
+         * @param prefix
+         * @param message message of the log which will be formatted using utils.format()
+         * @param args additional arguments
+         */
+        silly(prefix: string, message: any, ...args: any[]): void;
+        verbose(prefix: string, message: any, ...args: any[]): void;
+        info(prefix: string, message: any, ...args: any[]): void;
+        timing(prefix: string, message: any, ...args: any[]): void;
+        http(prefix: string, message: any, ...args: any[]): void;
+        notice(prefix: string, message: any, ...args: any[]): void;
+        warn(prefix: string, message: any, ...args: any[]): void;
+        error(prefix: string, message: any, ...args: any[]): void;
+        silent(prefix: string, message: any, ...args: any[]): void;
 
         enableColor(): void;
         disableColor(): void;

--- a/types/npmlog/npmlog-tests.ts
+++ b/types/npmlog/npmlog-tests.ts
@@ -14,8 +14,8 @@ npmlog.http(prefix, message);
 npmlog.warn(prefix, message);
 npmlog.error(prefix, message);
 
-//log with message object
-const messageObj = {message:"otherStr"};
+// log with message object
+const messageObj = { message: "otherStr" };
 npmlog.silly(prefix, messageObj);
 npmlog.verbose(prefix, messageObj);
 npmlog.info(prefix, messageObj);

--- a/types/npmlog/npmlog-tests.ts
+++ b/types/npmlog/npmlog-tests.ts
@@ -14,7 +14,16 @@ npmlog.http(prefix, message);
 npmlog.warn(prefix, message);
 npmlog.error(prefix, message);
 
-// ES6 module does't support changing variable exported by `export let`
+//log with message object
+const messageObj = {message:"otherStr"};
+npmlog.silly(prefix, messageObj);
+npmlog.verbose(prefix, messageObj);
+npmlog.info(prefix, messageObj);
+npmlog.http(prefix, messageObj);
+npmlog.warn(prefix, messageObj);
+npmlog.error(prefix, messageObj);
+
+// ES6 module doesn't support changing variable exported by `export let`
 // npmlog.level = "silly";
 
 npmlog.enableColor();

--- a/types/npmlog/package.json
+++ b/types/npmlog/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/npmlog",
-    "version": "4.1.9999",
+    "version": "7.0.9999",
     "projects": [
         "https://github.com/npm/npmlog#readme"
     ],


### PR DESCRIPTION
 - npm log uses util.format on the message object so its type should be any object

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/npm/npmlog/blob/ca6b1374f3eb8261c44934cb662fd66712103d9d/lib/log.js#L237)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
