### PR TITLE
[react-redux] Stop testing react-dom

### DIFF
--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -14,7 +14,6 @@
     "devDependencies": {
         "@types/object-assign": "*",
         "@types/prop-types": "*",
-        "@types/react-dom": "*",
         "@types/react-redux": "workspace:."
     },
     "owners": [

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1,6 +1,5 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import {
     Connect,
     connect,
@@ -603,16 +602,9 @@ class App extends React.Component<any, any> {
     }
 }
 
-const targetEl = document.getElementById("root");
-
-ReactDOM.render(
-    (
-        <Provider store={store}>
-            <App />
-        </Provider>
-    ),
-    targetEl,
-);
+<Provider store={store}>
+    <App />
+</Provider>;
 
 //
 // API
@@ -640,12 +632,9 @@ declare var addTodo: () => { type: string };
 declare var todoActionCreators: { [type: string]: (...args: any[]) => any };
 declare var counterActionCreators: { [type: string]: (...args: any[]) => any };
 
-ReactDOM.render(
-    <Provider store={store}>
-        <MyRootComponent />
-    </Provider>,
-    document.body,
-);
+<Provider store={store}>
+    <MyRootComponent />
+</Provider>;
 
 // Inject just dispatch and don't listen to store
 
@@ -766,7 +755,7 @@ const HelloMessage: React.FunctionComponent<HelloMessageProps> = (props) => {
     return <div>Hello {props.name}</div>;
 };
 const ConnectedHelloMessage = connect()(HelloMessage);
-ReactDOM.render(<ConnectedHelloMessage name="Sebastian" />, document.getElementById("content"));
+<ConnectedHelloMessage name="Sebastian" />;
 
 // stateless functions that uses mapStateToProps and mapDispatchToProps
 function TestStatelessFunctionWithMapArguments() {

--- a/types/react-redux/v5/package.json
+++ b/types/react-redux/v5/package.json
@@ -11,7 +11,6 @@
     },
     "devDependencies": {
         "@types/object-assign": "*",
-        "@types/react-dom": "*",
         "@types/react-redux": "workspace:."
     },
     "owners": [

--- a/types/react-redux/v5/react-redux-tests.tsx
+++ b/types/react-redux/v5/react-redux-tests.tsx
@@ -1,6 +1,5 @@
 import { Component, ReactElement } from "react";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Connect, connect, createProvider, DispatchProp, MapStateToProps, Options, Provider } from "react-redux";
 import { ActionCreator, ActionCreatorsMapObject, bindActionCreators, createStore, Dispatch, Store } from "redux";
 import objectAssign = require("object-assign");
@@ -415,16 +414,9 @@ class App extends Component<any, any> {
     }
 }
 
-const targetEl = document.getElementById("root");
-
-ReactDOM.render(
-    (
-        <Provider store={store}>
-            <App />
-        </Provider>
-    ),
-    targetEl,
-);
+<Provider store={store}>
+    <App />
+</Provider>;
 
 //
 // API
@@ -452,27 +444,21 @@ declare var addTodo: () => { type: string };
 declare var todoActionCreators: { [type: string]: (...args: any[]) => any };
 declare var counterActionCreators: { [type: string]: (...args: any[]) => any };
 
-ReactDOM.render(
-    <Provider store={store}>
-        <MyRootComponent />
-    </Provider>,
-    document.body,
-);
+<Provider store={store}>
+    <MyRootComponent />
+</Provider>;
 
 // TODO: for React Router 0.13
 //// TODO: error TS2339: Property 'run' does not exist on type 'typeof "react-router"'.
 //// TODO: error TS2339: Property 'HistoryLocation' does not exist on type 'typeof "react-router"'.
 // declare var routes: any;
 // Router.run(routes, Router.HistoryLocation, (Handler, routerState) => { // note "routerState" here
-//    ReactDOM.render(
 //        <Provider store={store}>
 //            {/*
 //             //TODO: error TS2339: Property 'routerState' does not exist on type 'RouteProp'.
 //             {() => <Handler routerState={routerState} />} // note "routerState" here: important to pass it down
 //            */}
-//        </Provider>,
-//        document.getElementById('root')
-//    );
+//        </Provider>;
 // });
 
 // Inject just dispatch and don't listen to store
@@ -631,7 +617,7 @@ const HelloMessage: React.FunctionComponent<HelloMessageProps> = (props) => {
     return <div>Hello {props.name}</div>;
 };
 let ConnectedHelloMessage = connect()(HelloMessage);
-ReactDOM.render(<ConnectedHelloMessage name="Sebastian" />, document.getElementById("content"));
+<ConnectedHelloMessage name="Sebastian" />;
 
 // stateless functions that uses mapStateToProps and mapDispatchToProps
 namespace TestStatelessFunctionWithMapArguments {
@@ -977,7 +963,7 @@ namespace TestCreateProvider {
     // This renders:
     // <h1>A is 1</h1>
     // <h1>A is 2</h1>
-    ReactDOM.render(<Combined />, document.body);
+    <Combined />;
 }
 
 namespace TestTypeInference {
@@ -991,17 +977,17 @@ namespace TestTypeInference {
     interface State {
         a: number;
     }
-    ReactDOM.render(<OnlyState b={1} />, document.body);
+    <OnlyState b={1} />;
 
     const OnlyDispatch = connect(
         undefined,
         (dispatch, props: { b: number }) => ({ action: () => dispatch({ type: "action", b: props.b }) }),
     )(props => <span onClick={props.action}>{props.b}</span>);
-    ReactDOM.render(<OnlyDispatch b={1} />, document.body);
+    <OnlyDispatch b={1} />;
 
     const StateAndDispatch = connect(
         (state: { a: number }, props: { b: number }) => ({ a: state.a, c: state.a + props.b }),
         (dispatch, props: { b: number }) => ({ action: () => dispatch({ type: "action", b: props.b }) }),
     )(props => <span>{props.a} + {props.b} = {props.c}</span>);
-    ReactDOM.render(<StateAndDispatch b={1} />, document.body);
+    <StateAndDispatch b={1} />;
 }

--- a/types/react-redux/v6/package.json
+++ b/types/react-redux/v6/package.json
@@ -12,7 +12,6 @@
     "devDependencies": {
         "@types/object-assign": "*",
         "@types/prop-types": "*",
-        "@types/react-dom": "*",
         "@types/react-redux": "workspace:."
     },
     "owners": [

--- a/types/react-redux/v6/react-redux-tests.tsx
+++ b/types/react-redux/v6/react-redux-tests.tsx
@@ -1,6 +1,5 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Connect, connect, createProvider, DispatchProp, MapStateToProps, Options, Provider } from "react-redux";
 import {
     ActionCreator,
@@ -517,15 +516,9 @@ class App extends React.Component<any, any> {
 
 const targetEl = document.getElementById("root");
 
-ReactDOM.render(
-    (
-        <Provider store={store}>
-            <App />
-        </Provider>
-    ),
-    targetEl,
-);
-
+<Provider store={store}>
+    <App />
+</Provider>;
 //
 // API
 // https://github.com/rackt/react-redux/blob/master/docs/api.md
@@ -552,12 +545,9 @@ declare var addTodo: () => { type: string };
 declare var todoActionCreators: { [type: string]: (...args: any[]) => any };
 declare var counterActionCreators: { [type: string]: (...args: any[]) => any };
 
-ReactDOM.render(
-    <Provider store={store}>
-        <MyRootComponent />
-    </Provider>,
-    document.body,
-);
+<Provider store={store}>
+    <MyRootComponent />
+</Provider>;
 
 // Inject just dispatch and don't listen to store
 
@@ -678,7 +668,7 @@ const HelloMessage: React.FunctionComponent<HelloMessageProps> = (props) => {
     return <div>Hello {props.name}</div>;
 };
 const ConnectedHelloMessage = connect()(HelloMessage);
-ReactDOM.render(<ConnectedHelloMessage name="Sebastian" />, document.getElementById("content"));
+<ConnectedHelloMessage name="Sebastian" />;
 
 // stateless functions that uses mapStateToProps and mapDispatchToProps
 function TestStatelessFunctionWithMapArguments() {


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.