### PR TITLE
fix(lint-staged): add missing types for possible config + fix typo

### DIFF
--- a/types/lint-staged/index.d.ts
+++ b/types/lint-staged/index.d.ts
@@ -1,11 +1,13 @@
-// This exists so lit-staged.config.js can do this:
+// This exists so lint-staged.config.js can do this:
 // /**
 //  * @type {import('lint-staged').Config}
 // */
 // export default { ... };
 
-export type Commands = string[] | string;
+export type Command = string;
+
+export type Commands = Command[] | Command;
 
 export type ConfigFn = (filenames: string[]) => Commands | Promise<Commands>;
 
-export type Config = ConfigFn | { [key: string]: Commands | ConfigFn };
+export type Config = ConfigFn | { [key: string]: Command | ConfigFn | Array<Command | ConfigFn> };

--- a/types/lint-staged/package.json
+++ b/types/lint-staged/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/lint-staged",
-    "version": "13.2.9999",
+    "version": "13.3.9999",
     "projects": [
         "https://github.com/okonet/lint-staged#readme"
     ],


### PR DESCRIPTION
This code change is not breaking, user's code that was utilizing old types should still compile without errors.
I added types for one more possible config which is not documented in examples, but implemented in the lint-staged.

I often use config file with format like this in complex projects:
```js
export default {
    "*": ["echo hi", () => "echo hello"]
    // for example, if I want to ignore list of staged files in a second command
}
```
As source code of lint-staged states
> Should be a string, a function, or an array of strings **and** functions.

Which means values of configuration object can contain array of mixed values of strings and functions. I included link to the source code containing this quote in the template below.

I did not added any tests, since all existing tests are taken from lint-staged readme example configurations and my configuration case is not included in the examples, so just let me know if you would like to add a test for this.

---

Template:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I am changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lint-staged/lint-staged/blob/master/lib/validateConfig.js#L85
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.