### PR TITLE
Add missing scene properties to Layout

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -455,6 +455,14 @@ export interface Layout {
     legend: Partial<Legend>;
     font: Partial<Font>;
     scene: Partial<Scene>;
+    scene2: Partial<Scene>;
+    scene3: Partial<Scene>;
+    scene4: Partial<Scene>;
+    scene5: Partial<Scene>;
+    scene6: Partial<Scene>;
+    scene7: Partial<Scene>;
+    scene8: Partial<Scene>;
+    scene9: Partial<Scene>;
     barmode: "stack" | "group" | "overlay" | "relative";
     barnorm: "" | "fraction" | "percent";
     bargap: number;


### PR DESCRIPTION
**Add missing scene properties that are needed when using several 3d subplots in one figure.**
<br>
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [-] Test the change in your own code. (Compile and run.)
       pnpm test  "plotly.js" fails on my Windows machine:
```
>definitely-typed@0.0.3 test C:\Users\Admin\Documents\vscodeprojects\DefinitelyTyped
> node --enable-source-maps node_modules/@definitelytyped/dtslint/ types "plotly.js" 

dtslint@0.0.197
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:239:11)
    at defaultLoad (node:internal/modules/esm/load:130:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:409:13)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:56)
    at new ModuleJob (node:internal/modules/esm/module_job:65:26)
    at #createModuleJob (node:internal/modules/esm/loader:303:17)
    at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:260:34)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:241:17)
    at async ModuleLoader.import (node:internal/modules/esm/loader:328:23)
 ELIFECYCLE  Test failed. See above for more details.
```


- [-] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [-] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://raw.githubusercontent.com/plotly/plotly.js/master/dist/plot-schema.json
```
"scene": {
     "description": "Sets a reference between this trace's 3D coordinate system and a 3D scene. If *scene* (the default value), the (x,y,z) coordinates refer to `layout.scene`. If *scene2*, the (x,y,z) coordinates refer to `layout.scene2`, and so on.",
     "dflt": "scene",
     "editType": "calc+clearAxisTypes",
     "valType": "subplotid"
    },
````
These scene2, scene3 etc. are missing.
Python demo:

```python
from plotly.subplots import make_subplots

make_subplots(
    rows=1,
    cols=10,
    specs=[
        [
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
            {"type": "scene"},
        ]
    ],
).layout
```
```python
Layout({
    'scene': {'domain': {'x': [0.0, 0.082], 'y': [0.0, 1.0]}},
    'scene10': {'domain': {'x': [0.9179999999999999, 0.9999999999999999], 'y': [0.0, 1.0]}},
    'scene2': {'domain': {'x': [0.10200000000000001, 0.184], 'y': [0.0, 1.0]}},
    'scene3': {'domain': {'x': [0.20400000000000001, 0.28600000000000003], 'y': [0.0, 1.0]}},
    'scene4': {'domain': {'x': [0.306, 0.388], 'y': [0.0, 1.0]}},
    'scene5': {'domain': {'x': [0.40800000000000003, 0.49000000000000005], 'y': [0.0, 1.0]}},
    'scene6': {'domain': {'x': [0.51, 0.592], 'y': [0.0, 1.0]}},
    'scene7': {'domain': {'x': [0.6120000000000001, 0.6940000000000001], 'y': [0.0, 1.0]}},
    'scene8': {'domain': {'x': [0.7140000000000001, 0.796], 'y': [0.0, 1.0]}},
    'scene9': {'domain': {'x': [0.8160000000000001, 0.898], 'y': [0.0, 1.0]}},
    'template': '...'
})
```


I used scene to scene9. More could also be used, but it's probably not common to do so. For the xaxis / yaxis property xaxis 1-9 was used, so I did it likewise.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/236b2b8ad6645789c9754bedf040e704f3d3d567/types/plotly.js/index.d.ts#L405

