### PR TITLE
[react-table-filter] Stop testing react-dom

### DIFF
--- a/types/react-table-filter/package.json
+++ b/types/react-table-filter/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-table-filter": "workspace:."
     },
     "owners": [

--- a/types/react-table-filter/react-table-filter-tests.ts
+++ b/types/react-table-filter/react-table-filter-tests.ts
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { TableFilter } from "react-table-filter";
 
 interface TestTableFilterProps extends TableFilter {}
@@ -15,4 +14,4 @@ class TestApp extends React.Component {
     }
 }
 
-ReactDOM.render(React.createElement(TestApp, {}), document.getElementById("test-app"));
+React.createElement(TestApp, {});


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.