### PR TITLE
Fix packages with new failing lints for `import = require` declarations

### DIFF
--- a/types/chec__commerce.js/features/cart.d.ts
+++ b/types/chec__commerce.js/features/cart.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { Asset } from "../types/asset";
 import { Cart as CartType } from "../types/cart";
 import { LineItem } from "../types/line-item";

--- a/types/chec__commerce.js/features/categories.d.ts
+++ b/types/chec__commerce.js/features/categories.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { Category } from "../types/category";
 import { PaginationMeta } from "../types/pagination";
 

--- a/types/chec__commerce.js/features/checkout.d.ts
+++ b/types/chec__commerce.js/features/checkout.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { CheckoutCapture } from "../types/checkout-capture";
 import { CheckoutCaptureResponse } from "../types/checkout-capture-response";
 import { CheckoutToken } from "../types/checkout-token";

--- a/types/chec__commerce.js/features/customer.d.ts
+++ b/types/chec__commerce.js/features/customer.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { Customer as CustomerType } from "../types/customer";
 import { Order as OrderType } from "../types/order";
 import { PaginationMeta } from "../types/pagination";

--- a/types/chec__commerce.js/features/merchants.d.ts
+++ b/types/chec__commerce.js/features/merchants.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { Merchant } from "../types/merchant";
 
 export class Merchants {

--- a/types/chec__commerce.js/features/products.d.ts
+++ b/types/chec__commerce.js/features/products.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 import { PaginationMeta } from "../types/pagination";
 import { Product } from "../types/product";
 import { Variant } from "../types/variant";

--- a/types/chec__commerce.js/features/services.d.ts
+++ b/types/chec__commerce.js/features/services.d.ts
@@ -1,4 +1,4 @@
-import Commerce = require("@chec/commerce.js");
+import Commerce = require("../");
 
 export interface LocaleListCountriesResponse {
     countries: { [name: string]: string };

--- a/types/core-util-is/core-util-is-tests.ts
+++ b/types/core-util-is/core-util-is-tests.ts
@@ -1,4 +1,4 @@
-import util = require("./");
+import util = require("core-util-is");
 
 // $ExpectType boolean
 util.isArray([]);

--- a/types/inflight/inflight-tests.ts
+++ b/types/inflight/inflight-tests.ts
@@ -1,4 +1,4 @@
-import inflight = require("./");
+import inflight = require("inflight");
 
 // $ExpectType ((a: string) => Promise<number>) | null
 const fn = inflight("key", async (a: string) => 1);

--- a/types/regex-escape/regex-escape-tests.ts
+++ b/types/regex-escape/regex-escape-tests.ts
@@ -1,4 +1,4 @@
-import RegexEscape = require(".");
+import RegexEscape = require("regex-escape");
 
 // @ts-expect-error No argument
 RegexEscape();


### PR DESCRIPTION
These will all fail after https://github.com/microsoft/DefinitelyTyped-tools/pull/834.

There's still one package that isn't fixed; https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-notifier/v5/index.d.ts which looks totally wrong.