### PR TITLE
`react-tagsinput`: correct `key` type in `RenderTagProps`

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -30,7 +30,7 @@ declare namespace TagsInput {
     interface RenderTagProps<Tag = any> extends TagProps {
         readonly disabled: boolean;
         readonly getTagDisplayValue: (tag: Tag) => string;
-        readonly onRemove: (tagIndex: number) => void;
+        readonly onRemove: (tagIndex: string | number) => void;
         readonly tag: Tag;
         readonly key: string | number;
     }

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -30,9 +30,9 @@ declare namespace TagsInput {
     interface RenderTagProps<Tag = any> extends TagProps {
         readonly disabled: boolean;
         readonly getTagDisplayValue: (tag: Tag) => string;
-        readonly onRemove: (tagIndex: string | number) => void;
+        readonly onRemove: (tagIndex: number) => void;
         readonly tag: Tag;
-        readonly key: string | number;
+        readonly key: number;
     }
 
     type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactChild;


### PR DESCRIPTION
I forgot to do this in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67335.

`key` is passed in to `onRemove`, so the types must match. For example: https://github.com/olahol/react-tagsinput/tree/48742e78a07de11a356d95c87b34e1c532c8cc71#rendertag