### PR TITLE
[react-bootstrap-table-next] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -1,6 +1,6 @@
 // documentation taken from https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/table-props.html
 
-import { Component, CSSProperties, ReactElement, SyntheticEvent } from "react";
+import { Component, CSSProperties, ReactElement, SyntheticEvent, JSX } from "react";
 
 export const ROW_SELECT_SINGLE = "radio";
 export const ROW_SELECT_MULTIPLE = "checkbox";


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.