### PR TITLE
[fundamental-react] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/fundamental-react/lib/List/List.d.ts
+++ b/types/fundamental-react/lib/List/List.d.ts
@@ -12,8 +12,8 @@ export type ListProps = {
     navigation?: boolean | undefined;
     partialNavigation?: boolean | undefined;
     selectable?: boolean | undefined;
-    footer?: string | JSX.Element | undefined;
-    header?: string | JSX.Element | undefined;
+    footer?: string | React.JSX.Element | undefined;
+    header?: string | React.JSX.Element | undefined;
 } & React.HTMLAttributes<HTMLAnchorElement>;
 
 export interface ListFooterProps {

--- a/types/fundamental-react/lib/Select/Select.d.ts
+++ b/types/fundamental-react/lib/Select/Select.d.ts
@@ -43,7 +43,7 @@ export interface SelectProps<T extends string = string> {
     ref?: React.Ref<HTMLDivElement> | undefined;
 }
 
-declare const Select: (<T extends string = string>(props: SelectProps<T> & { selectedKey?: T }) => JSX.Element) & {
+declare const Select: (<T extends string = string>(props: SelectProps<T> & { selectedKey?: T }) => React.JSX.Element) & {
     displayName: "Select";
 };
 


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.