### PR TITLE
[airbnb-prop-types] Match React types and runtime version

### DIFF
--- a/types/airbnb-prop-types/package.json
+++ b/types/airbnb-prop-types/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@types/airbnb-prop-types": "workspace:.",
-        "@types/react": "^15"
+        "@types/react": "^16"
     },
     "owners": [
         {

--- a/types/airbnb-prop-types/package.json
+++ b/types/airbnb-prop-types/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@types/airbnb-prop-types": "workspace:.",
-        "@types/react": "*"
+        "@types/react": "^15"
     },
     "owners": [
         {

--- a/types/airbnb-prop-types/tsconfig.json
+++ b/types/airbnb-prop-types/tsconfig.json
@@ -11,10 +11,7 @@
         "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "react": ["../react/v15/index.d.ts"]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/airbnb-prop-types/tsconfig.json
+++ b/types/airbnb-prop-types/tsconfig.json
@@ -11,7 +11,10 @@
         "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "react": ["../react/v15/index.d.ts"]
+        }
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Only 15.x is the latest stable release supported: https://github.com/airbnb/prop-types/blob/492c439574c6ede6a0753ea9ba8a2daec570443d/package.json#L45
