### PR TITLE
[react-tag-input] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -40,7 +40,7 @@ export interface ReactTagsProps {
     allowUnique?: boolean | undefined;
     allowDragDrop?: boolean | undefined;
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    renderSuggestion?(tag: Tag, query: string): React.ReactChild | void;
+    renderSuggestion?(tag: Tag, query: string): React.ReactElement | number | string | void;
     shouldRenderSuggestions?: ((query: string) => boolean) | undefined;
 
     classNames?: {


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).