### PR TITLE
[react-beautiful-dnd] Stop testing react-dom

### DIFF
--- a/types/react-beautiful-dnd/package.json
+++ b/types/react-beautiful-dnd/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-beautiful-dnd": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-beautiful-dnd": "workspace:."
     },
     "owners": [
         {

--- a/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
@@ -16,7 +16,6 @@ import {
     useMouseSensor,
     useTouchSensor,
 } from "react-beautiful-dnd";
-import * as ReactDOM from "react-dom";
 
 interface Item {
     id: string;
@@ -152,6 +151,6 @@ class App extends React.Component<{}, AppState> {
     }
 }
 
-ReactDOM.render(<App />, document.getElementById("app"));
+<App />;
 
 resetServerContext();

--- a/types/react-beautiful-dnd/v10/package.json
+++ b/types/react-beautiful-dnd/v10/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-beautiful-dnd": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-beautiful-dnd": "workspace:."
     },
     "owners": [
         {

--- a/types/react-beautiful-dnd/v10/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/v10/react-beautiful-dnd-tests.tsx
@@ -9,7 +9,6 @@ import {
     DropResult,
     ResponderProvided,
 } from "react-beautiful-dnd";
-import * as ReactDOM from "react-dom";
 
 interface Item {
     id: string;
@@ -132,5 +131,3 @@ class App extends React.Component<{}, AppState> {
         );
     }
 }
-
-ReactDOM.render(<App />, document.getElementById("app"));

--- a/types/react-beautiful-dnd/v11/package.json
+++ b/types/react-beautiful-dnd/v11/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-beautiful-dnd": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-beautiful-dnd": "workspace:."
     },
     "owners": [
         {

--- a/types/react-beautiful-dnd/v11/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/v11/react-beautiful-dnd-tests.tsx
@@ -11,7 +11,6 @@ import {
     resetServerContext,
     ResponderProvided,
 } from "react-beautiful-dnd";
-import * as ReactDOM from "react-dom";
 
 interface Item {
     id: string;
@@ -128,7 +127,5 @@ class App extends React.Component<{}, AppState> {
         );
     }
 }
-
-ReactDOM.render(<App />, document.getElementById("app"));
 
 resetServerContext();

--- a/types/react-beautiful-dnd/v12/package.json
+++ b/types/react-beautiful-dnd/v12/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-beautiful-dnd": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-beautiful-dnd": "workspace:."
     },
     "owners": [
         {

--- a/types/react-beautiful-dnd/v12/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/v12/react-beautiful-dnd-tests.tsx
@@ -137,4 +137,6 @@ class App extends React.Component<{}, AppState> {
     }
 }
 
+<App />;
+
 resetServerContext();

--- a/types/react-beautiful-dnd/v12/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/v12/react-beautiful-dnd-tests.tsx
@@ -13,7 +13,6 @@ import {
     resetServerContext,
     ResponderProvided,
 } from "react-beautiful-dnd";
-import * as ReactDOM from "react-dom";
 
 interface Item {
     id: string;
@@ -137,7 +136,5 @@ class App extends React.Component<{}, AppState> {
         );
     }
 }
-
-ReactDOM.render(<App />, document.getElementById("app"));
 
 resetServerContext();


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.