### PR TITLE
[react-bootstrap-table] Stop testing react-dom

### DIFF
--- a/types/react-bootstrap-table/package.json
+++ b/types/react-bootstrap-table/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-bootstrap-table": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-bootstrap-table": "workspace:."
     },
     "owners": [
         {

--- a/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -35,7 +35,6 @@ import {
     TableHeaderColumn,
     ToolBarProps,
 } from "react-bootstrap-table";
-import { render } from "react-dom";
 
 interface Product {
     id: number;
@@ -92,16 +91,13 @@ function priceFormatter(cell: number, row: Product) {
     return "<i class=\"glyphicon glyphicon-usd\"></i> " + cell;
 }
 
-render(
-    <BootstrapTable data={products} striped={true} hover={true} ignoreSinglePage>
-        <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
-        <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: "textarea", rows: 10 }}>
-            Product Name
-        </TableHeaderColumn>
-        <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>
-    </BootstrapTable>,
-    document.getElementById("app"),
-);
+<BootstrapTable data={products} striped={true} hover={true} ignoreSinglePage>
+    <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
+    <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: "textarea", rows: 10 }}>
+        Product Name
+    </TableHeaderColumn>
+    <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>
+</BootstrapTable>;
 
 const qualityType = {
     0: "good",

--- a/types/react-bootstrap-table/v2/package.json
+++ b/types/react-bootstrap-table/v2/package.json
@@ -10,8 +10,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-bootstrap-table": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-bootstrap-table": "workspace:."
     },
     "owners": [
         {

--- a/types/react-bootstrap-table/v2/react-bootstrap-table-tests.tsx
+++ b/types/react-bootstrap-table/v2/react-bootstrap-table-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ApplyFilterParameter, BootstrapTable, Filter, TableHeaderColumn } from "react-bootstrap-table";
-import { render } from "react-dom";
 
 const products = [{
     id: 1,
@@ -17,16 +16,13 @@ function priceFormatter(cell: any, row: any) {
     return "<i class=\"glyphicon glyphicon-usd\"></i> " + cell;
 }
 
-render(
-    <BootstrapTable data={products} striped={true} hover={true} ignoreSinglePage>
-        <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
-        <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: "textarea", rows: 10 }}>
-            Product Name
-        </TableHeaderColumn>
-        <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>
-    </BootstrapTable>,
-    document.getElementById("app"),
-);
+<BootstrapTable data={products} striped={true} hover={true} ignoreSinglePage>
+    <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
+    <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: "textarea", rows: 10 }}>
+        Product Name
+    </TableHeaderColumn>
+    <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>
+</BootstrapTable>;
 
 const qualityType = {
     0: "good",


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.