### PR TITLE
[react-onsenui] Stop testing react-dom

### DIFF
--- a/types/react-onsenui/package.json
+++ b/types/react-onsenui/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-onsenui": "workspace:."
     },
     "owners": [

--- a/types/react-onsenui/react-onsenui-tests.tsx
+++ b/types/react-onsenui/react-onsenui-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import {
     Button,
     Checkbox,
@@ -155,4 +154,4 @@ export class App extends React.Component<AppProps, AppState> {
     }
 }
 
-ReactDOM.render(<App />, document.getElementById("react-body"));
+<App />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.