### PR TITLE
[jasmine-enzyme] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/jasmine-enzyme/index.d.ts
+++ b/types/jasmine-enzyme/index.d.ts
@@ -13,7 +13,7 @@ declare global {
             toContainMatchingElement(selector: string): void;
             toContainMatchingElements(num: number, selector: string): void;
             toContainExactlyOneMatchingElement(selector: string): void;
-            toContainReact(reactInstance: JSX.Element): void;
+            toContainReact(reactInstance: React.JSX.Element): void;
             toExist(): void;
             toHaveClassName(className: string): void;
             toHaveDisplayName(tagName: string): void;
@@ -26,7 +26,7 @@ declare global {
             toHaveText(text?: string): void;
             toIncludeText(text: string): void;
             toHaveValue(value: any): void;
-            toMatchElement(reactInstance: JSX.Element): void;
+            toMatchElement(reactInstance: React.JSX.Element): void;
             toMatchSelector(selector: string): void;
         }
     }


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.