### PR TITLE
[react-simple-oauth2-login] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-simple-oauth2-login/index.d.ts
+++ b/types/react-simple-oauth2-login/index.d.ts
@@ -26,4 +26,4 @@ export interface OAuth2LoginProps {
     extraParams?: Record<string, any>;
 }
 
-export default function OAuth2Login(props: OAuth2LoginProps): JSX.Element;
+export default function OAuth2Login(props: OAuth2LoginProps): React.JSX.Element;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.