### PR TITLE
Update `@types/react`'s v16 `InputHTMLAttributes` to include `enterKeyHint` just like in v17 & v18

### DIFF
--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -2220,6 +2220,7 @@ declare namespace React {
         capture?: boolean | string | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
         disabled?: boolean | undefined;
+        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
         formEncType?: string | undefined;

--- a/types/react/v16/test/elementAttributes.tsx
+++ b/types/react/v16/test/elementAttributes.tsx
@@ -34,6 +34,9 @@ const testCases = [
     <input value={["one", "two"] as readonly string[]} />,
     <input value={["one", "two"] as string[]} />,
     <input value={["one", "two"]} />,
+    <input enterKeyHint="done" />,
+    // @ts-expect-error
+    <input enterKeyHint="don" />,
     <div role="alertdialog" />,
     <div role="none presentation" />,
     <svg role="treeitem" />,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [v17 types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v17/index.d.ts#L2222)
  - [v18 types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2367)
  - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
