### PR TITLE
[react-addons-create-fragment] Remove usage of deprecated ReactFragment

### DIFF
--- a/types/react-addons-create-fragment/index.d.ts
+++ b/types/react-addons-create-fragment/index.d.ts
@@ -2,4 +2,4 @@ import * as React from "react";
 
 export = createFragment;
 
-declare function createFragment(object: { [key: string]: React.ReactNode }): React.ReactFragment;
+declare function createFragment(object: { [key: string]: React.ReactNode }): Iterable<React.ReactNode>;


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactFragment` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).