### PR TITLE
[react-portal-tooltip] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-portal-tooltip/lib/ToolTip.d.ts
+++ b/types/react-portal-tooltip/lib/ToolTip.d.ts
@@ -6,7 +6,7 @@ declare class Tooltip extends React.Component<TooltipProps> {}
 export default Tooltip;
 
 export interface TooltipProps extends Card.CardProps {
-    parent: string | JSX.Element | React.RefObject<unknown>;
+    parent: string | React.JSX.Element | React.RefObject<unknown>;
     active?: boolean | undefined;
     group?: string | undefined;
     tooltipTimeout?: number | undefined;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.