### PR TITLE
[react-native-scrollable-tab-view] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-native-scrollable-tab-view/index.d.ts
+++ b/types/react-native-scrollable-tab-view/index.d.ts
@@ -120,7 +120,7 @@ export default class ScrollableTabView extends React.Component<ScrollableTabView
 // Each top-level child component should have a tabLabel prop
 // that can be used by the tab bar component to render out the labels.
 export type TabProps<T = {}> = T & {
-    tabLabel: React.ReactChild;
+    tabLabel: React.ReactElement | number | string;
 };
 
 export interface DefaultTabBarProps {


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).