### PR TITLE
hydra-box: fix rdf-loaders-registry dep to old version

### DIFF
--- a/types/hydra-box/package.json
+++ b/types/hydra-box/package.json
@@ -12,7 +12,7 @@
         "@types/express": "*",
         "@types/express-serve-static-core": "*",
         "@types/rdf-ext": "*",
-        "@types/rdf-loaders-registry": "*",
+        "@types/rdf-loaders-registry": "^0.3.0",
         "@types/rdfjs__express-handler": "*",
         "@types/set-link": "*"
     },


### PR DESCRIPTION
@types/rdf-loaders-registry is deprecated now, so switch to the old version.
