### PR TITLE
Revert "🤖 Merge PR #67583 [react] Fix TS autocompletion for CSSProperties by @Semigradsky"

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1649,7 +1649,7 @@ declare namespace React {
         onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
     }
 
-    export interface CSSProperties extends CSS.Properties<(string & {}) | number> {
+    export interface CSSProperties extends CSS.Properties<string | number> {
         /**
          * The index signature was removed to enable closed typing for style
          * using CSSType. You're able to use type assertion or module augmentation

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1652,7 +1652,7 @@ declare namespace React {
         onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
     }
 
-    export interface CSSProperties extends CSS.Properties<(string & {}) | number> {
+    export interface CSSProperties extends CSS.Properties<string | number> {
         /**
          * The index signature was removed to enable closed typing for style
          * using CSSType. You're able to use type assertion or module augmentation

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1555,7 +1555,7 @@ declare namespace React {
         onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
     }
 
-    export interface CSSProperties extends CSS.Properties<(string & {}) | number> {
+    export interface CSSProperties extends CSS.Properties<string | number> {
         /**
          * The index signature was removed to enable closed typing for style
          * using CSSType. You're able to use type assertion or module augmentation

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1555,7 +1555,7 @@ declare namespace React {
         onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
     }
 
-    export interface CSSProperties extends CSS.Properties<(string & {}) | number> {
+    export interface CSSProperties extends CSS.Properties<string | number> {
         /**
          * The index signature was removed to enable closed typing for style
          * using CSSType. You're able to use type assertion or module augmentation


### PR DESCRIPTION
Causes errors in `babel-plugin-glaze` that weren't caught in CI but are now with :

```
Error in babel-plugin-glaze
Error: 
/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/babel-plugin-glaze/babel-plugin-glaze-tests.tsx
  2:12  error  TypeScript@5.4 compile error: 
Expression produces a union type that is too complex to represent  @definitelytyped/expect
```
-- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/7347279483/job/20003436857#step:10:1799

/cc @Semigradsky 