### PR TITLE
[muicss] Stop testing react-dom

### DIFF
--- a/types/muicss/muicss-tests.tsx
+++ b/types/muicss/muicss-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import {
     Appbar,
@@ -160,5 +159,3 @@ class Test2 extends React.Component {
         );
     }
 }
-
-ReactDOM.render(<Test />, document.getElementById("root"));

--- a/types/muicss/package.json
+++ b/types/muicss/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/muicss": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/muicss": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.