### PR TITLE
[react-jsonschema-form] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -95,7 +95,7 @@ declare module "react-jsonschema-form" {
          */
         liveOmit?: boolean | undefined;
         /** Used to change the default `form` tag into a different HTML tag */
-        tagName?: keyof JSX.IntrinsicElements | React.ComponentType | undefined;
+        tagName?: keyof React.JSX.IntrinsicElements | React.ComponentType | undefined;
     }
 
     export default class Form<T> extends React.Component<FormProps<T>> {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.