### PR TITLE
[rasa-webchat] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/rasa-webchat/index.d.ts
+++ b/types/rasa-webchat/index.d.ts
@@ -223,7 +223,7 @@ export interface RasaWebchatProps {
      * @remarks This can only be used if you call the webchat from a React application
      * as you can't write a component in pure JavaScript.
      */
-    customComponent?: (messageData: any) => JSX.Element; // Assuming React JSX
+    customComponent?: (messageData: any) => React.JSX.Element; // Assuming React JSX
 
     /**
      * Call custom code on a specific widget event.


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.