### PR TITLE
[simple-react-lightbox] Stop testing react-dom

### DIFF
--- a/types/simple-react-lightbox/package.json
+++ b/types/simple-react-lightbox/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/simple-react-lightbox": "workspace:."
     },
     "owners": [

--- a/types/simple-react-lightbox/simple-react-lightbox-tests.tsx
+++ b/types/simple-react-lightbox/simple-react-lightbox-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { render } from "react-dom";
 import SimpleReactLightbox, { Elements, SRLWrapper, SRLWrapperOptions, useLightbox } from "simple-react-lightbox";
 
 const elements: Elements = [
@@ -86,39 +85,36 @@ const options: SRLWrapperOptions = {
     },
 };
 
-render(
-    <React.StrictMode>
-        <SimpleReactLightbox>
-            <SRLWrapper options={options}>
-                <a href="/product01.jpg" className="element_with_overlay">
-                    <div className="overlay">
-                        <h1>Funny cap</h1>
-                        <p>£30.00</p>
-                    </div>
-                    <img src="product/01.jpg" alt="Funny cap" />
-                </a>
-                <a href="/product02.jpg" className="element_with_overlay">
-                    <div className="overlay">
-                        <h1>Sunglasses</h1>
-                        <p>£90.00</p>
-                    </div>
-                    <img src="product/02.jpg" alt="Sunglasses" />
-                </a>
-                <div className="element_with_overlay">
-                    <div className="overlay">
-                        <h1>Funny cap</h1>
-                        <p>£30.00</p>
-                    </div>
-                    <img src="/product03.jpg" alt="Cool backpack" />
+<React.StrictMode>
+    <SimpleReactLightbox>
+        <SRLWrapper options={options}>
+            <a href="/product01.jpg" className="element_with_overlay">
+                <div className="overlay">
+                    <h1>Funny cap</h1>
+                    <p>£30.00</p>
                 </div>
-            </SRLWrapper>
-            <SimpleReactLightbox>
-                <SRLWrapper elements={elements} options={options} />
-            </SimpleReactLightbox>
+                <img src="product/01.jpg" alt="Funny cap" />
+            </a>
+            <a href="/product02.jpg" className="element_with_overlay">
+                <div className="overlay">
+                    <h1>Sunglasses</h1>
+                    <p>£90.00</p>
+                </div>
+                <img src="product/02.jpg" alt="Sunglasses" />
+            </a>
+            <div className="element_with_overlay">
+                <div className="overlay">
+                    <h1>Funny cap</h1>
+                    <p>£30.00</p>
+                </div>
+                <img src="/product03.jpg" alt="Cool backpack" />
+            </div>
+        </SRLWrapper>
+        <SimpleReactLightbox>
+            <SRLWrapper elements={elements} options={options} />
         </SimpleReactLightbox>
-    </React.StrictMode>,
-    document.getElementById("root"),
-);
+    </SimpleReactLightbox>
+</React.StrictMode>;
 
 const { openLightbox, closeLightbox } = useLightbox();
 


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.