### PR TITLE
Add dummy index.d.ts to extract-files

### DIFF
--- a/types/extract-files/index.d.ts
+++ b/types/extract-files/index.d.ts
@@ -1,0 +1,4 @@
+// Despite not having any definitions, this file must exist on DefinitelyTyped.
+// Currently, the tooling assumes that this file exists and performs extra lints,
+// as well as using it to figure out where things are.
+export {};

--- a/types/extract-files/package.json
+++ b/types/extract-files/package.json
@@ -5,6 +5,15 @@
     "projects": [
         "https://github.com/jaydenseric/extract-files#readme"
     ],
+    "exports": {
+        "./extractFiles.mjs": {
+            "types": "./extractFiles.d.mts"
+        },
+        "./isExtractableFile.mjs": {
+            "types": "./isExtractableFile.d.mts"
+        },
+        "./package.json": "./package.json"
+    },
     "devDependencies": {
         "@types/extract-files": "workspace:."
     },


### PR DESCRIPTION
It's still required. Based on the fix in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67904 by @felipelima-circle