### PR TITLE
[react-list] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component, JSX } from "react";
 
 type ItemRenderer = (index: number, key: number | string) => JSX.Element;
 type ItemsRenderer = (items: JSX.Element[], ref: string) => JSX.Element;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.