### PR TITLE
[recharts] Stop testing react-dom

### DIFF
--- a/types/recharts/package.json
+++ b/types/recharts/package.json
@@ -11,7 +11,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/recharts": "workspace:."
     },
     "owners": [

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import {
     Area,
     AreaChart,
@@ -348,5 +347,3 @@ class Component extends React.Component<{}, ComponentState> {
         );
     }
 }
-
-ReactDOM.render(<Component />, document.getElementById("app"));


### PR DESCRIPTION
Usage of react-dom in this package was not actuall testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.