### PR TITLE
[react/v16] Hack to fix 'too complex' message in editor / new ExpectType linter

### DIFF
--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -267,6 +267,18 @@ const Memoized2 = React.memo(
 );
 <Memoized2 bar="string" />;
 
+// This declaration should do nothing, but removing it causes some versions of
+// TypeScript to report "Expression produces a union type that is too complex to represent"
+// on Memoized3 below. This code is taken from elementAttributes.tsx from
+// react/v17, which does not fail.
+//
+// The message no longer appears as of https://github.com/microsoft/TypeScript/pull/56515 (5.4).
+declare global {
+    interface HTMLModElement {
+        cite: string;
+    }
+}
+
 const Memoized3 = React.memo(class Test extends React.Component<{ x?: string | undefined }> {});
 <Memoized3
     ref={ref => {


### PR DESCRIPTION
There's no good reason for this code to do anything, however, adding it makes a "too complex" error go away in the editor and the new ExpectType lint (https://github.com/microsoft/DefinitelyTyped-tools/pull/843).

https://github.com/microsoft/TypeScript/pull/56515 somehow fixed the problem, though (?)

The message does not show up with `tsc`, only in the editor and at lint time:

![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/5341706/771f4052-cf23-4b45-9eb9-3169695e54f6)

```
Error in react/v16
Error: 
/home/jabaile/work/DefinitelyTyped/types/react/v16/test/tsx.tsx
  271:1  error  TypeScript@4.5, 4.6, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4 compile error: 
Expression produces a union type that is too complex to represent  @definitelytyped/expect

✖ 1 problem (1 error, 0 warnings)

    at testTypesVersion (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/dist/index.js:176:15)
    at async runTests (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/dist/index.js:154:13)
```

There's definitely some weird TS bug going on here, but only in some versions. It'd be good to investigate this however this oddity is blocking the effort to drop tslint and this is harmless.