### PR TITLE
[react-leaflet-fullscreen-plugin] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-leaflet-fullscreen-plugin/index.d.ts
+++ b/types/react-leaflet-fullscreen-plugin/index.d.ts
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 export interface FullscreenProps {
     position?: "topleft" | "topright" | "bottomleft" | "bottomright" | undefined;
     title?: string | undefined;

--- a/types/react-leaflet-fullscreen-plugin/package.json
+++ b/types/react-leaflet-fullscreen-plugin/package.json
@@ -5,8 +5,10 @@
     "projects": [
         "https://github.com/elangobharathi/react-leaflet-fullscreen-plugin"
     ],
+    "dependencies": {
+        "@types/react": "*"
+    },
     "devDependencies": {
-        "@types/react": "*",
         "@types/react-leaflet-fullscreen-plugin": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.