### PR TITLE
Update existing @types/braintree-web ApplePayPaymentRequest "total" field to use a proper type matching Apple Pay JS API

### DIFF
--- a/types/braintree-web/apple-pay.d.ts
+++ b/types/braintree-web/apple-pay.d.ts
@@ -24,8 +24,7 @@ export interface ApplePayLineItem {
     automaticReloadPaymentThresholdAmount?: string;
 }
 
-// more info https://developer.apple.com/reference/applepayjs/1916082-applepay_js_data_types/paymentrequest
-
+// more info https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest
 //  billingContact
 //  Billing contact information for the user.
 //    countryCode
@@ -43,18 +42,15 @@ export interface ApplePayLineItem {
 //    shippingContact
 //  Shipping contact information for the user.
 //    shippingMethods
-// A set of available shipping methods.Totals for all shipping methods must be non- negative to pass validation.
+// A set of available shipping methods.Totals for all shipping methods must be non-negative to pass validation.
 //    shippingType
 //  How the items are to be shipped.This property is optional.If specified, it must be one or more of shipping, delivery, storePickup, or servicePickup.The default value is shipping.
 //    supportedNetworks
 //  Required.The payment networks supported by the merchant.The value must be one or more of amex, discover, interac, masterCard, privateLabel, or visa.
 //    total
-//  Required.The total amount for the payment.The total must be greater than zero and have a label to pass validation.
+//  Required.The total amount for the payment.A line item that represents the total for the payment.See https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916119-total
 export interface ApplePayPaymentRequest {
-    total: {
-        label: string;
-        amount: string;
-    };
+    total: ApplePayLineItem;
     countryCode: string;
     currencyCode: string;
     supportedNetworks: string[];

--- a/types/braintree-web/package.json
+++ b/types/braintree-web/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/braintree-web",
-    "version": "3.96.9999",
+    "version": "3.97.0000",
     "projects": [
         "https://github.com/braintree/braintree-web"
     ],

--- a/types/braintree-web/package.json
+++ b/types/braintree-web/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/braintree-web",
-    "version": "3.97.0000",
+    "version": "3.97.9999",
     "projects": [
         "https://github.com/braintree/braintree-web"
     ],

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -402,6 +402,18 @@ braintree.client.create(
             // { total: { }, countryCode: 'US', currencyCode: 'USD', merchantCapabilities: [ ], supportedNetworks: [ ] }
         });
 
+        // Check that apple pay createPaymentRequest total field allows "pending" type
+        braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
+            const total: braintree.ApplePayLineItem = { label: "Your Label", amount: "10.00", type: "pending" };
+            const request = {
+                total,
+            };
+
+            const paymentRequest = applePayInstance.createPaymentRequest(request);
+            console.log(paymentRequest);
+            // { total: { }, countryCode: 'US', currencyCode: 'USD', merchantCapabilities: [ ], supportedNetworks: [ ] }
+        });
+
         braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
             const request = {
                 countryCode: "US",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916119-total

This update is mainly to use a proper type for the "total" field when using ApplePayPaymentRequest.

Before current changes there was no option to specify the "type" field at the "total" making it impossible to do Apple Pay Payment pre-authorisation (those cases where the total is unknown but user give consent to be charged for any amount)

At official documentation https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916119-total

we can read:
```
total
A line item that represents the total for the payment.

required [ApplePayLineItem total; 
```

And ApplePayLineItem is https://developer.apple.com/documentation/apple_pay_on_the_web/applepaylineitem
