### PR TITLE
@types/node: Added info object result to Zlib functions.

### DIFF
--- a/types/inflation/index.d.ts
+++ b/types/inflation/index.d.ts
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 import { Readable } from "stream";
-import { ZlibOptions } from "zlib";
+import { ZlibOptionsWithoutInfo, ZlibOptionsWithInfo } from "zlib";
 
 export = inflate;
 
@@ -18,10 +18,20 @@ export = inflate;
 declare function inflate(req: Readable, options?: inflate.Options): Readable;
 
 declare namespace inflate {
-    interface Options extends ZlibOptions {
+    interface OptionsWithoutInfo extends ZlibOptionsWithoutInfo {
         /**
          * The encoding of the stream. If not given, will look in `stream.headers['content-encoding']`.
          */
         gzip?: "deflate" | "gzip" | "identity" | undefined;
     }
+    interface OptionsWithInfo extends ZlibOptionsWithInfo {
+        /**
+         * The encoding of the stream. If not given, will look in `stream.headers['content-encoding']`.
+         */
+        gzip?: "deflate" | "gzip" | "identity" | undefined;
+    }
+    /**
+     * I do not believe that passing info would matter with the actual JavaScript code and even if it did, it would be irrelevant from TypeScript's point of view. - @WilcoBakker
+     */
+    type Options = OptionsWithoutInfo | OptionsWithInfo;
 }

--- a/types/inflation/index.d.ts
+++ b/types/inflation/index.d.ts
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 import { Readable } from "stream";
-import { ZlibOptionsWithoutInfo, ZlibOptionsWithInfo } from "zlib";
+import { ZlibOptions } from "zlib";
 
 export = inflate;
 
@@ -18,20 +18,10 @@ export = inflate;
 declare function inflate(req: Readable, options?: inflate.Options): Readable;
 
 declare namespace inflate {
-    interface OptionsWithoutInfo extends ZlibOptionsWithoutInfo {
+    interface Options extends ZlibOptions {
         /**
          * The encoding of the stream. If not given, will look in `stream.headers['content-encoding']`.
          */
         gzip?: "deflate" | "gzip" | "identity" | undefined;
     }
-    interface OptionsWithInfo extends ZlibOptionsWithInfo {
-        /**
-         * The encoding of the stream. If not given, will look in `stream.headers['content-encoding']`.
-         */
-        gzip?: "deflate" | "gzip" | "identity" | undefined;
-    }
-    /**
-     * I do not believe that passing info would matter with the actual JavaScript code and even if it did, it would be irrelevant from TypeScript's point of view. - @WilcoBakker
-     */
-    type Options = OptionsWithoutInfo | OptionsWithInfo;
 }

--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -6,6 +6,10 @@ import {
     brotliDecompress,
     brotliDecompressSync,
     BrotliOptions,
+    CompressDeflateInfoResult,
+    CompressDeflateRawInfoResult,    
+    CompressInflateInfoResult,
+    CompressInflateRawInfoResult,
     constants,
     createBrotliCompress,
     createBrotliDecompress,
@@ -25,7 +29,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate
@@ -58,8 +62,8 @@ deflate(
             (err: Error | null, result: Buffer) => result,
         ),
 );
-const inflated = inflateSync(deflateSync(compressMe));
-const inflatedString = inflateSync(deflateSync(compressMeString));
+const inflated: Buffer = inflateSync(deflateSync(compressMe));
+const inflatedString: Buffer = inflateSync(deflateSync(compressMeString));
 
 deflateRaw(
     compressMe,
@@ -87,6 +91,50 @@ deflateRaw(
 );
 const inflatedRaw: Buffer = inflateRawSync(deflateRawSync(compressMe));
 const inflatedRawString: Buffer = inflateRawSync(deflateRawSync(compressMeString));
+
+// Deflate / Inflate With Info
+
+deflate(
+    compressMe,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateInfoResult) =>
+        inflate(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateInfoResult) => result,
+        ),
+);
+deflate(
+    compressMeString,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateInfoResult) =>
+        inflate(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateInfoResult) => result,
+        ),
+);
+const inflatedWithInfo: CompressInflateInfoResult = inflateSync(deflateSync(compressMe, { info: true }).buffer, { info: true });
+const inflatedStringWithInfo: CompressInflateInfoResult = inflateSync(deflateSync(compressMeString, { info: true }).buffer, { info: true });
+
+deflateRaw(
+    compressMe,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateRawInfoResult) =>
+        inflateRaw(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateRawInfoResult) => result,
+        ),
+);
+deflateRaw(
+    compressMeString,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateRawInfoResult) =>
+        inflateRaw(result.buffer, { finishFlush: constants.Z_SYNC_FLUSH, info: true }, (err: Error | null, result: CompressInflateRawInfoResult) => result),
+);
+const inflatedRawWithInfo: CompressInflateInfoResult = inflateRawSync(deflateRawSync(compressMe, { info: true }).buffer, { info: true });
+const inflatedRawStringWithInfo: CompressInflateInfoResult = inflateRawSync(deflateRawSync(compressMeString, { info: true }).buffer, { info: true });
 
 // gzip
 
@@ -153,17 +201,17 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
     const pDeflateRaw = promisify(deflateRaw);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGzip = promisify(gzip);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGunzip = promisify(gunzip);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
     const pInflate = promisify(inflate);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
     const pInflateRaw = promisify(inflateRaw);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pUnzip = promisify(unzip);
@@ -177,6 +225,10 @@ brotliDecompress(
         await pDeflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pDeflateRaw(Buffer.from("buf")); // $ExpectType Buffer
         await pDeflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pDeflate(Buffer.from("buf"), { info: true }); // $ExpectType CompressDeflateInfoResult
+        await pDeflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressDeflateInfoResult
+        await pDeflateRaw(Buffer.from("buf"), { info: true }); // $ExpectType CompressDeflateRawInfoResult
+        await pDeflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressDeflateRawInfoResult
         await pGzip(Buffer.from("buf")); // $ExpectType Buffer
         await pGzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pGunzip(Buffer.from("buf")); // $ExpectType Buffer
@@ -185,6 +237,10 @@ brotliDecompress(
         await pInflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pInflateRaw(Buffer.from("buf")); // $ExpectType Buffer
         await pInflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pInflate(Buffer.from("buf"), { info: true }); // $ExpectType CompressInflateInfoResult
+        await pInflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressInflateInfoResult
+        await pInflateRaw(Buffer.from("buf"), { info: true }); // $ExpectType CompressInflateRawInfoResult
+        await pInflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressInflateRawInfoResult
         await pUnzip(Buffer.from("buf")); // $ExpectType Buffer
         await pUnzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
     })();

--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/ts4.8/test/zlib.ts
+++ b/types/node/ts4.8/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/ts4.8/test/zlib.ts
+++ b/types/node/ts4.8/test/zlib.ts
@@ -32,7 +32,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate

--- a/types/node/ts4.8/test/zlib.ts
+++ b/types/node/ts4.8/test/zlib.ts
@@ -6,6 +6,10 @@ import {
     brotliDecompress,
     brotliDecompressSync,
     BrotliOptions,
+    CompressDeflateInfoResult,
+    CompressDeflateRawInfoResult,    
+    CompressInflateInfoResult,
+    CompressInflateRawInfoResult,
     constants,
     createBrotliCompress,
     createBrotliDecompress,
@@ -88,6 +92,50 @@ deflateRaw(
 const inflatedRaw: Buffer = inflateRawSync(deflateRawSync(compressMe));
 const inflatedRawString: Buffer = inflateRawSync(deflateRawSync(compressMeString));
 
+// Deflate / Inflate With Info
+
+deflate(
+    compressMe,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateInfoResult) =>
+        inflate(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateInfoResult) => result,
+        ),
+);
+deflate(
+    compressMeString,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateInfoResult) =>
+        inflate(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateInfoResult) => result,
+        ),
+);
+const inflatedWithInfo: CompressInflateInfoResult = inflateSync(deflateSync(compressMe, { info: true }).buffer, { info: true });
+const inflatedStringWithInfo: CompressInflateInfoResult = inflateSync(deflateSync(compressMeString, { info: true }).buffer, { info: true });
+
+deflateRaw(
+    compressMe,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateRawInfoResult) =>
+        inflateRaw(
+            result.buffer,
+            { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+            (err: Error | null, result: CompressInflateRawInfoResult) => result,
+        ),
+);
+deflateRaw(
+    compressMeString,
+    { finishFlush: constants.Z_SYNC_FLUSH, info: true },
+    (err: Error | null, result: CompressDeflateRawInfoResult) =>
+        inflateRaw(result.buffer, { finishFlush: constants.Z_SYNC_FLUSH, info: true }, (err: Error | null, result: CompressInflateRawInfoResult) => result),
+);
+const inflatedRawWithInfo: CompressInflateRawInfoResult = inflateRawSync(deflateRawSync(compressMe, { info: true }).buffer, { info: true });
+const inflatedRawStringWithInfo: CompressInflateRawInfoResult = inflateRawSync(deflateRawSync(compressMeString, { info: true }).buffer, { info: true});
+
 // gzip
 
 gzip(compressMe, (err: Error | null, result: Buffer) => gunzip(result, (err: Error | null, result: Buffer) => result));
@@ -153,17 +201,17 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
     const pDeflateRaw = promisify(deflateRaw);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGzip = promisify(gzip);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGunzip = promisify(gunzip);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
     const pInflate = promisify(inflate);
-    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
+    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
     const pInflateRaw = promisify(inflateRaw);
     // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pUnzip = promisify(unzip);
@@ -177,6 +225,10 @@ brotliDecompress(
         await pDeflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pDeflateRaw(Buffer.from("buf")); // $ExpectType Buffer
         await pDeflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pDeflate(Buffer.from("buf"), { info: true }); // $ExpectType CompressDeflateInfoResult
+        await pDeflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressDeflateInfoResult
+        await pDeflateRaw(Buffer.from("buf"), { info: true }); // $ExpectType CompressDeflateRawInfoResult
+        await pDeflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressDeflateRawInfoResult
         await pGzip(Buffer.from("buf")); // $ExpectType Buffer
         await pGzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pGunzip(Buffer.from("buf")); // $ExpectType Buffer
@@ -185,6 +237,10 @@ brotliDecompress(
         await pInflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
         await pInflateRaw(Buffer.from("buf")); // $ExpectType Buffer
         await pInflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pInflate(Buffer.from("buf"), { info: true }); // $ExpectType CompressInflateInfoResult
+        await pInflate(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressInflateInfoResult
+        await pInflateRaw(Buffer.from("buf"), { info: true }); // $ExpectType CompressInflateRawInfoResult
+        await pInflateRaw(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH, info: true }); // $ExpectType CompressInflateRawInfoResult
         await pUnzip(Buffer.from("buf")); // $ExpectType Buffer
         await pUnzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
     })();

--- a/types/node/ts4.8/test/zlib.ts
+++ b/types/node/ts4.8/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/ts4.8/zlib.d.ts
+++ b/types/node/ts4.8/zlib.d.ts
@@ -174,6 +174,14 @@ declare module "zlib" {
         buffer: Buffer;
         engine: Deflate;
     }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
     interface CompressInflateInfoResult {
         buffer: Buffer;
         engine: Inflate;
@@ -181,6 +189,10 @@ declare module "zlib" {
     interface CompressInflateRawInfoResult {
         buffer: Buffer;
         engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
     }
     /**
      * Creates and returns a new `BrotliCompress` object.
@@ -237,9 +249,12 @@ declare module "zlib" {
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
     type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
-    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
     type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -302,28 +317,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
@@ -360,15 +381,18 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/ts4.8/zlib.d.ts
+++ b/types/node/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/ts4.8/zlib.d.ts
+++ b/types/node/ts4.8/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/ts4.8/zlib.d.ts
+++ b/types/node/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,22 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +236,10 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,28 +270,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
@@ -296,28 +328,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */

--- a/types/node/v16/test/zlib.ts
+++ b/types/node/v16/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v16/test/zlib.ts
+++ b/types/node/v16/test/zlib.ts
@@ -32,7 +32,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate

--- a/types/node/v16/test/zlib.ts
+++ b/types/node/v16/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v16/ts4.8/test/zlib.ts
+++ b/types/node/v16/ts4.8/test/zlib.ts
@@ -202,19 +202,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v16/ts4.8/test/zlib.ts
+++ b/types/node/v16/ts4.8/test/zlib.ts
@@ -32,7 +32,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate

--- a/types/node/v16/ts4.8/test/zlib.ts
+++ b/types/node/v16/ts4.8/test/zlib.ts
@@ -202,19 +202,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v16/ts4.8/zlib.d.ts
+++ b/types/node/v16/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/v16/ts4.8/zlib.d.ts
+++ b/types/node/v16/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,34 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +248,13 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,93 +285,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v16/ts4.8/zlib.d.ts
+++ b/types/node/v16/ts4.8/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v16/zlib.d.ts
+++ b/types/node/v16/zlib.d.ts
@@ -174,6 +174,14 @@ declare module "zlib" {
         buffer: Buffer;
         engine: Deflate;
     }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
     interface CompressInflateInfoResult {
         buffer: Buffer;
         engine: Inflate;
@@ -181,6 +189,10 @@ declare module "zlib" {
     interface CompressInflateRawInfoResult {
         buffer: Buffer;
         engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
     }
     /**
      * Creates and returns a new `BrotliCompress` object.
@@ -237,9 +249,12 @@ declare module "zlib" {
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
     type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
-    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
     type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -302,28 +317,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
@@ -360,15 +381,18 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v16/zlib.d.ts
+++ b/types/node/v16/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/v16/zlib.d.ts
+++ b/types/node/v16/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v16/zlib.d.ts
+++ b/types/node/v16/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,22 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +236,10 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,28 +270,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
@@ -296,28 +328,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */

--- a/types/node/v18/test/zlib.ts
+++ b/types/node/v18/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v18/test/zlib.ts
+++ b/types/node/v18/test/zlib.ts
@@ -32,7 +32,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate

--- a/types/node/v18/test/zlib.ts
+++ b/types/node/v18/test/zlib.ts
@@ -221,19 +221,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v18/ts4.8/test/zlib.ts
+++ b/types/node/v18/ts4.8/test/zlib.ts
@@ -202,19 +202,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v18/ts4.8/test/zlib.ts
+++ b/types/node/v18/ts4.8/test/zlib.ts
@@ -32,7 +32,7 @@ import {
     unzipSync,
 } from "node:zlib";
 
-const compressMe = new Buffer("some data");
+const compressMe = Buffer.from("some data");
 const compressMeString = "compress me!";
 
 // Deflate / Inflate

--- a/types/node/v18/ts4.8/test/zlib.ts
+++ b/types/node/v18/ts4.8/test/zlib.ts
@@ -202,19 +202,19 @@ brotliDecompress(
     const pBrotliCompress = promisify(brotliCompress);
     // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflate = promisify(deflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressDeflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pDeflateRaw = promisify(deflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGzip = promisify(gzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressGunzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pGunzip = promisify(gunzip);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflate = promisify(inflate);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressInflateRawInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pInflateRaw = promisify(inflateRaw);
-    // $ExpectType { (buffer: InputType, options?: ZlibOptionsWithoutInfo | undefined): Promise<Buffer>; (buffer: InputType, options?: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; }
+    // $ExpectType { (buffer: InputType, options: ZlibOptionsWithInfo | undefined): Promise<CompressUnzipInfoResult>; (buffer: InputType, options?: ZlibOptions | undefined): Promise<Buffer>; }
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v18/ts4.8/zlib.d.ts
+++ b/types/node/v18/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/v18/ts4.8/zlib.d.ts
+++ b/types/node/v18/ts4.8/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,34 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +248,13 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,93 +285,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v18/ts4.8/zlib.d.ts
+++ b/types/node/v18/ts4.8/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v18/zlib.d.ts
+++ b/types/node/v18/zlib.d.ts
@@ -174,6 +174,14 @@ declare module "zlib" {
         buffer: Buffer;
         engine: Deflate;
     }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
     interface CompressInflateInfoResult {
         buffer: Buffer;
         engine: Inflate;
@@ -181,6 +189,10 @@ declare module "zlib" {
     interface CompressInflateRawInfoResult {
         buffer: Buffer;
         engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
     }
     /**
      * Creates and returns a new `BrotliCompress` object.
@@ -237,9 +249,12 @@ declare module "zlib" {
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
     type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
-    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
     type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -302,28 +317,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
@@ -360,15 +381,18 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v18/zlib.d.ts
+++ b/types/node/v18/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/v18/zlib.d.ts
+++ b/types/node/v18/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/v18/zlib.d.ts
+++ b/types/node/v18/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,22 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +236,10 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,28 +270,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
@@ -296,28 +328,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -174,6 +174,14 @@ declare module "zlib" {
         buffer: Buffer;
         engine: Deflate;
     }
+    interface CompressGzipInfoResult {
+        buffer: Buffer;
+        engine: Gzip;
+    }
+    interface CompressGunzipInfoResult {
+        buffer: Buffer;
+        engine: Gunzip;
+    }
     interface CompressInflateInfoResult {
         buffer: Buffer;
         engine: Inflate;
@@ -181,6 +189,10 @@ declare module "zlib" {
     interface CompressInflateRawInfoResult {
         buffer: Buffer;
         engine: Inflate;
+    }
+    interface CompressUnzipInfoResult {
+        buffer: Buffer;
+        engine: Unzip;
     }
     /**
      * Creates and returns a new `BrotliCompress` object.
@@ -237,9 +249,12 @@ declare module "zlib" {
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
     type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
-    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressGzipInfoCallback = (error: Error | null, result: CompressGzipInfoResult) => void;
+    type CompressGunzipInfoCallback = (error: Error | null, result: CompressGunzipInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;    
     type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressUnzipInfoCallback = (error: Error | null, result: CompressUnzipInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -302,28 +317,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
     /**
      * @since v0.6.0
      */
@@ -360,15 +381,18 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptionsBase {
+    interface ZlibOptions {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,15 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
+        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithoutInfo extends ZlibOptions {
         info?: false | undefined;
     }
-    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+    interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
-    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -113,9 +113,6 @@ declare module "zlib" {
         info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
-    interface ZlibOptionsWithoutInfo extends ZlibOptions {
-        info?: false | undefined;
-    }
     interface ZlibOptionsWithInfo extends ZlibOptions {
         info: true;
     }
@@ -285,114 +282,114 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateInfoResult;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGzipInfoCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Compress a chunk of data with `Gzip`.
      * @since v0.11.12
      */
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGzipInfoResult;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressGunzipInfoCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace gunzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressGunzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Gunzip`.
      * @since v0.11.12
      */
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function gunzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressGunzipInfoResult;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateInfoResult;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
     /**
      * @since v0.6.0
      */
     function unzip(buf: InputType, callback: CompressCallback): void;
-    function unzip(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressUnzipInfoCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
     namespace unzip {
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options: ZlibOptionsWithInfo): Promise<CompressUnzipInfoResult>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
     /**
      * Decompress a chunk of data with `Unzip`.
      * @since v0.11.12
      */
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
-    function unzipSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options: ZlibOptionsWithInfo): CompressUnzipInfoResult;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
     namespace constants {
         const BROTLI_DECODE: number;
         const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -92,7 +92,7 @@
  */
 declare module "zlib" {
     import * as stream from "node:stream";
-    interface ZlibOptions {
+    interface ZlibOptionsBase {
         /**
          * @default constants.Z_NO_FLUSH
          */
@@ -110,9 +110,15 @@ declare module "zlib" {
         memLevel?: number | undefined; // compression only
         strategy?: number | undefined; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer | undefined; // deflate/inflate only, empty dictionary by default
-        info?: boolean | undefined;
         maxOutputLength?: number | undefined;
     }
+    interface ZlibOptionsWithoutInfo extends ZlibOptionsBase {
+        info?: false | undefined;
+    }
+    interface ZlibOptionsWithInfo extends ZlibOptionsBase {
+        info: true;
+    }
+    type ZlibOptions = ZlibOptionsWithoutInfo | ZlibOptionsWithInfo;
     interface BrotliOptions {
         /**
          * @default constants.BROTLI_OPERATION_PROCESS
@@ -160,6 +166,22 @@ declare module "zlib" {
     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams {}
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
+    interface CompressDeflateInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressDeflateRawInfoResult {
+        buffer: Buffer;
+        engine: Deflate;
+    }
+    interface CompressInflateInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
+    interface CompressInflateRawInfoResult {
+        buffer: Buffer;
+        engine: Inflate;
+    }
     /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
@@ -214,6 +236,10 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
     type InputType = string | ArrayBuffer | NodeJS.ArrayBufferView;
     type CompressCallback = (error: Error | null, result: Buffer) => void;
+    type CompressDeflateInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
+    type CompressDeflateRawInfoCallback = (error: Error | null, result: CompressDeflateInfoResult) => void;
+    type CompressInflateRawInfoCallback = (error: Error | null, result: CompressInflateInfoResult) => void;
     /**
      * @since v11.7.0, v10.16.0
      */
@@ -244,28 +270,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateInfoCallback): void;
     namespace deflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateInfoResult>;
     }
     /**
      * Compress a chunk of data with `Deflate`.
      * @since v0.11.12
      */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateInfoResult;
     /**
      * @since v0.6.0
      */
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressDeflateRawInfoCallback): void;
     namespace deflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressDeflateRawInfoResult>;
     }
     /**
      * Compress a chunk of data with `DeflateRaw`.
      * @since v0.11.12
      */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function deflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressDeflateRawInfoResult;
     /**
      * @since v0.6.0
      */
@@ -296,28 +328,34 @@ declare module "zlib" {
      * @since v0.6.0
      */
     function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateInfoCallback): void;
     namespace inflate {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateInfoResult>;
     }
     /**
      * Decompress a chunk of data with `Inflate`.
      * @since v0.11.12
      */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateInfoResult;
     /**
      * @since v0.6.0
      */
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithoutInfo, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptionsWithInfo, callback: CompressInflateRawInfoCallback): void;
     namespace inflateRaw {
-        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithoutInfo): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptionsWithInfo): Promise<CompressInflateRawInfoResult>;
     }
     /**
      * Decompress a chunk of data with `InflateRaw`.
      * @since v0.11.12
      */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithoutInfo): Buffer;
+    function inflateRawSync(buf: InputType, options?: ZlibOptionsWithInfo): CompressInflateRawInfoResult;
     /**
      * @since v0.6.0
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  See `info` option [here](https://nodejs.org/api/zlib.html#class-options). (It states that if true, that it returns an object with buffer and engine.)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Albeit this only being a fix as TypeScript is only layer a top of JavaScript and TypeScript didn't reflect the JavaScript underneath it properly in this case, it is not out of the question though that some TypeScript code might break because of this so this is a breaking change.

This is a copy of #67021 which was accidently merged without changes.