### PR TITLE
[Chrome] Adds updateStaticRules/UpdateStaticRulesOptions to the declarativeNetRequest interface

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -12357,6 +12357,18 @@ declare namespace chrome.declarativeNetRequest {
         removeRuleIds?: number[] | undefined;
     }
 
+
+    export interface UpdateStaticRulesOptions {
+      /** Set of ids corresponding to rules in the Ruleset to disable. */
+      disableRuleIds?: number[];
+
+      /** Set of ids corresponding to rules in the Ruleset to enable. */
+      enableRuleIds?: number[];
+
+      /** The id corresponding to a static Ruleset. */
+      rulesetId: string;
+    }
+
     export interface UpdateRulesetOptions {
         /** The set of ids corresponding to a static Ruleset that should be disabled. */
         disableRulesetIds?: string[] | undefined;
@@ -12572,6 +12584,15 @@ declare namespace chrome.declarativeNetRequest {
      * This can happen for multiple reasons, such as invalid rule format, duplicate rule ID, rule count limit exceeded, and others.
      */
     export function updateSessionRules(options: UpdateRuleOptions): Promise<void>;
+
+
+    /** Disables and enables individual static rules in a Ruleset.
+     * Changes to rules belonging to a disabled Ruleset will take effect the next time that it becomes enabled.
+     *
+     * @return The `updateStaticRules` method either calls a provided callback if its finished or returnes as a `Promise` (MV3 only).
+     */
+    export function updateStaticRules(options: UpdateStaticRulesOptions): Promise<void>;
+    export function updateStaticRules(options: UpdateStaticRulesOptions, callback?: () => void): void;
 
     /** The rule that has been matched along with information about the associated request. */
     export interface RuleMatchedDebugEvent extends chrome.events.Event<(info: MatchedRuleInfoDebug) => void> {}

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -12357,16 +12357,15 @@ declare namespace chrome.declarativeNetRequest {
         removeRuleIds?: number[] | undefined;
     }
 
-
     export interface UpdateStaticRulesOptions {
-      /** Set of ids corresponding to rules in the Ruleset to disable. */
-      disableRuleIds?: number[];
+        /** Set of ids corresponding to rules in the Ruleset to disable. */
+        disableRuleIds?: number[];
 
-      /** Set of ids corresponding to rules in the Ruleset to enable. */
-      enableRuleIds?: number[];
+        /** Set of ids corresponding to rules in the Ruleset to enable. */
+        enableRuleIds?: number[];
 
-      /** The id corresponding to a static Ruleset. */
-      rulesetId: string;
+        /** The id corresponding to a static Ruleset. */
+        rulesetId: string;
     }
 
     export interface UpdateRulesetOptions {
@@ -12584,7 +12583,6 @@ declare namespace chrome.declarativeNetRequest {
      * This can happen for multiple reasons, such as invalid rule format, duplicate rule ID, rule count limit exceeded, and others.
      */
     export function updateSessionRules(options: UpdateRuleOptions): Promise<void>;
-
 
     /** Disables and enables individual static rules in a Ruleset.
      * Changes to rules belonging to a disabled Ruleset will take effect the next time that it becomes enabled.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -12587,7 +12587,8 @@ declare namespace chrome.declarativeNetRequest {
     /** Disables and enables individual static rules in a Ruleset.
      * Changes to rules belonging to a disabled Ruleset will take effect the next time that it becomes enabled.
      *
-     * @return The `updateStaticRules` method either calls a provided callback if its finished or returnes as a `Promise` (MV3 only).
+     * @return The `updateStaticRules` method either calls a provided callback if its finished or returns as a `Promise` (MV3 only).
+     * @since Chrome 111
      */
     export function updateStaticRules(options: UpdateStaticRulesOptions): Promise<void>;
     export function updateStaticRules(options: UpdateStaticRulesOptions, callback?: () => void): void;


### PR DESCRIPTION
Adds updateStaticRules function and UpdateStaticRulesOptions type. Defined here:
https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-UpdateStaticRulesOptions https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#method-updateStaticRules

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
