### PR TITLE
[node] make callback argument optional

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -948,7 +948,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -1033,7 +1033,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -1108,7 +1108,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -1261,7 +1261,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -40,7 +40,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -75,7 +75,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -123,7 +123,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -173,7 +173,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/node/ts4.8/stream.d.ts
+++ b/types/node/ts4.8/stream.d.ts
@@ -948,7 +948,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -1033,7 +1033,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -1108,7 +1108,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -1261,7 +1261,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/ts4.8/test/stream.ts
+++ b/types/node/ts4.8/test/stream.ts
@@ -40,7 +40,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -75,7 +75,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -123,7 +123,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -173,7 +173,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/node/v16/stream.d.ts
+++ b/types/node/v16/stream.d.ts
@@ -38,7 +38,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -829,7 +829,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -901,7 +901,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -1030,7 +1030,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/v16/test/stream.ts
+++ b/types/node/v16/test/stream.ts
@@ -38,7 +38,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -73,7 +73,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -121,7 +121,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -171,7 +171,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/node/v16/ts4.8/stream.d.ts
+++ b/types/node/v16/ts4.8/stream.d.ts
@@ -38,7 +38,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -793,7 +793,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -865,7 +865,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -994,7 +994,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/v16/ts4.8/test/stream.ts
+++ b/types/node/v16/ts4.8/test/stream.ts
@@ -38,7 +38,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -73,7 +73,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -121,7 +121,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -171,7 +171,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -46,7 +46,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -1025,7 +1025,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -1100,7 +1100,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -1229,7 +1229,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -39,7 +39,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -74,7 +74,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -122,7 +122,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -172,7 +172,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/node/v18/ts4.8/stream.d.ts
+++ b/types/node/v18/ts4.8/stream.d.ts
@@ -46,7 +46,7 @@ declare module "stream" {
             highWaterMark?: number | undefined;
             objectMode?: boolean | undefined;
             construct?(this: T, callback: (error?: Error | null) => void): void;
-            destroy?(this: T, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: T, error: Error | null, callback: (error?: Error | null) => void): void;
             autoDestroy?: boolean | undefined;
         }
         interface ReadableOptions extends StreamOptions<Readable> {
@@ -1025,7 +1025,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Duplex, callback: (error?: Error | null) => void): void;
-            destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Duplex, error: Error | null, callback: (error?: Error | null) => void): void;
         }
         /**
          * Duplex streams are streams that implement both the `Readable` and `Writable` interfaces.
@@ -1100,7 +1100,7 @@ declare module "stream" {
                 }>,
                 callback: (error?: Error | null) => void,
             ): void;
-            _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+            _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             _final(callback: (error?: Error | null) => void): void;
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
@@ -1229,7 +1229,7 @@ declare module "stream" {
                 callback: (error?: Error | null) => void,
             ): void;
             final?(this: Transform, callback: (error?: Error | null) => void): void;
-            destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
+            destroy?(this: Transform, error: Error | null, callback: (error?: Error | null) => void): void;
             transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: TransformCallback): void;
             flush?(this: Transform, callback: TransformCallback): void;
         }

--- a/types/node/v18/ts4.8/test/stream.ts
+++ b/types/node/v18/ts4.8/test/stream.ts
@@ -39,7 +39,7 @@ function simplified_stream_ctor_test() {
         destroy(error, cb) {
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         signal: new AbortSignal(),
@@ -74,7 +74,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -122,7 +122,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {
@@ -172,7 +172,7 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType Error | null
             error;
-            // $ExpectType (error: Error | null) => void
+            // $ExpectType (error?: Error | null | undefined) => void
             cb;
         },
         final(cb) {

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -525,7 +525,7 @@ declare namespace _Readable {
             chunk: ArrayLike<{ chunk: any; encoding: BufferEncoding | string }>,
             callback: (error?: Error | null) => void,
         ): void;
-        destroy?(this: _IWritable, error: Error | null, callback: (error: Error | null) => void): void;
+        destroy?(this: _IWritable, error: Error | null, callback: (error?: Error | null) => void): void;
         final?(this: _IWritable, callback: (error?: Error | null) => void): void;
     };
 


### PR DESCRIPTION
For `writable._destroy` ([`docs`](https://nodejs.org/docs/latest-v21.x/api/stream.html#writable_destroyerr-callback) [`.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/34da43bb3f9ad3d25145c31e47435436b05116bd/types/node/stream.d.ts#L566)) and `readable._destroy` ([`docs`](https://nodejs.org/docs/latest-v21.x/api/stream.html#readable_destroyerr-callback) [`.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/34da43bb3f9ad3d25145c31e47435436b05116bd/types/node/stream.d.ts#L725)), the first argument for `callback` are optional as defined in the documentation, but on `Duplex` ([`.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/34da43bb3f9ad3d25145c31e47435436b05116bd/types/node/stream.d.ts#L1111)) and `Transform` ([`.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/34da43bb3f9ad3d25145c31e47435436b05116bd/types/node/stream.d.ts#L1264C13-L1264C20)), they are required

This PR fixes that issue by making the first argument optional

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.