### PR TITLE
[node] Fix return type of `WASI.start` from `void` to `number`

### DIFF
--- a/types/node/test/wasi.ts
+++ b/types/node/test/wasi.ts
@@ -19,6 +19,6 @@ import { WASI } from "node:wasi";
         // const instance = await WebAssembly.instantiate(wasm, importObject);
         const instance = {};
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/ts4.8/test/wasi.ts
+++ b/types/node/ts4.8/test/wasi.ts
@@ -19,6 +19,6 @@ import { WASI } from "node:wasi";
         // const instance = await WebAssembly.instantiate(wasm, importObject);
         const instance = {};
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/ts4.8/wasi.d.ts
+++ b/types/node/ts4.8/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *

--- a/types/node/v16/test/wasi.ts
+++ b/types/node/v16/test/wasi.ts
@@ -15,6 +15,6 @@ import { WASI } from "node:wasi";
         const wasm = await WebAssembly.compile(fs.readFileSync("./demo.wasm"));
         const instance = await WebAssembly.instantiate(wasm, importObject);
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/v16/ts4.8/test/wasi.ts
+++ b/types/node/v16/ts4.8/test/wasi.ts
@@ -15,6 +15,6 @@ import { WASI } from "node:wasi";
         const wasm = await WebAssembly.compile(fs.readFileSync("./demo.wasm"));
         const instance = await WebAssembly.instantiate(wasm, importObject);
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/v16/ts4.8/wasi.d.ts
+++ b/types/node/v16/ts4.8/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *

--- a/types/node/v16/wasi.d.ts
+++ b/types/node/v16/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *

--- a/types/node/v18/test/wasi.ts
+++ b/types/node/v18/test/wasi.ts
@@ -18,6 +18,6 @@ import { WASI } from "node:wasi";
         // const instance = await WebAssembly.instantiate(wasm, importObject);
         const instance = {};
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/v18/ts4.8/test/wasi.ts
+++ b/types/node/v18/ts4.8/test/wasi.ts
@@ -18,6 +18,6 @@ import { WASI } from "node:wasi";
         // const instance = await WebAssembly.instantiate(wasm, importObject);
         const instance = {};
 
-        wasi.start(instance);
+        const exitCode: number = wasi.start(instance);
     })();
 }

--- a/types/node/v18/ts4.8/wasi.d.ts
+++ b/types/node/v18/ts4.8/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *

--- a/types/node/v18/wasi.d.ts
+++ b/types/node/v18/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -133,7 +133,7 @@ declare module "wasi" {
          * If `start()` is called more than once, an exception is thrown.
          * @since v13.3.0, v12.16.0
          */
-        start(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        start(instance: object): number; // TODO: avoid DOM dependency until WASM moved to own lib.
         /**
          * Attempt to initialize `instance` as a WASI reactor by invoking its`_initialize()` export, if it is present. If `instance` contains a `_start()`export, then an exception is thrown.
          *


### PR DESCRIPTION
Hi there! :wave: 

It seems that the return type of `WASI.start` in `@types/node` is not correct. It's marked as returning `void` when it always return a number, the exit code.

This type definition match the function definition for `v16`, `v18` and latest as can be seen in their source:

 - `v16`: https://github.com/nodejs/node/blob/v16.20.2/lib/wasi.js#L121
 - `v18`: https://github.com/nodejs/node/blob/v18.18.2/lib/wasi.js#L121
 - `v20`: https://github.com/nodejs/node/blob/v20.10.0/lib/wasi.js#L143

### Detailed explanation

The function `start` is defined as follow:

```js
  start(instance) {
    //...
    try {
      _start();
    } catch (err) {
      if (err !== kExitCode) {
        throw err;
      }
    }

    return this[kExitCode];
  }
```

`this[kExitCode]` is initialized to `0` in the `WASI` constructor and might be updated by another function `wasiReturnOnProcExit` which itself might be called by `_start` via `proc_exit`. The latter is only set if `returnOnExit` was either not set or provided `true`.

In every code path either a number will be returned or an exception will be thrown making the correct type to be `number` instead of `void`.

### Checks

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see previous section
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: N/A
