### PR TITLE
[emoji-mart] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -2,6 +2,8 @@ import React = require("react");
 
 import { CustomEmoji, EmojiData, EmojiSkin } from "./emoji-index/nimble-emoji-index";
 
+import { JSX } from "react";
+
 export type BackgroundImageFn = (set: EmojiSet, sheetSize: EmojiSheetSize) => string;
 export type EmojiSet = "apple" | "google" | "twitter" | "emojione" | "messenger" | "facebook";
 export type EmojiSheetSize = 16 | 20 | 32 | 64;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.