### PR TITLE
[react-draft-wysiwyg] Stop testing react-dom

### DIFF
--- a/types/react-draft-wysiwyg/package.json
+++ b/types/react-draft-wysiwyg/package.json
@@ -10,7 +10,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-draft-wysiwyg": "workspace:."
     },
     "owners": [

--- a/types/react-draft-wysiwyg/test/basic-content-state-tests.tsx
+++ b/types/react-draft-wysiwyg/test/basic-content-state-tests.tsx
@@ -1,7 +1,6 @@
 // From https://github.com/jpuri/react-draft-wysiwyg/blob/master/stories/
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor, RawDraftContentState } from "react-draft-wysiwyg";
 
 class BasicContentState extends React.Component<{}, { contentState: RawDraftContentState }> {
@@ -41,5 +40,3 @@ class BasicContentState extends React.Component<{}, { contentState: RawDraftCont
         );
     }
 }
-
-ReactDOM.render(<BasicContentState />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/basic-controlled-tests.tsx
+++ b/types/react-draft-wysiwyg/test/basic-controlled-tests.tsx
@@ -1,7 +1,6 @@
 // From https://github.com/jpuri/react-draft-wysiwyg/blob/master/stories/
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor, EditorState } from "react-draft-wysiwyg";
 
 class BasicControlled extends React.Component<{}, { editorState: EditorState }> {
@@ -28,5 +27,3 @@ class BasicControlled extends React.Component<{}, { editorState: EditorState }> 
         this.setState({ editorState });
     }
 }
-
-ReactDOM.render(<BasicControlled />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/basic-tests.tsx
+++ b/types/react-draft-wysiwyg/test/basic-tests.tsx
@@ -1,7 +1,6 @@
 // From https://github.com/jpuri/react-draft-wysiwyg/blob/master/stories/
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor } from "react-draft-wysiwyg";
 
 const Basic = () => (
@@ -13,5 +12,3 @@ const Basic = () => (
         />
     </div>
 );
-
-ReactDOM.render(<Basic />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/custom-style-map-tests.tsx
+++ b/types/react-draft-wysiwyg/test/custom-style-map-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor } from "react-draft-wysiwyg";
 
 const CustomStyleMapEditor = () => (
@@ -14,5 +13,3 @@ const CustomStyleMapEditor = () => (
         />
     </div>
 );
-
-ReactDOM.render(<CustomStyleMapEditor />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/custom-toolbar-tests.tsx
+++ b/types/react-draft-wysiwyg/test/custom-toolbar-tests.tsx
@@ -2,7 +2,6 @@
 
 import { RichUtils } from "draft-js";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor } from "react-draft-wysiwyg";
 
 class CustomOption extends React.Component<any, any> {
@@ -30,5 +29,3 @@ const CustomToolbar = () => (
         />
     </div>
 );
-
-ReactDOM.render(<CustomToolbar />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/focus-blur-callbacks-tests.tsx
+++ b/types/react-draft-wysiwyg/test/focus-blur-callbacks-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor } from "react-draft-wysiwyg";
 
 class FocusBlurCallbacks extends React.Component<any, any> {
@@ -40,5 +39,3 @@ class FocusBlurCallbacks extends React.Component<any, any> {
         );
     }
 }
-
-ReactDOM.render(<FocusBlurCallbacks />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/render-with-handle-key-command.tsx
+++ b/types/react-draft-wysiwyg/test/render-with-handle-key-command.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor, EditorProps } from "react-draft-wysiwyg";
 
 const RenderWithHandleKeyCommand = () => {
@@ -13,5 +12,3 @@ const RenderWithHandleKeyCommand = () => {
 
     return <Editor handleKeyCommand={handleKeyCommand} />;
 };
-
-ReactDOM.render(<RenderWithHandleKeyCommand />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/render-with-test-id.tsx
+++ b/types/react-draft-wysiwyg/test/render-with-test-id.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor } from "react-draft-wysiwyg";
 
 const RenderWithTestId = () => (
@@ -7,5 +6,3 @@ const RenderWithTestId = () => (
         <Editor webDriverTestID="test" />
     </div>
 );
-
-ReactDOM.render(<RenderWithTestId />, document.getElementById("target"));

--- a/types/react-draft-wysiwyg/test/uncontrolled-raw-draft-content-state.tsx
+++ b/types/react-draft-wysiwyg/test/uncontrolled-raw-draft-content-state.tsx
@@ -1,7 +1,6 @@
 // From https://github.com/jpuri/react-draft-wysiwyg/blob/master/docs/src/components/Docs/Props/EditorStateProp/index.js#L125
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { Editor, RawDraftContentState } from "react-draft-wysiwyg";
 
 class UncontrolledEditor extends React.Component<
@@ -44,5 +43,3 @@ class UncontrolledEditor extends React.Component<
         );
     }
 }
-
-ReactDOM.render(<UncontrolledEditor />, document.getElementById("target"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.