### PR TITLE
fix(react-scroll-sync): add innerRef to ScrollSyncPane

### DIFF
--- a/types/react-scroll-sync/index.d.ts
+++ b/types/react-scroll-sync/index.d.ts
@@ -14,6 +14,7 @@ export interface ScrollSyncPaneProps {
     children?: React.ReactNode;
     group?: string | string[] | undefined;
     enabled?: boolean | undefined;
+    innerRef?: React.Ref<HTMLElement>;
 }
 
 export const ScrollSync: React.FC<ScrollSyncProps>;

--- a/types/react-scroll-sync/package.json
+++ b/types/react-scroll-sync/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-scroll-sync",
-    "version": "0.8.9999",
+    "version": "0.9.9999",
     "projects": [
         "https://github.com/okonet/react-scroll-sync"
     ],

--- a/types/react-scroll-sync/react-scroll-sync-tests.tsx
+++ b/types/react-scroll-sync/react-scroll-sync-tests.tsx
@@ -3,13 +3,13 @@ import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
 
 (() => (
     <ScrollSync onSync={e => e.childNodes} proportional vertical horizontal enabled>
-        <ScrollSyncPane enabled group="one" attachTo={document.body}>
+        <ScrollSyncPane enabled group="one" attachTo={document.body} innerRef={null}>
             <div></div>
         </ScrollSyncPane>
-        <ScrollSyncPane enabled group="two" attachTo={document.body}>
+        <ScrollSyncPane enabled group="two" attachTo={document.body} innerRef={React.createRef()}>
             <div></div>
         </ScrollSyncPane>
-        <ScrollSyncPane enabled group={["one", "two"]} attachTo={document.body}>
+        <ScrollSyncPane enabled group={["one", "two"]} attachTo={document.body} innerRef={() => React.createRef()}>
             <div></div>
         </ScrollSyncPane>
     </ScrollSync>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Original Issue](https://github.com/okonet/react-scroll-sync/issues/79)
  - [PR changing the types](https://github.com/okonet/react-scroll-sync/pull/90) 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
