### PR TITLE
[jest-axe] Also extend `expect` from `@jest/globals`

### DIFF
--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -74,3 +74,9 @@ declare global {
     // axe-core depends on a global Node
     interface Node {}
 }
+
+declare module "@jest/expect" {
+    interface Matchers<R extends void | Promise<void>> {
+        toHaveNoViolations(): R;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - See below
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Jest allows importing `expect` from the `@jest/globals` package. However, when doing so, the `.toHaveNoViolations` typing wasn't detected. This change fixes that. Unfortunately, I wasn't sure how to add tests for this, since it depends on types obtained via the `jest` package, but existing tests still succeed, and the change did work in my own codebase. Happy to take suggestions on how to add proper tests.