### PR TITLE
[react-bootstrap-table] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -3,7 +3,7 @@
 // documentation taken from http://allenfang.github.io/react-bootstrap-table/docs.html
 
 import { EventEmitter } from "events";
-import { ComponentClass, ReactElement } from "react";
+import { ComponentClass, ReactElement, JSX } from "react";
 
 /**
  * Interface spec for sepcifying functionality to handle remotely


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.