### PR TITLE
fix(react-timeago): Correct inference of component props

### DIFF
--- a/types/react-timeago/index.d.ts
+++ b/types/react-timeago/index.d.ts
@@ -20,7 +20,7 @@ declare namespace ReactTimeago {
         nextFormatter?: Formatter,
     ) => React.ReactNode;
 
-    interface ReactTimeagoProps<T extends React.ComponentType | keyof JSX.IntrinsicElements = "time"> {
+    interface ReactTimeagoProps<T extends React.ElementType> {
         readonly live?: boolean | undefined;
         readonly minPeriod?: number | undefined;
         readonly maxPeriod?: number | undefined;
@@ -33,9 +33,10 @@ declare namespace ReactTimeago {
 }
 
 declare class ReactTimeago<
-    T extends React.ComponentType | keyof JSX.IntrinsicElements,
+    T extends React.ElementType<P>,
+    P = React.ComponentProps<T>,
 > extends React.Component<
-    ReactTimeago.ReactTimeagoProps<T> & React.ComponentProps<T>
+    ReactTimeago.ReactTimeagoProps<T> & P
 > {}
 
 export = ReactTimeago;

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -53,3 +53,14 @@ const ReactTimeagoCustomComponent: JSX.Element = (
         allowFontScaling
     />
 );
+
+const CustomJSXElement = ({ myProp }: { myProp: string }) => <div>{myProp}</div>;
+
+const ReactTimeagoCustomJSXElement: JSX.Element = (
+    <ReactTimeago
+        date={new Date()}
+        component={CustomJSXElement}
+        // props passed down to Text
+        myProp="myProp"
+    />
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-timeago#anything-else-optional

