### PR TITLE
[react-stack-grid] Stop testing react-dom

### DIFF
--- a/types/react-stack-grid/package.json
+++ b/types/react-stack-grid/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-stack-grid": "workspace:."
     },
     "owners": [

--- a/types/react-stack-grid/react-stack-grid-tests.tsx
+++ b/types/react-stack-grid/react-stack-grid-tests.tsx
@@ -1,60 +1,47 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import StackGrid, { easings, transitions } from "react-stack-grid";
 /** Default Options */
-ReactDOM.render(
-    <StackGrid columnWidth={150}>
-        <div key="key1">Item 1</div>
-        <div key="key2">Item 2</div>
-        <div key="key3">Item 3</div>
-    </StackGrid>,
-    document.querySelector(".app"),
-);
+<StackGrid columnWidth={150}>
+    <div key="key1">Item 1</div>
+    <div key="key2">Item 2</div>
+    <div key="key3">Item 3</div>
+</StackGrid>;
 /** Transition Options */
 const { scaleDown } = transitions;
-ReactDOM.render(
-    <StackGrid
-        columnWidth={150}
-        appear={scaleDown.appear}
-        appeared={scaleDown.appeared}
-        enter={scaleDown.enter}
-        entered={scaleDown.entered}
-        leaved={scaleDown.leaved}
-    >
-        <div key="key1">Item 1</div>
-        <div key="key2">Item 2</div>
-        <div key="key3">Item 3</div>
-    </StackGrid>,
-    document.querySelector(".app"),
-);
+<StackGrid
+    columnWidth={150}
+    appear={scaleDown.appear}
+    appeared={scaleDown.appeared}
+    enter={scaleDown.enter}
+    entered={scaleDown.entered}
+    leaved={scaleDown.leaved}
+>
+    <div key="key1">Item 1</div>
+    <div key="key2">Item 2</div>
+    <div key="key3">Item 3</div>
+</StackGrid>;
 
 /** Easing Options */
-ReactDOM.render(
-    <StackGrid
-        columnWidth={150}
-        appear={scaleDown.appear}
-        appeared={scaleDown.appeared}
-        enter={scaleDown.enter}
-        easing={easings.cubicOut}
-        entered={scaleDown.entered}
-        leaved={scaleDown.leaved}
-    >
-        <div key="key1">Item 1</div>
-        <div key="key2">Item 2</div>
-        <div key="key3">Item 3</div>
-    </StackGrid>,
-    document.querySelector(".app"),
-);
+<StackGrid
+    columnWidth={150}
+    appear={scaleDown.appear}
+    appeared={scaleDown.appeared}
+    enter={scaleDown.enter}
+    easing={easings.cubicOut}
+    entered={scaleDown.entered}
+    leaved={scaleDown.leaved}
+>
+    <div key="key1">Item 1</div>
+    <div key="key2">Item 2</div>
+    <div key="key3">Item 3</div>
+</StackGrid>;
 
 /** GridRef Options */
-ReactDOM.render(
-    <StackGrid
-        columnWidth={150}
-        gridRef={grid => grid.updateLayout()}
-    >
-        <div key="key1">Item 1</div>
-        <div key="key2">Item 2</div>
-        <div key="key3">Item 3</div>
-    </StackGrid>,
-    document.querySelector(".app"),
-);
+<StackGrid
+    columnWidth={150}
+    gridRef={grid => grid.updateLayout()}
+>
+    <div key="key1">Item 1</div>
+    <div key="key2">Item 2</div>
+    <div key="key3">Item 3</div>
+</StackGrid>;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.