### PR TITLE
[draft-js] Stop testing react-dom

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -1,6 +1,5 @@
 import * as Immutable from "immutable";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import {
     CompositeDecorator,
@@ -379,11 +378,6 @@ const CodeBlockTypeControl = (props: { editorState: EditorState; onToggle: (bloc
         return null;
     }
 };
-
-ReactDOM.render(
-    <RichEditorExample />,
-    document.getElementById("target"),
-);
 
 const editorState = EditorState.createEmpty();
 

--- a/types/draft-js/package.json
+++ b/types/draft-js/package.json
@@ -10,8 +10,7 @@
         "immutable": "~3.7.4"
     },
     "devDependencies": {
-        "@types/draft-js": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/draft-js": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.