### PR TITLE
sql.js - Fix Case for getRemainingSql Method Name

### DIFF
--- a/types/sql.js/index.d.ts
+++ b/types/sql.js/index.d.ts
@@ -268,7 +268,7 @@ declare class StatementIterator implements Iterator<Statement>, Iterable<Stateme
      * Get any un-executed portions remaining of the original SQL string
      * @see [https://sql.js.org/documentation/StatementIterator.html#["getRemainingSQL"]](https://sql.js.org/documentation/StatementIterator.html#%5B%22getRemainingSQL%22%5D)
      */
-    getRemainingSql(): string;
+    getRemainingSQL(): string;
 
     /**
      * Prepare the next available SQL statement

--- a/types/sql.js/sql.js-tests.ts
+++ b/types/sql.js/sql.js-tests.ts
@@ -102,6 +102,8 @@ initSqlJs().then(SqlJs => {
 
     const it = db2.iterateStatements(selectRecordStatement);
 
+    it.getRemainingSQL()
+
     let x = it.next();
 
     x = it.next();


### PR DESCRIPTION
getRemainingSql() doesn't exist and returns an error. getRemainingSQL() is the correct casing.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sql-js/sql.js/blob/master/src/api.js#L801
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.