### PR TITLE
[react-tag-input] Stop testing react-dom

### DIFF
--- a/types/react-tag-input/react-tag-input-tests.tsx
+++ b/types/react-tag-input/react-tag-input-tests.tsx
@@ -1,56 +1,52 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Tag, WithContext as ReactTags } from "react-tag-input";
 
 const tags = Array({ id: "0", text: "test" }, { id: "1", text: "testing" });
 
 const suggestions = Array({ id: "0", text: "test" }, { id: "1", text: "testing" });
 
-ReactDOM.render(
-    <ReactTags
-        tags={tags}
-        suggestions={suggestions}
-        delimiters={[13, 8, 188]} // Enter, Tab and Comma
-        placeholder="Some placeholder text"
-        labelField="Some label"
-        handleAddition={(tag: Tag) => console.log("Add: " + tag.text)}
-        handleDelete={(i: number) => console.log("Delete: " + i)}
-        handleDrag={(
-            tag: Tag,
-            currPos: number,
-            newPos: number,
-        ) => console.log("Drag: " + tag.text)}
-        handleInputChange={(value: string) => console.log("Changed to: ", value)}
-        handleFilterSuggestions={(
-            textInputValue: string,
-            possibleSuggestionsArray: Tag[],
-        ) => suggestions}
-        handleInputBlur={() => console.log("Blurred")}
-        autofocus={false}
-        allowAdditionFromPaste={false}
-        allowDeleteFromEmptyInput={false}
-        minQueryLength={0}
-        removeComponent={null}
-        autocomplete={true}
-        readOnly={false}
-        maxLength={64}
-        inputValue="Some input value"
-        inputFieldPosition="top"
-        inputProps={{ disabled: false }}
-        renderSuggestion={({ id, text }: Tag, query: string) => console.log("tag" + id, text)}
-        shouldRenderSuggestions={q => q !== "ignore_query"}
-        name="react-tags-field"
-        id="react-tags-field"
-        classNames={{
-            tags: "tagsClass",
-            tagInput: "tagInputClass",
-            tagInputField: "tagInputFieldClass",
-            selected: "selectedClass",
-            tag: "tagClass",
-            remove: "removeClass",
-            suggestions: "suggestionsClass",
-            activeSuggestion: "activeSuggestionClass",
-        }}
-    />,
-    document.getElementById("app"),
-);
+<ReactTags
+    tags={tags}
+    suggestions={suggestions}
+    delimiters={[13, 8, 188]} // Enter, Tab and Comma
+    placeholder="Some placeholder text"
+    labelField="Some label"
+    handleAddition={(tag: Tag) => console.log("Add: " + tag.text)}
+    handleDelete={(i: number) => console.log("Delete: " + i)}
+    handleDrag={(
+        tag: Tag,
+        currPos: number,
+        newPos: number,
+    ) => console.log("Drag: " + tag.text)}
+    handleInputChange={(value: string) => console.log("Changed to: ", value)}
+    handleFilterSuggestions={(
+        textInputValue: string,
+        possibleSuggestionsArray: Tag[],
+    ) => suggestions}
+    handleInputBlur={() => console.log("Blurred")}
+    autofocus={false}
+    allowAdditionFromPaste={false}
+    allowDeleteFromEmptyInput={false}
+    minQueryLength={0}
+    removeComponent={null}
+    autocomplete={true}
+    readOnly={false}
+    maxLength={64}
+    inputValue="Some input value"
+    inputFieldPosition="top"
+    inputProps={{ disabled: false }}
+    renderSuggestion={({ id, text }: Tag, query: string) => console.log("tag" + id, text)}
+    shouldRenderSuggestions={q => q !== "ignore_query"}
+    name="react-tags-field"
+    id="react-tags-field"
+    classNames={{
+        tags: "tagsClass",
+        tagInput: "tagInputClass",
+        tagInputField: "tagInputFieldClass",
+        selected: "selectedClass",
+        tag: "tagClass",
+        remove: "removeClass",
+        suggestions: "suggestionsClass",
+        activeSuggestion: "activeSuggestionClass",
+    }}
+/>;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.