### PR TITLE
[react-notification-system] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -4,8 +4,8 @@ declare namespace NotificationSystem {
     export type CallBackFunction = (notification: Notification) => void;
 
     export interface Notification {
-        title?: string | JSX.Element | undefined;
-        message?: string | JSX.Element | undefined;
+        title?: string | React.JSX.Element | undefined;
+        message?: string | React.JSX.Element | undefined;
         level?: "error" | "warning" | "info" | "success" | undefined;
         position?: "tr" | "tl" | "tc" | "br" | "bl" | "bc" | undefined;
         autoDismiss?: number | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.