### PR TITLE
[node] Add missed `version` option to `WASI` constructor. Allow to pass `undefined` to `import.meta.resolve`

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -267,18 +267,8 @@ declare module "module" {
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @since v20.6.0
-             *
-             * @param specifier The module specifier to resolve relative to the current module.
-             * @returns The absolute (`file:`) URL string for the resolved module.
-             */
-            resolve(specifier: string): string;
-            /**
-             * This `parent` parameter is only used when the `--experimental-import-meta-resolve`
+             * Second `parent` parameter is only used when the `--experimental-import-meta-resolve`
              * command flag enabled.
-             *
-             * Provides a module-relative resolution function scoped to each module, returning
-             * the URL string.
              *
              * @since v20.6.0
              *
@@ -286,7 +276,7 @@ declare module "module" {
              * @param parent The absolute parent module URL to resolve from.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specifier: string, parent: string | URL): string;
+            resolve(specifier: string, parent?: string | URL | undefined): string;
         }
     }
     export = Module;

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -55,6 +55,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
     importmeta.url; // $ExpectType string
     importmeta.resolve("local"); // $ExpectType string
     importmeta.resolve("local", "/parent"); // $ExpectType string
+    importmeta.resolve("local", undefined); // $ExpectType string
     importmeta.resolve("local", new URL("https://parent.module")); // $ExpectType string
 }
 

--- a/types/node/test/wasi.ts
+++ b/types/node/test/wasi.ts
@@ -3,6 +3,7 @@ import { WASI } from "node:wasi";
 
 {
     const wasi = new WASI({
+        version: 'preview1',
         args: process.argv,
         env: process.env,
         preopens: {

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -267,18 +267,8 @@ declare module "module" {
              * Provides a module-relative resolution function scoped to each module, returning
              * the URL string.
              *
-             * @since v20.6.0
-             *
-             * @param specifier The module specifier to resolve relative to the current module.
-             * @returns The absolute (`file:`) URL string for the resolved module.
-             */
-            resolve(specifier: string): string;
-            /**
-             * This `parent` parameter is only used when the `--experimental-import-meta-resolve`
+             * Second `parent` parameter is only used when the `--experimental-import-meta-resolve`
              * command flag enabled.
-             *
-             * Provides a module-relative resolution function scoped to each module, returning
-             * the URL string.
              *
              * @since v20.6.0
              *
@@ -286,7 +276,7 @@ declare module "module" {
              * @param parent The absolute parent module URL to resolve from.
              * @returns The absolute (`file:`) URL string for the resolved module.
              */
-            resolve(specifier: string, parent: string | URL): string;
+            resolve(specifier: string, parent?: string | URL | undefined): string;
         }
     }
     export = Module;

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -55,6 +55,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
     importmeta.url; // $ExpectType string
     importmeta.resolve("local"); // $ExpectType string
     importmeta.resolve("local", "/parent"); // $ExpectType string
+    importmeta.resolve("local", undefined); // $ExpectType string
     importmeta.resolve("local", new URL("https://parent.module")); // $ExpectType string
 }
 

--- a/types/node/ts4.8/test/wasi.ts
+++ b/types/node/ts4.8/test/wasi.ts
@@ -3,6 +3,7 @@ import { WASI } from "node:wasi";
 
 {
     const wasi = new WASI({
+        version: 'preview1',
         args: process.argv,
         env: process.env,
         preopens: {

--- a/types/node/ts4.8/wasi.d.ts
+++ b/types/node/ts4.8/wasi.d.ts
@@ -107,6 +107,12 @@ declare module "wasi" {
          * @default 2
          */
         stderr?: number | undefined;
+        /**
+         * The version of WASI requested.
+         * Currently the only supported versions are `'unstable'` and `'preview1'`.
+         * @since v20.0.0
+         */
+        version: string;
     }
     /**
      * The `WASI` class provides the WASI system call API and additional convenience

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -107,6 +107,12 @@ declare module "wasi" {
          * @default 2
          */
         stderr?: number | undefined;
+        /**
+         * The version of WASI requested.
+         * Currently the only supported versions are `'unstable'` and `'preview1'`.
+         * @since v20.0.0
+         */
+        version: string;
     }
     /**
      * The `WASI` class provides the WASI system call API and additional convenience


### PR DESCRIPTION
Related discussions:
- https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/67427
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66634#issuecomment-1808669168