### PR TITLE
[react-aria-menubutton] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -74,7 +74,7 @@ export interface MenuProps<T extends HTMLElement> extends Omit<React.HTMLProps<T
      * The HTML tag for this element. Default: 'div'.
      */
     tag?: T["tagName"] | undefined;
-    children: JSX.Element | (({ isOpen }: { isOpen: boolean }) => JSX.Element);
+    children: React.JSX.Element | (({ isOpen }: { isOpen: boolean }) => React.JSX.Element);
 }
 
 /**


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.