### PR TITLE
Fix logger Args type to receive any input instead of a string input

### DIFF
--- a/types/logger/index.d.ts
+++ b/types/logger/index.d.ts
@@ -1,13 +1,13 @@
 export function createLogger(logFilePath?: string): Logger;
 
 export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug";
-export type Args = (...args: string[]) => string | false;
+export type Args = (...args: any[]) => string | false;
 
 export class Logger {
     constructor(logFilePath?: string);
     format: (level: LogLevel, data: string, message: string) => string;
     setLevel: (level: LogLevel) => number | false;
-    log: (level: LogLevel, ...args: string[]) => string | false;
+    log: (level: LogLevel, ...args: any[]) => string | false;
     fatal: Args;
     error: Args;
     warn: Args;

--- a/types/logger/logger-tests.ts
+++ b/types/logger/logger-tests.ts
@@ -8,7 +8,7 @@ logToSTDOUT.fatal("fatal", "text1", "text2", "text3", "text4", "text5"); // $Exp
 logToSTDOUT.error("error", "text1", "text2", "text3", "text4"); // $ExpectType string | false
 logToSTDOUT.warn("warn", "text1", "text2", "text3"); // $ExpectType string | false
 logToSTDOUT.info("info", "text1", "text2"); // $ExpectType string | false
-logToSTDOUT.info("info", "text1", {"foo": "bar"}); // $ExpectType string | false
+logToSTDOUT.info("info", "text1", { "foo": "bar" }); // $ExpectType string | false
 logToSTDOUT.debug("debug", "text1"); // $ExpectType string | false
 
 createLogger("test.log"); // $ExpectType Logger

--- a/types/logger/logger-tests.ts
+++ b/types/logger/logger-tests.ts
@@ -8,6 +8,7 @@ logToSTDOUT.fatal("fatal", "text1", "text2", "text3", "text4", "text5"); // $Exp
 logToSTDOUT.error("error", "text1", "text2", "text3", "text4"); // $ExpectType string | false
 logToSTDOUT.warn("warn", "text1", "text2", "text3"); // $ExpectType string | false
 logToSTDOUT.info("info", "text1", "text2"); // $ExpectType string | false
+logToSTDOUT.info("info", "text1", {"foo": "bar"}); // $ExpectType string | false
 logToSTDOUT.debug("debug", "text1"); // $ExpectType string | false
 
 createLogger("test.log"); // $ExpectType Logger


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/quirkey/node-logger#summary

---

As per the `logger`/`node-logger` package description, this library is meant to create a logger which uses a console.log strategy. This means the logging function should be able to take many arguments. As per the README, it also says that these arguments can be of different types:

From https://github.com/quirkey/node-logger#logging
> Any of the logging methods take n arguments, which are each joined by ' ' (similar to console.log()). If an argument is not a string, it is string-ified by sys.inspect()

These implies that the arguments received can be of any type and the output should be a string.

Looking at the type definition of the JS `console.log` function, its arguments are of type `any[]` where the current type definition has it set to `string[]`. This PR attempts to bring compatibility of the argument's types to those of the `console.log` function to stray true to the original library's description

<img width="398" alt="Screenshot 2023-11-08 at 11 12 57" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/306053/5b192887-c8bc-4d69-87a7-376cb838cee7">



