### PR TITLE
fix(is-map): make function type guard

### DIFF
--- a/types/is-map/index.d.ts
+++ b/types/is-map/index.d.ts
@@ -1,3 +1,3 @@
-declare function isMap(value: unknown): value is Map<unknown, unknown>;
+declare function isMap(value: unknown): value is Map<any, any>;
 
 export = isMap;

--- a/types/is-map/index.d.ts
+++ b/types/is-map/index.d.ts
@@ -1,3 +1,3 @@
-declare function isMap(value: unknown): boolean;
+declare function isMap(value: unknown): value is Map<unknown, unknown>;
 
 export = isMap;

--- a/types/is-map/is-map-tests.ts
+++ b/types/is-map/is-map-tests.ts
@@ -12,7 +12,7 @@ isMap(new Set());
 const x: unknown = new Map();
 
 if (isMap(x)) {
-    // $ExpectType Map<unknown, unknown>
+    // $ExpectType Map<any, any>
     x;
 
     x.set(1, 1);
@@ -21,7 +21,7 @@ if (isMap(x)) {
 const y = new Map();
 
 if (isMap(y)) {
-    // $ExpectType Map<unknown, unknown>
+    // $ExpectType Map<any, any>
     y;
 
     y.delete(1);

--- a/types/is-map/is-map-tests.ts
+++ b/types/is-map/is-map-tests.ts
@@ -1,6 +1,34 @@
 import isMap = require("is-map");
 
-const tests = () => {
-    !isMap(new Set());
-    isMap(Symbol("foo"));
-};
+// $ExpectType boolean
+isMap(new Map());
+
+// $ExpectType boolean
+isMap(new WeakMap());
+
+// $ExpectType boolean
+isMap(new Set());
+
+const x: unknown = new Map();
+
+if (isMap(x)) {
+    // $ExpectType Map<unknown, unknown>
+    x;
+
+    x.set(1, 1);
+}
+
+const y = new Map();
+
+if (isMap(y)) {
+    // $ExpectType Map<unknown, unknown>
+    y;
+
+    y.delete(1);
+} else {
+    // $ExpectType never
+    y;
+
+    // @ts-expect-error
+    y.delete(1);
+}

--- a/types/is-map/package.json
+++ b/types/is-map/package.json
@@ -12,6 +12,10 @@
         {
             "name": "Ankan Bhattacharya",
             "githubUsername": "Ankan002"
+        },
+        {
+            "name": "Tristan F.",
+            "githubUsername": "LeoDog896"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/inspect-js/is-map/blob/e07e23affca99f469937dade44abc02e05a26739/index.js#L39
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Since many of the utilities in `inspect-js` serve as type guards (e.g. `is-set` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67585), `is-map` should also serve as a type guard.