### PR TITLE
[@types/object.groupby] Make output property types optional

### DIFF
--- a/types/object.groupby/index.d.ts
+++ b/types/object.groupby/index.d.ts
@@ -6,7 +6,7 @@
 declare function groupBy<T, K extends PropertyKey>(
     iterable: Iterable<T>,
     callbackfn: (value: T, index: number) => K,
-): Record<K, T[]>;
+): { [P in K]?: T[] };
 
 /**
  * Returns an object that groups the iterable of the iterable object into arrays, using the return value of the callback function as the key.
@@ -16,6 +16,6 @@ declare function groupBy<T, K extends PropertyKey>(
 declare function groupBy(
     iterable: Iterable<any>,
     callbackfn: (value: any, index: number) => PropertyKey,
-): Record<PropertyKey, any[]>;
+): { [P in PropertyKey]?: any[] };
 
 export = groupBy;

--- a/types/object.groupby/object.groupby-tests.ts
+++ b/types/object.groupby/object.groupby-tests.ts
@@ -1,10 +1,13 @@
 import groupBy = require("object.groupby");
 
-// $ExpectType Record<number, string[]>
+// $ExpectType { [P in number]?: string }
 groupBy(["a", "bb", "ccc"], v => v.length);
 
-// $ExpectType Record<"odd" | "even", number[]>
+// $ExpectType { odd?: number[]; even?: number[] }
 groupBy([1, 2, 3], v => v ? "odd" : "even");
 
-// $ExpectType Record<symbol, any[]>
+// $ExpectType { odd?: number[]; even?: number[] }
+groupBy([2, 4, 6], v => v % 2 !== 0 ? "odd" : "even");
+
+// $ExpectType { [P in symbol]?: any[] }
 groupBy([235, {} as any], v => Symbol(v.toString()));

--- a/types/object.groupby/object.groupby-tests.ts
+++ b/types/object.groupby/object.groupby-tests.ts
@@ -1,13 +1,13 @@
 import groupBy = require("object.groupby");
 
-// $ExpectType { [P in number]?: string }
+// $ExpectType { [x: number]: string[] | undefined }
 groupBy(["a", "bb", "ccc"], v => v.length);
 
-// $ExpectType { odd?: number[]; even?: number[] }
+// $ExpectType { odd?: number[] | undefined; even?: number[] | undefined }
 groupBy([1, 2, 3], v => v ? "odd" : "even");
 
-// $ExpectType { odd?: number[]; even?: number[] }
+// $ExpectType { odd?: number[] | undefined; even?: number[] | undefined }
 groupBy([2, 4, 6], v => v % 2 !== 0 ? "odd" : "even");
 
-// $ExpectType { [P in symbol]?: any[] }
+// $ExpectType { [x: symbol]: any[] | undefined }
 groupBy([235, {} as any], v => Symbol(v.toString()));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
-[x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
-[x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
-[x] [Run pnpm test <package to test>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [TC39 spec](https://tc39.es/proposal-array-grouping/)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

* * *

### Motivating Example

When running `Object.groupBy`, the specified callback function may not always output all of the possible types. When this happens, `Object.groupBy`, as per spec, will only include the keys that are actually output. To use an example, consider splitting an array into evens and odds ([TypeScript Playground](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwHMYdkAHAIQE8AeAFQBp4BpeEADwxFWAGd4AFYqRAwMlJiEoA+ABQAoeIvhZOMKACMIIAFzwAkqo1a6U+gqVgoECOqhgA1olS6ZANyvId8Bsu7tdqMgAtuoiAJTwALxSzGZhugBK4DgwwNRMjLQA2gC6UgDccnJgeDwY8HA8yBDlkYTEZFQyWQBMjAAsjABsOYxuHiAR0fDuEJ7wAKTwLVGRdQAM8AD88ABEIK5cq-C6qzjAwKthhZXVGAB0+8D5QA)):

```ts
const result = Object.groupBy([2, 4, 6], (value) => value % 2 === 0 ? "even" : "odd");
```

Here, `typeof result satisfies { even: number[]; odd: number[] }` but `JSON.stringify(result) === '{"even":[2,4,6]}'`. If we don’t know the value of the input array, it would be extremely unwise to start operating on `result.odd`.

### On `noUncheckedIndexedAccess`

For trivial examples, where `callbackFn` outputs `string` or `number` (ex. `Object.groupBy([1, 2, 3], value => value)`), we can solve this by enabling [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess), or we can opt out. This is presumably good, because it allows users to determine what level of type-safety they want.

However, `noUncheckedIndexedAccess` doesn’t apply to more complex types such as the even/odd example above. In that case, the user has no choice about the type-safety of their returns. In this example, with `noUncheckedIndexedAccess` enabled ([Playground](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwHMYdkAHAIQE8AeAFQBp4BpeEADwxFWAGd4AFYqRAwMlJiEoA+ABQAoeIvhZOMKACMIIAFzwAkqo1a6U+gqVgoECOqhgA1olS6ZANyvId8Bsu7tdqMgAtuoiAJTwALxSzGZhugBK4DgwwNRMjLQA2gC6UgDccnJgeDwY8HA8yBDlkYTEZFQyWQBMjAAsjABsOYxuHiAR0fDuEJ7wAKTwLVGRdQAM8AD88ABEIK5cq-C6qzjAwKthhSWoZfCc53WV1RgAdPvAhcWl5Tc1M3VEJBSUzQCMjDa8AAzL0RgMojFRp5ji8zuVLhhPhUQFUPll2jl8kA)):

```ts
const result = groupBy([2, 4, 6], (value) => value % 2 === 0 ? "even" : "odd");
const test = result.odd;

const result2 = groupBy([1, 2, 3], value => value);
const test2 = result2[4];
``` 

`typeof test2 satisfies number[] | undefined`, while `typeof test satisfies number[]`. This probably isn’t what users expect, or at least it’s not what I was expecting when I discovered this issue.

Specifically, the issue is that the unchecked index access rule only applies to unknown properties, but not mapped object types. When the output of `callbackFn` is a base type such as `string` or `number`, TypeScript treats these properties as ‘unknown’, since they’re infinite. But when `callbackFn` outputs a literal, or union of literals, these properties become ‘known’ and accessing them is no longer considered an unchecked index access.

### Potential Alternative
One alternative which would be somewhat less breaking would be to write (or similar):

```ts
declare function groupBy<T, K extends PropertyKey>(
    iterable: Iterable<T>,
    callbackfn: (value: T, index: number) => K,
): Record<K extends string ? string : K extends number ? number : K extends symbol ? symbol : never, T[]>;
```

This would unnarrow the key type, re-enabling the `noUncheckedIndexedAccess` behaviour, but losing the extra type information that would normally be inferable.

### Other Solutions Considered

I thought about all manner of clever ways to avoid having to always set every property to optional, but unfortunately there are no good solutions that feel simple enough to end up in `lib.d.ts`, which we’d want this to be eventually compatible with (if it doesn’t just directly adapt these types). There would be a lot of edge-casing more generally.

I specifically considered:
- Trying to determine if the output of `callbackFn` is a literal or array of literals, which would guarantee its availability (AFAIK there are no utility types which can distinguish `"even"` from `"even" | "odd"` and `string` which aren’t hacks)
- Guaranteeing that at least one possible option is required on the result type (using something like [`type-fest`’s `RequireAtLeastOne`](https://github.com/sindresorhus/type-fest/blob/a919f93384dba6e6d21e202a287986a6d4ea03e4/source/require-at-least-one.d.ts))

### Is this a breaking change?
I am not familiar with the versioning process for `@types` packages. This change will absolutely break the type-checking for existing code in existing repositories. On the other hand, it’s a bugfix which brings the types closer to the specification, and this package is a shim for a TC39 proposal so its types may not be expected to be stable? Any guidance here is appreciated and I’m happy to make those changes.