### PR TITLE
feat(eslint): document all `globals` values

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -750,7 +750,18 @@ linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: "latest" 
 linterWithFlatConfig.verify(SOURCE, [{ languageOptions: { ecmaVersion: 6 } }], "test.js");
 linterWithFlatConfig.verify(
     SOURCE,
-    [{ languageOptions: { ecmaVersion: 6 } }],
+    [{
+        languageOptions: {
+            ecmaVersion: 6,
+            globals: {
+                true: true,
+                false: false,
+                foo: 'readonly',
+                bar: 'writable',
+                baz: 'off',
+            },
+        },
+    }],
     "test.js",
 );
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -756,9 +756,9 @@ linterWithFlatConfig.verify(
             globals: {
                 true: true,
                 false: false,
-                foo: 'readonly',
-                bar: 'writable',
-                baz: 'off',
+                foo: "readonly",
+                bar: "writable",
+                baz: "off",
             },
         },
     }],

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1335,8 +1335,12 @@ export class ESLint {
 export namespace ESLint {
     type ConfigData<Rules extends Linter.RulesRecord = Linter.RulesRecord> = Omit<Linter.Config<Rules>, "$schema">;
 
+    interface Globals {
+        [name: string]: boolean | "writable" | "readonly" | "off";
+    }
+
     interface Environment {
-        globals?: { [name: string]: boolean } | undefined;
+        globals?: Globals | undefined;
         parserOptions?: Linter.ParserOptions | undefined;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/latest/use/configure/configuration-files-new#configuring-global-variables

> For each global variable key, set the corresponding value equal to "writable" to allow the variable to be overwritten or "readonly" to disallow overwriting. ... Globals can be disabled with the string "off".

Code: https://github.com/eslint/eslint/blob/3a22236f8d10af8a5bcafe56092651d3d681c99d/lib/source-code/source-code.js#L126-L147

Technically, it seems that the boolean values are deprecated:

> For historical reasons, the boolean value false and the string value "readable" are equivalent to "readonly". Similarly, the boolean value true and the string value "writeable" are equivalent to "writable". However, the use of older values is deprecated.