### PR TITLE
[react-sound] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-sound/react-sound-tests.tsx
+++ b/types/react-sound/react-sound-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import ReactSound from "react-sound";
 
-const ReactSoundRequiredOptions: JSX.Element = (
+const ReactSoundRequiredOptions: React.JSX.Element = (
     <ReactSound
         url="http://test.com"
         playStatus="STOPPED"
@@ -10,7 +10,7 @@ const ReactSoundRequiredOptions: JSX.Element = (
 
 const callbackFn = () => ({});
 
-const ReactSoundAllOptions: JSX.Element = (
+const ReactSoundAllOptions: React.JSX.Element = (
     <ReactSound
         url="http://test.com/audio.mp3"
         playStatus="PAUSED"


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.