### PR TITLE
[react] Disallow `undefined` dependencies in `useMemo`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1130,7 +1130,7 @@ declare namespace React {
      * @see https://react.dev/reference/react/useMemo
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: () => T, deps: DependencyList): T;
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -119,6 +119,16 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // inline object, to (manually) check if autocomplete works
     React.useReducer(reducer, { age: 42, name: "The Answer" });
 
+    // Missing deps are most likely an error and would also trigger react-hooks/exhaustive-deps
+    // @ts-expect-error
+    React.useCallback(() => {});
+
+    React.useCallback(
+        () => {},
+        // @ts-expect-error -- Go beyond what ESLint can do and also "missing deps" at the type-level
+        undefined,
+    );
+
     // Implicit any
     // @ts-expect-error
     const anyCallback = React.useCallback(value => {
@@ -229,11 +239,15 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useDebugValue(id, value => value.toFixed());
     React.useDebugValue(id);
 
-    // allow passing an explicit undefined
-    React.useMemo(() => {}, undefined);
-    // but don't allow it to be missing
+    // Missing deps are most likely an error and would also trigger react-hooks/exhaustive-deps
     // @ts-expect-error
     React.useMemo(() => {});
+
+    React.useMemo(
+        () => {},
+        // @ts-expect-error -- Go beyond what ESLint can do and also "missing deps" at the type-level
+        undefined,
+    );
 
     // useState convenience overload
     // default to undefined only (not that useful, but type-safe -- no {} or unknown!)

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1131,7 +1131,7 @@ declare namespace React {
      * @see https://react.dev/reference/react/useMemo
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: () => T, deps: DependencyList): T;
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *

--- a/types/react/ts5.0/test/hooks.tsx
+++ b/types/react/ts5.0/test/hooks.tsx
@@ -119,6 +119,16 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // inline object, to (manually) check if autocomplete works
     React.useReducer(reducer, { age: 42, name: "The Answer" });
 
+    // Missing deps are most likely an error and would also trigger react-hooks/exhaustive-deps
+    // @ts-expect-error
+    React.useCallback(() => {});
+
+    React.useCallback(
+        () => {},
+        // @ts-expect-error -- Go beyond what ESLint can do and also "missing deps" at the type-level
+        undefined,
+    );
+
     // Implicit any
     // @ts-expect-error
     const anyCallback = React.useCallback(value => {
@@ -229,11 +239,15 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useDebugValue(id, value => value.toFixed());
     React.useDebugValue(id);
 
-    // allow passing an explicit undefined
-    React.useMemo(() => {}, undefined);
-    // but don't allow it to be missing
+    // Missing deps are most likely an error and would also trigger react-hooks/exhaustive-deps
     // @ts-expect-error
     React.useMemo(() => {});
+
+    React.useMemo(
+        () => {},
+        // @ts-expect-error -- Go beyond what ESLint can do and also "missing deps" at the type-level
+        undefined,
+    );
 
     // useState convenience overload
     // default to undefined only (not that useful, but type-safe -- no {} or unknown!)


### PR DESCRIPTION
This was orriginally added in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33220 to allow "conditional memoization". But it looks like this is another "side-effect in `useMemo`" under the hood so we really shouldn't bless that at any level. You can always `@ts-expect-error` to indicate what you're doing instead of allowing `undefined` which is not descriptive.

Could not find any errors in a 1.4M LoC repo that this change caused.