### PR TITLE
[react-autocomplete] Stop testing react-dom

### DIFF
--- a/types/react-autocomplete/package.json
+++ b/types/react-autocomplete/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-autocomplete": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-autocomplete": "workspace:."
     },
     "owners": [
         {

--- a/types/react-autocomplete/react-autocomplete-tests.tsx
+++ b/types/react-autocomplete/react-autocomplete-tests.tsx
@@ -1,21 +1,15 @@
 import * as Autocomplete from "react-autocomplete";
 
 import * as React from "react";
-import { render } from "react-dom";
-
-declare const container: Element;
 
 const items = ["hello", "world"];
 
-render(
-    <Autocomplete
-        items={items}
-        getItemValue={(item) => item}
-        renderItem={(item) => <div key={item}>{item}</div>}
-        value={items[0]}
-    />,
-    container,
-);
+<Autocomplete
+    items={items}
+    getItemValue={(item) => item}
+    renderItem={(item) => <div key={item}>{item}</div>}
+    value={items[0]}
+/>;
 
 // @ts-expect-error
 const renderMenu: React.ComponentProps<typeof Autocomplete>["renderMenu"] = (item: string[]) => <div></div>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.