### PR TITLE
[react-facebook-login] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-facebook-login/dist/facebook-login-render-props.d.ts
+++ b/types/react-facebook-login/dist/facebook-login-render-props.d.ts
@@ -13,7 +13,7 @@ export interface RenderProps {
 }
 
 export interface ReactFacebookLoginRenderProps extends ReactFacebookLoginProps {
-    render?: (renderProps: RenderProps) => React.ReactChild;
+    render?: (renderProps: RenderProps) => React.ReactElement | number | string;
 }
 
 export default class FacebookLoginRender extends React.Component<


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).