### PR TITLE
[react-adal] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-adal/index.d.ts
+++ b/types/react-adal/index.d.ts
@@ -378,6 +378,6 @@ export function withAdalLogin(
     resource: string,
 ): (
     wrappedComponent: React.ComponentClass | React.FunctionComponent,
-    renderLoading: () => JSX.Element | null,
-    renderError: (error: any) => JSX.Element | null,
+    renderLoading: () => React.JSX.Element | null,
+    renderError: (error: any) => React.JSX.Element | null,
 ) => React.ComponentClass;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.