### PR TITLE
[rc-tooltip] Remove usage of deprecated ReactFragment

### DIFF
--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -40,7 +40,7 @@ declare namespace RCTooltip {
             | React.ReactElement
             | number
             | string
-            | React.ReactFragment
+            | Iterable<React.ReactNode>
             | React.ReactPortal;
         arrowContent?: React.ReactNode | undefined;
         getTooltipContainer?: (() => Element) | undefined;


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactFragment` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).