### PR TITLE
[assert-equal-jsx] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/assert-equal-jsx/index.d.ts
+++ b/types/assert-equal-jsx/index.d.ts
@@ -6,6 +6,6 @@ declare namespace assertEqualJSX {
     }
 }
 
-declare function assertEqualJSX(actual: JSX.Element, expected: JSX.Element, opts?: assertEqualJSX.AsssertOptions): void;
+declare function assertEqualJSX(actual: React.JSX.Element, expected: React.JSX.Element, opts?: assertEqualJSX.AsssertOptions): void;
 
 export = assertEqualJSX;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.