### PR TITLE
[rc-tooltip] Remove usage of deprecated ReactChild

### DIFF
--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -35,7 +35,7 @@ declare namespace RCTooltip {
         placement?: Placement | Object | undefined;
         align?: Object | undefined;
         onPopupAlign?: ((popupDomNode: Element, align: Object) => void) | undefined;
-        overlay: (() => React.ReactChild) | React.ReactChild | React.ReactFragment | React.ReactPortal;
+        overlay: (() => React.ReactElement | number | string) | React.ReactElement | number | string | React.ReactFragment | React.ReactPortal;
         arrowContent?: React.ReactNode | undefined;
         getTooltipContainer?: (() => Element) | undefined;
         destroyTooltipOnHide?: boolean | undefined;


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).