### PR TITLE
Work around pnpm bug for incomplete filtered installs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,16 +41,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-cache-
           restore-keys: ${{ runner.os }}-pnpm-store-cache-
 
-      - run: |
-          # If we're deleting packages, pnpm won't know what other unrelated packages
-          # need to be reinstalled that may now be sourced from npm instead of the
-          # local repo. Just pay the cost of the full install.
-          # HEAD^1 is the merge base (typically master) in PRs, or the previous commit in pushes.
-          if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
-            pnpm install
-          else
-            pnpm install --filter . --filter '...[HEAD^1]...'
-          fi
+      - run: ./scripts/pnpm-install.sh
         name: pnpm install
 
       # Run tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,16 +19,7 @@ jobs:
           pnpm --version
         displayName: 'Setup pnpm'
 
-      - script: |
-          # If we're deleting packages, pnpm won't know what other unrelated packages
-          # need to be reinstalled that may now be sourced from npm instead of the
-          # local repo. Just pay the cost of the full install.
-          # HEAD^1 is the merge base (typically master) in PRs, or the previous commit in pushes.
-          if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
-            pnpm install
-          else
-            pnpm install --filter . --filter '...[HEAD^1]...'
-          fi
+      - script: ./scripts/pnpm-install.sh
         displayName: 'pnpm install'
 
       - script: |

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -13,11 +13,8 @@ echo pnpm install --filter . --filter ...[HEAD^1]...
 pnpm install --filter . --filter ...[HEAD^1]...
 
 FILTERS=('--filter' '...@types/**[HEAD^1]...')
-PASS=0
 
-while [ ${#FILTERS[@]} -gt 0 ]; do
-    PASS=$((PASS + 1))
-
+while true; do
     OLD_FILTERS=("${FILTERS[@]}")
     FILTERS=()
 
@@ -33,6 +30,10 @@ while [ ${#FILTERS[@]} -gt 0 ]; do
         FILTERS+=("{./$i}...")
     done
 
-    echo PASS $PASS: pnpm install "${FILTERS[@]}"
+    if [ ${#FILTERS[@]} -eq 0 ]; then
+        break
+    fi
+
+    echo pnpm install "${FILTERS[@]}"
     pnpm install "${FILTERS[@]}"
 done

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -12,7 +12,7 @@ fi
 FILTERS=("--filter" "." "--filter" "...[HEAD^1]...")
 PASS=0
 
-while [ ${#TO_INSTALL[@]} -gt 0 ]; do
+while [ ${#FILTERS[@]} -gt 0 ]; do
     if [ $PASS -gt 0 ]; then
         echo "Pass $PASS"
     fi

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -9,17 +9,14 @@ fi
 # After installing everything the first time, reread the graph and see if anything was missing..
 # If something was missing, we install that again and repeat until nothing is missing.
 
-FILTERS=("--filter" "." "--filter" "...[HEAD^1]...")
+echo pnpm install --filter . --filter ...[HEAD^1]...
+pnpm install --filter . --filter ...[HEAD^1]...
+
+FILTERS=('--filter' '...@types/**[HEAD^1]...')
 PASS=0
 
 while [ ${#FILTERS[@]} -gt 0 ]; do
-    if [ $PASS -gt 0 ]; then
-        echo "Pass $PASS"
-    fi
     PASS=$((PASS + 1))
-
-    echo pnpm install "${FILTERS[@]}"
-    pnpm install "${FILTERS[@]}"
 
     OLD_FILTERS=("${FILTERS[@]}")
     FILTERS=()
@@ -28,11 +25,15 @@ while [ ${#FILTERS[@]} -gt 0 ]; do
         i=${i#*$PWD/}
 
         if [ ! -d "$i/node_modules" ]; then
+            echo "$i has node_modules"
             continue
         fi
 
         echo "$i is a transitive dep that resolves to the workspace and must be manually installed"
         FILTERS+=("--filter")
-        FILTERS+=("...{./$i}...")
+        FILTERS+=("{./$i}...")
     done
+
+    echo PASS $PASS: pnpm install "${FILTERS[@]}"
+    pnpm install "${FILTERS[@]}"
 done

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+
+if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
+    pnpm install
+    exit 0
+fi
+
+# Workaround for https://github.com/pnpm/pnpm/issues/7283
+# After installing everything the first time, reread the graph and see if anything was missing..
+# If something was missing, we install that again and repeat until nothing is missing.
+
+FILTERS=("--filter" "." "--filter" "...[HEAD^1]...")
+PASS=0
+
+while [ ${#TO_INSTALL[@]} -gt 0 ]; do
+    if [ $PASS -gt 0 ]; then
+        echo "Pass $PASS"
+    fi
+    PASS=$((PASS + 1))
+
+    echo pnpm install "${FILTERS[@]}"
+    pnpm install "${FILTERS[@]}"
+
+    OLD_FILTERS=("${FILTERS[@]}")
+    FILTERS=()
+
+    for i in $(pnpm ls --depth Infinity --parseable "${OLD_FILTERS[@]}" | grep -v node_modules | awk NF | sort -u); do
+        i=${i#*$PWD/}
+
+        if [ ! -d "$i/node_modules" ]; then
+            continue
+        fi
+
+        echo "$i is a transitive dep that resolves to the workspace and must be manually installed"
+        FILTERS+=("--filter")
+        FILTERS+=("...{./$i}...")
+    done
+done

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -24,8 +24,7 @@ while [ ${#FILTERS[@]} -gt 0 ]; do
     for i in $(pnpm ls --depth Infinity --parseable "${OLD_FILTERS[@]}" | grep -v node_modules | awk NF | sort -u); do
         i=${i#*$PWD/}
 
-        if [ ! -d "$i/node_modules" ]; then
-            echo "$i has node_modules"
+        if [ -d "$i/node_modules" ]; then
             continue
         fi
 


### PR DESCRIPTION
This is a workaround for https://github.com/pnpm/pnpm/issues/7283, targeted specifically at the incomplete filtered install aspect.

Effectively, this tries to do the "right thing" first. Then it looks at disk and checks to see if any of the existing packages are not actually installed. If they aren't then we loop again, repeating until we're finally installed.

This doesn't fix the problem for testing; `pnpm ls` as run by `dtslint-runner` does discover all of the transitive deps that mapped back into DT so are missing. But, that's not a regression from the state pre-pnpm, which had no idea about transitive deps at all (and avoided the partial dep problem by always mapping DT packages into DT via `typesRoot` and so on).