### PR TITLE
[material-ui-pagination] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/material-ui-pagination/material-ui-pagination-tests.tsx
+++ b/types/material-ui-pagination/material-ui-pagination-tests.tsx
@@ -29,7 +29,7 @@ class Pager extends React.Component<{}, PagerState> {
         const perPage = 10;
         const totalPage = Math.floor(length / perPage);
 
-        const list: JSX.Element[] = [];
+        const list: React.JSX.Element[] = [];
         for (let i = pageIndex * perPage; i < (pageIndex * perPage + perPage); i++) {
             list.push(<p key={`${i}`}>{`No.${i}`}</p>);
         }


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.