### PR TITLE
[react-bootstrap-table2-paginator] Stop testing react-dom

### DIFF
--- a/types/react-bootstrap-table2-paginator/package.json
+++ b/types/react-bootstrap-table2-paginator/package.json
@@ -10,8 +10,7 @@
     },
     "devDependencies": {
         "@types/react": "*",
-        "@types/react-bootstrap-table2-paginator": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-bootstrap-table2-paginator": "workspace:."
     },
     "owners": [
         {

--- a/types/react-bootstrap-table2-paginator/react-bootstrap-table2-paginator-tests.tsx
+++ b/types/react-bootstrap-table2-paginator/react-bootstrap-table2-paginator-tests.tsx
@@ -10,7 +10,6 @@ import paginationFactory, {
     PaginationProvider,
     PaginationTotalStandalone,
 } from "react-bootstrap-table2-paginator";
-import { render } from "react-dom";
 
 interface Product {
     id: number;
@@ -84,36 +83,30 @@ const productColumns: Array<ColumnDescription<Product>> = [
 /**
  * pagination test
  */
-render(
-    <BootstrapTable
-        data={products}
-        keyField="id"
-        pagination={paginationFactory({ sizePerPage: 10, page: 1 })}
-        columns={productColumns}
-    />,
-    document.getElementById("app"),
-);
+<BootstrapTable
+    data={products}
+    keyField="id"
+    pagination={paginationFactory({ sizePerPage: 10, page: 1 })}
+    columns={productColumns}
+/>;
 
 /**
  * PaginationProvider test
  */
 
-render(
-    <PaginationProvider
-        pagination={paginationFactory({ custom: true, totalSize: 2 })}
-    >
-        {({ paginationProps, paginationTableProps }) => (
-            <>
-                <PaginationTotalStandalone {...paginationProps} />
-                <PaginationListStandalone {...paginationProps} />
-                <BootstrapTable
-                    {...paginationTableProps}
-                    keyField="id"
-                    data={products}
-                    columns={productColumns}
-                />
-            </>
-        )}
-    </PaginationProvider>,
-    document.getElementById("app"),
-);
+<PaginationProvider
+    pagination={paginationFactory({ custom: true, totalSize: 2 })}
+>
+    {({ paginationProps, paginationTableProps }) => (
+        <>
+            <PaginationTotalStandalone {...paginationProps} />
+            <PaginationListStandalone {...paginationProps} />
+            <BootstrapTable
+                {...paginationTableProps}
+                keyField="id"
+                data={products}
+                columns={productColumns}
+            />
+        </>
+    )}
+</PaginationProvider>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.