### PR TITLE
[pacote] don't disable ExpectType errors

### DIFF
--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -23,17 +23,13 @@ const opts: pacote.Options = {
 pacote.resolve("pacote"); // $ExpectType Promise<string>
 pacote.resolve("pacote", opts); // $ExpectType Promise<string>
 
-// tslint:disable-next-line:expect
 pacote.manifest("pacote"); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
-// tslint:disable-next-line:expect
 pacote.manifest("pacote", opts); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
 pacote.manifest("pacote", { before: new Date() }); // $ExpectType Promise<Manifest & ManifestResult>
 pacote.manifest("pacote", { fullMetadata: true }); // $ExpectType Promise<Manifest & ManifestResult>
 
-// tslint:disable-next-line:expect
-pacote.packument("pacote"); // $ExpectType Promise<AbbreviatedPackument & PackumentResult>
-// tslint:disable-next-line:expect
-pacote.packument("pacote", opts); // $ExpectType Promise<AbbreviatedPackument & PackumentResult>
+pacote.packument("pacote"); // $ExpectType Promise<AbbreviatedPackument & PackumentResult> || Promise<{ versions: Record<string, AbbreviatedManifest>; } & Pick<Packument, "name" | "dist-tags"> & PackumentResult>
+pacote.packument("pacote", opts); // $ExpectType Promise<AbbreviatedPackument & PackumentResult> || Promise<{ versions: Record<string, AbbreviatedManifest>; } & Pick<Packument, "name" | "dist-tags"> & PackumentResult>
 pacote.packument("pacote", { fullMetadata: true }); // $ExpectType Promise<Packument & PackumentResult>
 
 pacote.extract("pacote", "./"); // $ExpectType Promise<FetchResult>


### PR DESCRIPTION
These tests disabled ExpectType failures. https://github.com/microsoft/DefinitelyTyped-tools/pull/843 will be porting the rule from tslint to eslint, so these disables won't apply anymore. It's better to just fix the expects anyhow; disabling the lint rule is the wrong way to fix the problem.