### PR TITLE
[react-copy-write] Stop testing react-dom

### DIFF
--- a/types/react-copy-write/package.json
+++ b/types/react-copy-write/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-copy-write": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-copy-write": "workspace:."
     },
     "owners": [
         {

--- a/types/react-copy-write/react-copy-write-tests.tsx
+++ b/types/react-copy-write/react-copy-write-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import createStore from "react-copy-write";
-import { render } from "react-dom";
 
 const { Provider, Consumer, mutate } = createStore({
     letter: "a",
@@ -29,5 +28,3 @@ const App = () => (
         </div>
     </Provider>
 );
-
-render(<App />, document.body);


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.