### PR TITLE
[iput] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/iput/index.d.ts
+++ b/types/iput/index.d.ts
@@ -14,5 +14,5 @@ export default class IPut extends React.Component<IputProp, IputState> {
     handleChange(e: React.ChangeEvent<HTMLInputElement>, i: number): void;
     handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>, i: number): void;
     handlePaste(e: React.ClipboardEvent<HTMLInputElement>, i: number): void;
-    render(): JSX.Element;
+    render(): React.JSX.Element;
 }


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.