### PR TITLE
[hig__button] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/hig__button/index.d.ts
+++ b/types/hig__button/index.d.ts
@@ -32,7 +32,7 @@ export interface Props {
     /** Prevents user interaction with the button */
     disabled?: boolean | undefined;
     /** A @hig/icon element */
-    icon?: JSX.Element | undefined;
+    icon?: React.JSX.Element | undefined;
     /** Sets the link of a button */
     link?: string | undefined;
     /** Triggers when you click the button */


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.