### PR TITLE
Update BrowserSync typings to reflect current JSDoc

### DIFF
--- a/types/browser-sync/browser-sync-tests.ts
+++ b/types/browser-sync/browser-sync-tests.ts
@@ -274,7 +274,7 @@ browserSync({
     watch: true,
     server: "./app",
     snippet: false,
-})
+});
 
 browserSync({
     httpModule: "http2",

--- a/types/browser-sync/browser-sync-tests.ts
+++ b/types/browser-sync/browser-sync-tests.ts
@@ -271,6 +271,12 @@ browserSync({
 });
 
 browserSync({
+    watch: true,
+    server: "./app",
+    snippet: false,
+})
+
+browserSync({
     httpModule: "http2",
 });
 

--- a/types/browser-sync/index.d.ts
+++ b/types/browser-sync/index.d.ts
@@ -10,297 +10,352 @@ import { ServeStaticOptions } from "serve-static";
 declare namespace browserSync {
     interface Options {
         /**
-         * Browsersync includes a user-interface that is accessed via a separate port. The UI allows to controls
-         * all devices, push sync updates and much more.
-         *
-         * port - Default: 3001
-         * weinre.port - Default: 8080
-         * Note: Requires at least version 2.0.0.
+         * Browsersync includes a user-interface that is accessed via a separate port.
+         * The UI allows to controls all devices, push sync updates and much more.
+         * @default false
          */
         ui?: UIOptions | boolean | undefined;
         /**
-         * Browsersync can watch your files as you work. Changes you make will either be injected into the page (CSS
-         * & images) or will cause all browsers to do a full-page refresh. See anymatch for more information on glob
-         * patterns.
-         * Default: false
+         * Browsersync can watch your files as you work. Changes you make will either
+         * be injected into the page (CSS & images) or will cause all browsers to do
+         * a full-page refresh.
+         * @default false
          */
         files?: string | (string | FileCallback | object)[] | undefined;
         /**
          * Specify which file events to respond to.
          * Available events: `add`, `change`, `unlink`, `addDir`, `unlinkDir`
+         * @default ["change"]
+         * @since 2.18.8
          */
         watchEvents?: WatchEvents | string[] | undefined;
         /**
-         * Watch files automatically.
+         * Watch files automatically - this should be used as an
+         * alternative to the `files` option. When this option is used, some directories
+         * will be ignored automatically such as `node_modules` `bower_components` `.sass-cache`
+         * `.vscode` `.git` `.idea`
+         * @default false
+         * @since 2.23.0
          */
         watch?: boolean | undefined;
         /**
-         * Patterns for any watchers to ignore.
-         * Anything provided here will end up inside 'watchOptions.ignored'.
+         * Patterns for any watchers to ignore. Anything provided here
+         * will end up inside `watchOptions.ignored`
+         * @default []
+         * @since 2.23.0
          */
         ignore?: string[] | undefined;
         /**
-         * Serve an index.html file for all non-asset routes.
-         * Useful when using client-routers.
+         * Serve an index.html file for all non-asset routes. Useful
+         * when using client-routers
+         * @default false
+         * @since 2.23.0
          */
         single?: boolean | undefined;
         /**
-         * File watching options that get passed along to Chokidar. Check their docs for available options
-         * Default: undefined
-         * Note: Requires at least version 2.6.0.
+         * File watching options that get passed along to [Chokidar](https://github.com/paulmillr/chokidar).
+         * Check their docs for available options
+         * @default undefined
+         * @since 2.6.0
          */
         watchOptions?: chokidar.WatchOptions | undefined;
         /**
          * Use the built-in static server for basic HTML/JS/CSS websites.
-         * Default: false
+         * @default false
          */
         server?: string | boolean | string[] | ServerOptions | undefined;
         /**
          * Proxy an EXISTING vhost. Browsersync will wrap your vhost with a proxy URL to view your site.
-         * Passing only a URL as a string equates to passing only target property of ProxyOptions type.
-         * target - Default: undefined
-         * ws - Default: undefined
-         * middleware - Default: undefined
-         * reqHeaders - Default: undefined
-         * proxyRes - Default: undefined (http.ServerResponse if expecting single parameter)
-         * proxyReq - Default: undefined
+         * @default false
          */
         proxy?: string | ProxyOptions | undefined;
         /**
          * Use a specific port (instead of the one auto-detected by Browsersync)
-         * Default: 3000
+         * @default 3000
          */
         port?: number | undefined;
         /**
          * Functions or actual plugins used as middleware.
+         * @default false
          */
         middleware?: MiddlewareHandler | PerRouteMiddleware | (MiddlewareHandler | PerRouteMiddleware)[] | undefined;
         /**
-         * Add additional directories from which static files should be served.
-         * Should only be used in proxy or snippet mode.
-         * Default: []
-         * Note: Requires at least version 2.8.0.
+         * Add additional directories from which static
+         * files should be served. Should only be used in `proxy` or `snippet`
+         * mode.
+         * @default []
+         * @since 2.8.0
          */
         serveStatic?: StaticOptions[] | string[] | undefined;
         /**
-         * Options that are passed to the serve-static middleware when you use the
-         * string[] syntax: eg: `serveStatic: ['./app']`.
-         * Please see [serve-static](https://github.com/expressjs/serve-static) for details.
+         * Options that are passed to the serve-static middleware
+         * when you use the string[] syntax: eg: `serveStatic: ['./app']`. Please see
+         * [serve-static](https://github.com/expressjs/serve-static) for details
+         * @since 2.17.0
          */
         serveStaticOptions?: ServeStaticOptions | undefined;
         /**
-         * Enable https for localhost development.
-         * Note: This may not be needed for proxy option as it will try to infer from your target url.
-         * Note: If privacy error is encountered please see HttpsOptions below, setting those will resolve.
-         * Note: Requires at least version 1.3.0.
+         * Enable https for localhost development. **Note** - this is not needed for proxy
+         * option as it will be inferred from your target url.
+         * @default undefined
+         * @since 1.3.0
          */
         https?: boolean | HttpsOptions | undefined;
         /**
-         * Override http module to allow using 3rd party server modules (such as http2).
+         * Override http module to allow using 3rd party server modules (such as http2)
+         * *Note*: these modules are not included in the Browsersync package - you need
+         * to 'npm install' any that you'd like to use.
+         * @default undefined
+         * @since 2.18.0
          */
         httpModule?: string | undefined;
         /**
          * Current working directory
+         * @since 2.23.0
          */
         cwd?: string;
-        /**
-         * Register callbacks via a regular option - this can be used to get access the Browsersync
-         * instance in situations where you cannot provide a callback via the normal API (for example,
-         * in a Gruntfile)
+         /**
+         * Register callbacks via a regular option - this can be used
+         * to get access the Browsersync instance in situations where you
+         * cannot provide a callback via the normal API (for example, in a Gruntfile)
          *
-         * This 'ready' callback can be used to access the Browsersync instance
+         * **Note**: Only the `ready` callback is currently supported here.
          */
         callbacks?: CallbacksOptions;
-        /**
+       /**
          * Clicks, Scrolls & Form inputs on any device will be mirrored to all others.
          * clicks - Default: true
          * scroll - Default: true
-         * forms - Default: true
+         * forms - Default: {
+                submit: true,
+                inputs: true,
+                toggles: true
+            }
          */
         ghostMode?: GhostOptions | boolean | undefined;
         /**
          * Can be either "info", "debug", "warn", or "silent"
-         * Default: info
+         * @default "info"
          */
         logLevel?: LogLevel | undefined;
         /**
-         * Change the console logging prefix. Useful if you're creating your own project based on Browsersync
-         * Default: BS
-         * Note: Requires at least version 1.5.1.
+         * Change the console logging prefix. Useful if you're creating your
+         * own project based on Browsersync
+         * @default "Browsersync"
+         * @since 1.5.1
          */
         logPrefix?: string | undefined;
         /**
          * Whether or not to log connections
-         * Default: false
+         * @default false
          */
         logConnections?: boolean | undefined;
         /**
          * Whether or not to log information about changed files
-         * Default: false
+         * @default true
          */
         logFileChanges?: boolean | undefined;
         /**
          * Log the snippet to the console when you're in snippet mode (no proxy/server)
-         * Default: true
-         * Note: Requires at least version 1.5.2.
+         * @default true
+         * @since 1.5.2
          */
         logSnippet?: boolean | undefined;
         /**
-         * You can control how the snippet is injected onto each page via a custom regex + function.
-         * You can also provide patterns for certain urls that should be ignored from the snippet injection.
-         * Note: Requires at least version 2.0.0.
+         * You can prevent Browsersync from injecting the connection snippet
+         * by passing `snippet: false`.
+         * @default undefined
+         */
+        snippet?: boolean | undefined;
+        /**
+         * You can control how the snippet is injected
+         * onto each page via a custom regex + function.
+         * You can also provide patterns for certain urls
+         * that should be ignored from the snippet injection.
+         * @since 2.0.0
          */
         snippetOptions?: SnippetOptions | undefined;
         /**
          * Add additional HTML rewriting rules.
-         * Default: false
-         * Note: Requires at least version 2.4.0.
+         * @since 2.4.0
+         * @default false
          */
         rewriteRules?: boolean | RewriteRules[] | undefined;
         /**
          * Tunnel the Browsersync server through a random Public URL
-         * Default: null
+         * @default null
          */
         tunnel?: string | boolean | undefined;
         /**
-         * Some features of Browsersync (such as xip & tunnel) require an internet connection, but if you're
-         * working offline, you can reduce start-up time by setting this option to false
+         * Some features of Browsersync (such as `xip` & `tunnel`) require an internet connection, but if you're
+         * working offline, you can reduce start-up time by setting this option to `false`
+         * @default undefined
          */
         online?: boolean | undefined;
         /**
-         * Default: true
          * Decide which URL to open automatically when Browsersync starts. Defaults to "local" if none set.
-         * Can be true, local, external, ui, ui-external, tunnel or false
+         * Can be `true`, `local`, `external`, `ui`, `ui-external`, `tunnel` or `false`
+         * @default true
          */
         open?: OpenOptions | boolean | undefined;
         /**
          * The browser(s) to open
-         * Default: default
+         * @default "default"
          */
         browser?: string | string[] | undefined;
         /**
          * Add HTTP access control (CORS) headers to assets served by Browsersync.
-         * Default: false
-         * Note: Requires at least version 2.16.0.
+         * @default false
+         * @since 2.16.0
          */
         cors?: boolean | undefined;
         /**
-         * Requires an internet connection - useful for services such as Typekit as it allows you to configure
-         * domains such as *.xip.io in your kit settings
-         * Default: false
+         * Requires an internet connection - useful for services such as [Typekit](https://typekit.com/)
+         * as it allows you to configure domains such as `*.xip.io` in your kit settings
+         * @default false
          */
         xip?: boolean | undefined;
         /**
+         * ¯\_(ツ)_/¯
+         * @default false
+         */
+        hostnameSuffix?: boolean | undefined;
+        /**
          * Reload each browser when Browsersync is restarted.
-         * Default: false
+         * @default false
          */
         reloadOnRestart?: boolean | undefined;
         /**
          * The small pop-over notifications in the browser are not always needed/wanted.
-         * Default: true
+         * @default true
          */
         notify?: boolean | undefined;
         /**
          * scrollProportionally: false // Sync viewports to TOP position
-         * Default: true
+         * @default true
          */
         scrollProportionally?: boolean | undefined;
         /**
          * How often to send scroll events
-         * Default: 0
+         * @default 0
          */
         scrollThrottle?: number | undefined;
         /**
-         * Decide which technique should be used to restore scroll position following a reload.
-         * Can be window.name or cookie
-         * Default: 'window.name'
+         * Decide which technique should be used to restore
+         * scroll position following a reload.
+         * Can be `window.name` or `cookie`
+         * @default "window.name"
          */
         scrollRestoreTechnique?: string | undefined;
         /**
-         * Sync the scroll position of any element on the page. Add any amount of CSS selectors
-         * Default: []
-         * Note: Requires at least version 2.9.0.
+         * Sync the scroll position of any element
+         * on the page. Add any amount of CSS selectors
+         * @default []
+         * @since 2.9.0
          */
         scrollElements?: string[] | undefined;
         /**
-         * Default: []
-         * Note: Requires at least version 2.9.0.
-         * Sync the scroll position of any element on the page - where any scrolled element will cause
-         * all others to match scroll position. This is helpful when a breakpoint alters which element
+         * Sync the scroll position of any element
+         * on the page - where any scrolled element
+         * will cause all others to match scroll position.
+         * This is helpful when a breakpoint alters which element
          * is actually scrolling
+         * @default []
+         * @since 2.9.0
          */
         scrollElementMapping?: string[] | undefined;
         /**
-         * Time, in milliseconds, to wait before instructing the browser to reload/inject following a file
-         * change event
-         * Default: 0
+         * Time, in milliseconds, to wait before
+         * instructing the browser to reload/inject following a
+         * file change event
+         * @default 0
          */
         reloadDelay?: number | undefined;
         /**
-         * Restrict the frequency in which browser:reload events can be emitted to connected clients
-         * Default: 0
-         * Note: Requires at least version 2.6.0.
+         * Wait for a specified window of event-silence before
+         * sending any reload events.
+         * @default 500
+         * @since 2.6.0
          */
         reloadDebounce?: number | undefined;
         /**
-         * Emit only the first event during sequential time windows of a specified duration.
-         * Note: Requires at least version 2.13.0.
+         * Emit only the first event during sequential time windows
+         * of a specified duration.
+         * @default 0
+         * @since 2.13.0
          */
         reloadThrottle?: number | undefined;
         /**
          * User provided plugins
-         * Default: []
-         * Note: Requires at least version 2.6.0.
+         * @default []
+         * @since 2.6.0
          */
         plugins?: any[] | undefined;
         /**
          * Whether to inject changes (rather than a page refresh)
-         * Default: true
+         * @default true
          */
         injectChanges?: boolean | undefined;
         /**
          * The initial path to load
+         * @default null
          */
-        startPath?: string | undefined;
+        startPath?: string | undefined | null;
         /**
          * Whether to minify the client script
-         * Default: true
+         * @default true
          */
         minify?: boolean | undefined;
         /**
          * Override host detection if you know the correct IP to use
+         * @default null
          */
-        host?: string | undefined;
+        host?: string | undefined | null;
         /**
-         * Specify a host to listen on. Use this if you want to prevent binding to all interfaces.
+         * Specify a host to listen on. Use this if you want to
+         * prevent binding to all interfaces.
          *
-         * Note: When you specify this option, it overrides the 'host' option
+         * **Note**: When you specify this option, it overrides the 'host' option
+         * @default undefined
          */
         listen?: string;
         /**
-         * Support environments where dynamic hostnames are not required (ie: electron).
+         * Support environments where dynamic hostnames are not required
+         * (ie: electron)
+         * @default false
+         * @since 2.14.0
          */
         localOnly?: boolean | undefined;
         /**
          * Send file-change events to the browser
-         * Default: true
+         * @default true
          */
         codeSync?: boolean | undefined;
         /**
          * Append timestamps to injected files
-         * Default: true
+         * @default true
          */
         timestamps?: boolean | undefined;
         /**
-         * ¯\_(ツ)_/¯
-         * Best guess, when ghostMode (or SocketIO?) is setup the events
+         * When ghostMode is setup the events
          * listed here will be emitted and able to hook into.
+         * @default [
+         * "scroll",
+         * "scroll:element",
+         * "input:text",
+         * "input:toggles",
+         * "form:submit",
+         * "form:reset",
+         * "click"
+         * ]
          */
         clientEvents?: string[] | undefined;
         /**
-         * Alter the script path for complete control over where the Browsersync Javascript is served
-         * from. Whatever you return from this function will be used as the script path.
-         * Note: Requires at least version 1.5.0.
+         * Alter the script path for complete control over where the Browsersync
+         * Javascript is served from. Whatever you return from this function
+         * will be used as the script path.
+         * @default undefined
+         * @since 1.5.0
          */
         scriptPath?: ((path: string) => string) | undefined;
         /**
@@ -311,23 +366,53 @@ declare namespace browserSync {
          * domain - Default: undefined
          * port - Default: undefined
          * clients.heartbeatTimeout - Default: 5000
-         * Note: Requires at least version 1.6.2.
+         * @since 1.6.2
          */
         socket?: SocketOptions | undefined;
         /**
          * Configure the script domain
+         * @since 2.14.0
          */
         script?: ScriptOptions | undefined;
-        /**
-         * ¯\_(ツ)_/¯
-         */
         tagNames?: TagNamesOptions | undefined;
         /**
-         * ¯\_(ツ)_/¯
+         * @default ["css", "png", "jpg", "jpeg", "svg", "gif", "webp", "map"]
          */
         injectFileTypes?: string[] | undefined;
         /**
-         * ¯\_(ツ)_/¯
+         * @default false
+         */
+        injectNotification?: boolean | undefined;
+        /**
+         * @default [
+         * "js",
+         * "css",
+         * "pdf",
+         * "map",
+         * "svg",
+         * "ico",
+         * "woff",
+         * "json",
+         * "eot",
+         * "ttf",
+         * "png",
+         * "jpg",
+         * "jpeg",
+         * "webp",
+         * "gif",
+         * "mp4",
+         * "mp3",
+         * "3gp",
+         * "ogg",
+         * "ogv",
+         * "webm",
+         * "m4a",
+         * "flv",
+         * "wmv",
+         * "avi",
+         * "swf",
+         * "scss"
+         * ]
          */
         excludeFileTypes?: string[] | undefined;
     }

--- a/types/browser-sync/index.d.ts
+++ b/types/browser-sync/index.d.ts
@@ -114,7 +114,7 @@ declare namespace browserSync {
          * @since 2.23.0
          */
         cwd?: string;
-         /**
+        /**
          * Register callbacks via a regular option - this can be used
          * to get access the Browsersync instance in situations where you
          * cannot provide a callback via the normal API (for example, in a Gruntfile)
@@ -122,7 +122,7 @@ declare namespace browserSync {
          * **Note**: Only the `ready` callback is currently supported here.
          */
         callbacks?: CallbacksOptions;
-       /**
+        /**
          * Clicks, Scrolls & Form inputs on any device will be mirrored to all others.
          * clicks - Default: true
          * scroll - Default: true

--- a/types/browser-sync/package.json
+++ b/types/browser-sync/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/browser-sync",
-    "version": "2.27.9999",
+    "version": "2.29.9999",
     "projects": [
         "http://www.browsersync.io/"
     ],


### PR DESCRIPTION
This PR uses [current BrowserSync JSDoc options](https://github.com/BrowserSync/browser-sync/blob/d787281a1b93af59b6fb58daed3e018bfcfcca6d/packages/browser-sync/lib/default-config.js). I have also added missing options like `snippet`. I have also took the liberty to remove unnecessary comments on non documented options.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/BrowserSync/browser-sync/blob/d787281a1b93af59b6fb58daed3e018bfcfcca6d/packages/browser-sync/lib/default-config.js
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

