### PR TITLE
[react-form] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-form/react-form-tests.tsx
+++ b/types/react-form/react-form-tests.tsx
@@ -498,7 +498,7 @@ function FourthMyForm() {
 
 // Few tests
 
-export function EmailField(props: any): JSX.Element {
+export function EmailField(props: any): React.JSX.Element {
     const data = useField("email", {
         defaultValue: props.defaultValue,
         defaultError: props.defaultError,

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -9,7 +9,7 @@ export type FormValues = Nested<FormValue>;
 export type Touched = Nested<boolean>;
 export type FormErrors = { [key: string]: FormError } | [{ [key: string]: FormError }];
 export type NestedErrors = Nested<FormErrors>;
-export type RenderReturn = JSX.Element | false | null;
+export type RenderReturn = React.JSX.Element | false | null;
 
 export interface FormProps {
     loadState?(props: FormProps, self: Form): FormState | undefined;

--- a/types/react-form/v2/index.d.ts
+++ b/types/react-form/v2/index.d.ts
@@ -12,7 +12,7 @@ export interface FormErrors {
     [key: string]: FormError;
 }
 export type NestedErrors = Nested<FormErrors>;
-export type RenderReturn = JSX.Element | false | null | never[];
+export type RenderReturn = React.JSX.Element | false | null | never[];
 
 export interface FormState {
     values: FormValues;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.