### PR TITLE
[material-ui-pagination] Stop testing react-dom

### DIFF
--- a/types/material-ui-pagination/material-ui-pagination-tests.tsx
+++ b/types/material-ui-pagination/material-ui-pagination-tests.tsx
@@ -1,10 +1,7 @@
 import * as ui from "material-ui";
 import Pagination from "material-ui-pagination";
 import { MuiThemeProvider } from "material-ui/styles";
-import * as PropTypes from "prop-types";
 import * as React from "react";
-import { Component } from "react";
-import * as ReactDOM from "react-dom";
 import injectTapEventPlugin = require("react-tap-event-plugin");
 
 // Needed for onTouchTap
@@ -65,5 +62,3 @@ const Index = () => (
         <Pager />
     </MuiThemeProvider>
 );
-
-ReactDOM.render(<Index />, document.getElementById("root") as HTMLElement);

--- a/types/material-ui-pagination/package.json
+++ b/types/material-ui-pagination/package.json
@@ -12,7 +12,6 @@
         "@types/material-ui": "*",
         "@types/material-ui-pagination": "workspace:.",
         "@types/prop-types": "*",
-        "@types/react-dom": "*",
         "@types/react-tap-event-plugin": "*"
     },
     "owners": [


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.