### PR TITLE
[jest] Change arguments of `todo` function not to set an invalid callback

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -563,7 +563,7 @@ declare namespace jest {
         /**
          * Sketch out which tests to write in the future.
          */
-        todo: It;
+        todo: (name: string) => void;
         /**
          * Experimental and should be avoided.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -148,11 +148,7 @@ it.skip("name", () => {}, 9001);
 it.skip("name", async () => {}, 9001);
 it.skip("name", (callback: jest.DoneCallback) => {}, 9001);
 
-it.todo("name", () => {});
-it.todo("name", async () => {});
-it.todo("name", () => {}, 9001);
-it.todo("name", async () => {}, 9001);
-it.todo("name", (callback: jest.DoneCallback) => {}, 9001);
+it.todo("name");
 
 it.concurrent("name", () => {});
 it.concurrent("name", async () => {});
@@ -186,11 +182,7 @@ fit.skip("name", () => {}, 9001);
 fit.skip("name", async () => {}, 9001);
 fit.skip("name", (callback: jest.DoneCallback) => {}, 9001);
 
-fit.todo("name", () => {});
-fit.todo("name", async () => {});
-fit.todo("name", () => {}, 9001);
-fit.todo("name", async () => {}, 9001);
-fit.todo("name", (callback: jest.DoneCallback) => {}, 9001);
+fit.todo("name");
 
 fit.concurrent("name", () => {});
 fit.concurrent("name", async () => {});
@@ -224,11 +216,7 @@ xit.skip("name", () => {}, 9001);
 xit.skip("name", async () => {}, 9001);
 xit.skip("name", (callback: jest.DoneCallback) => {}, 9001);
 
-xit.todo("name", () => {});
-xit.todo("name", async () => {});
-xit.todo("name", () => {}, 9001);
-xit.todo("name", async () => {}, 9001);
-xit.todo("name", (callback: jest.DoneCallback) => {}, 9001);
+xit.todo("name");
 
 xit.concurrent("name", () => {});
 xit.concurrent("name", async () => {});
@@ -262,11 +250,7 @@ test.skip("name", () => {}, 9001);
 test.skip("name", async () => {}, 9001);
 test.skip("name", (callback: jest.DoneCallback) => {}, 9001);
 
-test.todo("name", () => {});
-test.todo("name", async () => {});
-test.todo("name", () => {}, 9001);
-test.todo("name", async () => {}, 9001);
-test.todo("name", (callback: jest.DoneCallback) => {}, 9001);
+test.todo("name");
 
 test.concurrent("name", () => {});
 test.concurrent("name", async () => {});
@@ -300,11 +284,7 @@ xtest.skip("name", () => {}, 9001);
 xtest.skip("name", async () => {}, 9001);
 xtest.skip("name", (callback: jest.DoneCallback) => {}, 9001);
 
-xtest.todo("name", () => {});
-xtest.todo("name", async () => {});
-xtest.todo("name", () => {}, 9001);
-xtest.todo("name", async () => {}, 9001);
-xtest.todo("name", (callback: jest.DoneCallback) => {}, 9001);
+xtest.todo("name");
 
 xtest.concurrent("name", () => {});
 xtest.concurrent("name", async () => {});


### PR DESCRIPTION
Since `test.todo` of jest is not allowed to take a callback function as its second argument, I updated its type not to set an invalid callback.
[see here for the details](https://jestjs.io/docs/next/api#testtodoname)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tnyo43/typed-jest-todo
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
