### PR TITLE
[gl-react-image] Stop testing react-dom

### DIFF
--- a/types/gl-react-image/gl-react-image-tests.tsx
+++ b/types/gl-react-image/gl-react-image-tests.tsx
@@ -1,6 +1,5 @@
 import GLImage from "gl-react-image";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 const App = () => (
     <div>
@@ -15,4 +14,3 @@ const App = () => (
 
 const element = document.createElement("div");
 document.body.appendChild(element);
-ReactDOM.render(<App />, element);

--- a/types/gl-react-image/package.json
+++ b/types/gl-react-image/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/gl-react-image": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/gl-react-image": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.