### PR TITLE
[react-flag-icon-css] Stop testing react-dom

### DIFF
--- a/types/react-flag-icon-css/package.json
+++ b/types/react-flag-icon-css/package.json
@@ -10,7 +10,6 @@
         "csstype": "^3.0.2"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-flag-icon-css": "workspace:."
     },
     "owners": [

--- a/types/react-flag-icon-css/react-flag-icon-css-tests.tsx
+++ b/types/react-flag-icon-css/react-flag-icon-css-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import FlagIconFactory, { CustomFlagIconFactory, FlagIconSize } from "react-flag-icon-css";
 
 const FlagIcon = FlagIconFactory(React, { useCssModules: false });
@@ -24,7 +23,7 @@ const appProps: SimpleFlagComponentProps = {
     code: "it",
     size: "3x",
 };
-ReactDOM.render(<SimpleFlagComponent {...appProps} />, rootEL);
+<SimpleFlagComponent {...appProps} />;
 
 /**
  * based on https://github.com/matteocng/react-flag-icon-css#exampleCustomFlagsIndex
@@ -55,7 +54,7 @@ const appCustomProps: SimpleFlagComponentProps = {
     code: "ex1",
     size: "lg",
 };
-ReactDOM.render(<CustomFlagComponent {...appCustomProps} />, rootEL);
+<CustomFlagComponent {...appCustomProps} />;
 
 /**
  * based on 'props:children' test
@@ -77,4 +76,4 @@ const appChildrenProps: ChildrenFlagComponentProps = {
     size: "lg",
     children: <FlagIcon code="it" />,
 };
-ReactDOM.render(<ChildrenFlagComponent {...appChildrenProps} />, rootEL);
+<ChildrenFlagComponent {...appChildrenProps} />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.