### PR TITLE
[gl-react-native] Stop testing react-dom

### DIFF
--- a/types/gl-react-native/gl-react-native-tests.tsx
+++ b/types/gl-react-native/gl-react-native-tests.tsx
@@ -1,7 +1,6 @@
 import { GLSL, Node, Shaders } from "gl-react";
 import { Surface } from "gl-react-native";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 const shaders = Shaders.create({
     Test: {
@@ -24,4 +23,3 @@ const App = () => (
 
 const element = document.createElement("div");
 document.body.appendChild(element);
-ReactDOM.render(<App />, element);

--- a/types/gl-react-native/package.json
+++ b/types/gl-react-native/package.json
@@ -11,8 +11,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/gl-react-native": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/gl-react-native": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.