### PR TITLE
Changing metascraper version to avoid breaking change 

### DIFF
--- a/types/samirrayani__metascraper-shopping/package.json
+++ b/types/samirrayani__metascraper-shopping/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "metascraper": "^5.14.8"
+        "metascraper": ">=5.14.8 <=5.40.0"
     },
     "devDependencies": {
         "@types/samirrayani__metascraper-shopping": "workspace:."


### PR DESCRIPTION
Latest version of metascraper, 5.41.0 seems to break a number of packages https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=170268&view=results.
Rolling back to the working version to avoid such break.