### PR TITLE
[react-native-tab-navigator] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-native-tab-navigator/index.d.ts
+++ b/types/react-native-tab-navigator/index.d.ts
@@ -73,17 +73,17 @@ interface TabNavigatorItemProps {
     /**
      * Returns Item badge
      */
-    renderBadge?(): JSX.Element;
+    renderBadge?(): React.JSX.Element;
 
     /**
      * Returns Item icon
      */
-    renderIcon?(): JSX.Element;
+    renderIcon?(): React.JSX.Element;
 
     /**
      * Returns selected Item icon
      */
-    renderSelectedIcon?(): JSX.Element;
+    renderSelectedIcon?(): React.JSX.Element;
 }
 
 export class TabNavigator extends React.Component<TabNavigatorProps, any> {}


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.