### PR TITLE
[react-splitter-layout] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-splitter-layout/react-splitter-layout-tests.tsx
+++ b/types/react-splitter-layout/react-splitter-layout-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import SplitterLayout, { SplitterLayoutProps } from "react-splitter-layout";
 
 export class SplitterLayoutTest extends React.PureComponent {
-    render(): JSX.Element {
+    render(): React.JSX.Element {
         const props: SplitterLayoutProps = {
             percentage: true,
             secondaryInitialSize: 40,


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.