### PR TITLE
[react-no-ssr] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-no-ssr/index.d.ts
+++ b/types/react-no-ssr/index.d.ts
@@ -2,5 +2,5 @@ import * as React from "react";
 
 export default class NoSSR extends React.Component<{
     children?: React.ReactNode;
-    onSSR?: React.ReactChild | undefined;
+    onSSR?: React.ReactElement | number | string | undefined;
 }> {}


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).