### PR TITLE
Add Plan.Create Function Type

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -308,7 +308,7 @@ declare namespace braintree {
 
     interface PlanGateway {
         all(): Promise<{ plans: Plan[] }>;
-        create(request: SubscriptionCreateRequest): Promise<ValidatedResponse<Plan>>
+        create(request: PlanCreateRequest): Promise<ValidatedResponse<Plan>>;
     }
 
     interface SettlementBatchSummaryGateway {
@@ -1258,9 +1258,23 @@ declare namespace braintree {
         updatedAt: string;
     }
 
-    export interface PlanRequest {}
+    export interface PlanRequest {
+        addOns?: AddOn[] | undefined;
+        billingDayOfMonth: number;
+        billingFrequency: number;
+        currencyIsoCode: string;
+        description?: string | undefined;
+        discounts?: Discount[] | undefined;
+        name: string;
+        numberOfBillingCycles: number;
+        price: string;
+        trialDuration?: number | undefined;
+        trialDurationUnit?: string | undefined;
+        trialPeriod?: boolean | undefined;
+    }
 
-    export interface PlanCreateRequest extends PlanRequest {}
+    export interface PlanCreateRequest extends PlanRequest {
+    }
 
     /**
      * Settlement Batch Summary

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -308,6 +308,7 @@ declare namespace braintree {
 
     interface PlanGateway {
         all(): Promise<{ plans: Plan[] }>;
+        create(request: SubscriptionCreateRequest): Promise<ValidatedResponse<Plan>>
     }
 
     interface SettlementBatchSummaryGateway {
@@ -1256,6 +1257,10 @@ declare namespace braintree {
         trialPeriod?: boolean | undefined;
         updatedAt: string;
     }
+
+    export interface PlanRequest {}
+
+    export interface PlanCreateRequest extends PlanRequest {}
 
     /**
      * Settlement Batch Summary

--- a/types/braintree/package.json
+++ b/types/braintree/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/braintree",
-    "version": "3.3.9999",
+    "version": "3.8.0",
     "projects": [
         "https://github.com/braintree/braintree_node"
     ],


### PR DESCRIPTION
I'd like to add `BrainTree.Plan.create` as a typed function under the `BrainTree.Plan` type. 

The request should take `PlanCreateRequest` and return a validated Promise `Plan`