### PR TITLE
[react-tagsinput] Remove usage of deprecated ReactChild

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -35,7 +35,7 @@ declare namespace TagsInput {
         readonly key: number;
     }
 
-    type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactChild;
+    type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactElement | number | string;
 
     interface ReactTagsInputProps<Tag = any> {
         children?: React.ReactNode;


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).