### PR TITLE
[markdown-navbar] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/markdown-navbar/index.d.ts
+++ b/types/markdown-navbar/index.d.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from "react";
+import { MouseEvent, JSX } from "react";
 
 declare namespace MarkdownNavbar {
     interface MarkdownNavbarProps {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.