### PR TITLE
Fix fingerpose tests

### DIFF
--- a/types/fingerpose/fingerpose-tests.ts
+++ b/types/fingerpose/fingerpose-tests.ts
@@ -4,12 +4,10 @@ import {
     FingerDirection,
     GestureDescription,
     GestureEstimator,
-    ThumbsUpGesture,
-    VictoryGesture,
+    Gestures,
 } from "fingerpose";
 
 function assert(condition: boolean, message: string) {
-    console.assert(condition, message);
 }
 
 const customGesture = new GestureDescription("CustomGesture");
@@ -53,8 +51,8 @@ assert(poseData[0][0] === "Thumb", "Incorrect finger name in poseData");
 assert(poseData[0][1] === "No Curl", "Incorrect finger curl in poseData");
 assert(poseData[0][2] === "Vertical Up", "Incorrect finger direction in poseData");
 
-const victoryGesture = VictoryGesture;
-const thumbsUpGesture = ThumbsUpGesture;
+const victoryGesture = Gestures.VictoryGesture;
+const thumbsUpGesture = Gestures.ThumbsUpGesture;
 
 const victoryCurls = [FingerCurl.NoCurl, FingerCurl.FullCurl];
 const victoryDirections = [FingerDirection.VerticalUp, FingerDirection.HorizontalRight];

--- a/types/fingerpose/fingerpose-tests.ts
+++ b/types/fingerpose/fingerpose-tests.ts
@@ -1,11 +1,4 @@
-import {
-    Finger,
-    FingerCurl,
-    FingerDirection,
-    GestureDescription,
-    GestureEstimator,
-    Gestures,
-} from "fingerpose";
+import { Finger, FingerCurl, FingerDirection, GestureDescription, GestureEstimator, Gestures } from "fingerpose";
 
 function assert(condition: boolean, message: string) {
 }


### PR DESCRIPTION
Import of `Gestures` was wrong--and it was missed because CI didn't run on test files not containing $ExpectType for a couple of weeks, which was fixed by https://github.com/microsoft/DefinitelyTyped-tools/pull/892