### PR TITLE
[giusto__ink-router] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/giusto__ink-router/index.d.ts
+++ b/types/giusto__ink-router/index.d.ts
@@ -1,5 +1,5 @@
 import { History, Location } from "history";
-import { Component, ComponentType, ReactNode } from "react";
+import { Component, ComponentType, ReactNode, JSX } from "react";
 
 export interface RouterProps {
     children: NonNullable<ReactNode>;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.