### PR TITLE
[react] Move addons and mixin tests to their packages

### DIFF
--- a/types/react-addons-create-fragment/package.json
+++ b/types/react-addons-create-fragment/package.json
@@ -9,6 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
+        "@types/react-dom-factories": "*",
         "@types/react-addons-create-fragment": "workspace:."
     },
     "owners": [

--- a/types/react-addons-create-fragment/react-addons-create-fragment-tests.ts
+++ b/types/react-addons-create-fragment/react-addons-create-fragment-tests.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import * as React from "react";
 import * as DOM from "react-dom-factories";
 import createFragment = require("react-addons-create-fragment");
 

--- a/types/react-addons-create-fragment/react-addons-create-fragment-tests.ts
+++ b/types/react-addons-create-fragment/react-addons-create-fragment-tests.ts
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import * as DOM from "react-dom-factories";
+import createFragment = require("react-addons-create-fragment");
+
+createFragment({
+    a: DOM.div(),
+    b: ["a", false, React.createElement("span")],
+});

--- a/types/react-addons-create-fragment/tsconfig.json
+++ b/types/react-addons-create-fragment/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-create-fragment-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react-addons-linked-state-mixin/package.json
+++ b/types/react-addons-linked-state-mixin/package.json
@@ -9,6 +9,8 @@
         "@types/react": "*"
     },
     "devDependencies": {
+        "@types/create-react-class": "*",
+        "@types/react-dom-factories": "*",
         "@types/react-addons-linked-state-mixin": "workspace:."
     },
     "owners": [

--- a/types/react-addons-linked-state-mixin/react-addons-linked-state-mixin-tests.ts
+++ b/types/react-addons-linked-state-mixin/react-addons-linked-state-mixin-tests.ts
@@ -1,0 +1,26 @@
+import * as DOM from "react-dom-factories";
+import * as LinkedStateMixin from "react-addons-linked-state-mixin";
+import createReactClass = require("create-react-class");
+
+createReactClass({
+    mixins: [LinkedStateMixin],
+    getInitialState() {
+        return {
+            isChecked: false,
+            message: "hello!",
+        };
+    },
+    render() {
+        return DOM.div(
+            null,
+            DOM.input({
+                type: "checkbox",
+                checkedLink: this.linkState("isChecked"),
+            }),
+            DOM.input({
+                type: "text",
+                valueLink: this.linkState("message"),
+            }),
+        );
+    },
+});

--- a/types/react-addons-linked-state-mixin/react-addons-linked-state-mixin-tests.ts
+++ b/types/react-addons-linked-state-mixin/react-addons-linked-state-mixin-tests.ts
@@ -1,5 +1,5 @@
-import * as DOM from "react-dom-factories";
 import * as LinkedStateMixin from "react-addons-linked-state-mixin";
+import * as DOM from "react-dom-factories";
 import createReactClass = require("create-react-class");
 
 createReactClass({

--- a/types/react-addons-linked-state-mixin/tsconfig.json
+++ b/types/react-addons-linked-state-mixin/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-linked-state-mixin-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react-addons-pure-render-mixin/package.json
+++ b/types/react-addons-pure-render-mixin/package.json
@@ -9,6 +9,8 @@
         "@types/react": "*"
     },
     "devDependencies": {
+        "@types/create-react-class": "*",
+        "@types/react-dom-factories": "*",
         "@types/react-addons-pure-render-mixin": "workspace:."
     },
     "owners": [

--- a/types/react-addons-pure-render-mixin/react-addons-pure-render-mixin-tests.ts
+++ b/types/react-addons-pure-render-mixin/react-addons-pure-render-mixin-tests.ts
@@ -1,4 +1,3 @@
-
 import * as PureRenderMixin from "react-addons-pure-render-mixin";
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";

--- a/types/react-addons-pure-render-mixin/react-addons-pure-render-mixin-tests.ts
+++ b/types/react-addons-pure-render-mixin/react-addons-pure-render-mixin-tests.ts
@@ -1,0 +1,11 @@
+
+import * as PureRenderMixin from "react-addons-pure-render-mixin";
+import createReactClass = require("create-react-class");
+import * as DOM from "react-dom-factories";
+
+createReactClass({
+    mixins: [PureRenderMixin],
+    render() {
+        return DOM.div(null);
+    },
+});

--- a/types/react-addons-pure-render-mixin/tsconfig.json
+++ b/types/react-addons-pure-render-mixin/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-pure-render-mixin-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react-addons-update/react-addons-update-tests.ts
+++ b/types/react-addons-update/react-addons-update-tests.ts
@@ -1,0 +1,21 @@
+import update = require("react-addons-update");
+
+// These are copied from https://facebook.github.io/react/docs/update.html
+const initialArray = [1, 2, 3];
+const newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
+
+const collection = [1, 2, { a: [12, 17, 15] }];
+const newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
+// => [1, 2, {a: [12, 13, 14, 15]}]
+
+const obj = { a: 5, b: 3 };
+const newObj = update(obj, {
+    b: {
+        $apply: x => x * 2,
+    },
+});
+// => {a: 5, b: 6}
+const newObj2 = update(obj, { b: { $set: obj.b * 2 } });
+
+const objShallow = { a: 5, b: 3 };
+const newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}

--- a/types/react-addons-update/tsconfig.json
+++ b/types/react-addons-update/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-update-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -2,12 +2,6 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactDOMServer from "react-dom/server";
-import createFragment = require("react-addons-create-fragment");
-import * as LinkedStateMixin from "react-addons-linked-state-mixin";
-import * as PureRenderMixin from "react-addons-pure-render-mixin";
-import shallowCompare = require("react-addons-shallow-compare");
-import update = require("react-addons-update");
-import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
 import "trusted-types";
 
@@ -180,10 +174,6 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
                 onChange: event => console.log(event.target),
             }),
         );
-    }
-
-    shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: any): boolean {
-        return shallowCompare(this, nextProps, nextState);
     }
 
     getSnapshotBeforeUpdate(prevProps: Readonly<Props>) {
@@ -604,75 +594,6 @@ const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => 
 // The return type may not be an array
 // @ts-expect-error
 const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
-
-//
-// createFragment addon
-// --------------------------------------------------------------------------
-createFragment({
-    a: DOM.div(),
-    b: ["a", false, React.createElement("span")],
-});
-
-//
-// LinkedStateMixin addon
-// --------------------------------------------------------------------------
-createReactClass({
-    mixins: [LinkedStateMixin],
-    getInitialState() {
-        return {
-            isChecked: false,
-            message: "hello!",
-        };
-    },
-    render() {
-        return DOM.div(
-            null,
-            DOM.input({
-                type: "checkbox",
-                checkedLink: this.linkState("isChecked"),
-            }),
-            DOM.input({
-                type: "text",
-                valueLink: this.linkState("message"),
-            }),
-        );
-    },
-});
-
-//
-// PureRenderMixin addon
-// --------------------------------------------------------------------------
-createReactClass({
-    mixins: [PureRenderMixin],
-    render() {
-        return DOM.div(null);
-    },
-});
-
-//
-// update addon
-// --------------------------------------------------------------------------
-{
-    // These are copied from https://facebook.github.io/react/docs/update.html
-    const initialArray = [1, 2, 3];
-    const newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
-
-    const collection = [1, 2, { a: [12, 17, 15] }];
-    const newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
-    // => [1, 2, {a: [12, 13, 14, 15]}]
-
-    const obj = { a: 5, b: 3 };
-    const newObj = update(obj, {
-        b: {
-            $apply: x => x * 2,
-        },
-    });
-    // => {a: 5, b: 6}
-    const newObj2 = update(obj, { b: { $set: obj.b * 2 } });
-
-    const objShallow = { a: 5, b: 3 };
-    const newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}
-}
 
 //
 // Events

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -1,8 +1,8 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import * as ReactDOMServer from "react-dom/server";
 import * as DOM from "react-dom-factories";
+import * as ReactDOMServer from "react-dom/server";
 import "trusted-types";
 
 // NOTE: forward declarations for tests

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -2,12 +2,6 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactDOMServer from "react-dom/server";
-import createFragment = require("react-addons-create-fragment");
-import * as LinkedStateMixin from "react-addons-linked-state-mixin";
-import * as PureRenderMixin from "react-addons-pure-render-mixin";
-import shallowCompare = require("react-addons-shallow-compare");
-import update = require("react-addons-update");
-import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
 import "trusted-types";
 
@@ -180,10 +174,6 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
                 onChange: event => console.log(event.target),
             }),
         );
-    }
-
-    shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: any): boolean {
-        return shallowCompare(this, nextProps, nextState);
     }
 
     getSnapshotBeforeUpdate(prevProps: Readonly<Props>) {
@@ -612,75 +602,6 @@ const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => 
 // The return type may not be an array
 // @ts-expect-error
 const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
-
-//
-// createFragment addon
-// --------------------------------------------------------------------------
-createFragment({
-    a: DOM.div(),
-    b: ["a", false, React.createElement("span")],
-});
-
-//
-// LinkedStateMixin addon
-// --------------------------------------------------------------------------
-createReactClass({
-    mixins: [LinkedStateMixin],
-    getInitialState() {
-        return {
-            isChecked: false,
-            message: "hello!",
-        };
-    },
-    render() {
-        return DOM.div(
-            null,
-            DOM.input({
-                type: "checkbox",
-                checkedLink: this.linkState("isChecked"),
-            }),
-            DOM.input({
-                type: "text",
-                valueLink: this.linkState("message"),
-            }),
-        );
-    },
-});
-
-//
-// PureRenderMixin addon
-// --------------------------------------------------------------------------
-createReactClass({
-    mixins: [PureRenderMixin],
-    render() {
-        return DOM.div(null);
-    },
-});
-
-//
-// update addon
-// --------------------------------------------------------------------------
-{
-    // These are copied from https://facebook.github.io/react/docs/update.html
-    const initialArray = [1, 2, 3];
-    const newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
-
-    const collection = [1, 2, { a: [12, 17, 15] }];
-    const newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
-    // => [1, 2, {a: [12, 13, 14, 15]}]
-
-    const obj = { a: 5, b: 3 };
-    const newObj = update(obj, {
-        b: {
-            $apply: x => x * 2,
-        },
-    });
-    // => {a: 5, b: 6}
-    const newObj2 = update(obj, { b: { $set: obj.b * 2 } });
-
-    const objShallow = { a: 5, b: 3 };
-    const newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}
-}
 
 //
 // Events

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -1,8 +1,8 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import * as ReactDOMServer from "react-dom/server";
 import * as DOM from "react-dom-factories";
+import * as ReactDOMServer from "react-dom/server";
 import "trusted-types";
 
 // NOTE: forward declarations for tests


### PR DESCRIPTION
Since these tests are testing stuff from the package, their tests should live their as well. Integration testing with React actual still happens due to being in the same repo.