### PR TITLE
[factory-girl] Fix return type of the afterBuild and afterCreate hooks

### DIFF
--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -100,6 +100,16 @@ factory.extend(
     },
 );
 
+factory.extend(
+    "user",
+    "superuser",
+    { superpower: "flight" },
+    {
+        afterBuild: async (model, attrs, options) => {},
+        afterCreate: async (model, attrs, options) => {},
+    },
+);
+
 factory.extend("user", "email-related", () => {
     const score = scoreSequence();
     return {

--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -67,22 +67,14 @@ factory.define<User>(
     },
     {
         afterBuild: (model, attrs, options) => {
-            if (Array.isArray(attrs)) {
-                // for buildMany
-                attrs[0].email;
-            } else {
-                // for build
-                attrs.email;
-            }
+            // for buildMany & build
+            model.email = Array.isArray(attrs) ? attrs[0].email : attrs.email;
+            return model;
         },
         afterCreate: (model, attrs, options) => {
-            if (Array.isArray(attrs)) {
-                // for createMany
-                attrs[0].email;
-            } else {
-                // for create
-                attrs.email;
-            }
+            // for createMany & create
+            model.email = Array.isArray(attrs) ? attrs[0].email : attrs.email;
+            return model;
         },
     },
 );

--- a/types/factory-girl/index.d.ts
+++ b/types/factory-girl/index.d.ts
@@ -143,7 +143,7 @@ declare namespace factory {
         afterCreate?: Hook<T> | undefined;
     }
 
-    type Hook<T> = (model: any, attrs: T | T[], options: any) => void;
+    type Hook<T> = (model: any, attrs: T | T[], options: any) => any;
 }
 
 export = factory;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/simonexmachina/factory-girl#afterbuild-functionmodel-attrs-buildoptions
  - > The function should return the instance or a Promise for the instance.
  - https://github.com/simonexmachina/factory-girl#aftercreate-functionmodel-attrs-buildoptions
  - > The function should return the instance or throw an error. For asynchronous functions, it should return a promise that resolves with the instance or rejects with the error.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is a subtle mistake in the typing that was giving my project some grief. The return type of the `afterBuild` and `afterCreate` `Hook` function was defined as `void` but as per the official factory-girl docs it should return an instance of the model or a Promise which resolves to an instance. In an ideal world I would fix this with a generic. However since I am not 100% familiar with this code base I did not want to overcomplicate the fix and introduce breaking changes. So opted for the same type that the `model` parameter was already using.


