### PR TITLE
Fix Plotly.js Sankey Diagram TS

### DIFF
--- a/types/plotly.js/lib/traces/sankey.d.ts
+++ b/types/plotly.js/lib/traces/sankey.d.ts
@@ -37,7 +37,7 @@ export interface SankeyNode {
     groups: SankeyNode[];
     hoverinfo: "all" | "none" | "skip";
     hoverlabel: Partial<SankeyHoverLabel>;
-    hovertemplate: string[];
+    hovertemplate: string | string[];
     label: Datum[];
     line: Partial<{
         color: SankeyColor;


### PR DESCRIPTION
Per the documentation (https://plotly.com/python/reference/sankey/), the Plotly sankey node hovertemplate supports both string and string array inputs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/python/reference/sankey/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not a version update)
