### PR TITLE
[wordpress__notices] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -1,5 +1,5 @@
 import { StoreDescriptor } from "@wordpress/data";
-import { MouseEventHandler } from "react";
+import { MouseEventHandler, JSX } from "react";
 
 declare module "@wordpress/data" {
     function dispatch(key: "core/notices"): typeof import("./store/actions");


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.