### PR TITLE
[react-input-calendar] Stop testing react-dom

### DIFF
--- a/types/react-input-calendar/package.json
+++ b/types/react-input-calendar/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-input-calendar": "workspace:."
     },
     "owners": []

--- a/types/react-input-calendar/react-input-calendar-tests.tsx
+++ b/types/react-input-calendar/react-input-calendar-tests.tsx
@@ -1,4 +1,4 @@
 import ReactInputCalendar = require("react-input-calendar");
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-ReactDOM.render(<ReactInputCalendar />, document.body);
+
+<ReactInputCalendar />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.