### PR TITLE
[react-spinner] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-spinner/react-spinner-tests.tsx
+++ b/types/react-spinner/react-spinner-tests.tsx
@@ -1,4 +1,4 @@
 import * as React from "react";
 import Spinner from "react-spinner";
 
-const spinner: JSX.Element = <Spinner />;
+const spinner: React.JSX.Element = <Spinner />;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.