### PR TITLE
[css-tree] add walk.skip and walk.break

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -22,6 +22,8 @@ csstree.walk(ast, {
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>
         this.atrule; // $ExpectType Atrule | null
+        this.break; // $ExpectType symbol
+        this.skip; // $ExpectType symbol
     },
     leave(node, item, list) {
         this.root; // $ExpectType CssNode
@@ -30,10 +32,14 @@ csstree.walk(ast, {
         item; // $ExpectType ListItem<CssNode>
         list; // $ExpectType List<CssNode>
         this.atrule; // $ExpectType Atrule | null
+        this.break; // $ExpectType symbol
+        this.skip; // $ExpectType symbol
     },
     visit: "ClassSelector",
     reverse: false,
 });
+
+csstree.walk.skip; // $ExpectType symbol
 
 const findResult = csstree.find(ast, (node, item, list) => {
     node; // $ExpectType CssNode

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -536,6 +536,18 @@ export interface WalkContext {
     block: Block | null;
     declaration: Declaration | null;
     function: FunctionNode | PseudoClassSelector | PseudoElementSelector | null;
+    /**
+     * Stops traversal. No visitor function will be invoked once this value is
+     * returned by a visitor.
+     */
+    break: symbol;
+    /**
+     * Prevent the current node from being iterated. No visitor function will be
+     * invoked for its properties or children nodes; note that this value only
+     * has an effect for enter visitor as leave visitor invokes after iterating
+     * over all node's properties and children.
+     */
+    skip: symbol;
 }
 
 export type EnterOrLeaveFn<NodeType = CssNode> = (
@@ -602,6 +614,16 @@ export type WalkOptions =
     | WalkOptionsNoVisit;
 
 export function walk(ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+
+export namespace walk {
+    /**
+     * Prevent the current node from being iterated. No visitor function will be
+     * invoked for its properties or children nodes; note that this value only
+     * has an effect for enter visitor as leave visitor invokes after iterating
+     * over all node's properties and children.
+     */
+    const skip: symbol;
+}
 
 export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/csstree/csstree/blob/master/docs/traversal.md#walkast-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

> Walk visitor's function may return special values to control traversal:
> - `walk.break` or `this.break` – stops traversal, i.e. no visitor function will be invoked once this value is returned by a visitor;
> - `walk.skip` or `this.skip` – prevent current node from being iterated, i.e. no visitor function will be invoked for its properties or children nodes; note that this value only has an effect for `enter` visitor as `leave` visitor invokes after iterating over all node's properties and children.
> 
> https://github.com/csstree/csstree/blob/master/docs/traversal.md#walkast-options

> ```js
>     const walk = function(root, options) {
>        // …
>     };
> 
>     walk.break = breakWalk;
>     walk.skip = skipNode;
> ```
> 
> — https://github.com/csstree/csstree/blob/ba6dfd8bb0e33055c05f13803d04825d98dd2d8d/lib/walker/create.js#L167

---

CSSTree declares and documents two properties called `break` and `skip`. They appear in the `walk` function, and the `WalkContext` type.

However, I'm unable to declare the type for `break` in `export namespace walk` because `break` is a reserved word. Not sure what to do about that. Is there another way to tack a property onto a function? 🤔