### PR TITLE
[react-recaptcha-v3] Stop testing react-dom

### DIFF
--- a/types/react-recaptcha-v3/package.json
+++ b/types/react-recaptcha-v3/package.json
@@ -9,7 +9,6 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-recaptcha-v3": "workspace:."
     },
     "owners": [

--- a/types/react-recaptcha-v3/react-recaptcha-v3-tests.tsx
+++ b/types/react-recaptcha-v3/react-recaptcha-v3-tests.tsx
@@ -1,11 +1,7 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { ReCaptcha } from "react-recaptcha-v3";
 
-ReactDOM.render(
-    <ReCaptcha
-        sitekey="xxxxxx"
-        action="action"
-    />,
-    document.getElementById("form-recaptcha"),
-);
+<ReCaptcha
+    sitekey="xxxxxx"
+    action="action"
+/>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.