### PR TITLE
debug-js/debug: Update URL to `https://github.com/debug-js/debug`

### DIFF
--- a/types/debug/package.json
+++ b/types/debug/package.json
@@ -3,7 +3,7 @@
     "name": "@types/debug",
     "version": "4.1.9999",
     "projects": [
-        "https://github.com/visionmedia/debug"
+        "https://github.com/debug-js/debug"
     ],
     "dependencies": {
         "@types/ms": "*"


### PR DESCRIPTION
The package moved from https://github.com/visionmedia/debug to https://github.com/debug-js/debug. Github does redirect.

