### PR TITLE
[p5js] Fix definition without arguments for clear()

### DIFF
--- a/types/p5/src/color/setting.d.ts
+++ b/types/p5/src/color/setting.d.ts
@@ -250,6 +250,23 @@ declare module '../../index' {
         clear(r: number, g: number, b: number, a: number): p5;
 
         /**
+         *   Clears the pixels on the canvas. This function
+         *   makes every pixel 100% transparent. Calling
+         *   clear() doesn't clear objects created by createX()
+         *   functions such as createGraphics(), createVideo(),
+         *   and createImg(). These objects will remain
+         *   unchanged after calling clear() and can be
+         *   redrawn. In WebGL mode, this function can clear
+         *   the screen to a specific color. It interprets four
+         *   numeric parameters as normalized RGBA color
+         *   values. It also clears the depth buffer. If you
+         *   are not using the WebGL renderer, these parameters
+         *   will have no effect.
+         *   @chainable
+         */
+        clear(): p5;
+
+        /**
          *   Changes the way p5.js interprets color data. By
          *   default, the numeric parameters for fill(),
          *   stroke(), background(), and color() are defined by

--- a/types/p5/test/index.ts
+++ b/types/p5/test/index.ts
@@ -26,6 +26,8 @@ function s(
       50,
       50
     );
+    sketch.clear();
+    sketch.clear(1, 0.5, 0, 0);
   };
 }
 


### PR DESCRIPTION
Previous PR #67857 changed `global.d.ts` but not the underlying `setting.d.ts`

Sorry for this mistake. This PR fixes that.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/processing/p5.js/blob/fc660dd9613/src/color/setting.js#L449-L457) [doc](https://p5js.org/reference/#/p5/clear)
