### PR TITLE
[css-tree] Add types for walk.break and walk.skip

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -16,6 +16,8 @@ csstree.walk(ast, {});
 
 csstree.walk(ast, {
     enter(node, item, list) {
+        this.break; // $ExpectType symbol
+        this.skip; // $ExpectType symbol
         this.root; // $ExpectType CssNode
         this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType ClassSelector
@@ -24,6 +26,8 @@ csstree.walk(ast, {
         this.atrule; // $ExpectType Atrule | null
     },
     leave(node, item, list) {
+        this.break; // $ExpectType symbol
+        this.skip; // $ExpectType symbol
         this.root; // $ExpectType CssNode
         this.stylesheet; // $ExpectType StyleSheet | null
         node; // $ExpectType ClassSelector
@@ -34,6 +38,9 @@ csstree.walk(ast, {
     visit: "ClassSelector",
     reverse: false,
 });
+
+csstree.walk.break; // $ExpectType symbol
+csstree.walk.skip; // $ExpectType symbol
 
 const findResult = csstree.find(ast, (node, item, list) => {
     node; // $ExpectType CssNode

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -527,6 +527,18 @@ export interface GenerateOptions {
 export function generate(ast: CssNode, options?: GenerateOptions): string;
 
 export interface WalkContext {
+    /**
+     * Stops traversal. No visitor function will be invoked once this value is
+     * returned by a visitor.
+     */
+    break: symbol;
+    /**
+     * Prevent the current node from being iterated. No visitor function will be
+     * invoked for its properties or children nodes; note that this value only
+     * has an effect for enter visitor as leave visitor invokes after iterating
+     * over all node's properties and children.
+     */
+    skip: symbol;
     root: CssNode;
     stylesheet: StyleSheet | null;
     atrule: Atrule | null;
@@ -601,7 +613,19 @@ export type WalkOptions =
     | WalkOptionsVisit<WhiteSpace>
     | WalkOptionsNoVisit;
 
-export function walk(ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+export const walk: {
+    (ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+    /**
+     * Stops traversal. No visitor function will be invoked once this value is returned by a visitor.
+     */
+    readonly break: symbol;
+    /**
+     * Prevent the current node from being iterated. No visitor function will be invoked for its properties or children
+     * nodes; note that this value only has an effect for enter visitor as leave visitor invokes after iterating over
+     * all node's properties and children.
+     */
+    readonly skip: symbol;
+};
 
 export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
 


### PR DESCRIPTION
These properties are documented at:

https://github.com/csstree/csstree/blob/master/docs/traversal.md

> walk.break or this.break – stops traversal, i.e. no visitor function will be invoked once this value is returned by a
> visitor;

> walk.skip or this.skip – prevent current node from being iterated, i.e. no visitor function will be invoked for its
> properties or children nodes;

They can also be seen in the library code at:
https://github.com/csstree/csstree/blob/ba6dfd8bb0e33055c05f13803d04825d98dd2d8d/lib/walker/create.js#L242-L243

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.