### PR TITLE
Changing metascraper version to avoid breaking change

### DIFF
--- a/types/metascraper-address/package.json
+++ b/types/metascraper-address/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-address": "workspace:."

--- a/types/metascraper-amazon/package.json
+++ b/types/metascraper-amazon/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-amazon": "workspace:."

--- a/types/metascraper-author/package.json
+++ b/types/metascraper-author/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-author": "workspace:."

--- a/types/metascraper-clearbit/package.json
+++ b/types/metascraper-clearbit/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-clearbit": "workspace:."

--- a/types/metascraper-date/package.json
+++ b/types/metascraper-date/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-date": "workspace:."

--- a/types/metascraper-iframe/package.json
+++ b/types/metascraper-iframe/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-iframe": "workspace:."

--- a/types/metascraper-image/package.json
+++ b/types/metascraper-image/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-image": "workspace:."

--- a/types/metascraper-lang/package.json
+++ b/types/metascraper-lang/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-lang": "workspace:."

--- a/types/metascraper-logo-favicon/package.json
+++ b/types/metascraper-logo-favicon/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-logo-favicon": "workspace:."

--- a/types/metascraper-media-provider/package.json
+++ b/types/metascraper-media-provider/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-media-provider": "workspace:."

--- a/types/metascraper-publisher/package.json
+++ b/types/metascraper-publisher/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-publisher": "workspace:."

--- a/types/metascraper-soundcloud/package.json
+++ b/types/metascraper-soundcloud/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-soundcloud": "workspace:."

--- a/types/metascraper-spotify/package.json
+++ b/types/metascraper-spotify/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-spotify": "workspace:."

--- a/types/metascraper-title/package.json
+++ b/types/metascraper-title/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-title": "workspace:."

--- a/types/metascraper-url/package.json
+++ b/types/metascraper-url/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-url": "workspace:."

--- a/types/metascraper-video/package.json
+++ b/types/metascraper-video/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-video": "workspace:."

--- a/types/metascraper-youtube/package.json
+++ b/types/metascraper-youtube/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/metascraper-youtube": "workspace:."


### PR DESCRIPTION
Latest version of `metascraper`, 5.41.0 seems to break a number of packages https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=170268&view=results.
Rolling back to the working version to avoid such break.