### PR TITLE
[react-form/v1] Fix compat issues with React 15 types

### DIFF
--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -119,7 +119,7 @@ export interface FormFieldPropsWithoutField {
     children(api: FormApi): RenderReturn;
 }
 export type FormFieldProps = FormFieldPropsWithField | FormFieldPropsWithoutField;
-export const FormField: React.FC<FormFieldProps>;
+export const FormField: React.SFC<FormFieldProps>;
 
 // FormError
 export interface FormErrorProps {
@@ -127,7 +127,7 @@ export interface FormErrorProps {
     className?: string | undefined;
     style?: React.HTMLAttributes<HTMLElement>["style"] | undefined;
 }
-export const FormError: React.FC<FormErrorProps>;
+export const FormError: React.SFC<FormErrorProps>;
 
 export interface FormInputProps {
     field?: FormFieldPropsWithField["field"] | undefined;
@@ -141,7 +141,7 @@ export interface FormInputProps {
 export interface FormInputPropsWithChildren extends FormInputProps {
     children(api: FormFieldApi): React.ReactElement | null;
 }
-export const FormInput: React.FC<FormInputPropsWithChildren>;
+export const FormInput: React.SFC<FormInputPropsWithChildren>;
 
 // ==============================
 //             Inputs
@@ -176,7 +176,7 @@ export interface SelectProps extends SelectAttrs {
     errorProps?: FormInputProps["errorProps"] | undefined;
     placeholder?: string | undefined;
 }
-export const Select: React.FC<SelectProps>;
+export const Select: React.SFC<SelectProps>;
 
 export interface InputAttrs extends React.InputHTMLAttributes<HTMLInputElement> {
     onChange?: any;
@@ -192,7 +192,7 @@ export interface CheckboxProps extends InputAttrs {
     noTouch?: boolean | undefined;
     errorProps?: FormInputProps["errorProps"] | undefined;
 }
-export const Checkbox: React.FC<CheckboxProps>;
+export const Checkbox: React.SFC<CheckboxProps>;
 
 export interface TextareaAttrs extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     onChange?: any;
@@ -208,14 +208,14 @@ export interface TextareaProps extends TextareaAttrs {
     noTouch?: boolean | undefined;
     errorProps?: FormInputProps["errorProps"] | undefined;
 }
-export const Textarea: React.FC<TextareaProps>;
+export const Textarea: React.SFC<TextareaProps>;
 
 export interface NestedFormProps extends FormProps {
     field?: FormInputProps["field"] | undefined;
     children?: React.ReactElement<FormProps> | [React.ReactElement<FormProps>] | undefined;
     errorProps?: FormInputProps["errorProps"] | undefined;
 }
-export const NestedForm: React.FC<NestedFormProps>;
+export const NestedForm: React.SFC<NestedFormProps>;
 
 export interface TextProps extends InputAttrs {
     field?: FormInputProps["field"] | undefined;
@@ -227,7 +227,7 @@ export interface TextProps extends InputAttrs {
     noTouch?: boolean | undefined;
     errorProps?: FormInputProps["errorProps"] | undefined;
 }
-export const Text: React.FC<TextProps>;
+export const Text: React.SFC<TextProps>;
 
 export interface RadioGroupProps {
     children?: React.ReactNode;

--- a/types/react-form/v1/react-form-tests.tsx
+++ b/types/react-form/v1/react-form-tests.tsx
@@ -29,7 +29,7 @@ import {
 
 <FormError field="" />;
 
-const CustomInput: React.FC<React.HTMLAttributes<HTMLInputElement> & { field?: string | undefined }> = (
+const CustomInput: React.SFC<React.HTMLAttributes<HTMLInputElement> & { field?: string | undefined }> = (
     { field, ...rest },
 ) => {
     return (


### PR DESCRIPTION
Wasn't caught in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67873 but is now that https://github.com/microsoft/DefinitelyTyped-tools/pull/892 is released.

v15 types did not have `FunctionComponent` but still relied on the old "stateless functional components" terminology that was used before v16.

Fixes `Namespace 'React' has no exported member 'FC'  @definitelytyped/expect`

-- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/7347279483/job/20003436857#step:10:1807