### PR TITLE
[react-bootstrap-table2-toolkit] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-bootstrap-table2-toolkit/index.d.ts
+++ b/types/react-bootstrap-table2-toolkit/index.d.ts
@@ -1,6 +1,6 @@
 // documentation taken from https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/table-props.html
 
-import { CSSProperties, ReactNode } from "react";
+import { CSSProperties, ReactNode, JSX } from "react";
 import { ColumnDescription, SearchProps } from "react-bootstrap-table-next";
 
 /**


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.