### PR TITLE
[tar] Fix incorrect type for cwd option, filter stat arg

### DIFF
--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -3,6 +3,7 @@
 import stream = require("stream");
 import zlib = require("zlib");
 import MiniPass = require("minipass");
+import fs = require("fs");
 
 // #region Interfaces
 
@@ -243,7 +244,7 @@ export interface PackOptions {
      * A function that gets called with (path, stat) for each entry being added.
      * Return true to add the entry to the archive, or false to omit it.
      */
-    filter?(path: string, stat: FileStat): boolean;
+    filter?(path: string, stat: fs.Stats): boolean;
     /**
      * Omit metadata that is system-specific: ctime, atime, uid, gid, uname,
      * gname, dev, ino, and nlink. Note that mtime is still included, because
@@ -425,7 +426,7 @@ export interface CreateOptions {
      * A function that gets called with (path, stat) for each entry being
      * added. Return true to add the entry to the archive, or false to omit it.
      */
-    filter?(path: string, stat: FileStat): boolean;
+    filter?(path: string, stat: fs.Stats): boolean;
 
     /**
      * Omit metadata that is system-specific: ctime, atime, uid, gid, uname,
@@ -739,7 +740,7 @@ export interface ReplaceOptions {
      * A function that gets called with (path, stat) for each entry being
      * added. Return true to emit the entry from the archive, or false to skip it.
      */
-    filter?(path: string, stat: FileStat): boolean;
+    filter?(path: string, stat: fs.Stats): boolean;
 
     /**
      * Allow absolute paths. By default, / is stripped from absolute paths.

--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -229,7 +229,7 @@ export interface PackOptions {
      *
      * @default process.cwd()
      */
-    cwd?: string[];
+    cwd?: string;
     /**
      * A path portion to prefix onto the entries in the archive.
      */

--- a/types/tar/tar-tests.ts
+++ b/types/tar/tar-tests.ts
@@ -33,7 +33,7 @@ extract.on("entry", (entry: any) => undefined);
         filter: (path, stat): boolean => {
             // $ExpectType string
             path;
-            // $ExpectType FileStat
+            // $ExpectType Stats
             stat;
 
             return true;
@@ -138,4 +138,12 @@ fs.createReadStream("my-tarball.tgz")
 tar.list({
     file: "my-tarball.tgz",
     onentry: (entry) => entry.path.slice(1),
+    filter: (path, stat): boolean => {
+        // $ExpectType string
+        path;
+        // $ExpectType FileStat
+        stat;
+
+        return true;
+    },
 }).then(() => console.log("after listing"));

--- a/types/tar/tar-tests.ts
+++ b/types/tar/tar-tests.ts
@@ -24,12 +24,8 @@ readStream.pipe(extract);
 extract.on("entry", (entry: any) => undefined);
 
 {
-    const fixtures = path.resolve(__dirname, "fixtures");
-    const tars = path.resolve(fixtures, "tars");
-    const files = fs.readdirSync(tars);
-
     const options: tar.PackOptions = {
-        cwd: files,
+        cwd: __dirname,
         portable: true,
         // gzip: true,
         gzip: { flush: 1 },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/isaacs/node-tar/blob/main/lib/pack.js#L65 and https://github.com/isaacs/node-tar/blob/5bc9d404e88c39870e0fbb55655a53de6fbf0a04/lib/pack.js#L181
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~


`cwd` should most definitely be a string, not a string array. See also https://github.com/microsoft/DefinitelyTyped-tools/blob/80b4cef75ca231ae03a74dfed2222ed2150e07e0/packages/utils/src/io.ts#L272

Additionally, when using `Pack`, `create`, `update` (which use `Pack`), the stat object passed to filtering is `fs`'s stat as it's the on-disk file. Things which operate on the tarball directly still use a different object.  https://github.com/microsoft/DefinitelyTyped-tools/blob/80b4cef75ca231ae03a74dfed2222ed2150e07e0/packages/utils/src/io.ts#L285