### PR TITLE
[react-copy-write] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-copy-write/index.d.ts
+++ b/types/react-copy-write/index.d.ts
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component, JSX } from "react";
 
 // It'd be nice if this could somehow be improved! Perhaps we need variadic
 // kinds plus infer keyword? Alternatively unions may solve our issue if we had


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.