### PR TITLE
[react-instantsearch-core] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -798,7 +798,7 @@ export interface DynamicWidgetsExposed {
      * on the result of facetOrdering. This means that any child needs
      * to have either the “attribute” or “attributes” prop.
      */
-    children?: React.ReactChild;
+    children?: React.ReactElement | number | string;
     /**
      * A function to transform the attributes to render,
      * or using a different source to determine the attributes to render.

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -709,7 +709,7 @@ import { Hits, RefinementList } from "react-instantsearch-dom";
 });
 
 (() => {
-    function getAttribute(component: React.ReactChild): string | undefined {
+    function getAttribute(component: React.ReactElement | number | string): string | undefined {
         if (typeof component !== "object") {
             return undefined;
         }
@@ -735,7 +735,7 @@ import { Hits, RefinementList } from "react-instantsearch-dom";
         const widgets = new Map();
 
         React.Children.forEach(children, child => {
-            const attribute = getAttribute(child as React.ReactChild);
+            const attribute = getAttribute(child as React.ReactElement | number | string);
             if (!attribute) {
                 throw new Error("Could not find \"attribute\" prop");
             }


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).