### PR TITLE
Fixup vosk

### DIFF
--- a/types/vosk/index.d.ts
+++ b/types/vosk/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 export interface WordResult {
     /**
      * The confidence rate in the detection. 0 For unlikely, and 1 for totally accurate.

--- a/types/vosk/package.json
+++ b/types/vosk/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/alphacep/vosk-api/tree/master/nodejs"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/vosk": "workspace:."
     },

--- a/types/vosk/vosk-tests.ts
+++ b/types/vosk/vosk-tests.ts
@@ -1,4 +1,5 @@
-import vosk from "vosk";
+/// <reference types="node" />
+import vosk = require("vosk");
 
 main().catch(function(error) {
     throw error;
@@ -9,7 +10,7 @@ async function main(): Promise<void> {
     const model = new vosk.Model("../models/vosk");
     const recognizer = new vosk.Recognizer({ model: model, sampleRate: 16000 });
 
-    const chunk = new ArrayBuffer(0);
+    const chunk = new Buffer(0);
 
     if (recognizer.acceptWaveform(chunk)) {
         console.log(recognizer.result());


### PR DESCRIPTION
Vosk types were recently added and had a number of compile errors that CI didn't catch because of a bug. That bug is now fixed in https://github.com/microsoft/DefinitelyTyped-tools/pull/892.