### PR TITLE
Fix GHA workflow permissions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,10 +4,16 @@ on:
   schedule:
     - cron: '37 */6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   trigger_bot:
     runs-on: ubuntu-latest
     if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
+
+    permissions:
+      actions: write
 
     steps:
       - run: 'gh workflow run daily.yml -R DefinitelyTyped/dt-mergebot'

--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -9,10 +9,17 @@ on:
       - master
   workflow_dispatch: ~
 
+permissions:
+  contents: read
+
 jobs:
   dprint-fmt:
     runs-on: ubuntu-latest
     if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
+
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
A recent change forced permissions to be read-only by default, but not all of our workflows correctly declared what they needed to write.