### PR TITLE
[fbt] Replace usage of React's global JSX namespace with scoped JSX

### DIFF
--- a/types/fbt/index.d.ts
+++ b/types/fbt/index.d.ts
@@ -269,7 +269,7 @@ export interface FbtProps extends FbtOptions {
     desc: string;
 }
 
-declare global {
+declare module "react" {
     namespace JSX {
         type PropsWithChildren<P> = P & { children?: React.ReactNode | undefined };
         type PropsWithStringChild<P> = P & { children?: string | string[] | undefined };


### PR DESCRIPTION
Was deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464. Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67588.