### PR TITLE
[react-sticky-el] Allow any host component `*Cmp` props

### DIFF
--- a/types/react-sticky-el/index.d.ts
+++ b/types/react-sticky-el/index.d.ts
@@ -34,7 +34,7 @@ declare namespace Sticky {
          *
          * Defaults to 'div'.
          */
-        wrapperCmp?: keyof React.ReactHTML | React.ReactElement | undefined;
+        wrapperCmp?: keyof React.JSX.IntrinsicElements | React.ReactElement | undefined;
 
         /**
          * Anything that can be used by React.createElement. Used for holder
@@ -43,7 +43,7 @@ declare namespace Sticky {
          *
          * Defaults to 'div'.
          */
-        holderCmp?: keyof React.ReactHTML | React.ReactElement<HolderProps> | undefined;
+        holderCmp?: keyof React.JSX.IntrinsicElements | React.ReactElement<HolderProps> | undefined;
 
         /**
          * These props will be used to create `holderElement`.

--- a/types/react-sticky-el/react-sticky-el-tests.tsx
+++ b/types/react-sticky-el/react-sticky-el-tests.tsx
@@ -1,6 +1,14 @@
 import * as React from "react";
 import Sticky from "react-sticky-el";
 
+declare module "react" {
+    namespace JSX {
+        interface IntrinsicElements {
+            "custom-element": unknown;
+        }
+    }
+}
+
 const StickyBasic = () => <Sticky />;
 const StickyAllFeatures = () => (
     <Sticky
@@ -21,3 +29,5 @@ const StickyAllFeatures = () => (
         children="a child"
     />
 );
+
+<Sticky wrapperCmp="custom-element" />;


### PR DESCRIPTION
`ReactHTML` will be removed soon.
It also needlessly restricts components to known HTML components when probably any host component was meant.
This will also allow custom elements.

