### PR TITLE
[react-native] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
+++ b/types/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
@@ -92,7 +92,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of

--- a/types/react-native/Libraries/Lists/FlatList.d.ts
+++ b/types/react-native/Libraries/Lists/FlatList.d.ts
@@ -208,7 +208,7 @@ export abstract class FlatListComponent<
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -2901,7 +2901,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3280,7 +3280,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 export interface SliderPropsAndroid extends ViewProps {
@@ -4130,7 +4130,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -2931,7 +2931,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3314,7 +3314,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 export interface SliderPropsAndroid extends ViewProps {
@@ -4169,7 +4169,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -2949,7 +2949,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3331,7 +3331,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 export interface SliderPropsAndroid extends ViewProps {
@@ -4187,7 +4187,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.66/index.d.ts
+++ b/types/react-native/v0.66/index.d.ts
@@ -2998,7 +2998,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3250,7 +3250,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 /**
@@ -4113,7 +4113,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.67/index.d.ts
+++ b/types/react-native/v0.67/index.d.ts
@@ -3001,7 +3001,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3253,7 +3253,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 /**
@@ -4104,7 +4104,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -3034,7 +3034,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3286,7 +3286,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 /**
@@ -4137,7 +4137,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -2968,7 +2968,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3220,7 +3220,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 /**
@@ -4070,7 +4070,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.70/index.d.ts
+++ b/types/react-native/v0.70/index.d.ts
@@ -3090,7 +3090,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
@@ -3342,7 +3342,7 @@ export class RecyclerViewBackedScrollView extends RecyclerViewBackedScrollViewBa
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): React.JSX.Element;
 }
 
 /**
@@ -4191,7 +4191,7 @@ export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>>
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.71/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
+++ b/types/react-native/v0.71/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.d.ts
@@ -92,7 +92,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element;
+    renderNavigationView: () => React.JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of

--- a/types/react-native/v0.71/Libraries/Lists/FlatList.d.ts
+++ b/types/react-native/v0.71/Libraries/Lists/FlatList.d.ts
@@ -261,7 +261,7 @@ export class FlatList<ItemT = any> extends React.Component<
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => JSX.Element | null | undefined;
+    getScrollResponder: () => React.JSX.Element | null | undefined;
 
     /**
      * Provides a reference to the underlying host component

--- a/types/react-native/v0.71/test/index.tsx
+++ b/types/react-native/v0.71/test/index.tsx
@@ -668,7 +668,7 @@ export class FlatListTest extends React.Component<FlatListProps<number>, {}> {
 
     render() {
         const { ListEmptyComponent } = this.props;
-        const listEmptyComponent: JSX.Element | null | undefined = React.isValidElement(ListEmptyComponent)
+        const listEmptyComponent: React.JSX.Element | null | undefined = React.isValidElement(ListEmptyComponent)
             ? ListEmptyComponent
             : ListEmptyComponent && <ListEmptyComponent />;
 


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.