### PR TITLE
[reactcss] Stop testing react-dom

### DIFF
--- a/types/reactcss/package.json
+++ b/types/reactcss/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/reactcss": "workspace:."
     },
     "owners": [

--- a/types/reactcss/reactcss-tests.tsx
+++ b/types/reactcss/reactcss-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { FC } from "react";
-import { render } from "react-dom";
 import { CSS, default as reactCSS, hover, HoverProps, loop, LoopableProps } from "reactcss";
 
 interface TestHoverProps extends HoverProps<any> {}
@@ -61,7 +60,4 @@ const TestLoop: FC<TestLoopProps> = (props) => {
 
 const Test = hover(TestHover);
 
-render(
-    <Test />,
-    document.getElementById("main"),
-);
+<Test />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.