### PR TITLE
Update graphql-upload types

### DIFF
--- a/types/graphql-upload/GraphQLUpload.d.mts
+++ b/types/graphql-upload/GraphQLUpload.d.mts
@@ -1,4 +1,8 @@
 import { GraphQLScalarType } from "graphql";
+import { FileUpload } from "./processRequest.mjs";
 
-declare const GraphQLUpload: GraphQLScalarType;
+export { FileUpload } from "./processRequest.mjs";
+
+declare const GraphQLUpload: GraphQLScalarType<Promise<FileUpload>, never>;
+
 export default GraphQLUpload;

--- a/types/graphql-upload/Upload.d.mts
+++ b/types/graphql-upload/Upload.d.mts
@@ -1,13 +1,16 @@
-import { ReadStream } from "fs-capacitor";
+import { GraphQLScalarType } from "graphql";
+import processRequest, { FileUpload } from "./processRequest.mjs";
 
-export interface FileUpload {
-    filename: string;
-    mimetype: string;
-    encoding: string;
-    createReadStream(): ReadStream;
-}
+// We are keeping this export just to avoid breaking changes, but it should be removed on the next major release.
+export { FileUpload } from "./processRequest.mjs";
 
 export default class Upload {
     promise: Promise<FileUpload>;
-    file?: FileUpload;
+    resolve: (file: FileUpload) => void;
+    file: FileUpload | undefined;
+    reject: (reason?: any) => void;
 }
+
+export type GraphQLUpload = GraphQLScalarType<any, any>;
+
+export type processRequest = typeof processRequest;

--- a/types/graphql-upload/graphql-upload-tests.ts
+++ b/types/graphql-upload/graphql-upload-tests.ts
@@ -1,8 +1,10 @@
 import express from "express";
 import graphqlUploadExpress from "graphql-upload/graphqlUploadExpress.mjs";
 import graphqlUploadKoa from "graphql-upload/graphqlUploadKoa.mjs";
+import { FileUpload } from "graphql-upload/processRequest.mjs";
 import Upload from "graphql-upload/Upload.mjs";
 import Koa from "koa";
+import { createWriteStream, unlink } from "node:fs";
 
 express()
     .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
@@ -10,9 +12,28 @@ express()
 
 new Koa().use(graphqlUploadKoa({ maxFileSize: 10000000, maxFiles: 10 })).listen(3000);
 
-const manuallyHandleUpload = async (upload: Upload) => {
+export const manuallyHandleUpload = async (upload: Upload) => {
     if (upload instanceof Upload) {
         return upload.promise;
     }
     throw new Error("Upload is not an instance of Upload");
+};
+
+export const storeUpload = async (fileUpload: Promise<FileUpload>) => {
+    const { createReadStream, filename } = await fileUpload;
+    const stream = createReadStream();
+
+    await new Promise((resolve, reject) => {
+        const writeStream = createWriteStream(filename);
+        writeStream.on("finish", resolve);
+        writeStream.on("error", (error) => {
+            unlink(filename, () => {
+                reject(error);
+            });
+        });
+        stream.on("error", (error) => writeStream.destroy(error));
+        stream.pipe(writeStream);
+    });
+
+    return filename;
 };

--- a/types/graphql-upload/graphqlUploadExpress.d.mts
+++ b/types/graphql-upload/graphqlUploadExpress.d.mts
@@ -1,9 +1,15 @@
-import { RequestHandler } from "express";
+import { NextFunction, Request, Response } from "express";
+import { ProcessRequestFunction, ProcessRequestOptions } from "./processRequest.mjs";
 
-export interface UploadOptions {
-    maxFieldSize?: number | undefined;
-    maxFileSize?: number | undefined;
-    maxFiles?: number | undefined;
-}
+// We are keeping this type just to avoid breaking changes, but it should be removed on the next major release.
+export type UploadOptions = ProcessRequestOptions;
 
-export default function graphqlUploadExpress(uploadOptions?: UploadOptions): RequestHandler;
+export default function graphqlUploadExpress(
+    { processRequest, ...processRequestOptions }?: ProcessRequestOptions & {
+        processRequest?: ProcessRequestFunction;
+    },
+): (
+    request: Request,
+    response: Response,
+    next: NextFunction,
+) => void;

--- a/types/graphql-upload/graphqlUploadKoa.d.mts
+++ b/types/graphql-upload/graphqlUploadKoa.d.mts
@@ -1,11 +1,11 @@
-import { DefaultContext, DefaultState, Middleware } from "koa";
+import { ParameterizedContext } from "koa";
+import { ProcessRequestFunction, ProcessRequestOptions } from "./processRequest.mjs";
 
-export interface UploadOptions {
-    maxFieldSize?: number | undefined;
-    maxFileSize?: number | undefined;
-    maxFiles?: number | undefined;
-}
+// We are keeping this type just to avoid breaking changes, but it should be removed on the next major release.
+export type UploadOptions = ProcessRequestOptions;
 
-export default function graphqlUploadKoa<StateT = DefaultState, ContextT = DefaultContext>(
-    uploadOptions?: UploadOptions,
-): Middleware<StateT, ContextT>; // eslint-disable-line @definitelytyped/no-unnecessary-generics
+export default function graphqlUploadKoa(
+    { processRequest, ...processRequestOptions }?: ProcessRequestOptions & {
+        processRequest?: ProcessRequestFunction;
+    },
+): (ctx: ParameterizedContext, next: () => Promise<unknown>) => Promise<unknown>;

--- a/types/graphql-upload/index.d.ts
+++ b/types/graphql-upload/index.d.ts
@@ -1,4 +1,4 @@
-// Linter does not accept files without definitions. Disabling the rule at
-// the top of the file doesn't work either: It breaks the meta data parser.
-
+// Despite not having any definitions, this file must exist on DefinitelyTyped.
+// Currently, the tooling assumes that this file exists and performs extra lints,
+// as well as using it to figure out where things are.
 export {};

--- a/types/graphql-upload/package.json
+++ b/types/graphql-upload/package.json
@@ -29,7 +29,7 @@
         "@types/koa": "*",
         "@types/node": "*",
         "fs-capacitor": "^8.0.0",
-        "graphql": "0.13.1 - 16"
+        "graphql": "^16.3.0"
     },
     "devDependencies": {
         "@types/graphql-upload": "workspace:."

--- a/types/graphql-upload/processRequest.d.mts
+++ b/types/graphql-upload/processRequest.d.mts
@@ -1,11 +1,18 @@
-import { IncomingMessage, ServerResponse } from "http";
+import { ReadStreamOptions, WriteStream } from "fs-capacitor";
+import { GraphQLScalarType } from "graphql";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
 
-export interface UploadOptions {
+export interface ProcessRequestOptions {
     maxFieldSize?: number | undefined;
     maxFileSize?: number | undefined;
     maxFiles?: number | undefined;
 }
 
+// We are keeping this type just to avoid breaking changes, but it should be removed on the next major release.
+export type UploadOptions = ProcessRequestOptions;
+
+// We are keeping this interface just to avoid breaking changes, but it should be removed on the next major release.
 export interface GraphQLOperation {
     query: string;
     operationName?: null | string | undefined;
@@ -15,5 +22,44 @@ export interface GraphQLOperation {
 export default function processRequest(
     request: IncomingMessage,
     response: ServerResponse,
-    uploadOptions?: UploadOptions,
-): Promise<GraphQLOperation | GraphQLOperation[]>;
+    options?: ProcessRequestOptions,
+): Promise<
+    | {
+        [key: string]: unknown;
+    }
+    | Array<{
+        [key: string]: unknown;
+    }>
+>;
+
+export type GraphQLUpload = GraphQLScalarType<any, any>;
+
+export interface FileUpload {
+    filename: string;
+    mimetype: string;
+    encoding: string;
+    capacitor: WriteStream;
+    createReadStream: FileUploadCreateReadStream;
+}
+
+export type FileUploadCreateReadStream = (
+    options?: FileUploadCreateReadStreamOptions | undefined,
+) => Readable;
+
+export interface FileUploadCreateReadStreamOptions {
+    encoding?: ReadStreamOptions["encoding"];
+    highWaterMark?: ReadStreamOptions["highWaterMark"];
+}
+
+export type ProcessRequestFunction = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    options?: ProcessRequestOptions | undefined,
+) => Promise<
+    | {
+        [key: string]: unknown;
+    }
+    | Array<{
+        [key: string]: unknown;
+    }>
+>;

--- a/types/graphql-upload/tsconfig.json
+++ b/types/graphql-upload/tsconfig.json
@@ -15,6 +15,11 @@
     },
     "files": [
         "index.d.ts",
-        "graphql-upload-tests.ts"
+        "graphql-upload-tests.ts",
+        "GraphQLUpload.d.mts",
+        "graphqlUploadExpress.d.mts",
+        "graphqlUploadKoa.d.mts",
+        "processRequest.d.mts",
+        "Upload.d.mts"
     ]
 }


### PR DESCRIPTION
- `@types/graphql-upload` doesn't work with new version of the library
- Generate updated types from JSDoc types defined in the library
---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/66678#issuecomment-1716093027
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
