### PR TITLE
Add exports map and index.d.ts to extract-files

### DIFF
--- a/types/extract-files/tsconfig.json
+++ b/types/extract-files/tsconfig.json
@@ -14,6 +14,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "index.d.ts",
         "extractFiles.d.mts",
         "isExtractableFile.d.mts",
         "extract-files-tests.ts"


### PR DESCRIPTION
- I noticed I didn't add the exports map to package.json
- `index.d.ts` file must exist, so the tooling performs extra lints
---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#packagejson:~:text=This%20also%20applies%20if%20the%20implementation%20package%20has%20exports%20in%20its%20package.json.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
