### PR TITLE
Remove tslint mentions from README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,6 @@ If adding a new definition:
 - [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
 - [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
 - [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
-- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
 - [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
 
 If changing an existing definition:

--- a/README.es.md
+++ b/README.es.md
@@ -138,7 +138,6 @@ Tu paquete debería tener esta estructura:
 | `index.d.ts` | Este contiene los typings del paquete. |
 | [`<my-package>-tests.ts`](#my-package-teststs) | Este contiene una muestra del código con el que se realiza la prueba de escritura. Este código *no* es ejecutable, pero sí es type-checked. |
 | [`tsconfig.json`](#tsconfigjson) | Este permite ejecutar `tsc` dentro del paquete. |
-| [`tslint.json`](#linter-tslintjson) | Permite linting. |
 
 Generalas ejecutando `npm install -g dts-gen` y `dts-gen --dt --name <my-package> --template module`.
 Ve todas las opciones en [dts-gen](https://github.com/Microsoft/dts-gen).

--- a/README.es.md
+++ b/README.es.md
@@ -222,7 +222,7 @@ f("one");
 
 Para más detalles, vea el [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
 
-#### Linter: `tslint.json`
+#### Linter: `.eslintrc.json`
 
 The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -173,7 +173,6 @@ Votre paquet doit avoir cette structure :
 | `index.d.ts`  | Il contient les typages du paquet. |
 | [`<mon-paquet>-tests.ts`](#mon-paquet-teststs)  | Il contient un exemple de code qui teste les typages. Ce code *ne* s'exécute pas, mais il est vérifié. |
 | [`tsconfig.json`](#tsconfigjson) | Cela vous permet d'exécuter `tsc` à l'intérieur du paquet. |
-| [`tslint.json`](#linter-tslintjson)   | Activer le linting |
 | [`.eslintrc.json`](#linter-eslintrcjson)   | (Rarement) Nécessaire uniquement pour désactiver les règles de lint écrites pour eslint. |
 
 Vous pouvez les générer en lançant `npx dts-gen --dt --name <mon-paquet> --template module` si vous avez npm ≥ 5.2.0, `npm install -g dts-gen` et `dts-gen --dt --name <mon-paquet> --template module` dans le cas contraire.
@@ -277,17 +276,9 @@ f("one");
 
 Pour plus de détails, voir le readme de [dtslint](https://github.com/Microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests).
 
-#### Linter: `tslint.json`
-
-Le fichier de configuration du linter, `tslint.json` doit contenir `{ "extends" : "@definitelytyped/dtslint/dt.json" }`, et aucune règle supplémentaire.
-
-Si, pour une raison quelconque, une règle doit être désactivée, [désactivez-la pour cette ligne spécifique](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Désactive%20les%20règles%20listées%20pour%20la%20prochaine%20ligne) en utilisant `// tslint:disable-next-line:[nomRègle]` - pas pour tout le paquet, afin que la désactivation puisse être examinée. (Il y a quelques anciennes configurations de lint qui ont des contenus additionnels, mais cela ne devrait pas se produire dans un nouveau travail).
-
 ##### Linter: `.eslintrc.json`
 
-Definitely Typed est en train de passer à eslint pour le linting.
-Contrairement à tslint, vous n'avez pas besoin d'un fichier de configuration pour activer le linting.
-Comme pour tslint, vous devez désactiver des règles spécifiques uniquement sur des lignes spécifiques :
+Vous devez désactiver des règles spécifiques uniquement sur des lignes spécifiques :
 
 
 ```ts

--- a/README.it.md
+++ b/README.it.md
@@ -169,7 +169,6 @@ Il tuo package dovrebbe avere questa struttura:
 | `index.d.ts`  | Contiene le dichiarazioni dei tipi del package. |
 | [`<nome-package>-tests.ts`](#mio-package-teststs)  | Contiene codice di esempio con test delle dichiarazioni dei tipi. Se il codice *non* funziona anche se viene traspilato da tsc senza errori.
 | [`tsconfig.json`](#tsconfigjson) | Ti permette di eseguire `tsc` all'interno del package. |
-| [`tslint.json`](#linter-tslintjson)   | Abilita il linting. |
 
 Generali eseguento `npx dts-gen --dt --name <mio-package> --template module` se hai npm ≥ 5.2.0, altrimenti `npm install -g dts-gen` and `dts-gen --dt --name <my-package> --template module`.
 Leggi tutte le opzioni su [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -266,17 +265,9 @@ f("one");
 
 Per maggiori dettagli, leggi il readme di [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests).
 
-#### Linter: `tslint.json`
-
-Il file di configurazione del linter, `tslint.json`, dovrebbe contenere `{ "extends": "@definitelytyped/dtslint/dt.json" }` e nessun'altra regola.
-
-Se per qualche ragione qualche regola necessita di essere disabilitata, [disabilitala solo per la riga di codice in cui dovrebbe esserlo](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) usando `// tslint:disable-next-line:[ruleName]` e non disabilitandola per tutto il package, in modo tale che tu possa verificarne l'effetto. (CI sono alcune configurazioni lint legacy che hanno del contenuto aggiuntivo tuttavia non dovrebbe più accadere nei lavori futuri).
-
 ##### Linter: `.eslintrc.json`
 
-"Definitely Typed" sta migrando ad eslint per il linting.
-Al contrario di tslint qui non è necessario un file di configurazione per il linting.
-Proprio come tslint dovresti disabilitare le regole solo per determinate linee:
+Dovresti disabilitare le regole solo per determinate linee:
 
 ```ts
 // eslint-disable-next-line no-const-enum

--- a/README.ja.md
+++ b/README.ja.md
@@ -168,7 +168,6 @@ npm 上にないパッケージの型定義を追加したい場合は、その�
 | `index.d.ts` | 型定義が含まれる。 |
 | [`<パッケージ名>-tests.ts`](#パッケージ名-teststs)  | 型定義をテストするサンプルコードが含まれる。このコードは実行は**されません**が、型チェックはされます。 |
 | [`tsconfig.json`](#tsconfigjson) | パッケージ内で `tsc` を実行するのに必要。 |
-| [`tslint.json`](#linter-tslintjson) | Lint を有効にする。 |
 
 これらのファイルを生成するには、 npm 5.2.0 以上では `npx dts-gen --dt --name <パッケージ名> --template module` 、それより古い環境では `npm install -g dts-gen` と `dts-gen --dt --name <パッケージ名> --template module` を実行してください。
 dts-gen の全オプションは[こちら](https://github.com/Microsoft/dts-gen)で確認できます。
@@ -270,17 +269,9 @@ f("one");
 
 詳しくは、 [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) の README を参照してください。
 
-#### Linter: `tslint.json`
-
-リンターの設定ファイルである `tslint.json` は `{ "extends": "@definitelytyped/dtslint/dt.json" }` を含むべきであり、追加のルールは含まれていてはいけません。
-
-何らかの理由で特定のルールを無効にする必要がある場合は、[その特定の行に対して無効にしてください](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line)。ルール全体を無効にしないでください。無効にすることが確認可能であるようにするためです。（いくつかの既存のリント設定には追加の内容が含まれていることがあるが、新しい作業ではこれらは発生しないべきです。）
-
 ##### Linter: `.eslintrc.json`
 
-Definitely Typed はリントに eslint を使用するよう切り替えています。
-tslint とは異なり、リンティングを有効にするための設定ファイルは不要です。
-tslint と同様に、特定のルールは特定の行に対してのみ無効にするべきです：
+特定のルールは特定の行に対してのみ無効にするべきです：
 
 ```ts
 // eslint-disable-next-line no-const-enum

--- a/README.ko.md
+++ b/README.ko.md
@@ -156,7 +156,6 @@ npm 에 올라가 있지 않은 패키지를 위한 자료형(Typing) 패키지�
 | `index.d.ts` | 패키지를 위한 자료형(Typing)을 포함하는 파일입니다. |
 | [`<my-package>-tests.ts`](#my-package-teststs) | 자료형(Typing)의 테스트를 위한 파일입니다. 이 파일의 코드는 실행되지는 않지만, 자료형 검사(Type checking)를 통과해야 합니다. |
 | [`tsconfig.json`](#tsconfigjson) | `tsc` 명령을 돌릴 수 있게 해주는 파일입니다. |
-| [`tslint.json`](#linter-tslintjson) | 린터(Linter)를 사용할 수 있게 해주는 파일입니다. |
 
 이 파일들은, npm ≥ 5.2.0 에서는 `npx dts-gen --dt --name <my-package> --template module` 명령으로,
 그 이하 경우에는 `npm install -g dts-gen` 와 `dts-gen --dt --name <my-package> --template module` 명령으로 만들 수 있습니다.
@@ -243,11 +242,18 @@ f("one");
 
 [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) 저장소의 README 파일에서 더 자세한 내용을 확인하실 수 있습니다.
 
-#### Linter: `tslint.json`
+##### Linter: `.eslintrc.json`
 
-The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
+If for some reason a lint rule needs to be disabled, disable it for a specific line:
 
-If for some reason some rule needs to be disabled, [disable it for that specific line](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) using `// tslint:disable-next-line:[ruleName]` — not for the whole package, so that disabling can be reviewed. (There are some legacy lint configs that have additional contents, but these should not happen in new work.)
+```ts
+// eslint-disable-next-line no-const-enum
+const enum Const { One }
+const enum Enum { Two } // eslint-disable-line no-const-enum
+```
+
+You can still disable rules with an .eslintrc.json, but should not in new packages.
+Disabling rules for the entire package makes it harder to review.
 
 #### `tsconfig.json`
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Your package should have this structure:
 | `index.d.ts`  | This contains the typings for the package. |
 | [`<my-package>-tests.ts`](#my-package-teststs)  | This contains sample code which tests the typings. This code does *not* run, but it is type-checked. |
 | [`tsconfig.json`](#tsconfigjson) | This allows you to run `tsc` within the package. |
-| [`tslint.json`](#linter-tslintjson)   | Enables linting. |
 | [`.eslintrc.json`](#linter-eslintrcjson)   | (Rarely) Needed only to disable lint rules written for eslint. |
 | [`package.json`](#packagejson) | Contains metadata for the package, including its name, version and dependencies. |
 | [`.npmignore`](#npmignore) | Specifies which files are intended to be included in the package. |
@@ -276,18 +275,9 @@ f("one");
 
 For more details, see [dtslint](https://github.com/Microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
 
-#### Linter: `tslint.json`
-
-The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }` and no additional rules.
-
-If for some reason some rule needs to be disabled, [disable it for that specific line](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) using `// tslint:disable-next-line:[ruleName]` — not for the whole package, so that disabling can be reviewed. (There are some legacy lint configs that have additional contents, but these should not happen in new work.)
-
 ##### Linter: `.eslintrc.json`
 
-Definitely Typed is in the process of switching to eslint for linting.
-Unlike tslint, you don't need a config file to enable linting.
-Like tslint, you should disable specific rules only on specific lines:
-
+If for some reason a lint rule needs to be disabled, disable it for a specific line:
 
 ```ts
 // eslint-disable-next-line no-const-enum
@@ -296,6 +286,7 @@ const enum Enum { Two } // eslint-disable-line no-const-enum
 ```
 
 You can still disable rules with an .eslintrc.json, but should not in new packages.
+Disabling rules for the entire package makes it harder to review.
 
 #### `tsconfig.json`
 
@@ -488,7 +479,7 @@ npm packages should update within an hour. If it's been more than an hour, menti
 If the module you're referencing is a module (uses `export`), use an import.
 If the module you're referencing is an ambient module (uses `declare module`) or just declares globals, use `<reference types="" />`.
 
-#### Some packages have no `tslint.json` and some `tsconfig.json` are missing `"noImplicitAny": true`, `"noImplicitThis": true` or `"strictNullChecks": true`.
+#### Some packages have a `tsconfig.json` that is missing `"noImplicitAny": true`, `"noImplicitThis": true` or `"strictNullChecks": true`.
 
 Then they are wrong and we've not noticed yet. You can help by submitting a pull request to fix them.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -147,7 +147,6 @@ Seu pacote deve possuir a seguinte estrutura:
 | `index.d.ts` | Contém os tipos para o pacote. |
 | [`<my-package>-tests.ts`](#my-package-teststs) | Contém código de exemplo que testa os tipos. Esse código *não* é executado, mas seus tipos são checados. |
 | [`tsconfig.json`](#tsconfigjson) | Permite que você execute `tsc` dentro do pacote. |
-| [`tslint.json`](#linter-tslintjson) | Habilita a análise do código pelo linter. |
 
 Gere esses arquivos executando `npx dts-gen --dt --name nome-do-seu-pacote --template module` se você possuir a versão 5.2.0 ou mais recente do npm ou `npm install -g dts-gen` e `dts-gen --dt --name nome-do-seu-pacote --template module` caso possua uma versão mais antiga.
 Veja todas as opções em [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -247,11 +246,18 @@ f("um");
 
 Para mais detalhes, veja o arquivo readme do [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests).
 
-#### Linter: `tslint.json`
+##### Linter: `.eslintrc.json`
 
-The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
+If for some reason a lint rule needs to be disabled, disable it for a specific line:
 
-If for some reason some rule needs to be disabled, [disable it for that specific line](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) using `// tslint:disable-next-line:[ruleName]` — not for the whole package, so that disabling can be reviewed. (There are some legacy lint configs that have additional contents, but these should not happen in new work.)
+```ts
+// eslint-disable-next-line no-const-enum
+const enum Const { One }
+const enum Enum { Two } // eslint-disable-line no-const-enum
+```
+
+You can still disable rules with an .eslintrc.json, but should not in new packages.
+Disabling rules for the entire package makes it harder to review.
 
 #### `tsconfig.json`
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -153,7 +153,6 @@ Definitely Typed работает только благодаря вкладу �
 | `index.d.ts`  | Содержит типизацию для пакета.                                                                       |
 | [`<my-package>-tests.ts`](#my-package-teststs)  | Содержит пример кода, который проверяет типизацию. Этот код _не_ запускается, но он проверен на тип. |
 | [`tsconfig.json`](#tsconfigjson) | Позволяет вам запускать `tsc` внутри пакета.                                      |
-| [`tslint.json`](#linter-tslintjson)   | Включает linting.                                                            |
 
 Создайте их, запустив `npx dts-gen --dt --name <my-package> --template module` если у вас npm ≥ 5.2.0, `npm install -g dts-gen` и `dts-gen --dt --name <my-package> --template module` в противном случае.
 Посмотреть все варианты на [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -239,11 +238,18 @@ f('one');
 
 Для получения дополнительной информации см. [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
 
-#### Linter: `tslint.json`
+##### Linter: `.eslintrc.json`
 
-The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
+If for some reason a lint rule needs to be disabled, disable it for a specific line:
 
-If for some reason some rule needs to be disabled, [disable it for that specific line](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) using `// tslint:disable-next-line:[ruleName]` — not for the whole package, so that disabling can be reviewed. (There are some legacy lint configs that have additional contents, but these should not happen in new work.)
+```ts
+// eslint-disable-next-line no-const-enum
+const enum Const { One }
+const enum Enum { Two } // eslint-disable-line no-const-enum
+```
+
+You can still disable rules with an .eslintrc.json, but should not in new packages.
+Disabling rules for the entire package makes it harder to review.
 
 #### `tsconfig.json`
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -170,7 +170,6 @@ declare module "libname" {
 | `index.d.ts` | 此文件包含软件包的类型声明。 |
 | [`<my-package>-tests.ts`](#my-package-teststs) | 此文件包含测试类型声明的示例代码，其**不会**运行，但是它会通过类型检查。 |
 | [`tsconfig.json`](#tsconfigjson) | 此文件允许你在软件包中运行 `tsc`。 |
-| [`tslint.json`](#linter-tslintjson) | 启用 Lint。 |
 | [`.eslintrc.json`](#linter-eslintrcjson)   | （极少使用）仅在需要禁用 ESLint 规则时使用。 |
 
 如果你的 npm 版本高于 5.2.0，请运行 `npx dts-gen --dt --name <my-package> --template module` 来生成这些文件，否则请运行 `npm install -g dts-gen` 和 `dts-gen --dt --name <my-package> --template module`。
@@ -272,15 +271,9 @@ f("one");
 
 更多详细信息，请参见 [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) 的 README 文件。
 
-#### Linter: `tslint.json`
-
-Linter 的配置文件 `tslint.json` 只应包含 `{ "extends": "@definitelytyped/dtslint/dt.json" }`，并且不含其他规则。
-
-若出于某些原因，需要禁用规则，请使用 `// tslint:disable-next-line:[ruleName]` [在需要禁用规则的那一行禁用它](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line)，而不是在整个软件包内禁用，因此代码审核者可以审核禁用规则的代码。（一些陈旧的 Linter 配置文件可能包含额外内容，但这些内容不应该出现在新项目中。）
-
 ##### Linter: `.eslintrc.json`
 
-Definitely Typed 正在从 TSLint 迁移至 ESLint。与 TSLint 不同，ESLint 无需配置文件即可启用。你仅应在需要禁用规则的那一行处禁用规则，与 TSLint 相同：
+你仅应在需要禁用规则的那一行处禁用规则，与 TSLint 相同：
 
 ```ts
 // eslint-disable-next-line no-const-enum


### PR DESCRIPTION
I missed this when I deleted tslint from the rest of the repo.

I'm not sure whether I'll send changes to other languages since there are non-delete edits that I made in English, and I barely read most of these languages, let alone write them.