### PR TITLE
[marvelapp__react-ab-test] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/marvelapp__react-ab-test/index.d.ts
+++ b/types/marvelapp__react-ab-test/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="react" />
+import { JSX } from "react";
 
 export type ListenerCallback = (experimentName: string, variantName: string) => void;
 export interface Subscription {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.