### PR TITLE
(aws-lambda) Add missing operationName field in AppSyncAuthorizerEvent

### DIFF
--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -1,4 +1,5 @@
 import {
+    AppSyncAuthorizerHandler,
     AppSyncBatchResolverHandler,
     AppSyncIdentityCognito,
     AppSyncIdentityIAM,
@@ -163,3 +164,25 @@ const batchHandlerWithDefinedSourceTypes: AppSyncBatchResolverHandler<TestArgume
         },
     ];
 };
+
+
+interface AuthorizorTestArguments {
+    authorizationToken: string;
+    requestContext: any
+}
+
+const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = async(event) =>{
+
+    str = event.authorizationToken
+    anyObj = event.requestContext
+    str = event.requestContext.accountId
+    str = event.requestContext.apiId
+    str = event.requestContext.queryString
+    str = event.requestContext.requestId
+    anyObj = event.requestContext.variables
+    strOrUndefined = event.requestContext.operationName ? event.requestContext.operationName : undefined
+
+    return {
+        isAuthorized: true
+    }
+}

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -165,14 +165,12 @@ const batchHandlerWithDefinedSourceTypes: AppSyncBatchResolverHandler<TestArgume
     ];
 };
 
-
 interface AuthorizorTestArguments {
     authorizationToken: string;
     requestContext: any;
 }
 
-const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = async(event) => {
-
+const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = async (event) => {
     str = event.authorizationToken;
     anyObj = event.requestContext;
     str = event.requestContext.accountId;

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -168,21 +168,21 @@ const batchHandlerWithDefinedSourceTypes: AppSyncBatchResolverHandler<TestArgume
 
 interface AuthorizorTestArguments {
     authorizationToken: string;
-    requestContext: any
+    requestContext: any;
 }
 
-const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = async(event) =>{
+const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = async(event) => {
 
-    str = event.authorizationToken
-    anyObj = event.requestContext
-    str = event.requestContext.accountId
-    str = event.requestContext.apiId
-    str = event.requestContext.queryString
-    str = event.requestContext.requestId
-    anyObj = event.requestContext.variables
-    strOrUndefined = event.requestContext.operationName ? event.requestContext.operationName : undefined
+    str = event.authorizationToken;
+    anyObj = event.requestContext;
+    str = event.requestContext.accountId;
+    str = event.requestContext.apiId;
+    str = event.requestContext.queryString;
+    str = event.requestContext.requestId;
+    anyObj = event.requestContext.variables;
+    strOrUndefined = event.requestContext.operationName ? event.requestContext.operationName : undefined;
 
     return {
-        isAuthorized: true
-    }
-}
+        isAuthorized: true,
+    };
+};

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -73,6 +73,7 @@ export interface AppSyncAuthorizerEvent {
         accountId: string;
         requestId: string;
         queryString: string;
+        operationName: string;
         variables: { [key: string]: any };
     };
 }

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -73,7 +73,7 @@ export interface AppSyncAuthorizerEvent {
         accountId: string;
         requestId: string;
         queryString: string;
-        operationName: string;
+        operationName?: string;
         variables: { [key: string]: any };
     };
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `AppSyncAuthorizerEvent` is missing the `operationName` field from the `resolverContext` property. From the AWS docs, the example here clearly shows an `operationName` field. My observability platform is also capturing an `operationName` field in live workloads.

Docs: [https://aws.amazon.com/blogs/mobile/appsync-lambda-auth/](https://aws.amazon.com/blogs/mobile/appsync-lambda-auth/)

Example payload from docs:

```json

{
    "authorizationToken": "ExampleAUTHtoken123123123",
    "requestContext": {
        "apiId": "aaaaaa123123123example123",
        "accountId": "111122223333",
        "requestId": "f4081827-1111-4444-5555-5cf4695f339f",
        "queryString": "mutation CreateEvent {...}\n\nquery MyQuery {...}\n",
        "operationName": "MyQuery",
        "variables": {}
    }
}

```


