### PR TITLE
[redux-infinite-scroll] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/redux-infinite-scroll/index.d.ts
+++ b/types/redux-infinite-scroll/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, HTMLProps } from "react";
+import { Component, HTMLProps, JSX } from "react";
 
 interface InfiniteScrollerProps {
     elementIsScrollable?: boolean | undefined;

--- a/types/redux-infinite-scroll/redux-infinite-scroll-tests.tsx
+++ b/types/redux-infinite-scroll/redux-infinite-scroll-tests.tsx
@@ -9,7 +9,7 @@ class App extends React.Component {
     };
 
     _createData(numOfItems = this.state.numOfItems) {
-        const data: JSX.Element[] = [];
+        const data: React.JSX.Element[] = [];
         for (let i = 0; i < numOfItems; i++) {
             data.push(
                 <div key={i} className="test-item">Item #{i}</div>,


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.