### PR TITLE
[video-react] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/video-react/index.d.ts
+++ b/types/video-react/index.d.ts
@@ -1,4 +1,4 @@
-import { LegacyRef } from "react";
+import { LegacyRef, JSX } from "react";
 
 export type PlayerReference = HTMLVideoElement & StaticPlayerInstanceMethods;
 

--- a/types/video-react/video-react-tests.tsx
+++ b/types/video-react/video-react-tests.tsx
@@ -11,7 +11,7 @@ import {
 
 const testProps: PlayerProps = { autoPlay: true };
 
-function TestComponent(props: PlayerProps): JSX.Element {
+function TestComponent(props: PlayerProps): React.JSX.Element {
     return (
         <Player {...testProps}>
             <ControlBar>


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.