### PR TITLE
[whatwg-url] Fix type of baseURL

### DIFF
--- a/types/whatwg-url/index.d.ts
+++ b/types/whatwg-url/index.d.ts
@@ -88,13 +88,13 @@ export class URLSearchParams {
 }
 
 /** https://url.spec.whatwg.org/#concept-url-parser */
-export function parseURL(input: string, options?: { readonly baseURL?: string | undefined }): URLRecord | null;
+export function parseURL(input: string, options?: { readonly baseURL?: URLRecord | undefined }): URLRecord | null;
 
 /** https://url.spec.whatwg.org/#concept-basic-url-parser */
 export function basicURLParse(
     input: string,
     options?: {
-        baseURL?: string | undefined;
+        baseURL?: URLRecord | undefined;
         url?: URLRecord | undefined;
         stateOverride?: StateOverride | undefined;
     },

--- a/types/whatwg-url/test/whatwg-url.index.test.ts
+++ b/types/whatwg-url/test/whatwg-url.index.test.ts
@@ -18,7 +18,6 @@ new whatwgUrl.URL("foo", "http://example.com");
 
 // $ExpectType URLRecord | null
 const urlRecord = whatwgUrl.parseURL("http://example.com");
-whatwgUrl.parseURL("http://example.com", { baseURL: "foo" });
 
 if (urlRecord !== null) {
     urlRecord.scheme; // $ExpectType string
@@ -30,7 +29,7 @@ if (urlRecord !== null) {
     urlRecord.query; // $ExpectType string | null
     urlRecord.fragment; // $ExpectType string | null
     whatwgUrl.basicURLParse("http://example.com", { url: urlRecord }); // $ExpectType URLRecord | null
-    whatwgUrl.basicURLParse("http://example.com", { baseURL: "foo" }); // $ExpectType URLRecord | null
+    whatwgUrl.basicURLParse("/relative/path", { baseURL: urlRecord }); // $ExpectType URLRecord | null
     (
         [
             "scheme start",


### PR DESCRIPTION
`baseURL` being a string was incorrect. The `URL` class actually parses the `baseURL` before passing it to `parseURL`, see https://github.com/jsdom/whatwg-url/blob/6aa56a7ff00b24b45543d6efd7c1ae42c467bee9/lib/URL-impl.js#L13-L19

But both `parseURL` and `basicParseURL` just pass the base verbatim to `URLStateMachine`, which then tries to access members of that.

I confirmed this by testing whatwg-url in node:

```
$ node
Welcome to Node.js v18.18.2.
Type ".help" for more information.
> x = require('whatwg-url')
...
> base = x.parseURL(
> x.parseURL('/asdf?my=param', { baseURL: 'http://example.com' })
{
  scheme: undefined,
  username: undefined,
  password: undefined,
  host: undefined,
  port: undefined,
  path: [ 'asdf' ],
  query: 'my=param',
  fragment: null
}
> base = x.parseURL('http://example.com')
{
  scheme: 'http',
  username: '',
  password: '',
  host: 'example.com',
  port: null,
  path: [ '' ],
  query: null,
  fragment: null
}
> x.parseURL('/asdf?my=param', { baseURL: base })
{
  scheme: 'http',
  username: '',
  password: '',
  host: 'example.com',
  port: null,
  path: [ 'asdf' ],
  query: 'my=param',
  fragment: null
}
```

As you can see, passing a string causes multiple `undefined`s, while passing a URLRecord works as expected.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   https://github.com/jsdom/whatwg-url/blob/6aa56a7ff00b24b45543d6efd7c1ae42c467bee9/lib/URL-impl.js#L13-L19,
   also https://github.com/jsdom/whatwg-url/blob/6aa56a7ff00b24b45543d6efd7c1ae42c467bee9/lib/url-state-machine.js#L1214
   and
https://github.com/jsdom/whatwg-url/blob/6aa56a7ff00b24b45543d6efd7c1ae42c467bee9/lib/url-state-machine.js#L1246
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.