### PR TITLE
[rc-tooltip] Stop testing react-dom

### DIFF
--- a/types/rc-tooltip/package.json
+++ b/types/rc-tooltip/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/rc-tooltip": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/rc-tooltip": "workspace:."
     },
     "owners": [
         {

--- a/types/rc-tooltip/rc-tooltip-tests.tsx
+++ b/types/rc-tooltip/rc-tooltip-tests.tsx
@@ -1,57 +1,44 @@
 import Tooltip, { RCTooltip } from "rc-tooltip";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
-ReactDOM.render(
-    <Tooltip placement="left" trigger={["click"]} overlay={<span>tooltip</span>}>
-        <a href="#">hover</a>
-    </Tooltip>,
-    document.querySelector(".app"),
-);
+<Tooltip placement="left" trigger={["click"]} overlay={<span>tooltip</span>}>
+    <a href="#">hover</a>
+</Tooltip>;
 
-ReactDOM.render(
-    <Tooltip overlay="tooltip">
-        <a href="#">hover</a>
-    </Tooltip>,
-    document.querySelector(".app"),
-);
+<Tooltip overlay="tooltip">
+    <a href="#">hover</a>
+</Tooltip>;
 
-ReactDOM.render(
-    <Tooltip
-        placement="bottomRight"
-        trigger={["click", "focus"]}
-        overlay={<span>tooltip</span>}
-        overlayClassName="overlay"
-        mouseEnterDelay={0}
-        mouseLeaveDelay={0.1}
-        overlayStyle={{ color: "red" }}
-        prefixCls="my-"
-        transitionName="cool-transition"
-        onVisibleChange={() => console.log("visible changed")}
-        afterVisibleChange={() => console.log("after visible changed")}
-        visible
-        defaultVisible
-        onPopupAlign={(popup, align) => console.log("aligned:", popup, align)}
-        arrowContent={<div className="arrow" />}
-        getTooltipContainer={() => document.querySelector(".foo")!}
-        destroyTooltipOnHide
-        id="tooltip-id"
-    >
-        <a href="#">hover</a>
-    </Tooltip>,
-    document.querySelector(".another-app"),
-);
+<Tooltip
+    placement="bottomRight"
+    trigger={["click", "focus"]}
+    overlay={<span>tooltip</span>}
+    overlayClassName="overlay"
+    mouseEnterDelay={0}
+    mouseLeaveDelay={0.1}
+    overlayStyle={{ color: "red" }}
+    prefixCls="my-"
+    transitionName="cool-transition"
+    onVisibleChange={() => console.log("visible changed")}
+    afterVisibleChange={() => console.log("after visible changed")}
+    visible
+    defaultVisible
+    onPopupAlign={(popup, align) => console.log("aligned:", popup, align)}
+    arrowContent={<div className="arrow" />}
+    getTooltipContainer={() => document.querySelector(".foo")!}
+    destroyTooltipOnHide
+    id="tooltip-id"
+>
+    <a href="#">hover</a>
+</Tooltip>;
 
-ReactDOM.render(
-    <Tooltip
-        placement="bottomRight"
-        trigger={["click", "focus"]}
-        overlay={() => <span>tooltip</span>}
-    >
-        <a href="#">hover</a>
-    </Tooltip>,
-    document.querySelector(".another-app"),
-);
+<Tooltip
+    placement="bottomRight"
+    trigger={["click", "focus"]}
+    overlay={() => <span>tooltip</span>}
+>
+    <a href="#">hover</a>
+</Tooltip>;
 
 const props: RCTooltip.Props = {
     placement: "bottomRight",


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.