### PR TITLE
[react-document-title] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-document-title/index.d.ts
+++ b/types/react-document-title/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 interface DocumentTitleProps {
     title: string;
-    children?: React.ReactChild | null | undefined;
+    children?: React.ReactElement | number | string | null | undefined;
 }
 
 declare class DocumentTitle extends React.Component<DocumentTitleProps, any> {


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).