### PR TITLE
[wordpress__components] Remove usage of deprecated ReactChild

### DIFF
--- a/types/wordpress__components/responsive-wrapper/index.d.ts
+++ b/types/wordpress__components/responsive-wrapper/index.d.ts
@@ -1,8 +1,8 @@
-import { ComponentType, ReactChild } from "react";
+import { ComponentType, ReactElement } from "react";
 
 declare namespace ResponsiveWrapper {
     interface Props {
-        children: ReactChild;
+        children: ReactElement | number | string;
         naturalHeight: number;
         naturalWidth: number;
     }


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactChild` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).