### PR TITLE
Bump pnpm, don't explicitly ask for latest in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,11 +28,6 @@ jobs:
           fi
 
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: latest
-          run_install: false
 
       # TODO(jakebailey): this won't work in PRs; we may need to once nightly
       # refresh a new cache based on master, and then consume it here read-only in PRs.
@@ -88,9 +83,7 @@ jobs:
           node-version: '16'
 
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
 

--- a/.github/workflows/UpdateCodeowners.yml
+++ b/.github/workflows/UpdateCodeowners.yml
@@ -27,9 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
 

--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -21,9 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
 
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
 

--- a/.github/workflows/ghostbuster.yml
+++ b/.github/workflows/ghostbuster.yml
@@ -28,9 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
 
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
 

--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
       - run: pnpm remark --frail . .github

--- a/.github/workflows/support-window.yml
+++ b/.github/workflows/support-window.yml
@@ -27,9 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
       - uses: pnpm/action-setup@v2
-        name: Install pnpm
         with:
-          version: latest
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
       - name: Fetch TypeScript versions and release dates from npm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,9 @@ jobs:
           versionSpec: 16.x
           checkLatest: true
 
-      - script: npm install -g $(jq -r '.packageManager' < package.json)
+      - script: |
+          npm install -g $(jq -r '.packageManager' < package.json)
+          pnpm --version
         displayName: 'Setup pnpm'
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
           versionSpec: 16.x
           checkLatest: true
 
-      - script: npm install -g pnpm
+      - script: npm install -g $(jq -r '.packageManager' < package.json)
         displayName: 'Setup pnpm'
 
       - script: |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
     },
-    "packageManager": "pnpm@8.9.2",
+    "packageManager": "pnpm@8.10.0",
     "engines": {
         "pnpm": ">=8.9.2",
         "node": ">=7.8.0"


### PR DESCRIPTION
The `pnpm` action will automatically read the version out of `package.json`.

In Pipelines, I'm still using `npm i -g`, but extracting the version out using `jq`. This is the trick I use on TypeScript to install the proper version of `npm` without using corepack. Corepack has had some issues in CI that I'd rather not debug again. It's likely that I'll migrate a lot of the Pipelines stuff over to GHA anyway so it's good enough.