### PR TITLE
[react-column-resizer] Stop testing react-dom

### DIFF
--- a/types/react-column-resizer/package.json
+++ b/types/react-column-resizer/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-column-resizer": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-column-resizer": "workspace:."
     },
     "owners": [
         {

--- a/types/react-column-resizer/react-column-resizer-tests.tsx
+++ b/types/react-column-resizer/react-column-resizer-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import ColumnResizer from "react-column-resizer";
-import { render } from "react-dom";
 
 class TableComponent extends React.Component {
     render() {
@@ -26,4 +25,4 @@ class TableComponent extends React.Component {
     }
 }
 
-render(<TableComponent />, document.getElementById("main"));
+<TableComponent />;


### PR DESCRIPTION
Usage of react-dom in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.