### PR TITLE
[moxy__next-router-scroll] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/moxy__next-router-scroll/RouterScrollProvider.d.ts
+++ b/types/moxy__next-router-scroll/RouterScrollProvider.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, JSX } from "react";
 import { ShouldUpdateScroll } from "scroll-behavior";
 import { NextScrollBehaviorContext } from "./scroll-behavior";
 export default ScrollBehaviorProvider;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.