### PR TITLE
[fluent-react] Stop testing react-dom

### DIFF
--- a/types/fluent-react/fluent-react-tests.tsx
+++ b/types/fluent-react/fluent-react-tests.tsx
@@ -1,6 +1,5 @@
 import { FluentBundle, ftl } from "fluent";
 import { GetString, LocalizationProvider, Localized, withLocalization } from "fluent-react";
-import * as ReactDOM from "react-dom";
 
 // Localized examples:
 const Test = () => (
@@ -18,12 +17,9 @@ function* generateBundles(currentLocales: string[]) {
     }
 }
 
-ReactDOM.render(
-    <LocalizationProvider bundles={generateBundles(["en-US"])}>
-        <div />
-    </LocalizationProvider>,
-    document.getElementById("root"),
-);
+<LocalizationProvider bundles={generateBundles(["en-US"])}>
+    <div />
+</LocalizationProvider>;
 
 // withLocalization examples:
 interface Props {

--- a/types/fluent-react/package.json
+++ b/types/fluent-react/package.json
@@ -11,8 +11,7 @@
         "csstype": "^3.0.2"
     },
     "devDependencies": {
-        "@types/fluent-react": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/fluent-react": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.