### PR TITLE
relay-runtime: Expose provided variables tests-only resetDebugCache function.

### DIFF
--- a/types/relay-runtime/lib/util/withProvidedVariables.d.ts
+++ b/types/relay-runtime/lib/util/withProvidedVariables.d.ts
@@ -1,7 +1,12 @@
 import { ProvidedVariablesType } from "./RelayConcreteNode";
 import { Variables } from "./RelayRuntimeTypes";
 
-export default function withProvidedVariables(
-    userSuppliedVariables: Variables,
-    providedVariables: ProvidedVariablesType | null | undefined,
-): Variables;
+interface WithProvidedVariablesFn {
+    (
+        userSuppliedVariables: Variables,
+        providedVariables: ProvidedVariablesType | null | undefined,
+    ): Variables;
+    tests_only_resetDebugCache: undefined | (() => void);
+}
+declare const withProvidedVariables: WithProvidedVariablesFn;
+export default withProvidedVariables;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -749,3 +749,19 @@ ConnectionInterface.inject({
     PAGE_INFO_TYPE: "PageInfo",
     START_CURSOR: "startCursor",
 });
+
+// ~~~~~~~~~~~~~~~~~~
+// Provided variables
+// ~~~~~~~~~~~~~~~~~~
+
+__internal.withProvidedVariables({
+    one: "value",
+}, {
+    two: {
+        get() {
+            return "value";
+        },
+    },
+});
+
+__internal.withProvidedVariables.tests_only_resetDebugCache?.();


### PR DESCRIPTION
Adds [tests-only resetDebugCache function](https://github.com/facebook/relay/blob/97206df5106a412a898dd5cd81b55647df4a0584/packages/relay-runtime/util/withProvidedVariables.js#L66) to types. Fixes #65960.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
