### PR TITLE
[Node-Forge] Corrected pki.CertificateRequest to not extend pki.Certificate

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -525,7 +525,21 @@ declare module "node-forge" {
             verifySubjectKeyIdentifier(): boolean;
         }
 
-        interface CertificateRequest extends Certificate {
+        interface CertificateSigningRequest {
+            version: number;
+            signatureOid: string | null;
+            signature: any;
+            siginfo: {
+                algorithmOid: string | null;
+            };
+            subject: {
+                getField(sn: string | CertificateFieldOptions): any;
+                addField(attr: CertificateField): void;
+                attributes: CertificateField[];
+                hash: any;
+            };
+            publicKey: PublicKey | null;
+            attributes: CertificateField[];
             /**
              * Gets an issuer or subject attribute from its name, type, or short name.
              *
@@ -536,7 +550,34 @@ declare module "node-forge" {
              *
              * @return the attribute.
              */
-            getAttribute(opts: string | GetAttributeOpts): Attribute | null;
+            getAttribute(sn: string | GetAttributeOpts): Attribute | null;
+            addAttribute(attr: CertificateField): void;
+            md: md.MessageDigest | null;
+            signatureParameters: any;
+            certificationRequestInfo: asn1.Asn1 | null;
+        
+            /**
+             * Sets the subject of this csr.
+             *
+             * @param attrs the array of subject attributes to use.
+             * @param uniqueId an optional a unique ID to use.
+             */
+            setSubject(attrs: CertificateField[]): void;
+            setAttributes(attrs: CertificateField[]): void;
+            /**
+             * Signs this csr using the given private key.
+             *
+             * @param key the private key to sign with.
+             * @param md the message digest object to use (defaults to forge.md.sha1).
+             */
+            sign(key: pki.PrivateKey, md?: md.MessageDigest): void;
+            /**
+             * Attempts verify the signature on this csr using this
+             * csr's public key.
+             *
+             * @return true if verified, false if not.
+             */
+            verify(): boolean;
         }
 
         /**
@@ -595,21 +636,21 @@ declare module "node-forge" {
 
         function certificateFromAsn1(obj: asn1.Asn1, computeHash?: boolean): Certificate;
 
-        function certificationRequestFromAsn1(obj: asn1.Asn1, computeHash?: boolean): Certificate;
+        function certificationRequestFromAsn1(obj: asn1.Asn1, computeHash?: boolean): CertificateSigningRequest;
 
         function certificateToAsn1(cert: Certificate): asn1.Asn1;
 
-        function certificationRequestToAsn1(cert: Certificate): asn1.Asn1;
+        function certificationRequestToAsn1(cert: CertificateSigningRequest): asn1.Asn1;
 
         function decryptRsaPrivateKey(pem: PEM, passphrase?: string): rsa.PrivateKey;
 
         function createCertificate(): Certificate;
 
-        function certificationRequestToPem(cert: Certificate, maxline?: number): PEM;
+        function certificationRequestToPem(csr: CertificateSigningRequest, maxline?: number): PEM;
 
-        function certificationRequestFromPem(pem: PEM, computeHash?: boolean, strict?: boolean): Certificate;
+        function certificationRequestFromPem(pem: PEM, computeHash?: boolean, strict?: boolean): CertificateSigningRequest;
 
-        function createCertificationRequest(): CertificateRequest;
+        function createCertificationRequest(): CertificateSigningRequest;
 
         function certificateToPem(cert: Certificate, maxline?: number): PEM;
 

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -555,7 +555,7 @@ declare module "node-forge" {
             md: md.MessageDigest | null;
             signatureParameters: any;
             certificationRequestInfo: asn1.Asn1 | null;
-        
+
             /**
              * Sets the subject of this csr.
              *
@@ -648,7 +648,11 @@ declare module "node-forge" {
 
         function certificationRequestToPem(csr: CertificateSigningRequest, maxline?: number): PEM;
 
-        function certificationRequestFromPem(pem: PEM, computeHash?: boolean, strict?: boolean): CertificateSigningRequest;
+        function certificationRequestFromPem(
+            pem: PEM,
+            computeHash?: boolean,
+            strict?: boolean,
+        ): CertificateSigningRequest;
 
         function createCertificationRequest(): CertificateSigningRequest;
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -34,7 +34,44 @@ forge.pki.certificateFromAsn1(forge.pki.certificateToAsn1(cert));
 let certPem = forge.pki.certificateToPem(cert);
 let csr = forge.pki.createCertificationRequest();
 csr.publicKey = keypair.publicKey;
+csr.setAttributes([
+    {
+        name: "unstructuredName",
+        value: "My Company, Inc.",
+    },
+    {
+        name: "extensionRequest",
+        extensions: [
+            {
+                name: "subjectAltName",
+                altNames: [
+                    {
+                        // 2 is DNS type
+                        type: 2,
+                        value: "localhost",
+                    },
+                    {
+                        type: 2,
+                        value: "127.0.0.1",
+                    },
+                    {
+                        type: 2,
+                        value: "www.domain.net",
+                    },
+                ],
+            },
+        ],
+    },
+]);
+csr.addAttribute({
+    name: "challengePassword",
+    value: "password",
+});
 csr.sign(keypair.privateKey);
+csr.verify();
+csr.getAttribute({ name: "challengePassword" });
+csr.getAttribute({ name: "extensionRequest" }).extensions;
+forge.pki.certificationRequestFromPem( forge.pki.certificationRequestToPem(csr));
 forge.pki.certificationRequestFromAsn1(forge.pki.certificationRequestToAsn1(csr));
 
 // From https://github.com/digitalbazaar/forge#rsakem

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -71,7 +71,7 @@ csr.sign(keypair.privateKey);
 csr.verify();
 csr.getAttribute({ name: "challengePassword" });
 csr.getAttribute({ name: "extensionRequest" }).extensions;
-forge.pki.certificationRequestFromPem( forge.pki.certificationRequestToPem(csr));
+forge.pki.certificationRequestFromPem(forge.pki.certificationRequestToPem(csr));
 forge.pki.certificationRequestFromAsn1(forge.pki.certificationRequestToAsn1(csr));
 
 // From https://github.com/digitalbazaar/forge#rsakem


### PR DESCRIPTION
pki.CertificateRequest, extending Certificate, updated to CertificateSigningRequest, not extending Certificate, to more accurately reflect source code. Associated method signatures also updated. Tests added to validate changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Create certification request code](https://github.com/digitalbazaar/forge/blob/main/lib/x509.js#L1733-L1851)
  - Old CertificateRequest code extending Certificate created a conflict between the no-argument CertificateRequest.verify() (can be seen in code linked above) and Certificate.verify(child: Certificate). Making CertificateRequest no longer extend Certificate is required to fix this. Additionally, CertificateRequest was a poor name for a csr, so it was updated to CertificateSigningRequest. Finally, all methods referencing csrs were updated to use the CertificateSIgningRequest class, such as certificationRequestToAsn1, which previously used Certificate as the class of its input argument instead of CertificateRequest.
