### PR TITLE
[react-beforeunload] Stop testing react-dom

### DIFF
--- a/types/react-beforeunload/package.json
+++ b/types/react-beforeunload/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-beforeunload": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-beforeunload": "workspace:."
     },
     "owners": [
         {

--- a/types/react-beforeunload/react-beforeunload-tests.tsx
+++ b/types/react-beforeunload/react-beforeunload-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Beforeunload, useBeforeunload } from "react-beforeunload";
-import * as ReactDOM from "react-dom";
 
 function AppWithNoopHook() {
     useBeforeunload();
@@ -56,4 +55,3 @@ function App() {
         </>
     );
 }
-ReactDOM.render(<App />, document.getElementById("app"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.