### PR TITLE
[tuya-panel-kit] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/tuya-panel-kit/@react-navigation/core/types.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/core/types.d.ts
@@ -339,7 +339,7 @@ export declare type Descriptor<
     /**
      * Render the component associated with this route.
      */
-    render(): JSX.Element;
+    render(): React.JSX.Element;
     /**
      * Options for the route.
      */

--- a/types/tuya-panel-kit/@react-navigation/native/theming/ThemeProvider.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/native/theming/ThemeProvider.d.ts
@@ -6,5 +6,5 @@ declare type Props = {
     value: Theme;
     children: React.ReactNode;
 };
-export default function ThemeProvider({ value, children }: Props): JSX.Element;
+export default function ThemeProvider({ value, children }: Props): React.JSX.Element;
 export {};

--- a/types/tuya-panel-kit/@react-navigation/stack/navigators/createStackNavigator.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/stack/navigators/createStackNavigator.d.ts
@@ -1,6 +1,6 @@
-/// <reference types="react" />
 import { DefaultNavigatorOptions, StackNavigationState, StackRouterOptions } from "../../native";
 import type { StackNavigationConfig, StackNavigationEventMap, StackNavigationOptions } from "../types";
+import { JSX } from "react";
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 declare type Props = DefaultNavigatorOptions<StackNavigationOptions> & StackRouterOptions & StackNavigationConfig;
 declare function StackNavigator({ initialRouteName, children, screenOptions, ...rest }: Props): JSX.Element;

--- a/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderBackButton.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderBackButton.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="react" />
 import type { StackHeaderLeftButtonProps } from "../../types";
+import { JSX } from "react";
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 declare type Props = StackHeaderLeftButtonProps;
 export default function HeaderBackButton(

--- a/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderBackground.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderBackground.d.ts
@@ -5,5 +5,5 @@ declare type Props = ViewProps & {
     style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>> | undefined;
     children?: React.ReactNode | undefined;
 };
-export default function HeaderBackground({ style, ...rest }: Props): JSX.Element;
+export default function HeaderBackground({ style, ...rest }: Props): React.JSX.Element;
 export {};

--- a/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderTitle.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/stack/views/Header/HeaderTitle.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="react" />
 import { Animated, StyleProp, TextProps, TextStyle } from "react-native";
+import { JSX } from "react";
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 declare type Props = Omit<TextProps, "style"> & {
     tintColor?: string | undefined;

--- a/types/tuya-panel-kit/@react-navigation/stack/views/Stack/StackView.d.ts
+++ b/types/tuya-panel-kit/@react-navigation/stack/views/Stack/StackView.d.ts
@@ -170,6 +170,6 @@ export default class StackView extends React.Component<Props, State> {
     private handleGestureStart;
     private handleGestureEnd;
     private handleGestureCancel;
-    render(): JSX.Element;
+    render(): React.JSX.Element;
 }
 export {};

--- a/types/tuya-panel-kit/index.d.ts
+++ b/types/tuya-panel-kit/index.d.ts
@@ -10931,16 +10931,16 @@ export interface NavigationOptions {
     /**
      * 自定义渲染头部栏
      */
-    renderTopBar?: (() => JSX.Element) | undefined;
+    renderTopBar?: (() => React.JSX.Element) | undefined;
     /**
      * 自定义渲染状态栏
      */
-    renderStatusBar?: (() => JSX.Element) | undefined;
+    renderStatusBar?: (() => React.JSX.Element) | undefined;
 }
 
 export class NavigatorLayout<P = {}, S = {}> extends React.Component<P, { modalVisible: boolean } & S> {
     hookRoute(route: DeprecatedNavigatorRoute): NavigationOptions;
-    renderScene(route: DeprecatedNavigatorRoute, navigator: DeprecatedNavigator): JSX.Element | undefined;
+    renderScene(route: DeprecatedNavigatorRoute, navigator: DeprecatedNavigator): React.JSX.Element | undefined;
 }
 
 export interface NavigationRoute {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.