### PR TITLE
[fslightbox-react] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/fslightbox-react/index.d.ts
+++ b/types/fslightbox-react/index.d.ts
@@ -21,10 +21,10 @@ export interface CustomToolbarButtonProps extends Required<ToolbarButtonProps> {
 
 export interface FsLightboxProps {
     toggler: boolean;
-    sources?: Array<string | JSX.Element> | undefined;
+    sources?: Array<string | React.JSX.Element> | undefined;
 
     // captions
-    captions?: Array<string | JSX.Element> | undefined; // pro feature
+    captions?: Array<string | React.JSX.Element> | undefined; // pro feature
 
     // custom attributes
     customAttributes?: Array<{ [key: string]: string } | null> | undefined;
@@ -51,7 +51,7 @@ export interface FsLightboxProps {
 
     // thumbs
     thumbs?: Array<string | null> | undefined; // pro feature
-    thumbsIcons?: Array<JSX.Element | null> | undefined; // pro feature
+    thumbsIcons?: Array<React.JSX.Element | null> | undefined; // pro feature
 
     // animations
     initialAnimation?: string | undefined; // pro feature


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.