### PR TITLE
[react-loading-indicator] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-loading-indicator/react-loading-indicator-tests.tsx
+++ b/types/react-loading-indicator/react-loading-indicator-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import LoadingIndicator, { LoadingIndicatorColor, LoadingIndicatorProps } from "react-loading-indicator";
 
 export class LoadingIndicatorTest extends React.PureComponent {
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const color: LoadingIndicatorColor = {
             red: 224,
             green: 33,


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.