### PR TITLE
[material-ui] Stop testing react-dom

### DIFF
--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3,7 +3,6 @@ import {
   Component, ComponentClass, CSSProperties,
   FunctionComponent, ReactElement, ReactInstance, ValidationMap
 } from 'react';
-import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { muiThemeable } from 'material-ui/styles/muiThemeable';
@@ -6965,6 +6964,7 @@ class BottomNavigationExample extends Component<{}, {
   }
 }
 
+// "http://www.material-ui.com/#/get-started/usage"
 class MaterialUiTests extends Component {
     render() {
     return (
@@ -6975,9 +6975,3 @@ class MaterialUiTests extends Component {
     );
   }
 }
-
-// "http://www.material-ui.com/#/get-started/usage"
-ReactDOM.render(
-  <MaterialUiTests />,
-  document.getElementById('app')
-);

--- a/types/material-ui/package.json
+++ b/types/material-ui/package.json
@@ -13,7 +13,6 @@
     "devDependencies": {
         "@types/material-ui": "workspace:.",
         "@types/prop-types": "*",
-        "@types/react-dom": "*",
         "@types/react-tap-event-plugin": "*"
     },
     "owners": [


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.