### PR TITLE
Fix three tests

### DIFF
--- a/types/three/test/integration/three-examples/webgl_nodes_materials_instance_uniform.ts
+++ b/types/three/test/integration/three-examples/webgl_nodes_materials_instance_uniform.ts
@@ -12,7 +12,7 @@ import { nodeFrame } from 'three/examples/jsm/renderers/webgl/nodes/WebGLNodes';
 import { WebGLNodeBuilder } from 'three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder';
 const { add, mul } = Nodes;
 class InstanceUniformNode extends Nodes.Node {
-    uniformNode: Nodes.UniformNode;
+    uniformNode: Nodes.UniformNode<unknown>;
     constructor() {
         super('vec3');
         this.updateType = Nodes.NodeUpdateType.OBJECT;

--- a/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
@@ -17,19 +17,20 @@ import {
     ConstNode,
 } from 'three/examples/jsm/nodes/Nodes';
 
-import { ConvertType, Swizzable } from 'three/examples/jsm/nodes/shadernode/ShaderNode';
+import { ConvertType, Swizzable, ShaderNodeObject } from 'three/examples/jsm/nodes/shadernode/ShaderNode';
+import SplitNode from 'three/examples/jsm/nodes/utils/SplitNode';
 
 // just to type check
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
 function assertSwizzable<T extends Node>(_s: Swizzable<T>) {}
 
-export const color = new ConvertType('color');
+declare const color: ConvertType;
 const s = color(1);
 s.xyz;
 
 const aa = nodeArray([1, 2, 'hello']);
-aa[0].xy = s;
-aa[1].w = s;
+aa[0].xy = s as ShaderNodeObject<SplitNode>;
+aa[1].w = s as ShaderNodeObject<SplitNode>;
 aa[2] = 'hello';
 
 export const rotateUV = nodeProxy(RotateUVNode);


### PR DESCRIPTION
Broken by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67945, missed because CI wasn't reporting compile errors on test files with no $ExpectType (fixed by
https://github.com/microsoft/DefinitelyTyped-tools/pull/892).

I'm not at all sure these fixes are right, but they do suppress the compile errors.