### PR TITLE
[redux-infinite-scroll] Stop testing react-dom

### DIFF
--- a/types/redux-infinite-scroll/package.json
+++ b/types/redux-infinite-scroll/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/redux-infinite-scroll": "workspace:."
     },
     "owners": [

--- a/types/redux-infinite-scroll/redux-infinite-scroll-tests.tsx
+++ b/types/redux-infinite-scroll/redux-infinite-scroll-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import InfiniteScoller from "redux-infinite-scroll";
 
 class App extends React.Component {
@@ -46,5 +45,3 @@ class App extends React.Component {
         );
     }
 }
-
-ReactDOM.render(<App />, document.getElementById("app"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.