### PR TITLE
[rn-material-ui-textfield] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -67,8 +67,8 @@ export interface TextFieldProps extends TextInputProps {
     titleTextStyle?: StyleProp<TextStyle> | undefined;
     affixTextStyle?: StyleProp<TextStyle> | undefined;
     formatText?(text: string): string;
-    renderLeftAccessory?(): JSX.Element;
-    renderRightAccessory?(): JSX.Element;
+    renderLeftAccessory?(): React.JSX.Element;
+    renderRightAccessory?(): React.JSX.Element;
     onChangeText?(text: string): void;
     onFocus?(event: NativeSyntheticEvent<TextInputFocusEventData>): void;
     onBlur?(event: NativeSyntheticEvent<TextInputChangeEventData>): void;


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.