### PR TITLE
[atlaskit__single-select] Stop testing react-dom

### DIFF
--- a/types/atlaskit__single-select/atlaskit__single-select-tests.tsx
+++ b/types/atlaskit__single-select/atlaskit__single-select-tests.tsx
@@ -1,14 +1,8 @@
 import SingleSelect, { StatelessSelect } from "@atlaskit/single-select";
 
 import * as React from "react";
-import { render } from "react-dom";
 
-declare const container: Element;
-
-render(
-    <div>
-        <SingleSelect />
-        <StatelessSelect />
-    </div>,
-    container,
-);
+<div>
+    <SingleSelect />
+    <StatelessSelect />
+</div>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.