### PR TITLE
[rasa-webchat] Stop testing react-dom

### DIFF
--- a/types/rasa-webchat/package.json
+++ b/types/rasa-webchat/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/rasa-webchat": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/rasa-webchat": "workspace:."
     },
     "owners": [
         {

--- a/types/rasa-webchat/rasa-webchat-tests.tsx
+++ b/types/rasa-webchat/rasa-webchat-tests.tsx
@@ -1,6 +1,5 @@
 import RasaWebchat, { RasaWebchatProps } from "rasa-webchat";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 const validProps: RasaWebchatProps = {
     title: "Welcome",
@@ -51,4 +50,4 @@ const validProps: RasaWebchatProps = {
     assistBackgoundColor: "",
 };
 
-ReactDOM.render(<RasaWebchat {...validProps} />, document.body);
+<RasaWebchat {...validProps} />;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.