### PR TITLE
[react-autosuggest] Stop testing react-dom

### DIFF
--- a/types/react-autosuggest/package.json
+++ b/types/react-autosuggest/package.json
@@ -10,8 +10,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-autosuggest": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-autosuggest": "workspace:."
     },
     "owners": [
         {

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -1,6 +1,5 @@
 // region Imports
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import Autosuggest = require("react-autosuggest");
 // endregion
 
@@ -296,8 +295,6 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
     // endregion
 }
 
-ReactDOM.render(<ReactAutosuggestBasicTest />, document.getElementById("app"));
-
 interface LanguageGroup {
     title: string;
     languages: Language[];
@@ -509,8 +506,6 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
     // endregion
 }
 
-ReactDOM.render(<ReactAutosuggestMultipleTest />, document.getElementById("app"));
-
 interface Person {
     first: string;
     last: string;
@@ -621,8 +616,6 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
     }
     // endregion
 }
-
-ReactDOM.render(<ReactAutosuggestCustomTest />, document.getElementById("app"));
 
 const test: Autosuggest.InputProps<{ foo: string }> = {
     onChange: () => {},


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.