### PR TITLE
Fix pnpm install script for large PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,8 @@ jobs:
       - run: ./scripts/pnpm-install.sh
         name: pnpm install
 
+      - run: pnpm ls
+
       # Run tests
       - run: pnpm run test-all
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,9 @@ jobs:
       - script: ./scripts/pnpm-install.sh
         displayName: 'pnpm install'
 
+      - script: pnpm ls
+        displayName: 'pnpm ls'
+
       - script: |
           if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && pnpm run update-codeowners; fi
           git checkout -- .

--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -18,7 +18,18 @@ while true; do
     OLD_FILTERS=("${FILTERS[@]}")
     FILTERS=()
 
-    for i in $(pnpm ls --depth Infinity --parseable "${OLD_FILTERS[@]}" | grep -v node_modules | awk NF | sort -u); do
+    set +e
+    OUTPUT=$(pnpm ls --depth Infinity --parseable "${OLD_FILTERS[@]}")
+    CODE=$?
+    set -e
+
+    if [ $CODE -ne 0 ]; then
+        echo "pnpm ls failed while looking for missing deps; giving up and installing everything"
+        echo "$OUTPUT"
+        exec pnpm install
+    fi
+
+    for i in $(echo "$OUTPUT" | grep -v node_modules | awk NF | sort -u); do
         i=${i#*$PWD/}
 
         if [ -d "$i/node_modules" ]; then


### PR DESCRIPTION
This should unblock PRs like #67455 which touch many packages.

`pnpm` builds a massive string at some point (https://github.com/pnpm/pnpm/issues/5056 or https://github.com/pnpm/pnpm/issues/7079). The easiest workaround is to detect when the hack this script does fails, and just give up and resort to a full install.