### PR TITLE
[wordpress__editor] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__editor/components/post-taxonomies/index.d.ts
+++ b/types/wordpress__editor/components/post-taxonomies/index.d.ts
@@ -1,5 +1,5 @@
 import { Taxonomy } from "@wordpress/core-data";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, JSX } from "react";
 
 declare namespace PostTaxonomies {
     interface Props {

--- a/types/wordpress__editor/components/post-visibility/check.d.ts
+++ b/types/wordpress__editor/components/post-visibility/check.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType, JSX } from "react";
 
 declare namespace PostVisibilityCheck {
     interface RenderProps {


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.