### PR TITLE
[react-custom-scrollbars] Stop testing react-dom

### DIFF
--- a/types/react-custom-scrollbars/package.json
+++ b/types/react-custom-scrollbars/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-custom-scrollbars": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-custom-scrollbars": "workspace:."
     },
     "owners": [
         {

--- a/types/react-custom-scrollbars/react-custom-scrollbars-tests.tsx
+++ b/types/react-custom-scrollbars/react-custom-scrollbars-tests.tsx
@@ -1,10 +1,6 @@
 import * as React from "react";
 import Scrollbars from "react-custom-scrollbars";
-import { render } from "react-dom";
 
-render(
-    <Scrollbars style={{ width: 500 }}>
-        <div>Test</div>
-    </Scrollbars>,
-    document.getElementById("main"),
-);
+<Scrollbars style={{ width: 500 }}>
+    <div>Test</div>
+</Scrollbars>;

--- a/types/react-custom-scrollbars/v3/package.json
+++ b/types/react-custom-scrollbars/v3/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-custom-scrollbars": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-custom-scrollbars": "workspace:."
     },
     "owners": []
 }

--- a/types/react-custom-scrollbars/v3/react-custom-scrollbars-tests.tsx
+++ b/types/react-custom-scrollbars/v3/react-custom-scrollbars-tests.tsx
@@ -1,10 +1,6 @@
 import * as React from "react";
 import Scrollbars from "react-custom-scrollbars";
-import { render } from "react-dom";
 
-render(
-    <Scrollbars style={{ width: 500 }}>
-        <div>Test</div>
-    </Scrollbars>,
-    document.getElementById("main"),
-);
+<Scrollbars style={{ width: 500 }}>
+    <div>Test</div>
+</Scrollbars>;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.