### PR TITLE
[react-native-material-textfield] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-native-material-textfield/index.d.ts
+++ b/types/react-native-material-textfield/index.d.ts
@@ -49,8 +49,8 @@ export interface TextFieldProps extends TextInputProps {
     onPress?(event: Event): void;
     onChangeText?(text: string): void;
 
-    renderLeftAccessory?(): JSX.Element;
-    renderRightAccessory?(): JSX.Element;
+    renderLeftAccessory?(): React.JSX.Element;
+    renderRightAccessory?(): React.JSX.Element;
 
     lineType?: "solid" | "dotted" | "dashed" | "none" | undefined;
     disabledLineType?: "solid" | "dotted" | "dashed" | "none" | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.