### PR TITLE
[react-add-to-calendar] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-add-to-calendar/react-add-to-calendar-tests.tsx
+++ b/types/react-add-to-calendar/react-add-to-calendar-tests.tsx
@@ -9,13 +9,13 @@ const sampleEvent = {
     endTime: "2016-09-16T21:45:00-04:00",
 };
 
-const AddToCalendarRequiredOptions: JSX.Element = (
+const AddToCalendarRequiredOptions: React.JSX.Element = (
     <AddToCalendar
         event={sampleEvent}
     />
 );
 
-const AddToCalendarAllOptions: JSX.Element = (
+const AddToCalendarAllOptions: React.JSX.Element = (
     <AddToCalendar
         event={sampleEvent}
         buttonClassClosed="test"


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.