### PR TITLE
[loadable__server] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/loadable__server/index.d.ts
+++ b/types/loadable__server/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentType, ReactElement } from "react";
+import { Component, ComponentType, ReactElement, JSX } from "react";
 
 export type ChunkExtractorOptions =
     & {

--- a/types/loadable__server/loadable__server-tests.tsx
+++ b/types/loadable__server/loadable__server-tests.tsx
@@ -26,7 +26,7 @@ const {
     collectChunks(<div>Test</div>);
 
     // Should return jsx
-    const jsx: JSX.Element = collectChunks(<div>Test</div>);
+    const jsx: React.JSX.Element = collectChunks(<div>Test</div>);
 }
 
 // Some example attributes for get functions.


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.