### PR TITLE
[wordpress__components] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__components/autocomplete/index.d.ts
+++ b/types/wordpress__components/autocomplete/index.d.ts
@@ -1,5 +1,5 @@
 import { Value } from "@wordpress/rich-text";
-import { ReactNode } from "react";
+import { ReactNode, JSX } from "react";
 
 declare namespace Autocomplete {
     /**

--- a/types/wordpress__components/base-control/index.d.ts
+++ b/types/wordpress__components/base-control/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace BaseControl {
     interface ControlProps {

--- a/types/wordpress__components/card/body/index.d.ts
+++ b/types/wordpress__components/card/body/index.d.ts
@@ -1,5 +1,7 @@
 import Card from "..";
 
+import { JSX } from "react";
+
 declare namespace CardBody {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/card/divider/index.d.ts
+++ b/types/wordpress__components/card/divider/index.d.ts
@@ -1,5 +1,7 @@
 import { HorizontalRule } from "../../primitives";
 
+import { JSX } from "react";
+
 declare namespace CardDivider {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/card/footer/index.d.ts
+++ b/types/wordpress__components/card/footer/index.d.ts
@@ -1,5 +1,7 @@
 import Card from "..";
 
+import { JSX } from "react";
+
 declare namespace CardFooter {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/card/header/index.d.ts
+++ b/types/wordpress__components/card/header/index.d.ts
@@ -1,5 +1,7 @@
 import Card from "..";
 
+import { JSX } from "react";
+
 declare namespace CardHeader {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 declare namespace Card {
     type CardSize = "large" | "medium" | "small" | "extraSmall";
     type Props<T extends keyof JSX.IntrinsicElements> = {

--- a/types/wordpress__components/card/media/index.d.ts
+++ b/types/wordpress__components/card/media/index.d.ts
@@ -1,3 +1,4 @@
+import { JSX } from "react";
 declare namespace CardMedia {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/disabled/index.d.ts
+++ b/types/wordpress__components/disabled/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, Consumer, ReactNode } from "react";
+import { ComponentType, Consumer, ReactNode, JSX } from "react";
 
 declare namespace Disabled {
     interface Props {

--- a/types/wordpress__components/dropdown-menu/index.d.ts
+++ b/types/wordpress__components/dropdown-menu/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 import Button from "../button";
 import Dashicon from "../dashicon";

--- a/types/wordpress__components/dropdown/index.d.ts
+++ b/types/wordpress__components/dropdown/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 import Popover from "../popover";
 

--- a/types/wordpress__components/form-file-upload/index.d.ts
+++ b/types/wordpress__components/form-file-upload/index.d.ts
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, ComponentType } from "react";
+import { ChangeEventHandler, ComponentType, JSX } from "react";
 
 import IconButton from "../icon-button";
 

--- a/types/wordpress__components/icon-button/index.d.ts
+++ b/types/wordpress__components/icon-button/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 import Button from "../button";
 import Dashicon from "../dashicon";

--- a/types/wordpress__components/icon/index.d.ts
+++ b/types/wordpress__components/icon/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactComponentElement, ReactDOM, SVGProps } from "react";
+import { ComponentType, ReactComponentElement, ReactDOM, SVGProps, JSX } from "react";
 
 import Dashicon from "../dashicon";
 

--- a/types/wordpress__components/placeholder/index.d.ts
+++ b/types/wordpress__components/placeholder/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, HTMLProps } from "react";
+import { ComponentType, HTMLProps, JSX } from "react";
 
 import Icon from "../icon";
 

--- a/types/wordpress__components/primitives/svg/index.d.ts
+++ b/types/wordpress__components/primitives/svg/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 export const Circle: ComponentType<JSX.IntrinsicElements["circle"]>;
 export const G: ComponentType<JSX.IntrinsicElements["g"]>;

--- a/types/wordpress__components/radio-control/index.d.ts
+++ b/types/wordpress__components/radio-control/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 import BaseControl from "../base-control";
 

--- a/types/wordpress__components/select-control/index.d.ts
+++ b/types/wordpress__components/select-control/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, HTMLProps } from "react";
+import { ComponentType, HTMLProps, JSX } from "react";
 
 import BaseControl from "../base-control";
 

--- a/types/wordpress__components/slot-fill/slot.d.ts
+++ b/types/wordpress__components/slot-fill/slot.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 declare namespace Slot {
     interface Props {

--- a/types/wordpress__components/tab-panel/index.d.ts
+++ b/types/wordpress__components/tab-panel/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 declare namespace TabPanel {
     interface Tab {

--- a/types/wordpress__components/tooltip/index.d.ts
+++ b/types/wordpress__components/tooltip/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 import Popover from "../popover";
 import Shortcut from "../shortcut";

--- a/types/wordpress__components/ui/context/wordpress-component.d.ts
+++ b/types/wordpress__components/ui/context/wordpress-component.d.ts
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef, ElementType } from "react";
+import type { ComponentPropsWithRef, ElementType, JSX } from "react";
 
 /**
  * This file copied from https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/ui/context/wordpress-component.ts


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.