### PR TITLE
[react-app] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-app/index.d.ts
+++ b/types/react-app/index.d.ts
@@ -27,7 +27,7 @@ export interface CreateAppObject {
 }
 
 // exporting the createApp function
-export function createApp(createAppObject: CreateAppObject): JSX.Element;
+export function createApp(createAppObject: CreateAppObject): React.JSX.Element;
 
 export class Link extends React.Component<LinkProps> {}
 export class Layout extends React.Component<LayoutProps> {}


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.