### PR TITLE
[enzyme] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -2,6 +2,7 @@
 import {
     AllHTMLAttributes as ReactHTMLAttributes,
     Component,
+    JSX,
     ReactElement,
     SVGAttributes as ReactSVGAttributes,
 } from "react";


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.