### PR TITLE
[brainhubeu__react-carousel] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -24,8 +24,8 @@ export type CarouselPluginFunc = ({
     refs: Record<string, React.RefObject<HTMLElement>>;
 }) => {
     plugin?: (() => void) | undefined;
-    beforeCarouselItems?: (() => JSX.Element) | undefined;
-    afterCarouselItems?: (() => JSX.Element) | undefined;
+    beforeCarouselItems?: (() => React.JSX.Element) | undefined;
+    afterCarouselItems?: (() => React.JSX.Element) | undefined;
     carouselCustomProps?: (() => Record<string, () => any>) | undefined;
     trackCustomProps?: (() => Record<string, () => any>) | undefined;
     slideCustomProps?: (() => Record<string, () => any>) | undefined;
@@ -48,7 +48,7 @@ export interface CarouselProps {
     itemWidth?: number | undefined;
     value?: number | undefined;
     onChange?(value: number): void;
-    slides?: JSX.Element[] | undefined;
+    slides?: React.JSX.Element[] | undefined;
     offset?: number | undefined;
     draggable?: boolean | undefined;
     animationSpeed?: number | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.