### PR TITLE
[wordpress__block-editor] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__block-editor/components/alignment-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/alignment-toolbar.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 declare namespace AlignmentToolbar {
     interface Props {

--- a/types/wordpress__block-editor/components/block-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-controls.d.ts
@@ -1,5 +1,5 @@
 import { Slot, Toolbar } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace BlockControls {
     interface Props extends Pick<Toolbar.Props, "controls"> {

--- a/types/wordpress__block-editor/components/block-format-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-format-controls.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace BlockFormatControls {
     interface Props {

--- a/types/wordpress__block-editor/components/block-list.d.ts
+++ b/types/wordpress__block-editor/components/block-list.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 declare namespace BlockList {
     interface Props {

--- a/types/wordpress__block-editor/components/inner-blocks.d.ts
+++ b/types/wordpress__block-editor/components/inner-blocks.d.ts
@@ -1,5 +1,5 @@
 import { TemplateArray } from "@wordpress/blocks";
-import { ComponentType, Ref } from "react";
+import { ComponentType, Ref, JSX } from "react";
 
 import { EditorTemplateLock } from "../";
 

--- a/types/wordpress__block-editor/components/inspector-advanced-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-advanced-controls.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace InspectorAdvancedControls {
     interface Props {

--- a/types/wordpress__block-editor/components/inspector-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-controls.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace InspectorControls {
     interface Props {

--- a/types/wordpress__block-editor/components/media-placeholder.d.ts
+++ b/types/wordpress__block-editor/components/media-placeholder.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @definitelytyped/no-unnecessary-generics */
 import { Dashicon, DropZone } from "@wordpress/components";
-import { ComponentType, MouseEventHandler } from "react";
+import { ComponentType, MouseEventHandler, JSX } from "react";
 
 declare namespace MediaPlaceholder {
     type MediaPlaceholderMultipleAction = "add";

--- a/types/wordpress__block-editor/components/media-upload/index.d.ts
+++ b/types/wordpress__block-editor/components/media-upload/index.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 import { default as MediaPlaceholder } from "../media-placeholder";
 

--- a/types/wordpress__block-editor/components/rich-text.d.ts
+++ b/types/wordpress__block-editor/components/rich-text.d.ts
@@ -2,7 +2,7 @@
 import { BlockInstance } from "@wordpress/blocks";
 import { Autocomplete, ToolbarButton } from "@wordpress/components";
 import { displayShortcut, rawShortcut } from "@wordpress/keycodes";
-import { ComponentType, HTMLProps, ReactNode } from "react";
+import { ComponentType, HTMLProps, ReactNode, JSX } from "react";
 
 declare namespace RichText {
     interface Props<T extends keyof HTMLElementTagNameMap> extends Omit<HTMLProps<T>, "onChange"> {

--- a/types/wordpress__block-editor/components/url-popover.d.ts
+++ b/types/wordpress__block-editor/components/url-popover.d.ts
@@ -1,5 +1,5 @@
 import { Popover } from "@wordpress/components";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace URLPopover {
     interface Props extends Popover.Props {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.