### PR TITLE
[atlaskit__layer] Stop testing react-dom

### DIFF
--- a/types/atlaskit__layer/atlaskit__layer-tests.tsx
+++ b/types/atlaskit__layer/atlaskit__layer-tests.tsx
@@ -1,15 +1,9 @@
 import Layer from "@atlaskit/layer";
 
 import * as React from "react";
-import { render } from "react-dom";
 
-declare const container: Element;
-
-render(
-    <Layer
-        position="bottom left"
-        content={<h1>Hello, world!</h1>}
-        autoFlip={false}
-    />,
-    container,
-);
+<Layer
+    position="bottom left"
+    content={<h1>Hello, world!</h1>}
+    autoFlip={false}
+/>;

--- a/types/atlaskit__layer/package.json
+++ b/types/atlaskit__layer/package.json
@@ -10,8 +10,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/atlaskit__layer": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/atlaskit__layer": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.