### PR TITLE
[react-animals] Ensure types use same React version as runtime

### DIFF
--- a/types/react-animals/package.json
+++ b/types/react-animals/package.json
@@ -6,7 +6,7 @@
         "https://github.com/arvinpoddar/react-animals"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^16"
     },
     "devDependencies": {
         "@types/react-animals": "workspace:."

--- a/types/react-animals/tsconfig.json
+++ b/types/react-animals/tsconfig.json
@@ -11,12 +11,7 @@
         "jsx": "preserve",
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "react": [
-                "../../react/v16/index.d.ts"
-            ]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/react-animals/tsconfig.json
+++ b/types/react-animals/tsconfig.json
@@ -11,7 +11,12 @@
         "jsx": "preserve",
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "react": [
+                "../../react/v16/index.d.ts"
+            ]
+        }
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Main motivation is using a not-deprecated version of `React.VFC`