### PR TITLE
[react-instantsearch-core] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -451,7 +451,7 @@ export interface NumericMenuExposed {
     attribute: string;
     /** List of options. With a text label, and upper and lower bounds. */
     items: Array<{
-        label: string | JSX.Element;
+        label: string | React.JSX.Element;
         start?: number | undefined;
         end?: number | undefined;
     }>;

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -490,9 +490,9 @@ import { Hits, RefinementList } from "react-instantsearch-dom";
             className?: string | undefined;
             showLoadingIndicator?: boolean | undefined;
 
-            submit?: JSX.Element | undefined;
-            reset?: JSX.Element | undefined;
-            loadingIndicator?: JSX.Element | undefined;
+            submit?: React.JSX.Element | undefined;
+            reset?: React.JSX.Element | undefined;
+            loadingIndicator?: React.JSX.Element | undefined;
 
             onSubmit?: ((event: React.SyntheticEvent<HTMLFormElement>) => any) | undefined;
             onReset?: ((event: React.SyntheticEvent<HTMLFormElement>) => any) | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.