### PR TITLE
relay-runtime: Support multiple Uploadables in UploadableMap interface

### DIFF
--- a/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
+++ b/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
@@ -111,7 +111,7 @@ export type SubscribeFunction = (
 
 export type Uploadable = File | Blob;
 export interface UploadableMap {
-    [key: string]: Uploadable;
+    [key: string]: Uploadable | Uploadable[];
 }
 
 /**

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -26,6 +26,8 @@ import {
     ROOT_ID,
     ROOT_TYPE,
     Store,
+    Uploadable,
+    UploadableMap,
     Variables,
 } from "relay-runtime";
 
@@ -749,3 +751,55 @@ ConnectionInterface.inject({
     PAGE_INFO_TYPE: "PageInfo",
     START_CURSOR: "startCursor",
 });
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// UploadableMap
+// ~~~~~~~~~~~~~~~~~~~~~
+
+// Sample function that uses UploadableMap, simulating a real use-case
+function createUploadables(uploadables: UploadableMap) {
+    // This function would do something meaningful with UploadableMap
+    // For testing purposes, there's no implementation required
+}
+
+// Create instances of File and Blob to use as uploadables
+const file: Uploadable = new File([""], "filename.txt");
+const blob: Uploadable = new Blob([""], { type: "text/plain" });
+
+// Test the UploadableMap with a single File instance
+const singleFileUploadableMap: UploadableMap = {
+    "singleFile": file,
+};
+
+createUploadables(singleFileUploadableMap);
+
+// Test the UploadableMap with a single Blob instance
+const singleBlobUploadableMap: UploadableMap = {
+    "singleBlob": blob,
+};
+
+createUploadables(singleBlobUploadableMap);
+
+// Test the UploadableMap with multiple File instances
+const multipleFilesUploadableMap: UploadableMap = {
+    "multipleFiles": [file, file], // Multiple Files
+};
+
+createUploadables(multipleFilesUploadableMap);
+
+// Test the UploadableMap with multiple Blob instances
+const multipleBlobsUploadableMap: UploadableMap = {
+    "multipleBlobs": [blob, blob], // Multiple Blobs
+};
+
+createUploadables(multipleBlobsUploadableMap);
+
+// Test the UploadableMap with mixed single and multiple uploadable instances
+const mixedUploadableMap: UploadableMap = {
+    "singleFile": file,
+    "multipleFiles": [file, file],
+    "singleBlob": blob,
+    "multipleBlobs": [blob, blob],
+};
+
+createUploadables(mixedUploadableMap);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://relay.dev/docs/api-reference/use-mutation/

> uploadables: An optional uploadable map, an object representing **any number of uploadable items**, with one key per item. Each value must be of type File or Blob.


We've already been using the patch internally for some time.
