### PR TITLE
[react-currency-format] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-currency-format/index.d.ts
+++ b/types/react-currency-format/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentType, HTMLAttributes, InputHTMLAttributes } from "react";
+import { Component, ComponentType, HTMLAttributes, InputHTMLAttributes, JSX } from "react";
 
 declare namespace CurrencyFormat {
     /**


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.