### PR TITLE
[americanexpress__react-seo] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/americanexpress__react-seo/index.d.ts
+++ b/types/americanexpress__react-seo/index.d.ts
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 export interface Media {
     src: string;
     secureUrl?: string;

--- a/types/americanexpress__react-seo/package.json
+++ b/types/americanexpress__react-seo/package.json
@@ -5,9 +5,11 @@
     "projects": [
         "https://github.com/americanexpress/react-seo"
     ],
-    "devDependencies": {
-        "@types/americanexpress__react-seo": "workspace:.",
+    "dependencies": {
         "@types/react": "*"
+    },
+    "devDependencies": {
+        "@types/americanexpress__react-seo": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.