### PR TITLE
[react-click-outside] Stop testing react-dom

### DIFF
--- a/types/react-click-outside/package.json
+++ b/types/react-click-outside/package.json
@@ -9,8 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-click-outside": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-click-outside": "workspace:."
     },
     "owners": [
         {

--- a/types/react-click-outside/react-click-outside-tests.tsx
+++ b/types/react-click-outside/react-click-outside-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { render } from "react-dom";
 import enhanceWithClickOutside = require("react-click-outside");
 
 interface Props {
@@ -37,5 +36,5 @@ class ComponentWithDecorator extends React.Component<Props, State> {
 
 const ClickOutsideStatefulComponent = enhanceWithClickOutside(StatefulComponent);
 
-render(<ClickOutsideStatefulComponent text="" />, document.getElementById("test"));
-render(<ComponentWithDecorator text="" />, document.getElementById("test"));
+<ClickOutsideStatefulComponent text="" />;
+<ComponentWithDecorator text="" />;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.