### PR TITLE
[react-router-redux] Fix compat issues with latest dependencies

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -1,7 +1,7 @@
 import { History, Location, LocationDescriptor, LocationState, Path } from "history";
 import * as React from "react";
 import { match } from "react-router";
-import { Dispatch, Middleware, Reducer, Store } from "redux";
+import { Action, Dispatch, Middleware, Reducer, Store } from "redux";
 
 export interface ConnectedRouterProps<State> {
     children?: React.ReactNode;
@@ -16,7 +16,7 @@ export interface RouterState {
     location: Location | null;
 }
 
-export const routerReducer: Reducer<RouterState>;
+export const routerReducer: Reducer<RouterState, Action>;
 
 export const CALL_HISTORY_METHOD = "@@router/CALL_HISTORY_METHOD";
 

--- a/types/react-router-redux/react-router-redux-tests.tsx
+++ b/types/react-router-redux/react-router-redux-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { Provider } from "react-redux";
-import { applyMiddleware, combineReducers, createStore, Reducer } from "redux";
+import { applyMiddleware, combineReducers, createStore, Reducer, ReducersMapObject } from "redux";
 
 import createHistory from "history/createBrowserHistory";
 import { Route } from "react-router";
@@ -27,7 +27,7 @@ interface State {
 }
 
 // For testing, assume the router reducer is the only sub-reducer:
-const reducers: Reducer<State> = combineReducers<State>({ router: routerReducer });
+const reducers = combineReducers({ router: routerReducer });
 
 // Add the reducer to your store on the `router` key
 // Also apply our middleware for navigating

--- a/types/react-router-redux/react-router-redux-tests.tsx
+++ b/types/react-router-redux/react-router-redux-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { Provider } from "react-redux";
-import { applyMiddleware, combineReducers, createStore, Reducer, ReducersMapObject } from "redux";
+import { applyMiddleware, combineReducers, createStore } from "redux";
 
 import createHistory from "history/createBrowserHistory";
 import { Route } from "react-router";


### PR DESCRIPTION
Fixes

```
Error: /home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react-router-redux/react-router-redux-tests.tsx:30:67
ERROR: 30:67  expect  TypeScript@5.4 compile error: 
Type 'Reducer<RouterState>' is not assignable to type 'RouterState'.
ERROR: 53:16  expect  TypeScript@5.4 compile error: 
Argument of type 'RouterAction' is not assignable to parameter of type 'UnknownAction'.
  Index signature for type 'string' is missing in type 'RouterAction'.
```
-- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/7091732557/job/19301508685?pr=67430
(make sure you re-install node_modules when testing locally)

Unblocking https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67430 and all other React related PRs.