### PR TITLE
[material-ui] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1678,7 +1678,7 @@ declare namespace __MaterialUI {
             bodyStyle?: React.CSSProperties | undefined;
             children?: React.ReactNode;
             className?: string | undefined;
-            message: string | JSX.Element;
+            message: string | React.JSX.Element;
             onActionClick?: React.MouseEventHandler<{}> | undefined;
             /** @deprecated Use the open property to control the component instead */
             onDismiss?(): void; // DEPRECATED


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.