### PR TITLE
[react-syntax-highlighter] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -3,7 +3,7 @@ type lineTagPropsFunction = (lineNumber: number) => React.HTMLProps<HTMLElement>
 interface rendererNode {
     type: "element" | "text";
     value?: string | number | undefined;
-    tagName?: keyof JSX.IntrinsicElements | React.ComponentType<any> | undefined;
+    tagName?: keyof React.JSX.IntrinsicElements | React.ComponentType<any> | undefined;
     properties?: { className: any[]; [key: string]: any };
     children?: rendererNode[];
 }
@@ -30,8 +30,8 @@ declare module "react-syntax-highlighter" {
         wrapLongLines?: boolean | undefined;
         lineProps?: lineTagPropsFunction | React.HTMLProps<HTMLElement> | undefined;
         renderer?: (props: rendererProps) => React.ReactNode;
-        PreTag?: keyof JSX.IntrinsicElements | React.ComponentType<any> | undefined;
-        CodeTag?: keyof JSX.IntrinsicElements | React.ComponentType<any> | undefined;
+        PreTag?: keyof React.JSX.IntrinsicElements | React.ComponentType<any> | undefined;
+        CodeTag?: keyof React.JSX.IntrinsicElements | React.ComponentType<any> | undefined;
         [spread: string]: any;
     }
 

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -24,7 +24,7 @@ const codeString = `class CPP {
 }
 `;
 
-function hljsHighlighter(): JSX.Element {
+function hljsHighlighter(): React.JSX.Element {
     SyntaxHighlighter.supportedLanguages; // $ExpectType string[]
 
     return (
@@ -34,7 +34,7 @@ function hljsHighlighter(): JSX.Element {
     );
 }
 
-function hljsLightHighlighter(): JSX.Element {
+function hljsLightHighlighter(): React.JSX.Element {
     LightHighlighter.registerLanguage("javascript", javascript);
 
     return (
@@ -44,7 +44,7 @@ function hljsLightHighlighter(): JSX.Element {
     );
 }
 
-function prismHighlighter(): JSX.Element {
+function prismHighlighter(): React.JSX.Element {
     PrismSyntaxHighlighter.supportedLanguages; // $ExpectType string[]
     return (
         <PrismSyntaxHighlighter language="javascript" style={oneDark}>
@@ -53,7 +53,7 @@ function prismHighlighter(): JSX.Element {
     );
 }
 
-function primsLightHighlighter(): JSX.Element {
+function primsLightHighlighter(): React.JSX.Element {
     PrismLightHighlighter.registerLanguage("jsx", jsx);
 
     return (


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.