### PR TITLE
react-splitter-layout: use export = instead of export default

### DIFF
--- a/types/react-splitter-layout/index.d.ts
+++ b/types/react-splitter-layout/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export default class SplitterLayout extends React.PureComponent<SplitterLayoutProps> {
+export = class SplitterLayout extends React.PureComponent<SplitterLayoutProps> {
 }
 
 export type TPrimaryIndex = 0 | 1;


### PR DESCRIPTION
This was found by https://arethetypeswrong.github.io/?p=react-splitter-layout%404.0.0

It also fixes compatibility with recent `@types/react` updates.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
