### PR TITLE
[react-blessed] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-blessed/index.d.ts
+++ b/types/react-blessed/index.d.ts
@@ -7,8 +7,8 @@ export {};
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Callback = () => void | null | undefined;
-export type renderer = (c: JSX.Element, s: Blessed.Widgets.Screen, callback?: Callback) => React.Component | null;
-export function render(c: JSX.Element, s: Blessed.Widgets.Screen, callback?: Callback): React.Component | null;
+export type renderer = (c: React.JSX.Element, s: Blessed.Widgets.Screen, callback?: Callback) => React.Component | null;
+export function render(c: React.JSX.Element, s: Blessed.Widgets.Screen, callback?: Callback): React.Component | null;
 
 export function createBlessedRenderer(bls: any): renderer;
 


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.