### PR TITLE
[reactabular-table] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/reactabular-table/index.d.ts
+++ b/types/reactabular-table/index.d.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 export interface Column {
     property?: string | undefined;
     header?: {
-        label: string | JSX.Element;
+        label: string | React.JSX.Element;
         transforms?: ColumnTransform[] | undefined;
         formatters?: ColumnFormatter[] | undefined;
         draggable?: boolean | undefined;
@@ -18,24 +18,24 @@ export interface Column {
 }
 
 export interface Renderers {
-    table?: string | (() => JSX.Element) | undefined;
+    table?: string | (() => React.JSX.Element) | undefined;
     header?: {
-        wrapper?: string | ((props: any) => JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
-        row?: string | ((props: any) => JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
+        wrapper?: string | ((props: any) => React.JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
+        row?: string | ((props: any) => React.JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
         cell?:
             | string
-            | ((props: any, column: Column) => JSX.Element)
+            | ((props: any, column: Column) => React.JSX.Element)
             | ((props: any) => React.ReactInstance)
             | undefined;
     } | undefined;
     body?: {
-        wrapper?: string | ((props: any) => JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
-        row?: string | ((props: any, rowData: any) => JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
-        cell?: string | ((props: any) => JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
+        wrapper?: string | ((props: any) => React.JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
+        row?: string | ((props: any, rowData: any) => React.JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
+        cell?: string | ((props: any) => React.JSX.Element) | ((props: any) => React.ReactInstance) | undefined;
     } | undefined;
 }
 
-export type ColumnTransform = (label: string | JSX.Element | React.ReactInstance, props: {
+export type ColumnTransform = (label: string | React.JSX.Element | React.ReactInstance, props: {
     column: Column;
     columnIndex: number;
     property: string;
@@ -49,18 +49,18 @@ export type CellTransform = (value: any, props: {
     property: string;
 }) => any;
 
-export type ColumnFormatter = (label: string | JSX.Element, props: {
+export type ColumnFormatter = (label: string | React.JSX.Element, props: {
     rowData: any;
     column: Column;
     columnIndex: number;
-}) => string | JSX.Element;
+}) => string | React.JSX.Element;
 
 export type CellFormatter = (value: any, props: {
     column: Column;
     columnIndex: number;
     rowData: any;
     rowIndex: number;
-}) => string | JSX.Element;
+}) => string | React.JSX.Element;
 
 export interface ProviderProps {
     children?: React.ReactNode;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.