### PR TITLE
Use augmentation to define custom MDX components

### DIFF
--- a/types/mdx/index.d.ts
+++ b/types/mdx/index.d.ts
@@ -65,7 +65,7 @@ declare module "*.mdx" {
 }
 
 // Support markdown extensions from
-// https://github.com/sindresorhus/markdown-extensions/blob/v1.1.1/markdown-extensions.json
+// https://github.com/sindresorhus/markdown-extensions/blob/v2.0.0/markdown-extensions.json
 
 /**
  * A markdown file which exports a JSX component.

--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -79,6 +79,14 @@ declare global {
 
 // Test setup — User code
 
+declare function Planet(): JSX.Element;
+
+declare module "mdx/types.js" {
+    interface CustomComponents {
+        Planet: typeof Planet;
+    }
+}
+
 class CustomImageComponent {
     constructor(props: ImgProps) {}
 
@@ -124,6 +132,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -188,6 +197,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -252,6 +262,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -316,6 +327,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -380,6 +392,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -444,6 +457,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -508,6 +522,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;
@@ -572,6 +587,7 @@ const Div = customComponents.div!;
     universe={() => "and"}
     everything={42}
     components={{
+        Planet,
         a(props) {
             // $ExpectType AnchorProps
             props;

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -58,12 +58,42 @@ interface NestedMDXComponents {
 // Public MDX helper types
 
 /**
+ * You can augment this interface to define custom [components](https://mdxjs.com/guides/injecting-components/).
+ *
+ * This provides type safety when using the `components` prop or a components provider.
+ *
+ * @example
+ * ```ts
+ * import * as React from 'react'
+ *
+ * function Button(props: React.ComponentPropsWithoutRef<'button'>) {
+ *   return <button {...props} />
+ * }
+ *
+ * function Input(props: React.ComponentPropsWithoutRef<'input'>) {
+ *   return <input {...props} />
+ * }
+ *
+ * declare module 'mdx/types.js' {
+ *   interface CustomComponents {
+ *     Button: typeof Button
+ *     Namespace: {
+ *       Input: typeof Input
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface CustomComponents {}
+
+/**
  * MDX components may be passed as the `components`.
  *
  * The key is the name of the element to override. The value is the component to render instead.
  */
 export type MDXComponents =
     & NestedMDXComponents
+    & CustomComponents
     & {
         [Key in StringComponent]?: Component<JSX.IntrinsicElements[Key]>;
     }


### PR DESCRIPTION
This allows users to define custom MDX components in a type-safe manner using module augmentation.

On its own this feature provides little benefit (which isn’t none). Users force to consistently pass the same type of `components` to all MDX components or MDX component providers.

The biggest gain from this, is that it can be leveraged to provide type safety when using custom components **inside** MDX files. https://github.com/mdx-js/mdx-analyzer/issues/260

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mdx-js/mdx-analyzer/issues/260
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
