### PR TITLE
[needle] feat: add support for needle's use_proxy_from_env_var

### DIFF
--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -155,6 +155,12 @@ declare namespace core {
          * either here or through options.headers.
          */
         content_type?: string | undefined;
+        /**
+         * When false, needle will not use its default mechanism of picking up proxy configuration from environment variables.
+         *
+         * @default true
+         */
+        use_proxy_from_env_var?: boolean | undefined;
     }
 
     interface ResponseOptions {

--- a/types/needle/package.json
+++ b/types/needle/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/needle",
-    "version": "3.2.9999",
+    "version": "3.3.9999",
     "projects": [
         "https://github.com/tomas/needle"
     ],


### PR DESCRIPTION
Adds `use_proxy_from_env_var` to `NeedleOptions`. They were introduced in:
https://github.com/tomas/needle/pull/427

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


