### PR TITLE
react - Add phase "nested-update" to ProfilerOnRenderCallback type

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -452,7 +452,7 @@ declare namespace React {
      */
     type ProfilerOnRenderCallback = (
         id: string,
-        phase: "mount" | "update",
+        phase: "mount" | "update" | "nested-update",
         actualDuration: number,
         baseDuration: number,
         startTime: number,

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -335,6 +335,18 @@ let domNode = ReactDOM.findDOMNode(component);
 domNode = ReactDOM.findDOMNode(domNode as Element);
 const fragmentType: React.ComponentType = React.Fragment;
 
+// React.Profiler
+// @ts-expect-error
+const faultyProfilerRenderCallback: React.ProfilerOnRenderCallback = function(id: string, phase: "mount" | "update") {};
+const correctProfilerRenderCallback: React.ProfilerOnRenderCallback = function(
+    id: string,
+    phase: "mount" | "update" | "nested-update",
+    actualDuration: number,
+    baseDuration: number,
+    startTime: number,
+    commitTime: number,
+) {};
+
 //
 // React Elements
 // --------------------------------------------------------------------------

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -453,7 +453,7 @@ declare namespace React {
      */
     type ProfilerOnRenderCallback = (
         id: string,
-        phase: "mount" | "update",
+        phase: "mount" | "update" | "nested-update",
         actualDuration: number,
         baseDuration: number,
         startTime: number,

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -343,6 +343,18 @@ let domNode = ReactDOM.findDOMNode(component);
 domNode = ReactDOM.findDOMNode(domNode as Element);
 const fragmentType: React.ComponentType = React.Fragment;
 
+// React.Profiler
+// @ts-expect-error
+const faultyProfilerRenderCallback: React.ProfilerOnRenderCallback = function(id: string, phase: "mount" | "update") {};
+const correctProfilerRenderCallback: React.ProfilerOnRenderCallback = function(
+    id: string,
+    phase: "mount" | "update" | "nested-update",
+    actualDuration: number,
+    baseDuration: number,
+    startTime: number,
+    commitTime: number,
+) {};
+
 //
 // React Elements
 // --------------------------------------------------------------------------


### PR DESCRIPTION
The phase "nested-update" was added in react 18.0.0, [PR#20163](https://github.com/facebook/react/pull/20163) 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Pull Request](https://github.com/facebook/react/pull/20163), [Documentation](https://react.dev/reference/react/Profiler#onrender-callback)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
