### PR TITLE
[react-native-material-ui] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component, JSX } from "react";
 import { Image, StyleProp, TextStyle as TextStyleRaw, ViewStyle as ViewStyleRaw } from "react-native";
 
 export type ViewStyle = StyleProp<ViewStyleRaw>;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.