### PR TITLE
[googlepay] make `allowedCountryCodes` optional

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -40,6 +40,8 @@ allowedPaymentMethods[0].tokenizationSpecification = {
     },
 };
 
+const shippingAddressParametersEmptyObjectIsValid: google.payments.api.ShippingAddressParameters = {};
+
 const getGooglePaymentsClient = (env?: google.payments.api.Environment) => {
     return new google.payments.api.PaymentsClient({
         environment: env,

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -392,7 +392,7 @@ declare namespace google.payments.api {
          * If omitted, a shipping address from any supported country may be
          * returned.
          */
-        allowedCountryCodes: string[];
+        allowedCountryCodes?: string[];
 
         /**
          * Whether a phone number is additionally required from the buyer for


### PR DESCRIPTION
updating it to match the documentation:
https://developers.google.com/pay/api/web/reference/request-objects#ShippingAddressParameters

this parameter is nullable. it's also already implied in the current tsdoc comment:

```
If omitted, a shipping address from any supported country may be returned.
```

---

Please fill in this template.

- [x]  Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
