### PR TITLE
feat(sinon): make .define generic to enable IDE suggestions

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1692,9 +1692,9 @@ declare namespace Sinon {
          * @param key
          * @param value
          */
-        define<T, TKey extends keyof T>(
+        define<T>(
             obj: T,
-            key: TKey | PropertyKey,
+            key: keyof T | PropertyKey,
             value: unknown,
         ): void;
     }

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1685,12 +1685,16 @@ declare namespace Sinon {
         ): SinonStubbedInstance<TType>;
 
         /**
-         * Defines a property on the given object which will be torn down when
-         * the sandbox is restored
+         * Defines a property on the given object which will be torn down when the sandbox is restored.
+         * Attempts to define an already existing property will cause an exception.
+         * Attempts to pass undefined value will cause an exception.
+         * @param obj
+         * @param key
+         * @param value
          */
-        define(
-            obj: object,
-            key: PropertyKey,
+        define<T, TKey extends keyof T>(
+            obj: T,
+            key: TKey | PropertyKey,
             value: unknown,
         ): void;
     }

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -149,8 +149,8 @@ function testSandbox() {
     // Test .define
 
     class DefinableConfig {
-        public Value1: string;
-        public Value2: string;
+        Value1: string;
+        Value2: string;
     }
     
     const objToDefine = {};

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -145,11 +145,25 @@ function testSandbox() {
     // $ExpectType number
     objWithPrivateMembers.pubVar;
 
+
+    // Test .define
+
+    class DefinableConfig {
+        public Value1: string;
+        public Value2: string;
+    }
+    
     const objToDefine = {};
+    const objToDefineWithClass = new DefinableConfig();
 
     sb.define(objToDefine, "someKey", 123);
     sb.define(objToDefine, 100, 200);
     sb.define(objToDefine, Symbol("abc"), 200);
+
+    sb.define(objToDefineWithClass, "Value1", 100);
+    sb.define(objToDefineWithClass, Symbol("Value2"), 200);
+    sb.define(objToDefineWithClass, "Value3", 300);
+    sb.define(objToDefineWithClass, Symbol("Value4"), 200);
 
     // @ts-expect-error
     sb.define(objToDefine, {}, 123);

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -145,14 +145,13 @@ function testSandbox() {
     // $ExpectType number
     objWithPrivateMembers.pubVar;
 
-
     // Test .define
 
     class DefinableConfig {
         Value1: string;
         Value2: string;
     }
-    
+
     const objToDefine = {};
     const objToDefineWithClass = new DefinableConfig();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66888#discussion_r1395649214

I verified that property discovery in WebStorm works correctly when the type is declared as `keyof T | PropertyKey` rather than just `PropertyKey`.