### PR TITLE
@types/k6:  fix randomSeed type

### DIFF
--- a/types/k6/index.d.ts
+++ b/types/k6/index.d.ts
@@ -87,7 +87,7 @@ export function group<RT>(name: string, fn: () => RT): RT;
  * @example
  * randomSeed(123456789);
  */
-export function randomseed(int: number): void;
+export function randomSeed(int: number): void;
 
 /**
  * Suspend VU execution for the specified duration.


### PR DESCRIPTION
This PR fixes the type defn for k6's randomSeed. 

`randomSeed`'s type now matches the [documented function name](https://k6.io/docs/javascript-api/k6/randomseed/)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests: N/A this feature was not tested and the provided doc shows this fix is needed.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes]
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [k6/randomSeed](https://k6.io/docs/javascript-api/k6/randomseed/)

