### PR TITLE
Revert jquery/v2 changes to each callback's return

### DIFF
--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -1265,7 +1265,8 @@ interface JQueryStatic {
      */
     each<T>(
         collection: T[],
-        callback: (this: T, indexInArray: number, valueOfElement: T) => boolean | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        callback: (this: T, indexInArray: number, valueOfElement: T) => boolean | void,
     ): T[];
 
     /**
@@ -3489,7 +3490,8 @@ interface JQuery {
      * @param func A function to execute for each matched element. Can stop the loop by returning false.
      * @see {@link https://api.jquery.com/each/}
      */
-    each(func: (this: HTMLElement, index: number, elem: Element) => boolean | undefined): JQuery;
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    each(func: (this: HTMLElement, index: number, elem: Element) => boolean | void): JQuery;
 
     /**
      * Retrieve one of the elements matched by the jQuery object.


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67350a changed the return type of each's callback to `boolean | undefined` from `boolean | void`. Unfortunately, the return type of some callbacks is still inferred as `void`, as shown by some broken tests.

Missed previously because CI was mistakenly not showing type errors for test files without `$ExpectType` in them. Fixed by https://github.com/microsoft/DefinitelyTyped-tools/pull/892