### PR TITLE
[react-aria-live] Stop testing react-dom

### DIFF
--- a/types/react-aria-live/package.json
+++ b/types/react-aria-live/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-aria-live": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-aria-live": "workspace:."
     },
     "owners": [
         {

--- a/types/react-aria-live/react-aria-live-tests.tsx
+++ b/types/react-aria-live/react-aria-live-tests.tsx
@@ -1,41 +1,34 @@
 import * as React from "react";
-import { render } from "react-dom";
 
 import { LiveAnnouncer, LiveMessage, LiveMessenger } from "react-aria-live";
 
-render(
-    <LiveAnnouncer>
-        <LiveMessage
-            aria-live="polite"
-            message="hello"
-            clearOnUnmount
-        />
-    </LiveAnnouncer>,
-    document.getElementById("main"),
-);
+<LiveAnnouncer>
+    <LiveMessage
+        aria-live="polite"
+        message="hello"
+        clearOnUnmount
+    />
+</LiveAnnouncer>;
 
-render(
-    <LiveAnnouncer>
-        <LiveMessenger>
-            {({ announcePolite, announceAssertive }) => (
-                <>
-                    <button
-                        onClick={() => {
-                            announcePolite("Polite message");
-                        }}
-                    >
-                        Press me for a polite message
-                    </button>
-                    <button
-                        onClick={() => {
-                            announceAssertive("Assertive message", "UniqueId");
-                        }}
-                    >
-                        Press me for an assertive message
-                    </button>
-                </>
-            )}
-        </LiveMessenger>
-    </LiveAnnouncer>,
-    document.getElementById("main"),
-);
+<LiveAnnouncer>
+    <LiveMessenger>
+        {({ announcePolite, announceAssertive }) => (
+            <>
+                <button
+                    onClick={() => {
+                        announcePolite("Polite message");
+                    }}
+                >
+                    Press me for a polite message
+                </button>
+                <button
+                    onClick={() => {
+                        announceAssertive("Assertive message", "UniqueId");
+                    }}
+                >
+                    Press me for an assertive message
+                </button>
+            </>
+        )}
+    </LiveMessenger>
+</LiveAnnouncer>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.