### PR TITLE
[pdf-viewer-reactjs] Stop testing react-dom

### DIFF
--- a/types/pdf-viewer-reactjs/pdf-viewer-reactjs-tests.tsx
+++ b/types/pdf-viewer-reactjs/pdf-viewer-reactjs-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import PDFViewer = require("pdf-viewer-reactjs");
 
 const sources = {
@@ -189,5 +188,3 @@ class Example extends React.Component {
         );
     }
 }
-
-ReactDOM.render(<Example />, document.getElementById("root"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.