### PR TITLE
[react-virtualized-auto-sizer] Stop testing react-dom

### DIFF
--- a/types/react-virtualized-auto-sizer/package.json
+++ b/types/react-virtualized-auto-sizer/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-virtualized-auto-sizer": "workspace:."
     },
     "owners": [

--- a/types/react-virtualized-auto-sizer/react-virtualized-auto-sizer-tests.tsx
+++ b/types/react-virtualized-auto-sizer/react-virtualized-auto-sizer-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import AutoSizer, { Size } from "react-virtualized-auto-sizer";
 
 class TestAutoSizer extends AutoSizer {}
@@ -44,8 +43,3 @@ class TestApp extends React.Component {
         );
     }
 }
-
-ReactDOM.render(
-    <TestApp />,
-    document.getElementById("test-app"),
-);


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.