### PR TITLE
[wordpress__blocks] Remove usage of deprecated ReactChild

### DIFF
--- a/types/wordpress__blocks/api/children.d.ts
+++ b/types/wordpress__blocks/api/children.d.ts
@@ -1,4 +1,4 @@
-import { ReactChild } from "react";
+import { ReactElement } from "react";
 
 declare namespace children {
     /**
@@ -9,7 +9,7 @@ declare namespace children {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function concat(...blockNodes: ReactChild[]): ReactChild[];
+    function concat(...blockNodes: Array<ReactElement | number | string>): React.ReactElement | number | string[];
 
     /**
      * Given an iterable set of DOM nodes, returns equivalent block children.
@@ -19,7 +19,7 @@ declare namespace children {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function fromDOM(domNodes: ArrayLike<Node>): ReactChild[];
+    function fromDOM(domNodes: ArrayLike<Node>): Array<ReactElement | number | string>;
 
     /**
      * Given block children, returns an array of block nodes.
@@ -28,7 +28,7 @@ declare namespace children {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function getChildrenArray(children: ReactChild[]): ReactChild[];
+    function getChildrenArray(children: ReactElement | number | string[]): React.ReactElement | number | string[];
 
     /**
      * Given a selector, returns an hpq matcher generating a WPBlockChildren value
@@ -38,7 +38,7 @@ declare namespace children {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function matcher(selector: string): (domNode: Node & ParentNode) => ReactChild[];
+    function matcher(selector: string): (domNode: Node & ParentNode) => Array<React.ReactElement | number | string>;
 
     /**
      * Given a block node, returns its HTML string representation.
@@ -47,7 +47,7 @@ declare namespace children {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function toHTML(children: ReactChild[]): string;
+    function toHTML(children: React.ReactElement | number | string[]): string;
 }
 
 export default children;

--- a/types/wordpress__blocks/api/node.d.ts
+++ b/types/wordpress__blocks/api/node.d.ts
@@ -1,4 +1,4 @@
-import { JSX, ReactChild, ReactElement } from "react";
+import { JSX, ReactElement } from "react";
 
 import children from "./children";
 
@@ -50,7 +50,7 @@ declare namespace node {
      *
      * @deprecated since 11.17.0. Use the html source instead.
      */
-    function toHTML(node: ReactChild): string;
+    function toHTML(node: ReactElement | number | string): string;
 }
 
 export default node;

--- a/types/wordpress__blocks/api/parser.d.ts
+++ b/types/wordpress__blocks/api/parser.d.ts
@@ -1,4 +1,4 @@
-import { JSX, ReactChild } from "react";
+import { JSX, ReactElement } from "react";
 
 import { Block, BlockInstance } from "../";
 
@@ -68,7 +68,7 @@ export type Source<T> =
 
 // prettier-ignore
 export type SourceReturnValue<T> = T extends Schema.Attribute & { type: "boolean" } ? boolean | undefined
-    : T extends Schema.Children ? ReactChild[]
+    : T extends Schema.Children ? ReactElement | number | string[]
     : T extends Schema.Node ? JSX.Element | null
     : T extends Schema.Tag ? keyof (HTMLElementTagNameMap & SVGElementTagNameMap) | undefined
     : T extends Schema.Query<infer U> ? {
@@ -94,7 +94,10 @@ export function parseWithAttributeSchema(
     innerHTML: string,
     schema: Schema.Attribute | Schema.HTML | Schema.Text,
 ): string | undefined;
-export function parseWithAttributeSchema(innerHTML: string, schema: Schema.Children): ReactChild[];
+export function parseWithAttributeSchema(
+    innerHTML: string,
+    schema: Schema.Children,
+): Array<ReactElement | number | string>;
 export function parseWithAttributeSchema(innerHTML: string, schema: Schema.Node): JSX.Element | null;
 export function parseWithAttributeSchema(
     innerHTML: string,

--- a/types/wordpress__blocks/api/serializer.d.ts
+++ b/types/wordpress__blocks/api/serializer.d.ts
@@ -1,4 +1,4 @@
-import { ReactChild } from "react";
+import { ReactElement } from "react";
 
 import { Block, BlockInstance } from "../";
 
@@ -43,7 +43,7 @@ export function getSaveElement<T extends Record<string, any>>(
     blockTypeOrName: Block<T> | string,
     attributes: T,
     innerBlocks?: BlockInstance[],
-): ReactChild;
+): ReactElement | number | string;
 
 /**
  * Takes a block or set of blocks and returns the serialized post content.

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -82,10 +82,10 @@ blocks.updateCategory("foo", { title: "Foobar" });
 // children
 // ----------------------------------------------------------------------------
 
-// $ExpectType ReactChild[]
+// $ExpectType (string | number | ReactElement<any, string | JSXElementConstructor<any>>)[]
 blocks.children.fromDOM(document.querySelectorAll("div"));
 
-// $ExpectType (domNode: Node & ParentNode) => ReactChild[]
+// $ExpectType (domNode: Node & ParentNode) => (string | number | ReactElement<any, string | JSXElementConstructor<any>>)[]
 blocks.children.matcher(".foo");
 
 //
@@ -187,13 +187,13 @@ blocks.parseWithAttributeSchema(TEST_HTML, {
     selector: "#root",
 });
 
-// $ExpectType ReactChild[]
+// $ExpectType (string | number | ReactElement<any, string | JSXElementConstructor<any>>)[]
 blocks.parseWithAttributeSchema(TEST_HTML, {
     source: "children",
     selector: "#root",
 });
 
-// $ExpectType ReactChild[]
+// $ExpectType (string | number | ReactElement<any, string | JSXElementConstructor<any>>)[]
 blocks.parseWithAttributeSchema(TEST_HTML, {
     source: "children",
 });
@@ -586,10 +586,10 @@ blocks.getSaveContent(BLOCK, { foo: "bar" }, []);
 // @ts-expect-error
 blocks.getSavecontent(BLOCK, false, []);
 
-// $ExpectType ReactChild
+// $ExpectType string | number | ReactElement<any, string | JSXElementConstructor<any>>
 blocks.getSaveElement("my/foo", { foo: "bar" });
 
-// $ExpectType ReactChild
+// $ExpectType string | number | ReactElement<any, string | JSXElementConstructor<any>>
 blocks.getSaveElement(BLOCK, { foo: "bar" });
 
 // @ts-expect-error


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).