### PR TITLE
[simple-react-clipboard] Stop testing react-dom

### DIFF
--- a/types/simple-react-clipboard/simple-react-clipboard-tests.tsx
+++ b/types/simple-react-clipboard/simple-react-clipboard-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { render } from "react-dom";
 import Clipboard from "simple-react-clipboard";
 
 const text = "Hello World";
@@ -8,13 +7,10 @@ const props = {};
 const onSuccess = () => {};
 const onError = () => {};
 
-render(
-    <Clipboard
-        render={children}
-        text={text}
-        props={props}
-        onSuccess={onSuccess}
-        onError={onError}
-    />,
-    document.getElementById("root"),
-);
+<Clipboard
+    render={children}
+    text={text}
+    props={props}
+    onSuccess={onSuccess}
+    onError={onError}
+/>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.