### PR TITLE
[react-burger-menu] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -28,8 +28,8 @@ export interface Props {
     className?: string | undefined;
     crossButtonClassName?: string | undefined;
     crossClassName?: string | undefined;
-    customBurgerIcon?: JSX.Element | false | undefined;
-    customCrossIcon?: JSX.Element | false | undefined;
+    customBurgerIcon?: React.JSX.Element | false | undefined;
+    customCrossIcon?: React.JSX.Element | false | undefined;
     customOnKeyDown?(event: React.KeyboardEvent): void;
     disableAutoFocus?: boolean | undefined;
     disableCloseOnEsc?: boolean | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.