### PR TITLE
[moxy__next-router-scroll] Stop testing react-dom

### DIFF
--- a/types/moxy__next-router-scroll/moxy__next-router-scroll-tests.tsx
+++ b/types/moxy__next-router-scroll/moxy__next-router-scroll-tests.tsx
@@ -1,17 +1,9 @@
 import { RouterScrollProvider, useRouterScroll, withRouterScroll } from "moxy__next-router-scroll";
 import * as React from "react";
-import { render } from "react-dom";
 
-declare function beforeAll(f: () => void): void;
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 declare const expect: any;
-
-declare let reactRoot: any;
-
-beforeAll(() => {
-    reactRoot = document.createElement("div");
-});
 
 describe("useRouterScroll", () => {
     it("should return three funcitons", () => {
@@ -36,7 +28,6 @@ describe("useRouterScroll", () => {
                 );
             }
         }
-        render(<Component />, reactRoot);
     });
 });
 
@@ -58,7 +49,5 @@ describe("withRouterScroll", () => {
                 );
             }
         }
-
-        render(<Component />, reactRoot);
     });
 });

--- a/types/moxy__next-router-scroll/package.json
+++ b/types/moxy__next-router-scroll/package.json
@@ -12,8 +12,7 @@
         "scroll-behavior": "^0.11.0"
     },
     "devDependencies": {
-        "@types/moxy__next-router-scroll": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/moxy__next-router-scroll": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.