### PR TITLE
[react-autosuggest] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -82,7 +82,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
     };
     // endregion region Rendering methods
     inputRef = React.createRef<HTMLInputElement>();
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const { value, suggestions } = this.state;
 
         const theme = {
@@ -126,7 +126,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
         alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
     }
 
-    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): JSX.Element {
+    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): React.JSX.Element {
         const className = params.isHighlighted ? "highlighted" : undefined;
         return <span className={className}>{suggestion.name}</span>;
     }
@@ -228,7 +228,7 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
         suggestions: this.getSuggestions(""),
     };
     // endregion region Rendering methods
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const { value, suggestions } = this.state;
 
         const theme = {
@@ -263,7 +263,7 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
         alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
     }
 
-    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): JSX.Element {
+    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): React.JSX.Element {
         const className = params.isHighlighted ? "highlighted" : undefined;
         return <span className={className}>{suggestion.name}</span>;
     }
@@ -401,7 +401,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         };
     }
     // endregion region Rendering methods
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const { value, suggestions } = this.state;
 
         return (
@@ -435,16 +435,16 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         alert(`Selected language is ${language.name} (${language.year}).`);
     }
 
-    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): JSX.Element {
+    protected renderSuggestion(suggestion: Language, params: Autosuggest.RenderSuggestionParams): React.JSX.Element {
         const className = params.isHighlighted ? "highlighted" : undefined;
         return <span className={className}>{suggestion.name}</span>;
     }
 
-    protected renderSectionTitle(section: LanguageGroup): JSX.Element {
+    protected renderSectionTitle(section: LanguageGroup): React.JSX.Element {
         return <strong>{section.title}</strong>;
     }
 
-    protected renderInputComponent(inputProps: Autosuggest.RenderInputComponentProps): JSX.Element {
+    protected renderInputComponent(inputProps: Autosuggest.RenderInputComponentProps): React.JSX.Element {
         return (
             <div>
                 <input {...inputProps} />
@@ -456,7 +456,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         containerProps,
         children,
         query,
-    }: Autosuggest.RenderSuggestionsContainerParams): JSX.Element {
+    }: Autosuggest.RenderSuggestionsContainerParams): React.JSX.Element {
         return (
             <div {...containerProps}>
                 <span>{children}</span>
@@ -549,7 +549,7 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
         suggestions: this.getSuggestions(""),
     };
     // endregion region Rendering methods
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const { value, suggestions } = this.state;
 
         return (
@@ -567,7 +567,7 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
         );
     }
 
-    protected renderSuggestion(suggestion: Person, params: Autosuggest.RenderSuggestionParams): JSX.Element {
+    protected renderSuggestion(suggestion: Person, params: Autosuggest.RenderSuggestionParams): React.JSX.Element {
         const suggestionText = `${suggestion.first} ${suggestion.last}`;
         const query = params.query.trim();
         const parts = suggestionText.split(" ").map((part: string) => {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.