### PR TITLE
[node-telegram-bot-api] add secret_token to SetWebHookOptions

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -133,6 +133,7 @@ declare namespace TelegramBot {
         certificate?: string | Stream | undefined;
         max_connections?: number | undefined;
         allowed_updates?: string[] | undefined;
+        secret_token?: string | undefined;
     }
 
     interface GetUpdatesOptions {


### PR DESCRIPTION
Telegram API accepts optional `secret_token` field while setting web hook [docs](https://core.telegram.org/bots/api#setwebhook), which is missing in the current definitions. 
`node-telegram-bot-api` package also supports it: [src/telegram.js:811](https://github.com/yagop/node-telegram-bot-api/blob/4fa9a735bbe895b8185d4c7a384b18a1ab0408b0/src/telegram.js#L811).

This PR brings the field definition into the corresponding interface.

Running tests is blocked for me by #67921, but I've tested it locally on `node-telegram-bot-api` 0.64.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://core.telegram.org/bots/api#setwebhook https://github.com/yagop/node-telegram-bot-api/blob/master/src/telegram.js