### PR TITLE
barnard59-core: fix rdf-loaders-registry dep

### DIFF
--- a/types/barnard59-core/package.json
+++ b/types/barnard59-core/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/clownface": "*",
         "@types/node": "*",
-        "@types/rdf-loaders-registry": "*",
+        "@types/rdf-loaders-registry": "^0.3.0",
         "@types/readable-stream": "*",
         "rdf-js": "^4.0.2",
         "winston": "^3.3.3"


### PR DESCRIPTION
@types/rdf-loaders-registry is no longer published on DT because rdf-loaders-registry publishes its own types. Because barnard59-core types are far behind its source package, I decided to pin to the old types version.

Some barnard59 packages publish their own types now, but not barnard59 itself. Otherwise it would make more sense to deprecate all the barnard59 types as well.