### PR TITLE
[react-portal] Stop testing react-dom

### DIFF
--- a/types/react-portal/package.json
+++ b/types/react-portal/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-portal": "workspace:."
     },
     "owners": [

--- a/types/react-portal/react-portal-tests.tsx
+++ b/types/react-portal/react-portal-tests.tsx
@@ -1,6 +1,5 @@
 // Example from https://github.com/tajo/react-portal
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Portal, PortalWithState } from "react-portal";
 
 interface AppState {
@@ -77,4 +76,4 @@ export default class App extends React.Component<{}, AppState> {
     }
 }
 
-ReactDOM.render(<App />, document.getElementById("root"));
+<App />;

--- a/types/react-portal/v3/package.json
+++ b/types/react-portal/v3/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-portal": "workspace:."
     },
     "owners": [

--- a/types/react-portal/v3/react-portal-tests.tsx
+++ b/types/react-portal/v3/react-portal-tests.tsx
@@ -1,6 +1,5 @@
 // Example from https://github.com/tajo/react-portal
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as Portal from "react-portal";
 
 export default class App extends React.Component {
@@ -45,4 +44,4 @@ export class PseudoModal extends React.Component<{ children?: React.ReactNode; c
     }
 }
 
-ReactDOM.render(<App />, document.getElementById("react-body"));
+<App />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.