### PR TITLE
Update string.prototype.matchall for TS 5.4

### DIFF
--- a/types/string.prototype.matchall/index.d.ts
+++ b/types/string.prototype.matchall/index.d.ts
@@ -4,7 +4,7 @@
  * @param str string to match
  * @param regexp A variable name or string literal containing the regular expression pattern and flags.
  */
-declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpMatchArray>;
+declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpExecArray>;
 
 declare namespace matchAll {
     function shim(): void;

--- a/types/string.prototype.matchall/package.json
+++ b/types/string.prototype.matchall/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "name": "@types/string.prototype.matchall",
+    "minimumTypeScriptVersion": "5.4",
     "version": "4.0.9999",
     "projects": [
         "https://github.com/ljharb/String.prototype.matchAll#readme"

--- a/types/string.prototype.matchall/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/string.prototype.matchall-tests.ts
@@ -4,9 +4,9 @@ const str = "aabc";
 const nonRegexStr = "ab";
 const globalRegex = /[ac]/g;
 
-matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpMatchArray>
-matchAll(str, new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpMatchArray>
-matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpExecArray>
+matchAll(str, new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpExecArray>
+matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpExecArray>
 matchAll.shim(); // $ExpectType void
-str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
-str.matchAll(new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpMatchArray>
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpExecArray>
+str.matchAll(new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpExecArray>


### PR DESCRIPTION
matchAll actually returns RegExpExecArray not RegExpMatchArray -- index and input are not optional. TS 5.4 just fixed this, so string.prototype.matchall needs an update too.

Caused by https://github.com/microsoft/TypeScript/pull/55565
