### PR TITLE
[react-recaptcha] Stop testing react-dom

### DIFF
--- a/types/react-recaptcha/package.json
+++ b/types/react-recaptcha/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-recaptcha": "workspace:."
     },
     "owners": [

--- a/types/react-recaptcha/react-recaptcha-tests.tsx
+++ b/types/react-recaptcha/react-recaptcha-tests.tsx
@@ -1,8 +1,4 @@
 import Recaptcha = require("react-recaptcha");
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
-ReactDOM.render(
-    <Recaptcha sitekey="xxxxxxxxxxxxxxxxxxxx" />,
-    document.getElementById("example"),
-);
+<Recaptcha sitekey="xxxxxxxxxxxxxxxxxxxx" />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.