### PR TITLE
[react-css-collapse] Stop testing react-dom

### DIFF
--- a/types/react-css-collapse/package.json
+++ b/types/react-css-collapse/package.json
@@ -7,8 +7,7 @@
     ],
     "devDependencies": {
         "@types/react": "*",
-        "@types/react-css-collapse": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-css-collapse": "workspace:."
     },
     "owners": [
         {

--- a/types/react-css-collapse/react-css-collapse-tests.tsx
+++ b/types/react-css-collapse/react-css-collapse-tests.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { FC } from "react";
 import Collapse from "react-css-collapse";
-import { render } from "react-dom";
 
 const TestOpen: FC = () => (
     <Collapse isOpen>
@@ -10,5 +9,3 @@ const TestOpen: FC = () => (
         </div>
     </Collapse>
 );
-
-render(<TestOpen />, document.getElementById("main"));


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.