### PR TITLE
[react-aria-menubutton] Stop testing react-dom

### DIFF
--- a/types/react-aria-menubutton/package.json
+++ b/types/react-aria-menubutton/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-aria-menubutton": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-aria-menubutton": "workspace:."
     },
     "owners": [
         {

--- a/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
+++ b/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import { Button, closeMenu, Menu, MenuItem, openMenu, Wrapper } from "react-aria-menubutton";
 
@@ -32,8 +31,6 @@ class MyMenuButton extends React.Component {
         );
     }
 }
-
-ReactDOM.render(<MyMenuButton />, document.body);
 
 const words = [
     "pectinate",
@@ -108,8 +105,6 @@ class DemoOne extends React.Component<{}, DemoOneState> {
     }
 }
 
-ReactDOM.render(<DemoOne />, document.getElementById("demo-one"));
-
 closeMenu("");
 closeMenu("", { focusButton: true });
 
@@ -128,8 +123,6 @@ class ObjectMenuItem extends React.Component {
         );
     }
 }
-
-ReactDOM.render(<ObjectMenuItem />, document.body);
 
 class MenuWithRenderProp extends React.Component {
     render() {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.