### PR TITLE
[react-stickynode] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-stickynode/react-stickynode-tests.tsx
+++ b/types/react-stickynode/react-stickynode-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Sticky from "react-stickynode";
 
-const StickyAllOptions: JSX.Element = (
+const StickyAllOptions: React.JSX.Element = (
     <Sticky
         enabled={true}
         top={10}
@@ -20,19 +20,19 @@ const StickyAllOptions: JSX.Element = (
     </Sticky>
 );
 
-const StickyOptionalStringOptions: JSX.Element = (
+const StickyOptionalStringOptions: React.JSX.Element = (
     <Sticky top="#elem" bottomBoundary="#bottom" innerZ="1234">
         <div />
     </Sticky>
 );
 
-const StickyNoOptions: JSX.Element = (
+const StickyNoOptions: React.JSX.Element = (
     <Sticky>
         <div />
     </Sticky>
 );
 
-const StickyChildrenFunction: JSX.Element = (
+const StickyChildrenFunction: React.JSX.Element = (
     <Sticky>
         {status => {
             if (status.status === Sticky.STATUS_FIXED) {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.