### PR TITLE
[react-bootstrap-typeahead] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -207,7 +207,7 @@ export interface TypeaheadProps<T extends TypeaheadModel> {
     multiple?: boolean | undefined;
 
     /* Override default new selection text. */
-    newSelectionPrefix?: JSX.Element | string;
+    newSelectionPrefix?: React.JSX.Element | string;
 
     /* Invoked when the input is blurred. Receives an event. */
     onBlur?: ((e: Event) => void) | undefined;

--- a/types/react-bootstrap-typeahead/react-bootstrap-typeahead-tests.tsx
+++ b/types/react-bootstrap-typeahead/react-bootstrap-typeahead-tests.tsx
@@ -65,7 +65,7 @@ class BasicExample extends React.Component {
                 );
             });
             return [...accum, ...header, ...states];
-        }, [] as JSX.Element[]);
+        }, [] as React.JSX.Element[]);
 
         return menuItems;
     };


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.