### PR TITLE
[snowflake-sdk] Update Docs Links

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -163,7 +163,7 @@ export interface StreamOptions {
 
 /**
  * ### Related Docs
- * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#required-connection-options Required Connection Options}
+ * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#required-connection-options Required Connection Options}
  */
 export interface ConnectionOptions {
     /**
@@ -488,7 +488,7 @@ export type Bind = string | number;
  * ```
  *
  * ### Related Docs
- * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#binding-statement-parameters Binding Statement Parameters}
+ * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute#binding-statement-parameters Binding Statement Parameters}
  */
 export type Binds = Bind[] | InsertBinds;
 
@@ -501,7 +501,7 @@ export type Binds = Bind[] | InsertBinds;
  * ```
  *
  * ### Related Docs
- * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#binding-array-for-bulk-insert Binding Array For Bulk Insert}
+ * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute#binding-array-for-bulk-insert Binding Array For Bulk Insert}
  */
 export type InsertBinds = Bind[][];
 
@@ -553,20 +553,20 @@ export type Connection = NodeJS.EventEmitter & {
 
     /**
      * ### Related Docs
-     * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#executing-statements Executing Statements}
+     * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute Executing Statements}
      */
     execute(options: {
         sqlText: string;
         /**
          * ### Related Docs
-         * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#batch-processing-results Batch Processing Results}
+         * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-consume#streaming-results Streaming Results}
          */
         streamResult?: boolean | undefined;
         binds?: Binds | undefined;
 
         /**
          * ### Related Docs
-         * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#fetching-data-types-as-strings Fetching Data Types As Strings}
+         * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-consume#fetching-data-types-as-strings Fetching Data Types As Strings}
          */
         fetchAsString?: Array<"String" | "Boolean" | "Number" | "Date" | "JSON" | "Buffer"> | undefined;
         complete?: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
@@ -616,7 +616,7 @@ export interface ConfigureOptions {
  * Creates a new Connection instance.
  *
  * ### Related Docs
- * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#establishing-a-connection Establishing a Connection}
+ * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-connect Establishing a Connection}
  */
 export function createConnection(options: ConnectionOptions): Connection;
 


### PR DESCRIPTION
Updating documentation links from Snowflake. The current links in the types are dead.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
