### PR TITLE
[react-slick] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -29,7 +29,7 @@ export interface Settings {
     accessibility?: boolean | undefined;
     adaptiveHeight?: boolean | undefined;
     afterChange?(currentSlide: number): void;
-    appendDots?(dots: React.ReactNode): JSX.Element;
+    appendDots?(dots: React.ReactNode): React.JSX.Element;
     arrows?: boolean | undefined;
     asNavFor?: Slider | undefined;
     autoplaySpeed?: number | undefined;
@@ -40,7 +40,7 @@ export interface Settings {
     children?: React.ReactNode;
     className?: string | undefined;
     cssEase?: string | undefined;
-    customPaging?(index: number): JSX.Element;
+    customPaging?(index: number): React.JSX.Element;
     dotsClass?: string | undefined;
     dots?: boolean | undefined;
     draggable?: boolean | undefined;
@@ -51,7 +51,7 @@ export interface Settings {
     infinite?: boolean | undefined;
     initialSlide?: number | undefined;
     lazyLoad?: LazyLoadTypes | undefined;
-    nextArrow?: JSX.Element | undefined;
+    nextArrow?: React.JSX.Element | undefined;
     onEdge?(swipeDirection: SwipeDirection): void;
     onInit?(): void;
     onLazyLoad?(slidesToLoad: number[]): void;
@@ -60,7 +60,7 @@ export interface Settings {
     pauseOnDotsHover?: boolean | undefined;
     pauseOnFocus?: boolean | undefined;
     pauseOnHover?: boolean | undefined;
-    prevArrow?: JSX.Element | undefined;
+    prevArrow?: React.JSX.Element | undefined;
     responsive?: ResponsiveObject[] | undefined;
     rows?: number | undefined;
     rtl?: boolean | undefined;

--- a/types/react-slick/react-slick-tests.tsx
+++ b/types/react-slick/react-slick-tests.tsx
@@ -7,7 +7,7 @@ class LeftNavArrow extends React.Component<CustomArrowProps> {
     }
 }
 
-function RightNavArrow(props: CustomArrowProps): JSX.Element {
+function RightNavArrow(props: CustomArrowProps): React.JSX.Element {
     const { className, style, onClick } = props;
     return (
         <div


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.