### PR TITLE
types/archiver: Bump major version 5 -> 6

### DIFF
--- a/types/archiver/package.json
+++ b/types/archiver/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/archiver",
-    "version": "5.3.9999",
+    "version": "6.0.9999",
     "projects": [
         "https://github.com/archiverjs/node-archiver"
     ],


### PR DESCRIPTION
The "archiver" package is now on 6.x. Looking at the changelog [1], it doesn't appear there were any API changes. I think the major version was bumped purely because they dropped support for Node 10.

[1] https://github.com/archiverjs/node-archiver/compare/5.3.2...6.0.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- (N/A) [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
