### PR TITLE
[node] Update typings to v18.19.0

### DIFF
--- a/types/node/v18/package.json
+++ b/types/node/v18/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "18.18.9999",
+    "version": "18.19.9999",
     "nonNpm": true,
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/v18/process.d.ts
+++ b/types/node/v18/process.d.ts
@@ -902,6 +902,12 @@ declare module "process" {
                  */
                 setSourceMapsEnabled(value: boolean): void;
                 /**
+                 * The `process.sourceMapsEnabled` property returns whether the [Source Map v3](https://sourcemaps.info/spec.html) support for stack traces is enabled.
+                 * @since v18.19.0
+                 * @experimental
+                 */
+                readonly sourceMapsEnabled: boolean;
+                /**
                  * The `process.version` property contains the Node.js version string.
                  *
                  * ```js

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -148,19 +148,26 @@ declare module "node:test" {
     function only(name?: string, fn?: TestFn): Promise<void>;
     function only(options?: TestOptions, fn?: TestFn): Promise<void>;
     function only(fn?: TestFn): Promise<void>;
-
     /**
      * The type of a function under test. The first argument to this function is a
      * {@link TestContext} object. If the test uses callbacks, the callback function is passed as
      * the second argument.
      */
     type TestFn = (t: TestContext, done: (result?: any) => void) => any;
-
     /**
      * The type of a function under Suite.
      */
     type SuiteFn = (s: SuiteContext) => void | Promise<void>;
-
+    interface TestShard {
+        /**
+         * A positive integer between 1 and `<total>` that specifies the index of the shard to run.
+         */
+        index: number;
+        /**
+         * A positive integer that specifies the total number of shards to split the test files to.
+         */
+        total: number;
+    }
     interface RunOptions {
         /**
          * If a number is provided, then that many files would run in parallel.
@@ -170,26 +177,22 @@ declare module "node:test" {
          * @default true
          */
         concurrency?: number | boolean | undefined;
-
         /**
          * An array containing the list of files to run.
          * If unspecified, the test runner execution model will be used.
          */
         files?: readonly string[] | undefined;
-
         /**
          * Allows aborting an in-progress test execution.
          * @default undefined
          */
         signal?: AbortSignal | undefined;
-
         /**
          * A number of milliseconds the test will fail after.
          * If unspecified, subtests inherit this value from their parent.
          * @default Infinity
          */
         timeout?: number | undefined;
-
         /**
          * Sets inspector port of test child process.
          * If a nullish value is provided, each process gets its own port,
@@ -203,6 +206,11 @@ declare module "node:test" {
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
         /**
+         * If truthy, the test context will only run tests that have the `only` option set
+         * @since v18.19.0
+         */
+        only?: boolean;
+        /**
          * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
          */
         setup?: (root: Test) => void | Promise<void>;
@@ -211,6 +219,12 @@ declare module "node:test" {
          * @default false
          */
         watch?: boolean | undefined;
+        /**
+         * Running tests in a specific shard.
+         * @since v18.19.0
+         * @default undefined
+         */
+        shard?: TestShard | undefined;
     }
     class Test extends AsyncResource {
         concurrency: number;
@@ -561,7 +575,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<F | Implementation>;
-
         /**
          * This function is used to create a mock on an existing object method.
          * @param object The object whose method is being mocked.
@@ -600,7 +613,6 @@ declare module "node:test" {
             implementation: Function,
             options: MockMethodOptions,
         ): Mock<Function>;
-
         /**
          * This function is syntax sugar for {@link MockTracker.method} with `options.getter` set to `true`.
          */
@@ -622,7 +634,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<(() => MockedObject[MethodName]) | Implementation>;
-
         /**
          * This function is syntax sugar for {@link MockTracker.method} with `options.setter` set to `true`.
          */
@@ -644,7 +655,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<((value: MockedObject[MethodName]) => void) | Implementation>;
-
         /**
          * This function restores the default behavior of all mocks that were previously created by this `MockTracker`
          * and disassociates the mocks from the `MockTracker` instance. Once disassociated, the mocks can still be used,
@@ -654,12 +664,12 @@ declare module "node:test" {
          * If the global `MockTracker` is used extensively, calling this function manually is recommended.
          */
         reset(): void;
-
         /**
          * This function restores the default behavior of all mocks that were previously created by this `MockTracker`.
          * Unlike `mock.reset()`, `mock.restoreAll()` does not disassociate the mocks from the `MockTracker` instance.
          */
         restoreAll(): void;
+        timers: MockTimers;
     }
 
     const mock: MockTracker;
@@ -742,11 +752,172 @@ declare module "node:test" {
          */
         restore(): void;
     }
+    type Timer = "setInterval" | "clearInterval" | "setTimeout" | "clearTimeout";
+    /**
+     * Mocking timers is a technique commonly used in software testing to simulate and
+     * control the behavior of timers, such as `setInterval` and `setTimeout`,
+     * without actually waiting for the specified time intervals.
+     *
+     * The `MockTracker` provides a top-level `timers` export
+     * which is a `MockTimers` instance.
+     * @since v18.19.0
+     * @experimental
+     */
+    class MockTimers {
+        /**
+         * Enables timer mocking for the specified timers.
+         *
+         * **Note:** When you enable mocking for a specific timer, its associated
+         * clear function will also be implicitly mocked.
+         *
+         * Example usage:
+         *
+         * ```js
+         * import { mock } from 'node:test';
+         * mock.timers.enable(['setInterval']);
+         * ```
+         *
+         * The above example enables mocking for the `setInterval` timer and
+         * implicitly mocks the `clearInterval` function. Only the `setInterval`and `clearInterval` functions from `node:timers`,`node:timers/promises`, and`globalThis` will be mocked.
+         *
+         * Alternatively, if you call `mock.timers.enable()` without any parameters:
+         *
+         * All timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`, and `'clearTimeout'`)
+         * will be mocked. The `setInterval`, `clearInterval`, `setTimeout`, and `clearTimeout`functions from `node:timers`, `node:timers/promises`,
+         * and `globalThis` will be mocked.
+         * @since v18.19.0
+         */
+        enable(timers?: Timer[]): void;
+        /**
+         * This function restores the default behavior of all mocks that were previously
+         * created by this `MockTimers` instance and disassociates the mocks
+         * from the `MockTracker` instance.
+         *
+         * **Note:** After each test completes, this function is called on
+         * the test context's `MockTracker`.
+         *
+         * ```js
+         * import { mock } from 'node:test';
+         * mock.timers.reset();
+         * ```
+         * @since v18.19.0
+         */
+        reset(): void;
+        /**
+         * Advances time for all mocked timers.
+         *
+         * **Note:** This diverges from how `setTimeout` in Node.js behaves and accepts
+         * only positive numbers. In Node.js, `setTimeout` with negative numbers is
+         * only supported for web compatibility reasons.
+         *
+         * The following example mocks a `setTimeout` function and
+         * by using `.tick` advances in
+         * time triggering all pending timers.
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('mocks setTimeout to be executed synchronously without having to actually wait for it', (context) => {
+         *   const fn = context.mock.fn();
+         *
+         *   context.mock.timers.enable(['setTimeout']);
+         *
+         *   setTimeout(fn, 9999);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 0);
+         *
+         *   // Advance in time
+         *   context.mock.timers.tick(9999);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 1);
+         * });
+         * ```
+         *
+         * Alternativelly, the `.tick` function can be called many times
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('mocks setTimeout to be executed synchronously without having to actually wait for it', (context) => {
+         *   const fn = context.mock.fn();
+         *   context.mock.timers.enable(['setTimeout']);
+         *   const nineSecs = 9000;
+         *   setTimeout(fn, nineSecs);
+         *
+         *   const twoSeconds = 3000;
+         *   context.mock.timers.tick(twoSeconds);
+         *   context.mock.timers.tick(twoSeconds);
+         *   context.mock.timers.tick(twoSeconds);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 1);
+         * });
+         * ```
+         * @since v18.19.0
+         */
+        tick(milliseconds: number): void;
+        /**
+         * Triggers all pending mocked timers immediately.
+         *
+         * The example below triggers all pending timers immediately,
+         * causing them to execute without any delay.
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('runAll functions following the given order', (context) => {
+         *   context.mock.timers.enable(['setTimeout']);
+         *   const results = [];
+         *   setTimeout(() => results.push(1), 9999);
+         *
+         *   // Notice that if both timers have the same timeout,
+         *   // the order of execution is guaranteed
+         *   setTimeout(() => results.push(3), 8888);
+         *   setTimeout(() => results.push(2), 8888);
+         *
+         *   assert.deepStrictEqual(results, []);
+         *
+         *   context.mock.timers.runAll();
+         *
+         *   assert.deepStrictEqual(results, [3, 2, 1]);
+         * });
+         * ```
+         *
+         * **Note:** The `runAll()` function is specifically designed for
+         * triggering timers in the context of timer mocking.
+         * It does not have any effect on real-time system
+         * clocks or actual timers outside of the mocking environment.
+         * @since v18.19.0
+         */
+        runAll(): void;
+        /**
+         * Calls {@link MockTimers.reset()}.
+         */
+        [Symbol.dispose](): void;
+    }
 
     export { after, afterEach, before, beforeEach, describe, it, mock, run, test, test as default };
 }
 
-interface DiagnosticData {
+interface TestLocationInfo {
+    /**
+     * The column number where the test is defined, or
+     * `undefined` if the test was run through the REPL.
+     */
+    column?: number;
+    /**
+     * The path of the test file, `undefined` if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The line number where the test is defined, or
+     * `undefined` if the test was run through the REPL.
+     */
+    line?: number;
+}
+interface DiagnosticData extends TestLocationInfo {
     /**
      * The diagnostic message.
      */
@@ -755,12 +926,8 @@ interface DiagnosticData {
      * The nesting level of the test.
      */
     nesting: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestFail {
+interface TestFail extends TestLocationInfo {
     /**
      * Additional execution metadata.
      */
@@ -799,12 +966,8 @@ interface TestFail {
      * Present if `context.skip` is called.
      */
     skip?: string | boolean;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestPass {
+interface TestPass extends TestLocationInfo {
     /**
      * Additional execution metadata.
      */
@@ -839,12 +1002,8 @@ interface TestPass {
      * Present if `context.skip` is called.
      */
     skip?: string | boolean;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestPlan {
+interface TestPlan extends TestLocationInfo {
     /**
      * The nesting level of the test.
      */
@@ -853,12 +1012,8 @@ interface TestPlan {
      * The number of subtests that have ran.
      */
     count: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestStart {
+interface TestStart extends TestLocationInfo {
     /**
      * The test name.
      */
@@ -867,54 +1022,34 @@ interface TestStart {
      * The nesting level of the test.
      */
     nesting: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestStderr {
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
+interface TestStderr extends TestLocationInfo {
     /**
      * The message written to `stderr`
      */
     message: string;
 }
-interface TestStdout {
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
+interface TestStdout extends TestLocationInfo {
     /**
      * The message written to `stdout`
      */
     message: string;
 }
-interface TestEnqueue {
+interface TestEnqueue extends TestLocationInfo {
     /**
      * The test name
      */
     name: string;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
     /**
      * The nesting level of the test.
      */
     nesting: number;
 }
-interface TestDequeue {
+interface TestDequeue extends TestLocationInfo {
     /**
      * The test name
      */
     name: string;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
     /**
      * The nesting level of the test.
      */
@@ -970,5 +1105,9 @@ declare module "node:test/reporters" {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, Spec as spec, tap, TestEvent };
+    /**
+     * The `junit` reporter outputs test results in a jUnit XML format
+     */
+    function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
+    export { dot, junit, Spec as spec, tap, TestEvent };
 }

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -60,7 +60,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 {
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
-        console.log(context.importAssertions.type);
+        console.log(context.importAttributes.type);
 
         if (Math.random() > 0.5) {
             return {
@@ -106,5 +106,36 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
+    };
+}
+
+// Initialize hook
+{
+    const specifier = "./myLoader.js";
+    const parentURL = "some-url"; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL("data:") });
+    Module.register(specifier, parentURL);
+    Module.register(specifier, new URL("data:"));
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
+    interface TransferableData {
+        number: number;
+    }
+    Module.register<TransferableData>(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+
+    type MyInitializeHook = Module.InitializeHook<TransferableData>;
+    const initializeHook: MyInitializeHook = async ({ number }) => {
+        number; // $ExpectType number
     };
 }

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "node:stream";
 import { after, afterEach, before, beforeEach, describe, it, run, test } from "node:test";
-import { TestEvent } from "node:test/reporters";
+import { dot, junit, spec, tap, TestEvent } from "node:test/reporters";
 
 // run without options
 // $ExpectType TestsStream
@@ -21,8 +21,13 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ["executed"],
+    only: true,
     setup: (root) => {},
     watch: true,
+    shard: {
+        index: 1,
+        total: 3,
+    },
 });
 
 // TestsStream should be a NodeJS.ReadableStream
@@ -539,6 +544,32 @@ test("mocks a setter", (t) => {
         // $ExpectType unknown
         call.this;
     }
+});
+
+// @ts-expect-error
+dot();
+// $ExpectType AsyncGenerator<"\n" | "." | "X", void, unknown>
+dot("" as any);
+// @ts-expect-error
+tap();
+// $ExpectType AsyncGenerator<string, void, unknown>
+tap("" as any);
+// $ExpectType Spec
+new spec();
+// @ts-expect-error
+junit();
+// $ExpectType AsyncGenerator<string, void, unknown>
+junit("" as any);
+
+describe("Mock Timers Test Suite", () => {
+    it((t) => {
+        t.mock.timers.enable(["setTimeout"]);
+        // @ts-expect-error
+        t.mock.timers.enable(["DOES_NOT_EXIST"]);
+        t.mock.timers.enable();
+        t.mock.timers.reset();
+        t.mock.timers.tick(1000);
+    });
 });
 
 class TestReporter extends Transform {

--- a/types/node/v18/tls.d.ts
+++ b/types/node/v18/tls.d.ts
@@ -798,6 +798,18 @@ declare module "tls" {
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
     interface SecureContextOptions {
         /**
+         * If set, this will be called when a client opens a connection using the ALPN extension.
+         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
+         * respectively containing the server name from the SNI extension (if any) and an array of
+         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
+         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
+         * to reject the connection with a fatal alert. If a string is returned that does not match one of
+         * the client's ALPN protocols, an error will be thrown.
+         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
+         * @since v18.19.0
+         */
+        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        /**
          * Optionally override the trusted CA certificates. Default is to trust
          * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
          * replaced when CAs are explicitly specified using this option.

--- a/types/node/v18/ts4.8/process.d.ts
+++ b/types/node/v18/ts4.8/process.d.ts
@@ -902,6 +902,12 @@ declare module "process" {
                  */
                 setSourceMapsEnabled(value: boolean): void;
                 /**
+                 * The `process.sourceMapsEnabled` property returns whether the [Source Map v3](https://sourcemaps.info/spec.html) support for stack traces is enabled.
+                 * @since v18.19.0
+                 * @experimental
+                 */
+                readonly sourceMapsEnabled: boolean;
+                /**
                  * The `process.version` property contains the Node.js version string.
                  *
                  * ```js

--- a/types/node/v18/ts4.8/test.d.ts
+++ b/types/node/v18/ts4.8/test.d.ts
@@ -148,19 +148,26 @@ declare module "node:test" {
     function only(name?: string, fn?: TestFn): Promise<void>;
     function only(options?: TestOptions, fn?: TestFn): Promise<void>;
     function only(fn?: TestFn): Promise<void>;
-
     /**
      * The type of a function under test. The first argument to this function is a
      * {@link TestContext} object. If the test uses callbacks, the callback function is passed as
      * the second argument.
      */
     type TestFn = (t: TestContext, done: (result?: any) => void) => any;
-
     /**
      * The type of a function under Suite.
      */
     type SuiteFn = (s: SuiteContext) => void | Promise<void>;
-
+    interface TestShard {
+        /**
+         * A positive integer between 1 and `<total>` that specifies the index of the shard to run.
+         */
+        index: number;
+        /**
+         * A positive integer that specifies the total number of shards to split the test files to.
+         */
+        total: number;
+    }
     interface RunOptions {
         /**
          * If a number is provided, then that many files would run in parallel.
@@ -170,26 +177,22 @@ declare module "node:test" {
          * @default true
          */
         concurrency?: number | boolean | undefined;
-
         /**
          * An array containing the list of files to run.
          * If unspecified, the test runner execution model will be used.
          */
         files?: readonly string[] | undefined;
-
         /**
          * Allows aborting an in-progress test execution.
          * @default undefined
          */
         signal?: AbortSignal | undefined;
-
         /**
          * A number of milliseconds the test will fail after.
          * If unspecified, subtests inherit this value from their parent.
          * @default Infinity
          */
         timeout?: number | undefined;
-
         /**
          * Sets inspector port of test child process.
          * If a nullish value is provided, each process gets its own port,
@@ -203,6 +206,11 @@ declare module "node:test" {
          */
         testNamePatterns?: string | RegExp | string[] | RegExp[];
         /**
+         * If truthy, the test context will only run tests that have the `only` option set
+         * @since v18.19.0
+         */
+        only?: boolean;
+        /**
          * A function that accepts the TestsStream instance and can be used to setup listeners before any tests are run.
          */
         setup?: (root: Test) => void | Promise<void>;
@@ -211,6 +219,12 @@ declare module "node:test" {
          * @default false
          */
         watch?: boolean | undefined;
+        /**
+         * Running tests in a specific shard.
+         * @since v18.19.0
+         * @default undefined
+         */
+        shard?: TestShard | undefined;
     }
     class Test extends AsyncResource {
         concurrency: number;
@@ -561,7 +575,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<F | Implementation>;
-
         /**
          * This function is used to create a mock on an existing object method.
          * @param object The object whose method is being mocked.
@@ -600,7 +613,6 @@ declare module "node:test" {
             implementation: Function,
             options: MockMethodOptions,
         ): Mock<Function>;
-
         /**
          * This function is syntax sugar for {@link MockTracker.method} with `options.getter` set to `true`.
          */
@@ -622,7 +634,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<(() => MockedObject[MethodName]) | Implementation>;
-
         /**
          * This function is syntax sugar for {@link MockTracker.method} with `options.setter` set to `true`.
          */
@@ -644,7 +655,6 @@ declare module "node:test" {
             implementation?: Implementation,
             options?: MockFunctionOptions,
         ): Mock<((value: MockedObject[MethodName]) => void) | Implementation>;
-
         /**
          * This function restores the default behavior of all mocks that were previously created by this `MockTracker`
          * and disassociates the mocks from the `MockTracker` instance. Once disassociated, the mocks can still be used,
@@ -654,12 +664,12 @@ declare module "node:test" {
          * If the global `MockTracker` is used extensively, calling this function manually is recommended.
          */
         reset(): void;
-
         /**
          * This function restores the default behavior of all mocks that were previously created by this `MockTracker`.
          * Unlike `mock.reset()`, `mock.restoreAll()` does not disassociate the mocks from the `MockTracker` instance.
          */
         restoreAll(): void;
+        timers: MockTimers;
     }
 
     const mock: MockTracker;
@@ -742,11 +752,172 @@ declare module "node:test" {
          */
         restore(): void;
     }
+    type Timer = "setInterval" | "clearInterval" | "setTimeout" | "clearTimeout";
+    /**
+     * Mocking timers is a technique commonly used in software testing to simulate and
+     * control the behavior of timers, such as `setInterval` and `setTimeout`,
+     * without actually waiting for the specified time intervals.
+     *
+     * The `MockTracker` provides a top-level `timers` export
+     * which is a `MockTimers` instance.
+     * @since v18.19.0
+     * @experimental
+     */
+    class MockTimers {
+        /**
+         * Enables timer mocking for the specified timers.
+         *
+         * **Note:** When you enable mocking for a specific timer, its associated
+         * clear function will also be implicitly mocked.
+         *
+         * Example usage:
+         *
+         * ```js
+         * import { mock } from 'node:test';
+         * mock.timers.enable(['setInterval']);
+         * ```
+         *
+         * The above example enables mocking for the `setInterval` timer and
+         * implicitly mocks the `clearInterval` function. Only the `setInterval`and `clearInterval` functions from `node:timers`,`node:timers/promises`, and`globalThis` will be mocked.
+         *
+         * Alternatively, if you call `mock.timers.enable()` without any parameters:
+         *
+         * All timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`, and `'clearTimeout'`)
+         * will be mocked. The `setInterval`, `clearInterval`, `setTimeout`, and `clearTimeout`functions from `node:timers`, `node:timers/promises`,
+         * and `globalThis` will be mocked.
+         * @since v18.19.0
+         */
+        enable(timers?: Timer[]): void;
+        /**
+         * This function restores the default behavior of all mocks that were previously
+         * created by this `MockTimers` instance and disassociates the mocks
+         * from the `MockTracker` instance.
+         *
+         * **Note:** After each test completes, this function is called on
+         * the test context's `MockTracker`.
+         *
+         * ```js
+         * import { mock } from 'node:test';
+         * mock.timers.reset();
+         * ```
+         * @since v18.19.0
+         */
+        reset(): void;
+        /**
+         * Advances time for all mocked timers.
+         *
+         * **Note:** This diverges from how `setTimeout` in Node.js behaves and accepts
+         * only positive numbers. In Node.js, `setTimeout` with negative numbers is
+         * only supported for web compatibility reasons.
+         *
+         * The following example mocks a `setTimeout` function and
+         * by using `.tick` advances in
+         * time triggering all pending timers.
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('mocks setTimeout to be executed synchronously without having to actually wait for it', (context) => {
+         *   const fn = context.mock.fn();
+         *
+         *   context.mock.timers.enable(['setTimeout']);
+         *
+         *   setTimeout(fn, 9999);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 0);
+         *
+         *   // Advance in time
+         *   context.mock.timers.tick(9999);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 1);
+         * });
+         * ```
+         *
+         * Alternativelly, the `.tick` function can be called many times
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('mocks setTimeout to be executed synchronously without having to actually wait for it', (context) => {
+         *   const fn = context.mock.fn();
+         *   context.mock.timers.enable(['setTimeout']);
+         *   const nineSecs = 9000;
+         *   setTimeout(fn, nineSecs);
+         *
+         *   const twoSeconds = 3000;
+         *   context.mock.timers.tick(twoSeconds);
+         *   context.mock.timers.tick(twoSeconds);
+         *   context.mock.timers.tick(twoSeconds);
+         *
+         *   assert.strictEqual(fn.mock.callCount(), 1);
+         * });
+         * ```
+         * @since v18.19.0
+         */
+        tick(milliseconds: number): void;
+        /**
+         * Triggers all pending mocked timers immediately.
+         *
+         * The example below triggers all pending timers immediately,
+         * causing them to execute without any delay.
+         *
+         * ```js
+         * import assert from 'node:assert';
+         * import { test } from 'node:test';
+         *
+         * test('runAll functions following the given order', (context) => {
+         *   context.mock.timers.enable(['setTimeout']);
+         *   const results = [];
+         *   setTimeout(() => results.push(1), 9999);
+         *
+         *   // Notice that if both timers have the same timeout,
+         *   // the order of execution is guaranteed
+         *   setTimeout(() => results.push(3), 8888);
+         *   setTimeout(() => results.push(2), 8888);
+         *
+         *   assert.deepStrictEqual(results, []);
+         *
+         *   context.mock.timers.runAll();
+         *
+         *   assert.deepStrictEqual(results, [3, 2, 1]);
+         * });
+         * ```
+         *
+         * **Note:** The `runAll()` function is specifically designed for
+         * triggering timers in the context of timer mocking.
+         * It does not have any effect on real-time system
+         * clocks or actual timers outside of the mocking environment.
+         * @since v18.19.0
+         */
+        runAll(): void;
+        /**
+         * Calls {@link MockTimers.reset()}.
+         */
+        [Symbol.dispose](): void;
+    }
 
     export { after, afterEach, before, beforeEach, describe, it, mock, run, test, test as default };
 }
 
-interface DiagnosticData {
+interface TestLocationInfo {
+    /**
+     * The column number where the test is defined, or
+     * `undefined` if the test was run through the REPL.
+     */
+    column?: number;
+    /**
+     * The path of the test file, `undefined` if test is not ran through a file.
+     */
+    file?: string;
+    /**
+     * The line number where the test is defined, or
+     * `undefined` if the test was run through the REPL.
+     */
+    line?: number;
+}
+interface DiagnosticData extends TestLocationInfo {
     /**
      * The diagnostic message.
      */
@@ -755,12 +926,8 @@ interface DiagnosticData {
      * The nesting level of the test.
      */
     nesting: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestFail {
+interface TestFail extends TestLocationInfo {
     /**
      * Additional execution metadata.
      */
@@ -799,12 +966,8 @@ interface TestFail {
      * Present if `context.skip` is called.
      */
     skip?: string | boolean;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestPass {
+interface TestPass extends TestLocationInfo {
     /**
      * Additional execution metadata.
      */
@@ -839,12 +1002,8 @@ interface TestPass {
      * Present if `context.skip` is called.
      */
     skip?: string | boolean;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestPlan {
+interface TestPlan extends TestLocationInfo {
     /**
      * The nesting level of the test.
      */
@@ -853,12 +1012,8 @@ interface TestPlan {
      * The number of subtests that have ran.
      */
     count: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestStart {
+interface TestStart extends TestLocationInfo {
     /**
      * The test name.
      */
@@ -867,54 +1022,34 @@ interface TestStart {
      * The nesting level of the test.
      */
     nesting: number;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
 }
-interface TestStderr {
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
+interface TestStderr extends TestLocationInfo {
     /**
      * The message written to `stderr`
      */
     message: string;
 }
-interface TestStdout {
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
+interface TestStdout extends TestLocationInfo {
     /**
      * The message written to `stdout`
      */
     message: string;
 }
-interface TestEnqueue {
+interface TestEnqueue extends TestLocationInfo {
     /**
      * The test name
      */
     name: string;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
     /**
      * The nesting level of the test.
      */
     nesting: number;
 }
-interface TestDequeue {
+interface TestDequeue extends TestLocationInfo {
     /**
      * The test name
      */
     name: string;
-    /**
-     * The path of the test file, undefined if test is not ran through a file.
-     */
-    file?: string;
     /**
      * The nesting level of the test.
      */
@@ -970,5 +1105,9 @@ declare module "node:test/reporters" {
     class Spec extends Transform {
         constructor();
     }
-    export { dot, Spec as spec, tap, TestEvent };
+    /**
+     * The `junit` reporter outputs test results in a jUnit XML format
+     */
+    function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
+    export { dot, junit, Spec as spec, tap, TestEvent };
 }

--- a/types/node/v18/ts4.8/test/module.ts
+++ b/types/node/v18/ts4.8/test/module.ts
@@ -60,7 +60,7 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 {
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
-        console.log(context.importAssertions.type);
+        console.log(context.importAttributes.type);
 
         if (Math.random() > 0.5) {
             return {
@@ -106,5 +106,36 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
+    };
+}
+
+// Initialize hook
+{
+    const specifier = "./myLoader.js";
+    const parentURL = "some-url"; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL("data:") });
+    Module.register(specifier, parentURL);
+    Module.register(specifier, new URL("data:"));
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
+    interface TransferableData {
+        number: number;
+    }
+    Module.register<TransferableData>(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+
+    type MyInitializeHook = Module.InitializeHook<TransferableData>;
+    const initializeHook: MyInitializeHook = async ({ number }) => {
+        number; // $ExpectType number
     };
 }

--- a/types/node/v18/ts4.8/test/test.ts
+++ b/types/node/v18/ts4.8/test/test.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "node:stream";
 import { after, afterEach, before, beforeEach, describe, it, run, test } from "node:test";
-import { TestEvent } from "node:test/reporters";
+import { dot, junit, spec, tap, TestEvent } from "node:test/reporters";
 
 // run without options
 // $ExpectType TestsStream
@@ -21,8 +21,13 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ["executed"],
+    only: true,
     setup: (root) => {},
     watch: true,
+    shard: {
+        index: 1,
+        total: 3,
+    },
 });
 
 // TestsStream should be a NodeJS.ReadableStream
@@ -539,6 +544,32 @@ test("mocks a setter", (t) => {
         // $ExpectType unknown
         call.this;
     }
+});
+
+// @ts-expect-error
+dot();
+// $ExpectType AsyncGenerator<"\n" | "." | "X", void, unknown>
+dot("" as any);
+// @ts-expect-error
+tap();
+// $ExpectType AsyncGenerator<string, void, unknown>
+tap("" as any);
+// $ExpectType Spec
+new spec();
+// @ts-expect-error
+junit();
+// $ExpectType AsyncGenerator<string, void, unknown>
+junit("" as any);
+
+describe("Mock Timers Test Suite", () => {
+    it((t) => {
+        t.mock.timers.enable(["setTimeout"]);
+        // @ts-expect-error
+        t.mock.timers.enable(["DOES_NOT_EXIST"]);
+        t.mock.timers.enable();
+        t.mock.timers.reset();
+        t.mock.timers.tick(1000);
+    });
 });
 
 class TestReporter extends Transform {

--- a/types/node/v18/ts4.8/tls.d.ts
+++ b/types/node/v18/ts4.8/tls.d.ts
@@ -798,6 +798,18 @@ declare module "tls" {
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
     interface SecureContextOptions {
         /**
+         * If set, this will be called when a client opens a connection using the ALPN extension.
+         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
+         * respectively containing the server name from the SNI extension (if any) and an array of
+         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
+         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
+         * to reject the connection with a fatal alert. If a string is returned that does not match one of
+         * the client's ALPN protocols, an error will be thrown.
+         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
+         * @since v18.19.0
+         */
+        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        /**
          * Optionally override the trusted CA certificates. Default is to trust
          * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
          * replaced when CAs are explicitly specified using this option.

--- a/types/node/v18/ts4.8/vm.d.ts
+++ b/types/node/v18/ts4.8/vm.d.ts
@@ -37,7 +37,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/vm.js)
  */
 declare module "vm" {
-    import { ImportAssertions } from "node:module";
+    import { ImportAttributes } from "node:module";
     interface Context extends NodeJS.Dict<any> {}
     interface BaseOptions {
         /**
@@ -68,7 +68,7 @@ declare module "vm" {
          * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAssertions: ImportAssertions) => Module)
+            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module)
             | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -560,7 +560,11 @@ declare module "vm" {
     type ModuleLinker = (
         specifier: string,
         referencingModule: Module,
-        extra: { assert: Object },
+        extra: {
+            /** @deprecated Use `attributes` instead */
+            assert: ImportAttributes;
+            attributes: ImportAttributes;
+        },
     ) => Module | Promise<Module>;
     type ModuleStatus = "unlinked" | "linking" | "linked" | "evaluating" | "evaluated" | "errored";
     class Module {

--- a/types/node/v18/vm.d.ts
+++ b/types/node/v18/vm.d.ts
@@ -37,7 +37,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/vm.js)
  */
 declare module "vm" {
-    import { ImportAssertions } from "node:module";
+    import { ImportAttributes } from "node:module";
     interface Context extends NodeJS.Dict<any> {}
     interface BaseOptions {
         /**
@@ -68,7 +68,7 @@ declare module "vm" {
          * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAssertions: ImportAssertions) => Module)
+            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module)
             | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -560,7 +560,11 @@ declare module "vm" {
     type ModuleLinker = (
         specifier: string,
         referencingModule: Module,
-        extra: { assert: Object },
+        extra: {
+            /** @deprecated Use `attributes` instead */
+            assert: ImportAttributes;
+            attributes: ImportAttributes;
+        },
     ) => Module | Promise<Module>;
     type ModuleStatus = "unlinked" | "linking" | "linked" | "evaluating" | "evaluated" | "errored";
     class Module {


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v18.19.0

- esm: use import attributes instead of import assertions
- vm: use import attributes instead of import assertions
- test_runner: accept `only` in `run`
- test_runner: add junit reporter
- test_runner: expose location of tests
- test_runner: add shards support
- test_runner: add initial draft for fakeTimers
- lib: add api to detect whether source-maps are enabled
- lib: add tracing channel to diagnostics_channel
- tls: add ALPNCallback server option for dynamic ALPN negotiation
- esm: add `initialize` hook, integrate with `register`

