### PR TITLE
[mui-datatables] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -430,7 +430,7 @@ export type MUIDataTableOptions = Partial<{
         handleSearch: (text: string) => void,
         hideSearch: () => void,
         options: any,
-    ) => React.Component | JSX.Element;
+    ) => React.Component | React.JSX.Element;
     /**
      * Override default sorting with custom function.
      * If you just need to override the sorting for a particular column, see the sortCompare method in the Column options.


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.