### PR TITLE
[react-gravatar] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-gravatar/index.d.ts
+++ b/types/react-gravatar/index.d.ts
@@ -12,14 +12,14 @@ declare class Gravatar extends React.Component<Gravatar.Props> {
 
     static readonly defaultProps: Gravatar.Props;
 
-    render(): JSX.Element | null;
+    render(): React.JSX.Element | null;
 }
 
 declare namespace Gravatar {
     type DefaultImage = "404" | "mm" | "mp" | "identicon" | "monsterid" | "wavatar" | "retro" | "blank";
     type Rating = "g" | "pg" | "r" | "x";
 
-    interface Props extends Partial<JSX.IntrinsicElements["img"]> {
+    interface Props extends Partial<React.JSX.IntrinsicElements["img"]> {
         /**
          * The email address used to look up the Gravatar image.
          * If you wish to avoid sending an email address to the client, you can compute the md5 hash on the server and


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.