### PR TITLE
[wordpress__blocks] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__blocks/api/categories.d.ts
+++ b/types/wordpress__blocks/api/categories.d.ts
@@ -1,5 +1,7 @@
 import { Dashicon } from "@wordpress/components";
 
+import { JSX } from "react";
+
 export interface Category {
     slug: string;
     title: string;

--- a/types/wordpress__blocks/api/node.d.ts
+++ b/types/wordpress__blocks/api/node.d.ts
@@ -1,4 +1,4 @@
-import { ReactChild, ReactElement } from "react";
+import { ReactChild, ReactElement, JSX } from "react";
 
 import children from "./children";
 

--- a/types/wordpress__blocks/api/parser.d.ts
+++ b/types/wordpress__blocks/api/parser.d.ts
@@ -1,4 +1,4 @@
-import { ReactChild } from "react";
+import { ReactChild, JSX } from "react";
 
 import { Block, BlockInstance } from "../";
 


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.