### PR TITLE
Revert "Update types for vscode 1.84 (#67270)"

### DIFF
--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Type Definition for Visual Studio Code 1.84 Extension API
+ * Type Definition for Visual Studio Code 1.83 Extension API
  * See https://code.visualstudio.com/api for more information
  */
 
@@ -1558,7 +1558,7 @@ declare module 'vscode' {
 		 */
 		with(change: {
 			/**
-			 * The new scheme, defaults to this Uri's scheme.
+			 * The new scheme, defauls to this Uri's scheme.
 			 */
 			scheme?: string;
 			/**
@@ -11326,7 +11326,7 @@ declare module 'vscode' {
 		 * tree objects in a data transfer. See the documentation for `DataTransferItem` for how best to take advantage of this.
 		 *
 		 * To add a data transfer item that can be dragged into the editor, use the application specific mime type "text/uri-list".
-		 * The data for "text/uri-list" should be a string with `toString()`ed Uris separated by `\r\n`. To specify a cursor position in the file,
+		 * The data for "text/uri-list" should be a string with `toString()`ed Uris separated by newlines. To specify a cursor position in the file,
 		 * set the Uri's fragment to `L3,5`, where 3 is the line number and 5 is the column number.
 		 *
 		 * @param source The source items for the drag and drop operation.
@@ -17615,37 +17615,6 @@ declare module 'vscode' {
 		 * Associated file location.
 		 */
 		location?: Location;
-
-		/**
-		 * Context value of the test item. This can be used to contribute message-
-		 * specific actions to the test peek view. The value set here can be found
-		 * in the `testMessage` property of the following `menus` contribution points:
-		 *
-		 * - `testing/message/context` - context menu for the message in the results tree
-		 * - `testing/message/content` - a prominent button overlaying editor content where
-		 *    the message is displayed.
-		 *
-		 * For example:
-		 *
-		 * ```json
-		 * "contributes": {
-		 *   "menus": {
-		 *     "testing/message/content": [
-		 *       {
-		 *         "command": "extension.deleteCommentThread",
-		 *         "when": "testMessage == canApplyRichDiff"
-		 *       }
-		 *     ]
-		 *   }
-		 * }
-		 * ```
-		 *
-		 * The command will be called with an object containing:
-		 * - `test`: the {@link TestItem} the message is associated with, *if* it
-		 *    is still present in the {@link TestController.items} collection.
-		 * - `message`: the {@link TestMessage} instance.
-		 */
-		contextValue?: string;
 
 		/**
 		 * Creates a new TestMessage that will present as a diff in the editor.


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67270 was mistakenly merged without a version bump; I guess these PRs aren't reviewed. Unfortunately no test failed as the change looked like any other minor change.

To fix this, we need to revert the PR to publish another 1.83, then revert the revert in #67287.