### PR TITLE
[wordpress__block-editor] Remove usage of deprecated ReactFragment

### DIFF
--- a/types/wordpress__block-editor/components/warning.d.ts
+++ b/types/wordpress__block-editor/components/warning.d.ts
@@ -1,8 +1,8 @@
-import { ComponentType, MouseEventHandler, ReactFragment, ReactNode } from "react";
+import { ComponentType, MouseEventHandler, ReactNode } from "react";
 
 declare namespace Warning {
     interface Props {
-        actions?: ReactFragment | undefined;
+        actions?: Iterable<ReactNode> | undefined;
         children: ReactNode;
         className?: string | undefined;
         secondaryActions?:


### PR DESCRIPTION
This PR removes the usage of the deprecated `ReactFragment` type (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451).