### PR TITLE
[react-instantsearch-dom] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -119,9 +119,9 @@ export interface SearchBoxProps extends CommonWidgetProps {
     searchAsYouType?: boolean | undefined;
     showLoadingIndicator?: boolean | undefined;
 
-    submit?: JSX.Element | undefined;
-    reset?: JSX.Element | undefined;
-    loadingIndicator?: JSX.Element | undefined;
+    submit?: React.JSX.Element | undefined;
+    reset?: React.JSX.Element | undefined;
+    loadingIndicator?: React.JSX.Element | undefined;
 
     onSubmit?: ((event: React.SyntheticEvent<HTMLFormElement>) => any) | undefined;
     onReset?: ((event: React.SyntheticEvent<HTMLFormElement>) => any) | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.