### PR TITLE
Allow mitm types to work without esModuleInterop

### DIFF
--- a/types/mitm/index.d.ts
+++ b/types/mitm/index.d.ts
@@ -4,37 +4,40 @@ declare module "mitm" {
     import * as http from "http";
     import * as net from "net";
 
-    interface SocketOptions {
-        port: number;
-        host?: string | undefined;
-        localAddress?: string | undefined;
-        localPort?: string | undefined;
-        family?: number | undefined;
-        allowHalfOpen?: boolean | undefined;
+    function mitm(): mitm.Mitm;
+
+    namespace mitm {
+        interface SocketOptions {
+            port: number;
+            host?: string | undefined;
+            localAddress?: string | undefined;
+            localPort?: string | undefined;
+            family?: number | undefined;
+            allowHalfOpen?: boolean | undefined;
+        }
+
+        interface BypassableSocket extends net.Socket {
+            bypass(): void;
+        }
+
+        type SocketConnectCallback = (socket: BypassableSocket, opts: SocketOptions) => void;
+
+        type SocketConnectionCallback = (socket: net.Socket, opts: SocketOptions) => void;
+
+        type HttpCallback = (request: http.IncomingMessage, response: http.ServerResponse) => void;
+
+        type Event = "connect" | "connection" | "request";
+
+        type Callback = SocketConnectCallback | SocketConnectionCallback | HttpCallback;
+
+        interface Mitm {
+            disable(): void;
+            on(event: Event, callback: Callback): void;
+            on(event: "connect", callback: SocketConnectCallback): void;
+            on(event: "connection", callback: SocketConnectionCallback): void;
+            on(event: "request", callback: HttpCallback): void;
+        }
     }
 
-    interface BypassableSocket extends net.Socket {
-        bypass(): void;
-    }
-
-    type SocketConnectCallback = (socket: BypassableSocket, opts: SocketOptions) => void;
-
-    type SocketConnectionCallback = (socket: net.Socket, opts: SocketOptions) => void;
-
-    type HttpCallback = (request: http.IncomingMessage, response: http.ServerResponse) => void;
-
-    type Event = "connect" | "connection" | "request";
-
-    type Callback = SocketConnectCallback | SocketConnectionCallback | HttpCallback;
-
-    interface Mitm {
-        disable(): void;
-        on(event: Event, callback: Callback): void;
-        on(event: "connect", callback: SocketConnectCallback): void;
-        on(event: "connection", callback: SocketConnectionCallback): void;
-        on(event: "request", callback: HttpCallback): void;
-    }
-
-    function _(): Mitm;
-    export = _;
+    export = mitm;
 }


### PR DESCRIPTION
The current definition doesn't seem to work on my code base, but this one does. I cannot say I understand everything that's going on :)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [-] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [-] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [-] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

