### PR TITLE
[git-semver-tags] update types to reflect new Promise-based api introduced in 7.x

### DIFF
--- a/types/git-semver-tags/git-semver-tags-tests.ts
+++ b/types/git-semver-tags/git-semver-tags-tests.ts
@@ -1,25 +1,24 @@
 import * as gitSemverTags from "git-semver-tags";
 
-declare const callback: gitSemverTags.Callback;
 declare const options: gitSemverTags.Options;
 
-// $ExpectType void
-gitSemverTags(callback);
-
-gitSemverTags({ tagPrefix: "skip/", skipUnstable: true }, (err, tags) => {
-    if (err) {
-        //
-    }
-});
-
-// $ExpectType void
-gitSemverTags(options, callback);
-
-// @ts-expect-error
+// $ExpectType Promise<string[]>
 gitSemverTags();
 
-// @ts-expect-error
+// $ExpectType Promise<string[]>
 gitSemverTags(options);
 
 // @ts-expect-error
-gitSemverTags(callback, options);
+gitSemverTags({ ...options, foo: "bar" });
+
+// @ts-expect-error
+gitSemverTags({ ...options, lernaTags: "not a boolean" });
+
+// @ts-expect-error
+gitSemverTags({ ...options, package: 123 });
+
+// @ts-expect-error
+gitSemverTags({ ...options, tagPrefix: 123 });
+
+// @ts-expect-error
+gitSemverTags({ ...options, skipUnstable: "not a boolean" });

--- a/types/git-semver-tags/index.d.ts
+++ b/types/git-semver-tags/index.d.ts
@@ -1,12 +1,9 @@
 /**
  * Get all git semver tags of your repository in reverse chronological order
  */
-declare function gitSemverTags(options: gitSemverTags.Options, callback: gitSemverTags.Callback): void;
-declare function gitSemverTags(callback: gitSemverTags.Callback): void;
+declare function gitSemverTags(options?: gitSemverTags.Options): Promise<string[]>;
 
 declare namespace gitSemverTags {
-    type Callback = (error: any, tags: string[]) => void;
-
     interface Options {
         /**
          * Extract lerna style tags (`foo-package@2.0.0`) from the git history, rather

--- a/types/git-semver-tags/package.json
+++ b/types/git-semver-tags/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/git-semver-tags",
-    "version": "4.1.9999",
+    "version": "7.0.9999",
     "projects": [
         "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/git-semver-tags#readme"
     ],


### PR DESCRIPTION
This PR updates the types for `git-semver-tags` to reflect the breaking API changes introduced in `7.x`. Basically, instead of Node style callback, a `Promise` is returned instead.

I also added a couple more cases in the tests such to cover each of the options available in `gitSemverTags.Options`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [CHANGELOG](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/git-semver-tags/CHANGELOG.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
