### PR TITLE
Inputmask: Added definitions for "stripLeadingZeroes" and "substitute…

### DIFF
--- a/types/inputmask/index.d.ts
+++ b/types/inputmask/index.d.ts
@@ -523,6 +523,18 @@ declare namespace Inputmask {
          */
         inputFormat?: string | undefined;
         /**
+         * Strip leading zeroes
+         *
+         * @default true
+         */
+        stripLeadingZeroes?: boolean | undefined;
+        /**
+         * Substitude the radixpoint to allow , for . and vice versa
+         *
+         * @default true
+         */
+        substituteRadixPoint?: boolean | undefined;
+        /**
          * Format of the unmasked value. This is only effective when used with the datetime alias.
          */
         outputFormat?: string | undefined;


### PR DESCRIPTION
…RadixPoint" options

Added definitions for "stripLeadingZeroes" and "substituteRadixPoint" numeric extensions options

Reference:
1. https://robinherbots.github.io/Inputmask/#/documentation/numeric#stripleadingzeroes
2. https://robinherbots.github.io/Inputmask/#/documentation/numeric#substituteradixpoint

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<[url here](https://robinherbots.github.io/Inputmask/#/documentation/numeric#stripleadingzeroes)>>](https://robinherbots.github.io/Inputmask/#/documentation/numeric#stripleadingzeroes) https://robinherbots.github.io/Inputmask/#/documentation/numeric#substituteradixpoint)
