### PR TITLE
[react] Deprecate Mixin types

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -794,6 +794,9 @@ declare namespace React {
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
+    /**
+     * @deprecated https://legacy.reactjs.org/blog/2016/07/13/mixins-considered-harmful.html
+     */
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>> | undefined;
         statics?: {
@@ -809,6 +812,9 @@ declare namespace React {
         getInitialState?(): S;
     }
 
+    /**
+     * @deprecated https://legacy.reactjs.org/blog/2016/07/13/mixins-considered-harmful.html
+     */
     interface ComponentSpec<P, S> extends Mixin<P, S> {
         render(): ReactNode;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -795,6 +795,9 @@ declare namespace React {
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
+    /**
+     * @deprecated https://legacy.reactjs.org/blog/2016/07/13/mixins-considered-harmful.html
+     */
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>> | undefined;
         statics?: {
@@ -810,6 +813,9 @@ declare namespace React {
         getInitialState?(): S;
     }
 
+    /**
+     * @deprecated https://legacy.reactjs.org/blog/2016/07/13/mixins-considered-harmful.html
+     */
     interface ComponentSpec<P, S> extends Mixin<P, S> {
         render(): ReactNode;
 


### PR DESCRIPTION
These aren't used at runtime anymore hand have long been outcast for a long time. Will be removed in React 19 types.