### PR TITLE
[serverless] Support proper throwing of user errors in plugins

### DIFF
--- a/types/serverless/classes/ServerlessError.d.ts
+++ b/types/serverless/classes/ServerlessError.d.ts
@@ -1,0 +1,5 @@
+declare class ServerlessError extends Error {
+    constructor(message?: string);
+}
+
+export = ServerlessError;

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -3,6 +3,7 @@ import PluginManager = require("./classes/PluginManager");
 import Utils = require("./classes/Utils");
 import YamlParser = require("./classes/YamlParser");
 import AwsProvider = require("./plugins/aws/provider/awsProvider");
+import ServerlessError = require("./classes/ServerlessError");
 
 declare namespace Serverless {
     interface Options {
@@ -58,6 +59,10 @@ declare namespace Serverless {
     }
 
     type Event = AwsProvider.Event | object;
+
+    interface Classes {
+        Error: typeof ServerlessError;
+    }
 }
 
 declare class Serverless {
@@ -86,6 +91,7 @@ declare class Serverless {
     yamlParser: YamlParser;
     pluginManager: PluginManager;
 
+    classes: Serverless.Classes;
     config: Serverless.Config;
     configurationFilename: string;
     serverlessDirPath: string;

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -61,12 +61,29 @@ class BadPlugin implements Plugin {
     constructor(badArg: number) {}
 }
 
+// Test a plugin that throws an user error exception
+class ThrowUserErrorPlugin implements Plugin {
+    hooks: Plugin.Hooks;
+    constructor(serverless: Serverless, options: Serverless.Options, logging: Plugin.Logging) {
+        this.hooks = {
+            "command:start": () => {},
+        };
+        // $ExpectType ServerlessError
+        const errorWithoutMessage = new serverless.classes.Error();
+        // $ExpectType ServerlessError
+        const errorWithMessage = new serverless.classes.Error("an error message");
+        throw new serverless.classes.Error("Invalid configuration in X");
+    }
+}
+
 const manager = new PluginManager(serverless);
 manager.addPlugin(CustomPlugin);
 // Test adding a plugin with an incorrect constructor
 // prettier-ignore
 // @ts-expect-error
 manager.addPlugin(BadPlugin);
+// Test adding a plugin that throws an user error exception
+manager.addPlugin(ThrowUserErrorPlugin);
 
 // Test a plugin with bad arguments for a variable resolver
 class BadVariablePlugin1 implements Plugin {


### PR DESCRIPTION
[serverless] Support proper throwing of user errors in plugins

The example below is the recommended way according to Serverless Docs [1]:

    throw new serverless.classes.Error('Invalid configuration in X');

[1] https://www.serverless.com/framework/docs/guides/plugins/cli-output#errors

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
