### PR TITLE
Update ember for TS 5.4

### DIFF
--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = Ember.Object & { name: string, isHappy: boolean }
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,
@@ -13,7 +13,7 @@ const people = Ember.A([
 ]);
 
 assertType<number>(people.get("length"));
-assertType<Person>(people.get("lastObject"));
+assertType<Person | undefined>(people.get("lastObject"));
 assertType<boolean>(people.isAny("isHappy"));
 // @ts-expect-error
 assertType<boolean>(people.isAny("isHappy", "false"));
@@ -22,7 +22,7 @@ assertType<Ember.Enumerable<Person>>(people.filterBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.rejectBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.filter(person => person.get("name") === "Yehuda"));
 assertType<typeof people>(people.get("[]"));
-assertType<Person>(people.get("[]").get("firstObject"));
+assertType<Person | undefined>(people.get("[]").get("firstObject"));
 
 assertType<Ember.Array<boolean>>(people.mapBy("isHappy"));
 assertType<unknown[]>(people.mapBy("name.length"));

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = Ember.Object & { name: string, isHappy: boolean }
+type Person = Ember.Object & { name: string; isHappy: boolean };
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,

--- a/types/ember/test/ember-tests.ts
+++ b/types/ember/test/ember-tests.ts
@@ -139,7 +139,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: typeof Person3.prototype): boolean => {
+const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/test/ember-tests.ts
+++ b/types/ember/test/ember-tests.ts
@@ -139,7 +139,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
+const isHappy = (person: Ember.Object & { name: string; isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/test/extend.ts
+++ b/types/ember/test/extend.ts
@@ -13,9 +13,6 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<string>(Person.prototype.firstName);
-assertType<() => string>(Person.prototype.getFullName);
-
 const person = Person.create({
     firstName: "Joe",
     lastName: "Blow",

--- a/types/ember/test/reopen.ts
+++ b/types/ember/test/reopen.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = { name: string; sayHello(): void } & Ember.Object;
 const Person = Ember.Object.extend({
     name: "",
     sayHello() {
@@ -9,7 +9,9 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<Person>(Person.reopen());
+assertType<
+    Readonly<typeof Ember.Object> & { new(properties?: object | undefined): Person }
+>(Person.reopen());
 
 assertType<string>(Person.create().name);
 Person.create().sayHello(); // $ExpectType void
@@ -29,7 +31,6 @@ assertType<string>(Person2.species);
 const tom = Person2.create({
     name: "Tom Dale",
 });
-
 // @ts-expect-error
 const badTom = Person2.create({ name: 99 });
 

--- a/types/ember/v2/test/array.ts
+++ b/types/ember/v2/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = Ember.Object & { name: string, isHappy: boolean };
+type Person = Ember.Object & { name: string; isHappy: boolean };
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,

--- a/types/ember/v2/test/array.ts
+++ b/types/ember/v2/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = Ember.Object & { name: string, isHappy: boolean };
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,
@@ -13,14 +13,14 @@ const people = Ember.A([
 ]);
 
 assertType<number>(people.get("length"));
-assertType<Person>(people.get("lastObject"));
+assertType<Person | undefined>(people.get("lastObject"));
 assertType<boolean>(people.isAny("isHappy"));
 assertType<boolean>(people.isAny("isHappy", "false"));
 assertType<Ember.Enumerable<Person>>(people.filterBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.rejectBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.filter(person => person.get("name") === "Yehuda"));
 assertType<typeof people>(people.get("[]"));
-assertType<Person>(people.get("[]").get("firstObject"));
+assertType<Person | undefined>(people.get("[]").get("firstObject"));
 
 assertType<Ember.Array<boolean>>(people.mapBy("isHappy"));
 assertType<any[]>(people.mapBy("name.length"));

--- a/types/ember/v2/test/ember-tests.ts
+++ b/types/ember/v2/test/ember-tests.ts
@@ -125,7 +125,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: typeof Person3.prototype): boolean => {
+const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/v2/test/ember-tests.ts
+++ b/types/ember/v2/test/ember-tests.ts
@@ -125,7 +125,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
+const isHappy = (person: Ember.Object & { name: string; isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/v2/test/extend.ts
+++ b/types/ember/v2/test/extend.ts
@@ -13,9 +13,6 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<string>(Person.prototype.firstName);
-assertType<() => string>(Person.prototype.getFullName);
-
 const person = Person.create({
     firstName: "Joe",
     lastName: "Blow",

--- a/types/ember/v2/test/reopen.ts
+++ b/types/ember/v2/test/reopen.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = Ember.Object & { name: string, sayHello(): void };
+type Person = Ember.Object & { name: string; sayHello(): void };
 const Person = Ember.Object.extend({
     name: "",
     sayHello() {

--- a/types/ember/v2/test/reopen.ts
+++ b/types/ember/v2/test/reopen.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = Ember.Object & { name: string, sayHello(): void };
 const Person = Ember.Object.extend({
     name: "",
     sayHello() {
@@ -9,7 +9,7 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<Person>(Person.reopen());
+assertType<Readonly<typeof Ember.Object> & { new(properties?: object | undefined): Person }>(Person.reopen());
 
 assertType<string>(Person.create().name);
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type

--- a/types/ember/v3/test/array.ts
+++ b/types/ember/v3/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = Ember.Object & { name: string, isHappy: boolean };
+type Person = Ember.Object & { name: string; isHappy: boolean };
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,

--- a/types/ember/v3/test/array.ts
+++ b/types/ember/v3/test/array.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = Ember.Object & { name: string, isHappy: boolean };
 const Person = Ember.Object.extend({
     name: "",
     isHappy: false,
@@ -13,14 +13,14 @@ const people = Ember.A([
 ]);
 
 assertType<number>(people.get("length"));
-assertType<Person>(people.get("lastObject"));
+assertType<Person | undefined>(people.get("lastObject"));
 assertType<boolean>(people.isAny("isHappy"));
 assertType<boolean>(people.isAny("isHappy", "false"));
 assertType<Ember.Enumerable<Person>>(people.filterBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.rejectBy("isHappy"));
 assertType<Ember.Enumerable<Person>>(people.filter(person => person.get("name") === "Yehuda"));
 assertType<typeof people>(people.get("[]"));
-assertType<Person>(people.get("[]").get("firstObject"));
+assertType<Person | undefined>(people.get("[]").get("firstObject"));
 
 assertType<Ember.Array<boolean>>(people.mapBy("isHappy"));
 assertType<any[]>(people.mapBy("name.length"));

--- a/types/ember/v3/test/ember-tests.ts
+++ b/types/ember/v3/test/ember-tests.ts
@@ -125,7 +125,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: typeof Person3.prototype): boolean => {
+const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/v3/test/ember-tests.ts
+++ b/types/ember/v3/test/ember-tests.ts
@@ -125,7 +125,7 @@ const people2 = Ember.A([
     Person3.create({ name: "Yehuda", isHappy: true }),
     Person3.create({ name: "Majd", isHappy: false }),
 ]);
-const isHappy = (person: Ember.Object & { name: string, isHappy: boolean }): boolean => {
+const isHappy = (person: Ember.Object & { name: string; isHappy: boolean }): boolean => {
     return !!person.get("isHappy");
 };
 people2.every(isHappy);

--- a/types/ember/v3/test/extend.ts
+++ b/types/ember/v3/test/extend.ts
@@ -13,9 +13,6 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<string>(Person.prototype.firstName);
-assertType<() => string>(Person.prototype.getFullName);
-
 const person = Person.create({
     firstName: "Joe",
     lastName: "Blow",

--- a/types/ember/v3/test/reopen.ts
+++ b/types/ember/v3/test/reopen.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = Ember.Object & { name: string, sayHello(): void };
 const Person = Ember.Object.extend({
     name: "",
     sayHello() {
@@ -9,7 +9,7 @@ const Person = Ember.Object.extend({
     },
 });
 
-assertType<Person>(Person.reopen());
+assertType<Readonly<typeof Ember.Object> & { new(properties?: object | undefined): Person }>(Person.reopen());
 
 assertType<string>(Person.create().name);
 Person.create().sayHello(); // $ExpectType void

--- a/types/ember/v3/test/reopen.ts
+++ b/types/ember/v3/test/reopen.ts
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { assertType } from "./lib/assert";
 
-type Person = Ember.Object & { name: string, sayHello(): void };
+type Person = Ember.Object & { name: string; sayHello(): void };
 const Person = Ember.Object.extend({
     name: "",
     sayHello() {

--- a/types/ember__array/test/array.ts
+++ b/types/ember__array/test/array.ts
@@ -3,7 +3,7 @@ import MutableArray from "@ember/array/mutable";
 import EmberObject from "@ember/object";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = EmberObject & { name: string, isHappy: boolean };
 const Person = EmberObject.extend({
     name: "",
     isHappy: false,
@@ -12,8 +12,8 @@ const Person = EmberObject.extend({
 const people = A([Person.create({ name: "Yehuda", isHappy: true }), Person.create({ name: "Majd", isHappy: false })]);
 
 assertType<number>(people.get("length"));
-assertType<Person>(people.get("lastObject"));
-assertType<Person>(people.get("firstObject"));
+assertType<Person | undefined>(people.get("lastObject"));
+assertType<Person | undefined>(people.get("firstObject"));
 assertType<boolean>(people.isAny("isHappy"));
 assertType<boolean>(people.isAny("isHappy", false));
 // @ts-expect-error
@@ -30,7 +30,7 @@ const persons5: Person[] = people.filter(person => person.get("name") === "Yehud
 const persons6: MutableArray<Person> = people.filter(person => person.get("name") === "Yehuda");
 
 assertType<typeof people>(people.get("[]"));
-assertType<Person>(people.get("[]").get("firstObject"));
+assertType<Person | undefined>(people.get("[]").get("firstObject"));
 
 assertType<boolean[]>(people.mapBy("isHappy"));
 assertType<unknown[]>(people.mapBy("name.length"));

--- a/types/ember__array/test/array.ts
+++ b/types/ember__array/test/array.ts
@@ -3,7 +3,7 @@ import MutableArray from "@ember/array/mutable";
 import EmberObject from "@ember/object";
 import { assertType } from "./lib/assert";
 
-type Person = EmberObject & { name: string, isHappy: boolean };
+type Person = EmberObject & { name: string; isHappy: boolean };
 const Person = EmberObject.extend({
     name: "",
     isHappy: false,

--- a/types/ember__array/v3/test/array.ts
+++ b/types/ember__array/v3/test/array.ts
@@ -25,7 +25,7 @@ const persons5: Person[] = people.filter(person => person.get("name") === "Yehud
 const persons6: MutableArray<Person> = people.filter(person => person.get("name") === "Yehuda");
 
 assertType<typeof people>(people.get("[]"));
-assertType<Person | undefined>(people.get("[]").get("firstObject")); // $ExpectType any
+assertType<Person | undefined>(people.get("[]").get("firstObject")); // $ExpectType Person | undefined
 
 assertType<boolean[]>(people.mapBy("isHappy")); // $ExpectType boolean[]
 assertType<any[]>(people.mapBy("name.length"));

--- a/types/ember__array/v3/test/array.ts
+++ b/types/ember__array/v3/test/array.ts
@@ -3,7 +3,7 @@ import MutableArray from "@ember/array/mutable";
 import EmberObject from "@ember/object";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = EmberObject & { name: string; isHappy: boolean };
 const Person = EmberObject.extend({
     name: "",
     isHappy: false,
@@ -12,8 +12,8 @@ const Person = EmberObject.extend({
 const people = A([Person.create({ name: "Yehuda", isHappy: true }), Person.create({ name: "Majd", isHappy: false })]);
 
 assertType<number>(people.get("length"));
-assertType<Person>(people.get("lastObject"));
-assertType<Person>(people.get("firstObject"));
+assertType<Person | undefined>(people.get("lastObject"));
+assertType<Person | undefined>(people.get("firstObject"));
 assertType<boolean>(people.isAny("isHappy"));
 assertType<boolean>(people.isAny("isHappy", "false"));
 
@@ -25,7 +25,7 @@ const persons5: Person[] = people.filter(person => person.get("name") === "Yehud
 const persons6: MutableArray<Person> = people.filter(person => person.get("name") === "Yehuda");
 
 assertType<typeof people>(people.get("[]"));
-assertType<Person>(people.get("[]").get("firstObject")); // $ExpectType any
+assertType<Person | undefined>(people.get("[]").get("firstObject")); // $ExpectType any
 
 assertType<boolean[]>(people.mapBy("isHappy")); // $ExpectType boolean[]
 assertType<any[]>(people.mapBy("name.length"));

--- a/types/ember__object/test/extend.ts
+++ b/types/ember__object/test/extend.ts
@@ -13,9 +13,6 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<string>(Person.prototype.firstName);
-assertType<() => string>(Person.prototype.getFullName);
-
 const person = Person.create({
     firstName: "Joe",
     lastName: "Blow",

--- a/types/ember__object/test/reopen.ts
+++ b/types/ember__object/test/reopen.ts
@@ -2,7 +2,7 @@ import EmberObject from "@ember/object";
 import Mixin from "@ember/object/mixin";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = EmberObject & { name: string, sayHello(): void };
 const Person = EmberObject.extend({
     name: "",
     sayHello() {
@@ -10,7 +10,7 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<Person>(Person.reopen());
+assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person}>(Person.reopen());
 
 assertType<string>(Person.create().name);
 // tslint:disable-next-line no-void-expression

--- a/types/ember__object/test/reopen.ts
+++ b/types/ember__object/test/reopen.ts
@@ -2,7 +2,7 @@ import EmberObject from "@ember/object";
 import Mixin from "@ember/object/mixin";
 import { assertType } from "./lib/assert";
 
-type Person = EmberObject & { name: string, sayHello(): void };
+type Person = EmberObject & { name: string; sayHello(): void };
 const Person = EmberObject.extend({
     name: "",
     sayHello() {
@@ -10,7 +10,7 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person}>(Person.reopen());
+assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person }>(Person.reopen());
 
 assertType<string>(Person.create().name);
 // tslint:disable-next-line no-void-expression

--- a/types/ember__object/v3/test/extend.ts
+++ b/types/ember__object/v3/test/extend.ts
@@ -13,9 +13,6 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<string>(Person.prototype.firstName);
-assertType<() => string>(Person.prototype.getFullName);
-
 const person = Person.create({
     firstName: "Joe",
     lastName: "Blow",

--- a/types/ember__object/v3/test/reopen.ts
+++ b/types/ember__object/v3/test/reopen.ts
@@ -2,7 +2,7 @@ import EmberObject from "@ember/object";
 import Mixin from "@ember/object/mixin";
 import { assertType } from "./lib/assert";
 
-type Person = typeof Person.prototype;
+type Person = EmberObject & { name: string, sayHello(): void };
 const Person = EmberObject.extend({
     name: "",
     sayHello() {
@@ -10,7 +10,7 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<Person>(Person.reopen());
+assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person}>(Person.reopen());
 
 assertType<string>(Person.create().name);
 // tslint:disable-next-line no-void-expression

--- a/types/ember__object/v3/test/reopen.ts
+++ b/types/ember__object/v3/test/reopen.ts
@@ -2,7 +2,7 @@ import EmberObject from "@ember/object";
 import Mixin from "@ember/object/mixin";
 import { assertType } from "./lib/assert";
 
-type Person = EmberObject & { name: string, sayHello(): void };
+type Person = EmberObject & { name: string; sayHello(): void };
 const Person = EmberObject.extend({
     name: "",
     sayHello() {
@@ -10,7 +10,7 @@ const Person = EmberObject.extend({
     },
 });
 
-assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person}>(Person.reopen());
+assertType<Readonly<typeof EmberObject> & { new(properties?: object | undefined): Person }>(Person.reopen());
 
 assertType<string>(Person.create().name);
 // tslint:disable-next-line no-void-expression


### PR DESCRIPTION
Ember is broken by https://github.com/microsoft/TypeScript/pull/54753

The discussion on this PR ending at
https://github.com/microsoft/TypeScript/pull/54753#issuecomment-1658631909 makes me think that these breaks are acceptable where they aren't strict improvements.

The core problem is that `Person.prototype : any` before the PR and `Person.prototype: Ember.Object` after. Because it was `any` before, tests break in a variety of ways:

- I deleted the test of Person.prototype.firstName. This now has a type error, and doesn't seem likely to be used that much.
- I converted `type Person = typeof Person.prototype` to `Ember.Object & { name: string, isHappy: boolean }`. This is technically correct although clumsy -- and I don't *think* people were writing that in production code before anyway. The tests relying on `Person` were previously useless, in any case.
- The type test of `Person.reopen()` was just wrong, so I fixed it, also clumsily.
- The reopen test does specify a 'static' method `createPerson` that explicitly returns `Person`, so maybe people do write `typeof Person.prototype` in production code?