### PR TITLE
[natural-drag-animation-rbdnd] Stop testing react-dom

### DIFF
--- a/types/natural-drag-animation-rbdnd/natural-drag-animation-rbdnd-tests.tsx
+++ b/types/natural-drag-animation-rbdnd/natural-drag-animation-rbdnd-tests.tsx
@@ -1,7 +1,6 @@
 import NaturalDragAnimation from "natural-drag-animation-rbdnd";
 import * as React from "react";
 import { DragDropContext, Draggable, DraggableLocation, Droppable, DropResult } from "react-beautiful-dnd";
-import * as ReactDOM from "react-dom";
 
 interface listItemType {
     id: string;
@@ -124,8 +123,6 @@ class List extends React.Component<{}, { items: listItemType[]; selected: listIt
         );
     }
 }
-
-ReactDOM.render(<List />, document.getElementById("root"));
 
 const grid = 8;
 

--- a/types/natural-drag-animation-rbdnd/package.json
+++ b/types/natural-drag-animation-rbdnd/package.json
@@ -10,8 +10,7 @@
         "@types/react-beautiful-dnd": "*"
     },
     "devDependencies": {
-        "@types/natural-drag-animation-rbdnd": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/natural-drag-animation-rbdnd": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.