### PR TITLE
[react-click-outside-hook] Stop testing react-dom

### DIFF
--- a/types/react-click-outside-hook/package.json
+++ b/types/react-click-outside-hook/package.json
@@ -7,8 +7,7 @@
     ],
     "devDependencies": {
         "@types/react": "*",
-        "@types/react-click-outside-hook": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-click-outside-hook": "workspace:."
     },
     "owners": [
         {

--- a/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
+++ b/types/react-click-outside-hook/react-click-outside-hook-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { render } from "react-dom";
 
 import { useClickOutside } from "react-click-outside-hook";
 
@@ -7,5 +6,3 @@ function Component() {
     const [ref, hasClickedOutside] = useClickOutside();
     return <div ref={ref}>{hasClickedOutside.toString()}</div>;
 }
-
-render(<Component />, document.getElementById("test"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.