### PR TITLE
Changing csstype version to avoid breaks

### DIFF
--- a/types/mui-datatables/package.json
+++ b/types/mui-datatables/package.json
@@ -10,7 +10,7 @@
         "@emotion/styled": "^11.10.5",
         "@mui/material": "^5.11.4",
         "@types/react": "*",
-        "csstype": "^3.1.1"
+        "csstype": "3.1.1 || 3.1.2"
     },
     "devDependencies": {
         "@types/mui-datatables": "workspace:."


### PR DESCRIPTION
Latest version of `csstype`, 3.1.3 seems to break `mui-datatables` package https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=170268&view=logs&j=9d906afe-3eb5-5d79-316d-86f3f3fa360c&t=09716206-abc7-5ba2-2ea2-6c6fe97a3aad
Rolling back to the working version to avoid the break.