### PR TITLE
[re-carousel] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/re-carousel/index.d.ts
+++ b/types/re-carousel/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, CSSProperties } from "react";
+import { ComponentType, CSSProperties, JSX } from "react";
 
 interface WidgetProps {
     index: number;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.