### PR TITLE
fix(@babel/traverse): pass correct options to `Node::traverse`

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -468,3 +468,7 @@ const outerIdentifierPathTrue = newPath.getOuterBindingIdentifierPaths(true);
 outerIdentifierPathTrue; // $ExpectType Record<string, NodePath<Identifier>[]>
 const outerIdentifierPathBoolean = newPath.getOuterBindingIdentifierPaths(booleanVar);
 outerIdentifierPathBoolean; // $ExpectType Record<string, NodePath<Identifier> | NodePath<Identifier>[]>
+
+newPath.traverse({
+    denylist: ["TypeAnnotation"],
+});

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -392,8 +392,8 @@ export class NodePath<T = Node> {
 
     buildCodeFrameError(msg: string, Error?: ErrorConstructor): Error;
 
-    traverse<T>(visitor: Visitor<T>, state: T): void;
-    traverse(visitor: Visitor): void;
+    traverse<T>(visitor: TraverseOptions<T>, state: T): void;
+    traverse(visitor: TraverseOptions): void;
 
     set(key: string, node: any): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/365aa94656c0a6f149663de05f747e8f4f940a1a/packages/babel-traverse/src/path/index.ts#L139-L143
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As can be seen from the link above, `Node::traverse` is the same as the top level `traverse` export, except given all options instead of `visitor` and optionally `state`. So the types should match this: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/177903b416231ee8733e33ca9fd2ca7d77bc13a4/types/babel__traverse/index.d.ts#L6-L7, i.e. pass `TraverseOptions`, not `Visitor`.

FWIW, this worked before, but broke in #64628