### PR TITLE
[react-katex] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-katex/index.d.ts
+++ b/types/react-katex/index.d.ts
@@ -16,6 +16,6 @@ export interface MathComponentPropsWithChildren {
 
 export type MathComponentProps = MathComponentPropsWithMath | MathComponentPropsWithChildren;
 
-export function BlockMath(props: MathComponentProps): JSX.Element;
+export function BlockMath(props: MathComponentProps): React.JSX.Element;
 
-export function InlineMath(props: MathComponentProps): JSX.Element;
+export function InlineMath(props: MathComponentProps): React.JSX.Element;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.