### PR TITLE
[react-resolver] Ensure React types match runtime version

### DIFF
--- a/types/react-resolver/package.json
+++ b/types/react-resolver/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ericclemmons/react-resolver"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^16"
     },
     "devDependencies": {
         "@types/react-resolver": "workspace:."


### PR DESCRIPTION
Mostly because `react-resolver` still relies on factories.

See https://github.com/ericclemmons/react-resolver/blob/7b1e3a763d7c05fa764df1cce34fc2d6a3df8bb4/package.json#L10