### PR TITLE
[react-aria-modal] Stop testing react-dom

### DIFF
--- a/types/react-aria-modal/package.json
+++ b/types/react-aria-modal/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-aria-modal": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-aria-modal": "workspace:."
     },
     "owners": [
         {

--- a/types/react-aria-modal/react-aria-modal-tests.tsx
+++ b/types/react-aria-modal/react-aria-modal-tests.tsx
@@ -1,41 +1,29 @@
 import * as React from "react";
 import AriaModal from "react-aria-modal";
-import { render } from "react-dom";
-
-declare const appContainer: HTMLElement;
 
 const onExit = () => {};
 
-render(
-    <AriaModal onExit={onExit} titleId="describedby" underlayClickExits>
-        <p id="describedby">Hello world</p>
-    </AriaModal>,
-    appContainer,
-);
+<AriaModal onExit={onExit} titleId="describedby" underlayClickExits>
+    <p id="describedby">Hello world</p>
+</AriaModal>;
 
 const DisplacedModal = AriaModal.renderTo("#some-id");
 
-render(
-    <DisplacedModal onExit={onExit} titleId="describedby" underlayClickExits>
-        <p id="describedby">Hello world</p>
-    </DisplacedModal>,
-    appContainer,
-);
+<DisplacedModal onExit={onExit} titleId="describedby" underlayClickExits>
+    <p id="describedby">Hello world</p>
+</DisplacedModal>;
 
-render(
-    <AriaModal
-        onExit={() => {}}
-        alert={true}
-        focusDialog={true}
-        titleText="A top modal"
-        underlayClickExits={false}
-        verticallyCenter={true}
-        underlayColor={false}
-    >
-        <div>Hello</div>
-    </AriaModal>,
-    appContainer,
-);
+<AriaModal
+    onExit={() => {}}
+    alert={true}
+    focusDialog={true}
+    titleText="A top modal"
+    underlayClickExits={false}
+    verticallyCenter={true}
+    underlayColor={false}
+>
+    <div>Hello</div>
+</AriaModal>;
 
 const AriaModalOnExitBasic = (
     <AriaModal


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.