### PR TITLE
[react-table] Stop testing react-dom

### DIFF
--- a/types/react-table/v6/package.json
+++ b/types/react-table/v6/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-table": "workspace:."
     },
     "owners": [

--- a/types/react-table/v6/react-table-tests.tsx
+++ b/types/react-table/v6/react-table-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 // Import React Table
 import ReactTable, { Column, FinalState, Instance } from "react-table";
@@ -197,5 +196,3 @@ const Component = (props: {}) => {
         )
     );
 };
-
-ReactDOM.render(<Component />, document.getElementById("root"));

--- a/types/react-table/v6/test/select-table-tests.tsx
+++ b/types/react-table/v6/test/select-table-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import ReactTable, { Column } from "react-table";
 import selectTableHOC, {
@@ -46,12 +45,9 @@ const columns: Column[] = [
     { Header: "Name", accessor: "name" },
 ];
 
-ReactDOM.render(
-    <SelectTable
-        {...selectTableAdditionalProps}
-        data={data}
-        columns={columns}
-        ref={React.createRef()}
-    />,
-    document.getElementById("root"),
-);
+<SelectTable
+    {...selectTableAdditionalProps}
+    data={data}
+    columns={columns}
+    ref={React.createRef()}
+/>;

--- a/types/react-table/v6/test/tree-table-tests.tsx
+++ b/types/react-table/v6/test/tree-table-tests.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-
 import ReactTable, { Column } from "react-table";
 import treeTableHOC from "react-table/lib/hoc/treeTable";
 
@@ -13,7 +11,4 @@ const columns: Column[] = [
     { Header: "Name", accessor: "name" },
 ];
 
-ReactDOM.render(
-    <TreeTable data={data} columns={columns} ref={React.createRef()} />,
-    document.getElementById("root"),
-);
+<TreeTable data={data} columns={columns} ref={React.createRef()} />;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.