### PR TITLE
[gl-react-headless] Stop testing react-dom

### DIFF
--- a/types/gl-react-headless/gl-react-headless-tests.tsx
+++ b/types/gl-react-headless/gl-react-headless-tests.tsx
@@ -1,7 +1,6 @@
 import { GLSL, Node, Shaders } from "gl-react";
 import { Surface } from "gl-react-headless";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 const shaders = Shaders.create({
     Test: {
@@ -24,4 +23,3 @@ const App = () => (
 
 const element = document.createElement("div");
 document.body.appendChild(element);
-ReactDOM.render(<App />, element);

--- a/types/gl-react-headless/package.json
+++ b/types/gl-react-headless/package.json
@@ -10,8 +10,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/gl-react-headless": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/gl-react-headless": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.