### PR TITLE
[gatsbyjs__reach-router] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
+++ b/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
@@ -96,4 +96,4 @@ const refObject: React.RefObject<HTMLAnchorElement> = { current: null };
 render(<Link innerRef={refObject} to="./foo"></Link>, document.getElementById("app-root"));
 render(<Link ref={refObject} to="./foo"></Link>, document.getElementById("app-root"));
 
-const elem: JSX.Element = <Link<number> state={5} to="./foo">Click me!</Link>;
+const elem: React.JSX.Element = <Link<number> state={5} to="./foo">Click me!</Link>;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.