### PR TITLE
[loadable__component] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -19,7 +19,7 @@ export type ComponentResolver<Props, Module = DefaultComponent<Props>> = (
 
 export interface OptionsWithoutResolver<Props> {
     cacheKey?(props: Props): any;
-    fallback?: JSX.Element | undefined;
+    fallback?: React.JSX.Element | undefined;
     ssr?: boolean | undefined;
 }
 
@@ -41,7 +41,7 @@ export interface LoadableComponentMethods<Props> {
 }
 
 export interface ExtraComponentProps {
-    fallback?: JSX.Element | undefined;
+    fallback?: React.JSX.Element | undefined;
 }
 
 export type LoadableComponent<Props> =
@@ -60,7 +60,7 @@ export type LoadableClassComponent<Component extends React.ComponentClass> =
 
 export type LoadableLibrary<Module> =
     & React.ComponentType<{
-        fallback?: JSX.Element | undefined;
+        fallback?: React.JSX.Element | undefined;
         children?: ((module: Module) => React.ReactNode) | undefined;
         ref?: React.Ref<Module> | undefined;
     }>


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.