### PR TITLE
[imapflow] correct fetch options type, correct StatusObject uidNext name, optional threadId in FetchMessageObject 

### DIFF
--- a/types/imapflow/imapflow-tests.ts
+++ b/types/imapflow/imapflow-tests.ts
@@ -38,3 +38,6 @@ client.list();
 
 // $Expect Promise<MailboxDeleteResponse>
 client.mailboxDelete("INBOX.example");
+
+// $Expect Promise<StatusObject>
+client.status("INBOX", { uidNext: true });

--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -122,7 +122,7 @@ export class ImapFlow extends EventEmitter {
     fetch(
         range: SequenceString | number[] | SearchObject,
         query: FetchQueryObject,
-        options?: { uid?: boolean; changedSince: bigint },
+        options?: { uid?: boolean; changedSince?: bigint; binary?: boolean },
     ): AsyncGenerator<FetchMessageObject, never, void>;
 }
 

--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -291,7 +291,7 @@ export interface StatusObject {
     path: string;
     messages?: number;
     recent?: number;
-    uid?: number;
+    uidNext?: number;
     uidValidity?: bigint;
     unseen?: number;
     highestModseq?: bigint;

--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -196,7 +196,7 @@ export interface FetchMessageObject {
     source: Buffer;
     modseq: BigInt;
     emailId: string;
-    threadId: string;
+    threadId?: string;
     labels: Set<string>;
     size: number;
     flags: Set<string>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://imapflow.com/global.html#FetchMessageObject, https://imapflow.com/global.html#StatusObject, https://imapflow.com/module-imapflow-ImapFlow.html#fetch
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
