### PR TITLE
[react-google-login-component] Ensure React types match runtime version

### DIFF
--- a/types/react-google-login-component/package.json
+++ b/types/react-google-login-component/package.json
@@ -6,7 +6,7 @@
         "https://github.com/kennetpostigo/react-google-login-component"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^16"
     },
     "devDependencies": {
         "@types/react-google-login-component": "workspace:."


### PR DESCRIPTION
16.x is the highest major supported: https://unpkg.com/browse/react-google-login-component@0.9.3/package.json