### PR TITLE
Fix failing tests after #67455

### DIFF
--- a/types/tablesorter/System/TriggerNameMap.d.ts
+++ b/types/tablesorter/System/TriggerNameMap.d.ts
@@ -80,7 +80,7 @@ export interface TriggerNameMap<TElement = HTMLElement> {
     /**
      * Performs a search.
      */
-    search: [readonly string[]?] | boolean;
+    search: [(readonly string[])?] | boolean;
 
     /**
      * Opens the specified page.

--- a/types/ungap__structured-clone/ungap__structured-clone-tests.ts
+++ b/types/ungap__structured-clone/ungap__structured-clone-tests.ts
@@ -6,7 +6,7 @@ interface AnyRecord {
 const serializable: AnyRecord = { any: "serializable" };
 
 structuredClone(serializable); // $ExpectType AnyRecord
-structuredClone.serialize({ any: "serializable" }); // $ExpectType SerializedRecord
+structuredClone.serialize({ any: "serializable" }); // $ExpectType [SerializedRecordIndex[], ...[number, any][]]
 // prettier-ignore
 structuredClone.deserialize([ // $ExpectType any
     [2, [[1, 2]]],


### PR DESCRIPTION
These failing packages were missed in the PR run.

Not sure why the `SerializedRecord` alias is getting erased with the change.