### PR TITLE
Revert "Fix item types for @types/steam-tradeoffer-manager"

### DIFF
--- a/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
+++ b/types/steam-tradeoffer-manager/lib/classes/TradeOffer.d.ts
@@ -1,32 +1,6 @@
 import TradeOfferManager = require("../../index");
 import SteamID = require("steamid");
 import CEconItem = require("steamcommunity/classes/CEconItem");
-import { appid, assetid, contextid } from "steamcommunity";
-
-interface BaseItem {
-    appid: appid;
-    contextid: contextid;
-    amount?: number | undefined;
-}
-
-interface ItemWithId extends BaseItem {
-    id: assetid;
-    assetid?: assetid | undefined;
-}
-
-interface ItemWithAssetId extends BaseItem {
-    id?: assetid | undefined;
-    assetid: assetid;
-}
-
-/**
- * The item object should be in the same format as is returned by the Steam inventory. That is, it should have the following properties:
- * - `assetid` - The item's asset ID within its context (the property can also be named `id`)
- * - `appid` - The ID of the app to which the item belongs
- * - `contextid` - The ID of the context within the app to which the item belongs
- * - `amount` - Default 1, if the item is stackable, this is how much of the stack will be added
- */
-type Item = ItemWithId | ItemWithAssetId;
 
 export = TradeOffer;
 
@@ -66,13 +40,13 @@ declare class TradeOffer {
      * An array of items to be given from your account should this offer be accepted
      * - If this offer has not yet been sent or was just sent, object in this array will not contain `classid` or `instanceid` properties, as it would had you loaded a sent offer
      */
-    readonly itemsToGive: Array<Item | CEconItem>;
+    readonly itemsToGive: CEconItem[];
 
     /**
      * An array of items to be given from the other account and received by yours should this offer be accepted
      * - If this offer has not yet been sent or was just sent, object in this array will not contain `classid` or `instanceid` properties, as it would had you loaded a sent offer
      */
-    readonly itemsToReceive: Array<Item | CEconItem>;
+    readonly itemsToReceive: CEconItem[];
 
     /**
      * `true` if this offer was sent by you, `false` if you received it
@@ -195,14 +169,14 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    addMyItem(item: Item): boolean;
+    addMyItem(item: CEconItem): boolean;
 
     /**
      * Convenience method which simply calls addMyItem for each item in the array. Returns the number of items that were successfully added.
      *
      * @param items - An array of item objects
      */
-    addMyItems(items: Item[]): number;
+    addMyItems(items: CEconItem[]): number;
 
     /**
      * Removes an item from your side of the trade offer. Returns true if the item was found and removed successfully, or false if the item wasn't found in the offer.
@@ -211,28 +185,28 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    removeMyItem(item: Item): boolean;
+    removeMyItem(item: CEconItem): boolean;
 
     /**
      * Convenience method which simply calls removeMyItem for each item in the array. Returns the number of items that were successfully removed.
      *
      * @param items - An array of item objects
      */
-    removeMyItems(items: Item[]): number;
+    removeMyItems(items: CEconItem[]): number;
 
     /**
      * Same as addMyItem, but for the partner's side of the trade.
      *
      * @param item - An item object
      */
-    addTheirItem(item: Item): boolean;
+    addTheirItem(item: CEconItem): boolean;
 
     /**
      * Convenience method which simply calls addTheirItem for each item in the array. Returns the number of items that were successfully added.
      *
      * @param items - An array of item objects
      */
-    addTheirItems(items: Item[]): number;
+    addTheirItems(items: CEconItem[]): number;
 
     /**
      * Removes an item from the other side of the trade offer. Returns true if the item was found and removed successfully, or false if the item wasn't found in the offer.
@@ -241,21 +215,21 @@ declare class TradeOffer {
      *
      * @param item - An item object
      */
-    removeTheirItem(item: Item): boolean;
+    removeTheirItem(item: CEconItem): boolean;
 
     /**
      * Convenience method which simply calls removeTheirItem for each item in the array. Returns the number of items that were successfully removed.
      *
      * @param items - An array of item objects
      */
-    removeTheirItems(items: Item[]): number;
+    removeTheirItems(items: CEconItem[]): number;
 
     /**
      * Returns true if the given item is in this offer, or false if not.
      *
      * @param item - An item object containing `appid`, `contextid`, and `assetid`/`id` properties
      */
-    containsItem(item: Item): boolean;
+    containsItem(item: CEconItem): boolean;
 
     /**
      * Sets this unsent offer's message. Messages are limited by Steam to 128 characters.

--- a/types/steam-tradeoffer-manager/steam-tradeoffer-manager-tests.ts
+++ b/types/steam-tradeoffer-manager/steam-tradeoffer-manager-tests.ts
@@ -11,12 +11,7 @@ let manager = new TradeOfferManager();
 const user = new SteamUser();
 const steam = new Steam.SteamClient();
 const offer = manager.createOffer("123");
-const item1 = new CEconItem("a", "b", "c");
-const item2 = {
-    appid: 1234,
-    contextid: 1234,
-    assetid: "1234",
-};
+const item = new CEconItem("a", "b", "c");
 
 // ----- TradeOfferManager -----
 
@@ -91,10 +86,10 @@ manager.loadUserInventory("123", 440, 2, true, (err, inventory, currencies) => {
 manager.getOfferToken((err, token: string) => {
 });
 
-manager.getOffersContainingItem(item1, true, (err, sent: TradeOffer[], received: TradeOffer[]) => {
+manager.getOffersContainingItem(item, true, (err, sent: TradeOffer[], received: TradeOffer[]) => {
 });
 
-manager.getOffersContainingItem(item1, (err, sent, received) => {
+manager.getOffersContainingItem(item, (err, sent, received) => {
 });
 
 manager.doPoll();
@@ -114,41 +109,31 @@ offer.loadPartnerInventory(440, 2, (err, inventory, currencies) => {
 });
 
 // $ExpectType boolean
-offer.addMyItem(item1);
-// $ExpectType boolean
-offer.addMyItem(item2);
+offer.addMyItem(item);
 
 // $ExpectType number
-offer.addMyItems([item1, item2]);
+offer.addMyItems([item, item]);
 
 // $ExpectType boolean
-offer.removeMyItem(item1);
-// $ExpectType boolean
-offer.removeMyItem(item2);
+offer.removeMyItem(item);
 
 // $ExpectType number
-offer.removeMyItems([item1, item2]);
+offer.removeMyItems([item, item]);
 
 // $ExpectType boolean
-offer.addTheirItem(item1);
-// $ExpectType boolean
-offer.addTheirItem(item2);
+offer.addTheirItem(item);
 
 // $ExpectType number
-offer.addTheirItems([item1, item2]);
+offer.addTheirItems([item, item]);
 
 // $ExpectType boolean
-offer.removeTheirItem(item1);
-// $ExpectType boolean
-offer.removeTheirItem(item2);
+offer.removeTheirItem(item);
 
 // $ExpectType number
-offer.removeTheirItems([item1, item2]);
+offer.removeTheirItems([item, item]);
 
 // $ExpectType boolean
-offer.containsItem(item1);
-// $ExpectType boolean
-offer.containsItem(item2);
+offer.containsItem(item);
 
 offer.setMessage("a");
 


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#67150

@Nicklason this commit is not correct because BaseItem doesn't extend CEconItem as well. Partially my fault for not checking this against my own code. I mentioned this in the old one, but https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/EconItem it says this is identical to CEconItem. So now my code that says

```js
offer.itemsToReceive.forEach(item => {
                if (item.appid == 440 && item.market_hash_name === 'Mann Co. Supply Crate Key') {
```

doesn't compile anymore because `market_hash_name` doesn't exist.