### PR TITLE
[regex-escape] Add types for regex-escape

### DIFF
--- a/types/regex-escape/index.d.ts
+++ b/types/regex-escape/index.d.ts
@@ -1,0 +1,31 @@
+declare namespace RegexEscape {
+    /**
+     * Adds the `escape` function to the {@link RegExp} class.
+     * Note that this behaviour is **not** reflected by the types
+     */
+    function proto(): typeof RegexEscape;
+    /**
+     * A version of the `proto` function that will modify
+     * the {@link RegExp} class's types
+     *
+     * This *does not technically reflect the real code*,
+     * but can be useful for the type assertion provided
+     *
+     * @param regexp The actual {@link RegExp} object
+     * @example
+     * RegexEscape.proto(RegExp);
+     * RegExp.escape("$foo"); // "\\$foo"
+     */
+    function proto(regexp: RegExpConstructor): asserts regexp is RegExpConstructor & { escape: typeof RegexEscape };
+}
+
+/**
+ * Escapes a string for use in a regular expression
+ * @param input The string to escape
+ * @return The escaped string
+ * @example
+ * RegExp.escape("$foo"); // "\\$foo"
+ */
+declare function RegexEscape(input: string): string;
+
+export = RegexEscape;

--- a/types/regex-escape/package.json
+++ b/types/regex-escape/package.json
@@ -1,0 +1,17 @@
+{
+    "private": true,
+    "name": "@types/regex-escape",
+    "version": "3.4.9999",
+    "projects": [
+        "https://github.com/IonicaBizau/regex-escape.js"
+    ],
+    "devDependencies": {
+        "@types/regex-escape": "workspace:."
+    },
+    "owners": [
+        {
+            "name": "Adam Thompson-Sharpe",
+            "githubUsername": "MysteryBlokHed"
+        }
+    ]
+}

--- a/types/regex-escape/regex-escape-tests.ts
+++ b/types/regex-escape/regex-escape-tests.ts
@@ -1,0 +1,17 @@
+import RegexEscape = require(".");
+
+// @ts-expect-error No argument
+RegexEscape();
+RegexEscape("$foo");
+
+// @ts-expect-error Does not exist yet
+RegExp.escape();
+// @ts-expect-error Does not exist yet
+RegExp.escape("foo");
+
+RegexEscape.proto();
+RegexEscape.proto(RegExp);
+
+// @ts-expect-error No argument
+RegExp.escape();
+RegExp.escape("foo");

--- a/types/regex-escape/tsconfig.json
+++ b/types/regex-escape/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "regex-escape-tests.ts"]
+}

--- a/types/regex-escape/tslint.json
+++ b/types/regex-escape/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package regex-escape (<https://www.npmjs.com/package/regex-escape>).

**Note:** There is an overloaded function that doesn’t actually exist in the code, but that I added to provide a type assertion. If there is a better way to do this (or if it shouldn’t be there at all), let me know and I’ll change it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
