### PR TITLE
[react-svg-pan-zoom] Stop testing react-dom

### DIFF
--- a/types/react-svg-pan-zoom/package.json
+++ b/types/react-svg-pan-zoom/package.json
@@ -10,7 +10,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-svg-pan-zoom": "workspace:."
     },
     "owners": [

--- a/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
+++ b/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import {
     fitToViewer,
     MODE_PANNING,
@@ -135,8 +134,3 @@ class MyViewer extends React.Component {
         );
     }
 }
-
-ReactDOM.render(
-    <Example1 />,
-    document.getElementById("app"),
-);


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.