### PR TITLE
[react-toastr] Ensure React types match runtime version

### DIFF
--- a/types/react-toastr/package.json
+++ b/types/react-toastr/package.json
@@ -7,7 +7,7 @@
         "https://tomchentw.github.io/react-toastr"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^16"
     },
     "devDependencies": {
         "@types/react-toastr": "workspace:."


### PR DESCRIPTION
Mostly because `react-toastr` still uses factory patterns.

See https://github.com/tomchentw/react-toastr/blob/fcd3b4b7e6031dde7c128921489bffaad85729a9/package.json#L83