### PR TITLE
[react-redux] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -6,6 +6,7 @@ import {
     JSXElementConstructor,
     NamedExoticComponent,
     ReactNode,
+    JSX,
 } from "react";
 
 import { Action, AnyAction, Dispatch, Store } from "redux";

--- a/types/react-redux/v5/react-redux-tests.tsx
+++ b/types/react-redux/v5/react-redux-tests.tsx
@@ -409,7 +409,7 @@ connect<ICounterStateProps, ICounterDispatchProps, {}, ICounterStateProps & ICou
 )(Counter);
 
 class App extends Component<any, any> {
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         // ...
         return null;
     }

--- a/types/react-redux/v6/index.d.ts
+++ b/types/react-redux/v6/index.d.ts
@@ -10,7 +10,14 @@
 // to update this type definitions for redux@4.x from redux@3.x.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321
 
-import { Component, ComponentClass, ComponentType, FunctionComponent, ReactNode } from "react";
+import {
+    Component,
+    ComponentClass,
+    ComponentType,
+    FunctionComponent,
+    ReactNode,
+    JSX,
+} from "react";
 
 import { Action, ActionCreator, AnyAction, Dispatch, Store } from "redux";
 


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.