### PR TITLE
relay-runtime: Align SelectorStoreUpdater.data type with official Flow type

### DIFF
--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -658,7 +658,7 @@ function markNotificationAsRead(source: string, storyID: string) {
         onError: err => console.error(err),
         updater: (store, data) => {
             const story = store.get(storyID);
-            if (story) {
+            if (story && data) {
                 story.setValue(data.markReadNotification.notification.seenState, "seenState");
             }
         },

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -864,9 +864,7 @@ export type StoreUpdater = (store: RecordSourceProxy) => void;
  */
 export type SelectorStoreUpdater<T = object> = (
     store: RecordSourceSelectorProxy<T>,
-    // Actually SelectorData, but mixed is inconvenient to access deeply in
-    // product code.
-    data: T,
+    data: T | null | undefined,
 ) => void;
 
 /**

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -2,6 +2,7 @@ import {
     __internal,
     CacheConfig,
     commitLocalUpdate,
+    commitMutation,
     ConcreteRequest,
     ConnectionHandler,
     ConnectionInterface,
@@ -181,6 +182,24 @@ interface UserQuery {
     response: UserQuery$data;
     variables: {};
 }
+
+commitMutation<{
+    response: { setUsername?: { name?: string | null } | null };
+    variables: { name: string };
+}>(environment, {
+    mutation: graphql`
+        mutation setUserName($name: String!) {
+            setUsername(name: $name) {
+                name
+            }
+        }
+    `,
+    variables: { name: "" },
+    updater(store, data) {
+        const newName = data?.setUsername?.name;
+        newName && store.get("userid")?.setValue(newName, "name");
+    },
+});
 
 function storeUpdater(store: RecordSourceSelectorProxy, dataRef: UserFragment_updatable$key) {
     store.invalidateStore();


### PR DESCRIPTION
Makes optional the type of `SelectorStoreUpdater.data`, to align with the official Flow type since Relay 13: https://github.com/facebook/relay/blob/ab92df525948d0d445101c97c489ce8c3087a990/packages/relay-runtime/store/RelayStoreTypes.js#L1124. My guess is that this subtle change was missed at some point along the upgrade path.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/ab92df525948d0d445101c97c489ce8c3087a990/packages/relay-runtime/store/RelayStoreTypes.js#L1124
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.