### PR TITLE
[react-tabs-redux] Stop testing react-dom

### DIFF
--- a/types/react-tabs-redux/package.json
+++ b/types/react-tabs-redux/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-tabs-redux": "workspace:."
     },
     "owners": [

--- a/types/react-tabs-redux/react-tabs-redux-tests.tsx
+++ b/types/react-tabs-redux/react-tabs-redux-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { TabContent, TabContentProps, TabLink, TabLinkProps, Tabs, TabsProps } from "react-tabs-redux";
 
 interface TestTabsProps extends TabsProps {
@@ -36,8 +35,3 @@ class TestApp extends React.Component {
         );
     }
 }
-
-ReactDOM.render(
-    <TestApp />,
-    document.getElementById("test-app"),
-);


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.