### PR TITLE
[react-bytesize-icons] Stop testing react-dom

### DIFF
--- a/types/react-bytesize-icons/package.json
+++ b/types/react-bytesize-icons/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-bytesize-icons": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-bytesize-icons": "workspace:."
     },
     "owners": [
         {

--- a/types/react-bytesize-icons/react-bytesize-icons-tests.tsx
+++ b/types/react-bytesize-icons/react-bytesize-icons-tests.tsx
@@ -23,40 +23,37 @@ import {
     ZoomOut,
     ZoomReset,
 } from "react-bytesize-icons";
-import { render } from "react-dom";
 
-render(<Activity />, document.getElementById("test"));
-render(<External width={42} color="blue" />, document.getElementById("test"));
-render(
-    <Export
-        width={42}
-        height={21}
-        strokeWidth="10%"
-        strokeLinejoin="bevel"
-        strokeLinecap="butt"
-        color="blue"
-        className="exportClass"
-        id="export"
-    />,
-    document.getElementById("test"),
-);
+<Activity />;
+<External width={42} color="blue" />;
 
-render(<Bag />, document.getElementById("test"));
-render(<Clipboard />, document.getElementById("test"));
-render(<CreditCard />, document.getElementById("test"));
-render(<Desktop />, document.getElementById("test"));
-render(<Feed />, document.getElementById("test"));
-render(<Filter />, document.getElementById("test"));
-render(<Fullscreen />, document.getElementById("test"));
-render(<FullscreenExit />, document.getElementById("test"));
-render(<GitHub width={42} />, document.getElementById("test"));
-render(<Microphone />, document.getElementById("test"));
-render(<Mobile />, document.getElementById("test"));
-render(<Move />, document.getElementById("test"));
-render(<Moon />, document.getElementById("test"));
-render(<SignIn />, document.getElementById("test"));
-render(<SignOut />, document.getElementById("test"));
-render(<Telephone />, document.getElementById("test"));
-render(<ZoomIn />, document.getElementById("test"));
-render(<ZoomOut />, document.getElementById("test"));
-render(<ZoomReset />, document.getElementById("test"));
+<Export
+    width={42}
+    height={21}
+    strokeWidth="10%"
+    strokeLinejoin="bevel"
+    strokeLinecap="butt"
+    color="blue"
+    className="exportClass"
+    id="export"
+/>;
+
+<Bag />;
+<Clipboard />;
+<CreditCard />;
+<Desktop />;
+<Feed />;
+<Filter />;
+<Fullscreen />;
+<FullscreenExit />;
+<GitHub width={42} />;
+<Microphone />;
+<Mobile />;
+<Move />;
+<Moon />;
+<SignIn />;
+<SignOut />;
+<Telephone />;
+<ZoomIn />;
+<ZoomOut />;
+<ZoomReset />;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.