### PR TITLE
[cxs] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -3,14 +3,14 @@ import { CSSObject } from "../index";
 
 type ApparentComponentProps<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
-> = C extends React.JSXElementConstructor<infer P> ? JSX.LibraryManagedAttributes<C, P>
+    C extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+> = C extends React.JSXElementConstructor<infer P> ? React.JSX.LibraryManagedAttributes<C, P>
     : React.ComponentPropsWithRef<C>;
 
 declare const cxsComponent: {
     <
         Component extends
-            | keyof JSX.IntrinsicElements
+            | keyof React.JSX.IntrinsicElements
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             | React.JSXElementConstructor<any>,
         PropsType extends object & ApparentComponentProps<Component>,


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.