### PR TITLE
Add missing typings to node-fetch Response

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -184,13 +184,14 @@ export interface ResponseInit {
     statusText?: string | undefined;
     timeout?: number | undefined;
     url?: string | undefined;
+    counter?: number | undefined;
 }
 
 interface URLLike {
     href: string;
 }
 
-export type HeadersInit = Headers | string[][] | { [key: string]: string };
+export type HeadersInit = Headers | string[][] | { [key: string]: string } | { [key: string]: string[] };
 // HeaderInit is exported to support backwards compatibility. See PR #34382
 export type HeaderInit = HeadersInit;
 export type BodyInit =

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -191,7 +191,7 @@ interface URLLike {
     href: string;
 }
 
-export type HeadersInit = Headers | string[][] | { [key: string]: string } | { [key: string]: string[] };
+export type HeadersInit = Headers | string[][] | { [key: string]: string | string[] };
 // HeaderInit is exported to support backwards compatibility. See PR #34382
 export type HeaderInit = HeadersInit;
 export type BodyInit =

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -266,7 +266,6 @@ function test_ResponseInitCounter() {
     });
 }
 
-
 async function test_BlobText() {
     const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -197,6 +197,7 @@ function test_headers() {
     [...headers.entries()]; // $ExpectType [string, string][]
     [...headers.keys()]; // $ExpectType string[]
     [...headers.values()]; // $ExpectType string[]
+    headers.raw(); // $ExpectType { [k: string]: string[]; }
 }
 
 function test_isRedirect() {
@@ -237,6 +238,34 @@ function test_ResponseInit() {
         });
     });
 }
+
+function test_ResponseInitRawHeaders() {
+    fetch("http://test.com", {}).then(response => {
+        const responseWithRawHeaders = new Response(response.body, {
+            url: response.url,
+            size: response.size,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers.raw(),
+            timeout: response.timeout,
+        });
+    });
+}
+
+function test_ResponseInitCounter() {
+    fetch("http://test.com", {}).then(response => {
+        const redirectedResponse = new Response(response.body, {
+            url: response.url,
+            size: response.size,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            timeout: response.timeout,
+            counter: 5,
+        });
+    });
+}
+
 
 async function test_BlobText() {
     const someString = await new Blob(["Hello world"]).text(); // $ExpectType string

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -235,33 +235,20 @@ function test_ResponseInit() {
             statusText: response.statusText,
             headers: response.headers,
             timeout: response.timeout,
+            counter: 5,
         });
     });
 }
 
 function test_ResponseInitRawHeaders() {
     fetch("http://test.com", {}).then(response => {
-        const responseWithRawHeaders = new Response(response.body, {
+        new Response(response.body, {
             url: response.url,
             size: response.size,
             status: response.status,
             statusText: response.statusText,
             headers: response.headers.raw(),
             timeout: response.timeout,
-        });
-    });
-}
-
-function test_ResponseInitCounter() {
-    fetch("http://test.com", {}).then(response => {
-        const redirectedResponse = new Response(response.body, {
-            url: response.url,
-            size: response.size,
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-            timeout: response.timeout,
-            counter: 5,
         });
     });
 }


### PR DESCRIPTION
The `counter` option in `ResponseInit` can be seen in the source code [here](https://github.com/node-fetch/node-fetch/blob/2.x/src/response.js#L44C15-L44C15).

The ability to construct `Response` with headers of type `{ [key: string]: string[] }` (which is also what's returned by `response.headers.raw()`) can be confirmed experimentally:

```js
const { Readable } = require('stream');
const fetch = require('node-fetch');

const response = new fetch.Response(
  Readable.from(Buffer.alloc(0)),
  {
    url: 'http://test.com',
    status: 200,
    headers: {
      'x-my-header': ['abc', 'xyz'],
    },
    size: 0,
    timeout: 0,
    counter: 5,
  }
);

console.log('x-my-header value:', response.headers.get('x-my-header'));
console.log('Redirected:', response.redirected); // change the "counter" to 0 and this will be false
```

This writes to the console:

```
x-my-header value: abc,xyz
Redirected: true
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.