### PR TITLE
[react-snapshot] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-snapshot/index.d.ts
+++ b/types/react-snapshot/index.d.ts
@@ -1,3 +1,3 @@
 import * as React from "react";
 
-export function render(rootComponent: React.Component | JSX.Element, domElement: HTMLElement | null): void;
+export function render(rootComponent: React.Component | React.JSX.Element, domElement: HTMLElement | null): void;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.