### PR TITLE
[react] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -854,21 +854,9 @@ declare namespace React {
         JSXElementConstructor<infer P> ? P
         : T extends keyof JSX.IntrinsicElements ? JSX.IntrinsicElements[T]
         : {};
-    /**
-     * Get the props of a component that supports the `ref` prop.
-     *
-     * WARNING: Use `CustomComponentPropsWithRef` if you know that `T` is not a host component for better type-checking performance.
-     */
     type ComponentPropsWithRef<T extends ElementType> = T extends (new(props: infer P) => Component<any, any>)
         ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
         : PropsWithRef<ComponentProps<T>>;
-    /**
-     * Like `ComponentPropsWithRef` but without support for host components (i.e. just "custom components") to improve type-checking performance.
-     */
-    type CustomComponentPropsWithRef<T extends ComponentType> = T extends (new(props: infer P) => Component<any, any>)
-        ? (PropsWithoutRef<P> & RefAttributes<InstanceType<T>>)
-        : T extends ((props: infer P, legacyContext?: any) => ReactNode) ? PropsWithRef<P>
-        : never;
     type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
 
     type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
@@ -879,7 +867,7 @@ declare namespace React {
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
     // but can be given its own specific name
-    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<CustomComponentPropsWithRef<T>> & {
+    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<ComponentPropsWithRef<T>> & {
         readonly type: T;
     };
 
@@ -892,7 +880,7 @@ declare namespace React {
         propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean,
     ): MemoExoticComponent<T>;
 
-    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<CustomComponentPropsWithRef<T>> & {
+    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
         readonly _result: T;
     };
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -579,10 +579,10 @@ const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined
 
 declare const numberChildren: number[];
 declare const nodeChildren: React.ReactNode;
-declare const elementChildren: JSX.Element[];
-declare const mixedChildren: Array<JSX.Element | string>;
-declare const singlePluralChildren: JSX.Element | JSX.Element[];
-declare const renderPropsChildren: () => JSX.Element;
+declare const elementChildren: React.JSX.Element[];
+declare const mixedChildren: Array<React.JSX.Element | string>;
+declare const singlePluralChildren: React.JSX.Element | React.JSX.Element[];
+declare const renderPropsChildren: () => React.JSX.Element;
 
 // $ExpectType null
 const mappedChildrenArray0 = React.Children.map(null, num => num);

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -224,32 +224,32 @@ interface WeakComponentProps3 {
 }
 
 // $ExpectType true
-type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+type weakComponentTest1 = React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
     foo?: string | null | undefined;
     bar: boolean;
 } ? true
     : false;
 // $ExpectType true
 type weakComponentTest2 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
         foo?: string | null | undefined;
         bar: number;
     } ? true
         : false;
 // $ExpectType true
 type weakComponentTest3 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
         foo: string;
         bar: boolean;
     } ? true
         : false;
 
 // @ts-expect-error
-const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { foo: "" };
-const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { bar: true };
@@ -261,25 +261,25 @@ interface WeakIndexedComponentProps {
     [K: string]: any;
 }
 
-const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > = {};
-const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > // @ts-expect-error
  = { foo: "" };
-const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest3: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: "" };
-const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest4: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: 4 };
 
-const optionalUnionPropTest: JSX.LibraryManagedAttributes<
+const optionalUnionPropTest: React.JSX.LibraryManagedAttributes<
     { propTypes: {} },
     { optional?: string } | { optional?: number }
 > = {};

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 import PropTypes = require("prop-types");
 import React = require("react");
 
@@ -335,48 +336,15 @@ const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 
 // NOTE: this test _requires_ TypeScript 3.1
 // It is passing, for what it's worth.
-const Memoized7 = React.memo((() => {
-    function HasDefaultProps(props: { test: boolean }) {
-        return null;
-    }
-    HasDefaultProps.defaultProps = {
-        test: true,
-    };
-    return HasDefaultProps;
-})());
-// $ExpectType boolean
-Memoized7.type.defaultProps.test;
-
-// From type-fest
-type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = never> =
-    & (
-        | Required<Pick<ObjectType, KeysType>>
-        | Partial<Record<KeysType, never>>
-    )
-    & Omit<ObjectType, KeysType>;
-
-type MemoizedProps = RequireAllOrNone<{ foo: string; bar: number }, "foo" | "bar">;
-declare module "react" {
-    namespace JSX {
-        interface IntrinsicElements {
-            "memoized-element": MemoizedProps;
-        }
-    }
-}
-// $ExpectType Element
-<memoized-element />;
-// $ExpectType Element
-<memoized-element foo="f" bar={42} />;
-// @ts-expect-error
-<memoized-element bar={42} />;
-
-const Memoized8 = React.memo((props: MemoizedProps) => <div />);
-// $ExpectType Element
-<Memoized8 />;
-// $ExpectType Element
-<Memoized8 foo="" bar={42} />;
-// @ts-expect-error
-<Memoized8 bar={42} />;
+// const Memoized7 = React.memo((() => {
+//     function HasDefaultProps(props: { test: boolean }) { return null; }
+//     HasDefaultProps.defaultProps = {
+//         test: true
+//     };
+//     return HasDefaultProps;
+// })());
+// // $ExpectType boolean
+// Memoized7.type.defaultProps.test;
 
 const LazyClassComponent = React.lazy(async () => ({ default: ComponentWithPropsAndState }));
 const LazyMemoized3 = React.lazy(async () => ({ default: Memoized3 }));
@@ -625,17 +593,17 @@ function CustomSelect(props: {
     >;
 }): JSX.Element {
     return (
-        <div>
+        (<div>
             <ul>{props.children}</ul>
             <select>
                 {React.Children.map(props.children, child => (
                     // key should be mappable from children.
-                    <option key={child.key} value={child.props.value}>
+                    (<option key={child.key} value={child.props.value}>
                         {child.props.children}
-                    </option>
+                    </option>)
                 ))}
             </select>
-        </div>
+        </div>)
     );
 }
 function CustomSelectOption(props: {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -855,21 +855,9 @@ declare namespace React {
         JSXElementConstructor<infer P> ? P
         : T extends keyof JSX.IntrinsicElements ? JSX.IntrinsicElements[T]
         : {};
-    /**
-     * Get the props of a component that supports the `ref` prop.
-     *
-     * WARNING: Use `CustomComponentPropsWithRef` if you know that `T` is not a host component for better type-checking performance.
-     */
     type ComponentPropsWithRef<T extends ElementType> = T extends (new(props: infer P) => Component<any, any>)
         ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
         : PropsWithRef<ComponentProps<T>>;
-    /**
-     * Like `ComponentPropsWithRef` but without support for host components (i.e. just "custom components") to improve type-checking performance.
-     */
-    type CustomComponentPropsWithRef<T extends ComponentType> = T extends (new(props: infer P) => Component<any, any>)
-        ? (PropsWithoutRef<P> & RefAttributes<InstanceType<T>>)
-        : T extends ((props: infer P, legacyContext?: any) => ReactNode) ? PropsWithRef<P>
-        : never;
     type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
 
     type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
@@ -880,7 +868,7 @@ declare namespace React {
 
     // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
     // but can be given its own specific name
-    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<CustomComponentPropsWithRef<T>> & {
+    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<ComponentPropsWithRef<T>> & {
         readonly type: T;
     };
 
@@ -893,7 +881,7 @@ declare namespace React {
         propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean,
     ): MemoExoticComponent<T>;
 
-    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<CustomComponentPropsWithRef<T>> & {
+    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
         readonly _result: T;
     };
 

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -587,10 +587,10 @@ const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined
 
 declare const numberChildren: number[];
 declare const nodeChildren: React.ReactNode;
-declare const elementChildren: JSX.Element[];
-declare const mixedChildren: Array<JSX.Element | string>;
-declare const singlePluralChildren: JSX.Element | JSX.Element[];
-declare const renderPropsChildren: () => JSX.Element;
+declare const elementChildren: React.JSX.Element[];
+declare const mixedChildren: Array<React.JSX.Element | string>;
+declare const singlePluralChildren: React.JSX.Element | React.JSX.Element[];
+declare const renderPropsChildren: () => React.JSX.Element;
 
 // $ExpectType null
 const mappedChildrenArray0 = React.Children.map(null, num => num);

--- a/types/react/ts5.0/test/managedAttributes.tsx
+++ b/types/react/ts5.0/test/managedAttributes.tsx
@@ -224,32 +224,32 @@ interface WeakComponentProps3 {
 }
 
 // $ExpectType true
-type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+type weakComponentTest1 = React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
     foo?: string | null | undefined;
     bar: boolean;
 } ? true
     : false;
 // $ExpectType true
 type weakComponentTest2 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
         foo?: string | null | undefined;
         bar: number;
     } ? true
         : false;
 // $ExpectType true
 type weakComponentTest3 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
         foo: string;
         bar: boolean;
     } ? true
         : false;
 
 // @ts-expect-error
-const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { foo: "" };
-const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { bar: true };
@@ -261,25 +261,25 @@ interface WeakIndexedComponentProps {
     [K: string]: any;
 }
 
-const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > = {};
-const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > // @ts-expect-error
  = { foo: "" };
-const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest3: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: "" };
-const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest4: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: 4 };
 
-const optionalUnionPropTest: JSX.LibraryManagedAttributes<
+const optionalUnionPropTest: React.JSX.LibraryManagedAttributes<
     { propTypes: {} },
     { optional?: string } | { optional?: number }
 > = {};

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 import PropTypes = require("prop-types");
 import React = require("react");
 
@@ -335,48 +336,15 @@ const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 
 // NOTE: this test _requires_ TypeScript 3.1
 // It is passing, for what it's worth.
-const Memoized7 = React.memo((() => {
-    function HasDefaultProps(props: { test: boolean }) {
-        return null;
-    }
-    HasDefaultProps.defaultProps = {
-        test: true,
-    };
-    return HasDefaultProps;
-})());
-// $ExpectType boolean
-Memoized7.type.defaultProps.test;
-
-// From type-fest
-type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = never> =
-    & (
-        | Required<Pick<ObjectType, KeysType>>
-        | Partial<Record<KeysType, never>>
-    )
-    & Omit<ObjectType, KeysType>;
-
-type MemoizedProps = RequireAllOrNone<{ foo: string; bar: number }, "foo" | "bar">;
-declare module "react" {
-    namespace JSX {
-        interface IntrinsicElements {
-            "memoized-element": MemoizedProps;
-        }
-    }
-}
-// $ExpectType Element
-<memoized-element />;
-// $ExpectType Element
-<memoized-element foo="f" bar={42} />;
-// @ts-expect-error
-<memoized-element bar={42} />;
-
-const Memoized8 = React.memo((props: MemoizedProps) => <div />);
-// $ExpectType Element
-<Memoized8 />;
-// $ExpectType Element
-<Memoized8 foo="" bar={42} />;
-// @ts-expect-error
-<Memoized8 bar={42} />;
+// const Memoized7 = React.memo((() => {
+//     function HasDefaultProps(props: { test: boolean }) { return null; }
+//     HasDefaultProps.defaultProps = {
+//         test: true
+//     };
+//     return HasDefaultProps;
+// })());
+// // $ExpectType boolean
+// Memoized7.type.defaultProps.test;
 
 const LazyClassComponent = React.lazy(async () => ({ default: ComponentWithPropsAndState }));
 const LazyMemoized3 = React.lazy(async () => ({ default: Memoized3 }));
@@ -625,17 +593,17 @@ function CustomSelect(props: {
     >;
 }): JSX.Element {
     return (
-        <div>
+        (<div>
             <ul>{props.children}</ul>
             <select>
                 {React.Children.map(props.children, child => (
                     // key should be mappable from children.
-                    <option key={child.key} value={child.props.value}>
+                    (<option key={child.key} value={child.props.value}>
                         {child.props.children}
-                    </option>
+                    </option>)
                 ))}
             </select>
-        </div>
+        </div>)
     );
 }
 function CustomSelectOption(props: {

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -608,10 +608,10 @@ const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined
 
 declare const numberChildren: number[];
 declare const nodeChildren: React.ReactNode;
-declare const elementChildren: JSX.Element[];
-declare const mixedChildren: Array<JSX.Element | string>;
-declare const singlePluralChildren: JSX.Element | JSX.Element[];
-declare const renderPropsChildren: () => JSX.Element;
+declare const elementChildren: React.JSX.Element[];
+declare const mixedChildren: Array<React.JSX.Element | string>;
+declare const singlePluralChildren: React.JSX.Element | React.JSX.Element[];
+declare const renderPropsChildren: () => React.JSX.Element;
 
 // $ExpectType null
 const mappedChildrenArray0 = React.Children.map(null, num => num);

--- a/types/react/v16/test/managedAttributes.tsx
+++ b/types/react/v16/test/managedAttributes.tsx
@@ -224,32 +224,32 @@ interface WeakComponentProps3 {
 }
 
 // $ExpectType true
-type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+type weakComponentTest1 = React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
     foo?: string | null | undefined;
     bar: boolean;
 } ? true
     : false;
 // $ExpectType true
 type weakComponentTest2 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
         foo?: string | null | undefined;
         bar: number;
     } ? true
         : false;
 // $ExpectType true
 type weakComponentTest3 =
-    JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+    React.JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
         foo: string;
         bar: boolean;
     } ? true
         : false;
 
 // @ts-expect-error
-const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { foo: "" };
-const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<
+const weakComponentOptionalityTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakComponentProps3
 > = { bar: true };
@@ -261,25 +261,25 @@ interface WeakIndexedComponentProps {
     [K: string]: any;
 }
 
-const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest1: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > = {};
-const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest2: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     IndexedComponentProps
 > // @ts-expect-error
  = { foo: "" };
-const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest3: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: "" };
-const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<
+const weakComponentIndexedTest4: React.JSX.LibraryManagedAttributes<
     { propTypes: typeof weakComponentPropTypes },
     WeakIndexedComponentProps
 > = { foo: 4 };
 
-const optionalUnionPropTest: JSX.LibraryManagedAttributes<
+const optionalUnionPropTest: React.JSX.LibraryManagedAttributes<
     { propTypes: {} },
     { optional?: string } | { optional?: number }
 > = {};

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 import PropTypes = require("prop-types");
 import React = require("react");
 
@@ -532,17 +533,17 @@ function CustomSelect(props: {
     >;
 }): JSX.Element {
     return (
-        <div>
+        (<div>
             <ul>{props.children}</ul>
             <select>
                 {React.Children.map(props.children, child => (
                     // key should be mappable from children.
-                    <option key={child.key} value={child.props.value}>
+                    (<option key={child.key} value={child.props.value}>
                         {child.props.children}
-                    </option>
+                    </option>)
                 ))}
             </select>
-        </div>
+        </div>)
     );
 }
 function CustomSelectOption(props: {

--- a/types/react/v17/test/index.ts
+++ b/types/react/v17/test/index.ts
@@ -607,10 +607,10 @@ const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined
 
 declare const numberChildren: number[];
 declare const nodeChildren: React.ReactNode;
-declare const elementChildren: JSX.Element[];
-declare const mixedChildren: Array<JSX.Element | string>;
-declare const singlePluralChildren: JSX.Element | JSX.Element[];
-declare const renderPropsChildren: () => JSX.Element;
+declare const elementChildren: React.JSX.Element[];
+declare const mixedChildren: Array<React.JSX.Element | string>;
+declare const singlePluralChildren: React.JSX.Element | React.JSX.Element[];
+declare const renderPropsChildren: () => React.JSX.Element;
 
 // $ExpectType null
 const mappedChildrenArray0 = React.Children.map(null, num => num);

--- a/types/react/v17/test/tsx.tsx
+++ b/types/react/v17/test/tsx.tsx
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 import PropTypes = require("prop-types");
 import React = require("react");
 
@@ -545,17 +546,17 @@ function CustomSelect(props: {
     >;
 }): JSX.Element {
     return (
-        <div>
+        (<div>
             <ul>{props.children}</ul>
             <select>
                 {React.Children.map(props.children, child => (
                     // key should be mappable from children.
-                    <option key={child.key} value={child.props.value}>
+                    (<option key={child.key} value={child.props.value}>
                         {child.props.children}
-                    </option>
+                    </option>)
                 ))}
             </select>
-        </div>
+        </div>)
     );
 }
 function CustomSelectOption(props: {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.