### PR TITLE
[react-touch] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/react-touch/index.d.ts
+++ b/types/react-touch/index.d.ts
@@ -41,7 +41,7 @@ export interface DraggableCallbackArgument extends DraggableStyle {
     dy: number;
 }
 
-export type DraggableCallback = (argument: DraggableCallbackArgument) => JSX.Element;
+export type DraggableCallback = (argument: DraggableCallbackArgument) => React.JSX.Element;
 
 export interface DraggableProps {
     /**

--- a/types/react-touch/react-touch-tests.tsx
+++ b/types/react-touch/react-touch-tests.tsx
@@ -37,7 +37,7 @@ export class DraggableTest extends React.PureComponent {
         return <Draggable style={style} children={this.callback} />;
     }
 
-    private readonly callback = (argument: DraggableCallbackArgument): JSX.Element => {
+    private readonly callback = (argument: DraggableCallbackArgument): React.JSX.Element => {
         return <div />;
     };
 }


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.