### PR TITLE
[react-mce] Stop testing react-dom

### DIFF
--- a/types/react-mce/package.json
+++ b/types/react-mce/package.json
@@ -10,7 +10,6 @@
         "@types/tinymce": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-mce": "workspace:."
     },
     "owners": [

--- a/types/react-mce/react-mce-tests.tsx
+++ b/types/react-mce/react-mce-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import TinyMCE = require("react-mce");
 
 class Example extends React.Component {
@@ -35,4 +34,4 @@ class Example extends React.Component {
     }
 }
 
-ReactDOM.render(<Example />, document.getElementById("root"));
+<Example />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.