### PR TITLE
[react-user-tour] Stop testing react-dom

### DIFF
--- a/types/react-user-tour/package.json
+++ b/types/react-user-tour/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-user-tour": "workspace:."
     },
     "owners": [

--- a/types/react-user-tour/react-user-tour-tests.tsx
+++ b/types/react-user-tour/react-user-tour-tests.tsx
@@ -3,10 +3,7 @@
 // Definitions by: Carlo Cancellieri <https://github.com/ccancellieri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types='react-dom' />
-
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import ReactUserTour from "react-user-tour";
 
@@ -52,5 +49,3 @@ class TestApp extends React.Component<{}, State> {
         );
     }
 }
-
-ReactDOM.render(React.createElement(TestApp, {}), document.getElementById("test-app"));


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.