### PR TITLE
[react-native-snackbar-component] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-native-snackbar-component/index.d.ts
+++ b/types/react-native-snackbar-component/index.d.ts
@@ -13,7 +13,7 @@ export interface SnackbarComponentProps {
     top?: number | Animated.Value | undefined;
     bottom?: number | Animated.Value | undefined;
     position?: "bottom" | "top" | undefined;
-    textMessage?: string | JSX.Element | undefined;
+    textMessage?: string | React.JSX.Element | undefined;
     autoHidingTime?: number | undefined;
     visible?: boolean | undefined;
     containerStyle?: ViewStyle | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.