### PR TITLE
[wordpress__edit-post] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__edit-post/components/block-settings-menu/plugin-block-settings-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/block-settings-menu/plugin-block-settings-menu-item.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, MouseEventHandler } from "react";
+import { ComponentType, MouseEventHandler, JSX } from "react";
 
 declare namespace PluginBlockSettingsMenuItem {
     interface Props {

--- a/types/wordpress__edit-post/components/header/plugin-more-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/header/plugin-more-menu-item.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon, MenuItem } from "@wordpress/components";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace PluginMoreMenuItem {
     interface Props extends Omit<MenuItem.Props, "href"> {

--- a/types/wordpress__edit-post/components/header/plugin-sidebar-more-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/header/plugin-sidebar-more-menu-item.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace PluginSidebarMoreMenuItem {
     interface Props {

--- a/types/wordpress__edit-post/components/sidebar/plugin-document-setting-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-document-setting-panel.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon, Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace PluginDocumentSettingPanel {
     interface Props {

--- a/types/wordpress__edit-post/components/sidebar/plugin-post-publish-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-post-publish-panel.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace PluginPostPublishPanel {
     interface Props {

--- a/types/wordpress__edit-post/components/sidebar/plugin-post-status-info.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-post-status-info.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace PluginPostStatusInfo {
     interface Props {

--- a/types/wordpress__edit-post/components/sidebar/plugin-pre-publish-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-pre-publish-panel.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, JSX } from "react";
 
 declare namespace PluginPrePublishPanel {
     interface Props {

--- a/types/wordpress__edit-post/components/sidebar/plugin-sidebar.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-sidebar.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace PluginSidebar {
     interface Props {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.