### PR TITLE
[matomo-tracker-react-native] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/matomo-tracker-react-native/index.d.ts
+++ b/types/matomo-tracker-react-native/index.d.ts
@@ -78,7 +78,7 @@ export interface MatomoProviderProps {
     children: React.ReactElement;
 }
 
-export function MatomoProvider(props: MatomoProviderProps): JSX.Element;
+export function MatomoProvider(props: MatomoProviderProps): React.JSX.Element;
 
 export const MatomoContext: React.Context<{}>;
 export interface InstanceProps {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.