### PR TITLE
[react-wow] Stop testing react-dom

### DIFF
--- a/types/react-wow/package.json
+++ b/types/react-wow/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-wow": "workspace:."
     },
     "owners": [

--- a/types/react-wow/react-wow-tests.tsx
+++ b/types/react-wow/react-wow-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import ReactWOW from "react-wow";
 
 const App = () => (
@@ -7,5 +6,3 @@ const App = () => (
         <img src="https://unsplash.it/900/900/?random" />
     </ReactWOW>
 );
-
-ReactDOM.render(<App />, document.getElementById("app"));


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.