### PR TITLE
[datatables.net] Fix wrong return type of `RowMethods.remove`

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -873,6 +873,8 @@ const row_20 = dt.row("selector").node();
 const row_21 = dt.row("selector").remove();
 const row_22: string = dt.row("selector").id();
 const row_23: string = dt.row("selector").id(false);
+// $ExpectType Api
+const row_24: DataTables.Api = dt.row("selector").remove();
 
 const rows_1 = dt.rows();
 const rows_2 = dt.rows().remove();

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -954,7 +954,7 @@ declare namespace DataTables {
         /**
          * Delete the selected row from the DataTable.
          */
-        remove(): Node;
+        remove(): Api;
 
         /**
          * Selects this row.


### PR DESCRIPTION
This commit fixes wrong return type of `RowMethods.remove`.
It used to return a `Node`, which is bound to be `Api`.

See [datatables.net Reference](https://datatables.net/reference/api/row().remove())
  

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [datatables.net Reference](https://datatables.net/reference/api/row().remove())
