### PR TITLE
[carbon-components-react] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
+++ b/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
@@ -21,7 +21,7 @@ export type AspectRatioDefaultProps =
         as?: undefined;
     };
 
-export type AspectRatioIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type AspectRatioIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & AspectRatioBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -39,7 +39,7 @@ export type AspectRatioCustomComponentProps<
     : never;
 
 declare function AspectRatio(props: AspectRatioDefaultProps): FCReturn;
-declare function AspectRatio<T extends keyof JSX.IntrinsicElements>(props: AspectRatioIntrinsicProps<T>): FCReturn;
+declare function AspectRatio<T extends keyof React.JSX.IntrinsicElements>(props: AspectRatioIntrinsicProps<T>): FCReturn;
 declare function AspectRatio<T extends ReactComponentConstructor<never>>(
     props: AspectRatioCustomComponentProps<T>,
 ): FCReturn;

--- a/types/carbon-components-react/lib/components/Button/Button.d.ts
+++ b/types/carbon-components-react/lib/components/Button/Button.d.ts
@@ -70,7 +70,7 @@ export interface ButtonAnchorProps extends ButtonBaseProps, Omit<ReactAnchorAttr
     href: string;
 }
 
-export type ButtonIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type ButtonIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & ButtonBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -101,7 +101,7 @@ export type ButtonCustomComponentProps<
 declare function Button(props: ForwardRefProps<HTMLButtonElement, ButtonDefaultProps & ButtonKindProps>): FCReturn;
 // tslint:disable:unified-signatures breaks certain usages
 declare function Button(props: ForwardRefProps<HTMLAnchorElement, ButtonAnchorProps & ButtonKindProps>): FCReturn;
-declare function Button<T extends keyof JSX.IntrinsicElements, R extends HTMLElement = HTMLElement>(
+declare function Button<T extends keyof React.JSX.IntrinsicElements, R extends HTMLElement = HTMLElement>(
     props: ForwardRefProps<R, ButtonIntrinsicProps<T> & ButtonKindProps>,
 ): FCReturn;
 declare function Button<T extends ReactComponentConstructor<never>, R = unknown>(

--- a/types/carbon-components-react/lib/components/DangerButton/DangerButton.d.ts
+++ b/types/carbon-components-react/lib/components/DangerButton/DangerButton.d.ts
@@ -5,7 +5,7 @@ import { ButtonAnchorProps, ButtonCustomComponentProps, ButtonDefaultProps, Butt
 declare function DangerButton(props: FCProps<ButtonDefaultProps>): FCReturn;
 // tslint:disable:unified-signatures breaks certain usages
 declare function DangerButton(props: FCProps<ButtonAnchorProps>): FCReturn;
-declare function DangerButton<T extends keyof JSX.IntrinsicElements>(props: FCProps<ButtonIntrinsicProps<T>>): FCReturn;
+declare function DangerButton<T extends keyof React.JSX.IntrinsicElements>(props: FCProps<ButtonIntrinsicProps<T>>): FCReturn;
 declare function DangerButton<T extends ReactComponentConstructor<never>>(
     props: FCProps<ButtonCustomComponentProps<T>>,
 ): FCReturn;

--- a/types/carbon-components-react/lib/components/Dialog/index.d.ts
+++ b/types/carbon-components-react/lib/components/Dialog/index.d.ts
@@ -1,6 +1,8 @@
 import { FCReturn, ForwardRefProps, ReactComponentConstructor } from "../../../typings/shared";
 import { FocusScopeCustomComponentProps, FocusScopeDefaultProps, FocusScopeIntrinsicProps } from "../FocusScope";
 
+import { JSX } from "react";
+
 // Props used by Dialog that are not inherited from FocusScope usage
 interface DialogBaseProps {
     "aria-labelledby": string;

--- a/types/carbon-components-react/lib/components/FocusScope/index.d.ts
+++ b/types/carbon-components-react/lib/components/FocusScope/index.d.ts
@@ -27,7 +27,7 @@ export type FocusScopeDefaultProps =
         as?: undefined;
     };
 
-export type FocusScopeIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type FocusScopeIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & FocusScopeBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -45,7 +45,7 @@ export type FocusScopeCustomComponentProps<
     : never;
 
 declare function FocusScope(props: ForwardRefProps<HTMLDivElement, FocusScopeDefaultProps>): FCReturn;
-declare function FocusScope<T extends keyof JSX.IntrinsicElements, R extends HTMLElement = HTMLElement>(
+declare function FocusScope<T extends keyof React.JSX.IntrinsicElements, R extends HTMLElement = HTMLElement>(
     props: ForwardRefProps<R, FocusScopeIntrinsicProps<T>>,
 ): FCReturn;
 declare function FocusScope<T extends ReactComponentConstructor<never>, R = unknown>(

--- a/types/carbon-components-react/lib/components/Grid/Column.d.ts
+++ b/types/carbon-components-react/lib/components/Grid/Column.d.ts
@@ -36,7 +36,7 @@ export type ColumnDefaultProps =
         as?: undefined;
     };
 
-export type ColumnIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type ColumnIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & ColumnBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -54,7 +54,7 @@ export type ColumnCustomComponentProps<
     : never;
 
 declare function Column(props: ColumnDefaultProps): FCReturn;
-declare function Column<T extends keyof JSX.IntrinsicElements>(props: ColumnIntrinsicProps<T>): FCReturn;
+declare function Column<T extends keyof React.JSX.IntrinsicElements>(props: ColumnIntrinsicProps<T>): FCReturn;
 declare function Column<T extends ReactComponentConstructor<never>>(props: ColumnCustomComponentProps<T>): FCReturn;
 
 export default Column;

--- a/types/carbon-components-react/lib/components/Grid/Grid.d.ts
+++ b/types/carbon-components-react/lib/components/Grid/Grid.d.ts
@@ -28,7 +28,7 @@ export type GridDefaultProps =
         as?: undefined;
     };
 
-export type GridIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type GridIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & GridBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -46,7 +46,7 @@ export type GridCustomComponentProps<
     : never;
 
 declare function Grid(props: GridDefaultProps): FCReturn;
-declare function Grid<T extends keyof JSX.IntrinsicElements>(props: GridIntrinsicProps<T>): FCReturn;
+declare function Grid<T extends keyof React.JSX.IntrinsicElements>(props: GridIntrinsicProps<T>): FCReturn;
 declare function Grid<T extends ReactComponentConstructor<never>>(props: GridCustomComponentProps<T>): FCReturn;
 
 export default Grid;

--- a/types/carbon-components-react/lib/components/Grid/Row.d.ts
+++ b/types/carbon-components-react/lib/components/Grid/Row.d.ts
@@ -25,7 +25,7 @@ export type RowDefaultProps =
         as?: undefined;
     };
 
-export type RowIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type RowIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & RowBaseProps
     & SafeProps<JSXIntrinsicElementProps<K>>
     & {
@@ -43,7 +43,7 @@ export type RowCustomComponentProps<C extends ReactComponentConstructor<never>> 
     : never;
 
 declare function Row(props: RowDefaultProps): FCReturn;
-declare function Row<T extends keyof JSX.IntrinsicElements>(props: RowIntrinsicProps<T>): FCReturn;
+declare function Row<T extends keyof React.JSX.IntrinsicElements>(props: RowIntrinsicProps<T>): FCReturn;
 declare function Row<T extends ReactComponentConstructor<never>>(props: RowCustomComponentProps<T>): FCReturn;
 
 export default Row;

--- a/types/carbon-components-react/lib/components/Heading/index.d.ts
+++ b/types/carbon-components-react/lib/components/Heading/index.d.ts
@@ -13,7 +13,7 @@ export type SectionDefaultProps = ReactAttr & {
     as?: undefined;
 };
 
-export type SectionIntrinsicProps<K extends keyof JSX.IntrinsicElements> = SafeProps<JSXIntrinsicElementProps<K>> & {
+export type SectionIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> = SafeProps<JSXIntrinsicElementProps<K>> & {
     as: K;
 };
 
@@ -25,7 +25,7 @@ export type SectionCustomComponentProps<
     : never;
 
 declare function Section(props: SectionDefaultProps): FCReturn;
-declare function Section<T extends keyof JSX.IntrinsicElements>(props: SectionIntrinsicProps<T>): FCReturn;
+declare function Section<T extends keyof React.JSX.IntrinsicElements>(props: SectionIntrinsicProps<T>): FCReturn;
 declare function Section<T extends ReactComponentConstructor<never>>(props: SectionCustomComponentProps<T>): FCReturn;
 
 export interface HeadingProps extends ReactAttr {}

--- a/types/carbon-components-react/lib/components/Layout/LayoutDirection.d.ts
+++ b/types/carbon-components-react/lib/components/Layout/LayoutDirection.d.ts
@@ -19,7 +19,7 @@ export type LayoutDirectionDefaultProps =
         as?: undefined;
     };
 
-export type LayoutDirectionIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type LayoutDirectionIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & LayoutDirectionBaseProps
     & JSXIntrinsicElementProps<K>
     & {
@@ -37,7 +37,7 @@ export type LayoutDirectionCustomComponentProps<
     : never;
 
 declare function LayoutDirection(props: LayoutDirectionDefaultProps): FCReturn;
-declare function LayoutDirection<T extends keyof JSX.IntrinsicElements>(
+declare function LayoutDirection<T extends keyof React.JSX.IntrinsicElements>(
     props: LayoutDirectionIntrinsicProps<T>,
 ): FCReturn;
 declare function LayoutDirection<T extends ReactComponentConstructor<never>>(

--- a/types/carbon-components-react/lib/components/Popover/index.d.ts
+++ b/types/carbon-components-react/lib/components/Popover/index.d.ts
@@ -47,7 +47,7 @@ export type PopoverDefaultProps =
         as?: undefined;
     };
 
-export type PopoverIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type PopoverIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & PopoverBaseProps
     & SafePopoverProps<JSXIntrinsicElementProps<K>>
     & {
@@ -65,7 +65,7 @@ export type PopoverCustomComponentProps<
     : never;
 
 declare function Popover(props: ForwardRefProps<HTMLSpanElement, PopoverDefaultProps>): FCReturn;
-declare function Popover<T extends keyof JSX.IntrinsicElements, R = HTMLElement>(
+declare function Popover<T extends keyof React.JSX.IntrinsicElements, R = HTMLElement>(
     props: ForwardRefProps<R, PopoverIntrinsicProps<T>>,
 ): FCReturn;
 declare function Popover<T extends ReactComponentConstructor<never>, R = unknown>(

--- a/types/carbon-components-react/lib/components/PrimaryButton/PrimaryButton.d.ts
+++ b/types/carbon-components-react/lib/components/PrimaryButton/PrimaryButton.d.ts
@@ -5,7 +5,7 @@ import { ButtonAnchorProps, ButtonCustomComponentProps, ButtonDefaultProps, Butt
 declare function PrimaryButton(props: FCProps<ButtonDefaultProps>): FCReturn;
 // tslint:disable:unified-signatures breaks certain usages
 declare function PrimaryButton(props: FCProps<ButtonAnchorProps>): FCReturn;
-declare function PrimaryButton<T extends keyof JSX.IntrinsicElements>(
+declare function PrimaryButton<T extends keyof React.JSX.IntrinsicElements>(
     props: FCProps<ButtonIntrinsicProps<T>>,
 ): FCReturn;
 declare function PrimaryButton<T extends ReactComponentConstructor<never>>(

--- a/types/carbon-components-react/lib/components/SecondaryButton/SecondaryButton.d.ts
+++ b/types/carbon-components-react/lib/components/SecondaryButton/SecondaryButton.d.ts
@@ -5,7 +5,7 @@ import { ButtonAnchorProps, ButtonCustomComponentProps, ButtonDefaultProps, Butt
 declare function SecondaryButton(props: FCProps<ButtonDefaultProps>): FCReturn;
 // tslint:disable:unified-signatures breaks certain usages
 declare function SecondaryButton(props: FCProps<ButtonAnchorProps>): FCReturn;
-declare function SecondaryButton<T extends keyof JSX.IntrinsicElements>(
+declare function SecondaryButton<T extends keyof React.JSX.IntrinsicElements>(
     props: FCProps<ButtonIntrinsicProps<T>>,
 ): FCReturn;
 declare function SecondaryButton<T extends ReactComponentConstructor<never>>(

--- a/types/carbon-components-react/lib/components/Text/Text.d.ts
+++ b/types/carbon-components-react/lib/components/Text/Text.d.ts
@@ -20,7 +20,7 @@ export type TextDefaultProps =
         as?: undefined;
     };
 
-export type TextIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type TextIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & TextBaseProps
     & JSXIntrinsicElementProps<K>
     & {
@@ -38,7 +38,7 @@ export type TextCustomComponentProps<
     : never;
 
 declare function Text(props: TextDefaultProps): FCReturn;
-declare function Text<T extends keyof JSX.IntrinsicElements>(props: TextIntrinsicProps<T>): FCReturn;
+declare function Text<T extends keyof React.JSX.IntrinsicElements>(props: TextIntrinsicProps<T>): FCReturn;
 declare function Text<T extends ReactComponentConstructor<never>>(props: TextCustomComponentProps<T>): FCReturn;
 
 export { Text };

--- a/types/carbon-components-react/lib/components/UIShell/Content.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/Content.d.ts
@@ -13,7 +13,7 @@ export type ContentDefaultProps =
         tagName?: undefined;
     };
 
-export type ContentIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
+export type ContentIntrinsicProps<K extends keyof React.JSX.IntrinsicElements> =
     & ContentBaseProps
     & JSXIntrinsicElementProps<K>
     & {
@@ -21,6 +21,6 @@ export type ContentIntrinsicProps<K extends keyof JSX.IntrinsicElements> =
     };
 
 declare function Content(props: ContentDefaultProps): FCReturn;
-declare function Content<T extends keyof JSX.IntrinsicElements>(props: ContentIntrinsicProps<T>): FCReturn;
+declare function Content<T extends keyof React.JSX.IntrinsicElements>(props: ContentIntrinsicProps<T>): FCReturn;
 
 export default Content;

--- a/types/carbon-components-react/typings/shared.d.ts
+++ b/types/carbon-components-react/typings/shared.d.ts
@@ -79,9 +79,9 @@ export type ForwardRefProps<T, P = {}> = React.PropsWithoutRef<React.PropsWithCh
 export type ForwardRefReturn<T, P = {}> = React.ForwardRefExoticComponent<ForwardRefProps<T, P>>;
 
 export type JSXIntrinsicElementProps<
-    K extends keyof JSX.IntrinsicElements,
+    K extends keyof React.JSX.IntrinsicElements,
     REF extends boolean = false,
-> = REF extends true ? JSX.IntrinsicElements[K] : Omit<JSX.IntrinsicElements[K], "ref">;
+> = REF extends true ? React.JSX.IntrinsicElements[K] : Omit<React.JSX.IntrinsicElements[K], "ref">;
 
 // for "as" props
 export type ReactComponentConstructor<P> = ((props: P) => FCReturn) | (new(props: P) => React.Component<unknown, any>);


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.