### PR TITLE
[react-slider] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-slider/index.d.ts
+++ b/types/react-slider/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, HTMLProps, RefCallback } from "react";
+import { Component, HTMLProps, RefCallback, JSX } from "react";
 
 interface HTMLPropsWithRefCallback<T> extends HTMLProps<T> {
     ref: RefCallback<T>;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.