### PR TITLE
[react-router-redux] Stop testing react-dom

### DIFF
--- a/types/react-router-redux/package.json
+++ b/types/react-router-redux/package.json
@@ -12,7 +12,6 @@
         "redux": ">= 3.7.2"
     },
     "devDependencies": {
-        "@types/react-dom": "*",
         "@types/react-redux": "*",
         "@types/react-router-redux": "workspace:."
     },

--- a/types/react-router-redux/react-router-redux-tests.tsx
+++ b/types/react-router-redux/react-router-redux-tests.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import { Provider } from "react-redux";
 import { applyMiddleware, combineReducers, createStore } from "redux";
@@ -37,17 +36,15 @@ const store = createStore(
 );
 
 const Home = () => <div>Home</div>;
-ReactDOM.render(
-    <Provider store={store}>
-        {/* ConnectedRouter will use the store from Provider automatically */}
-        <ConnectedRouter history={history}>
-            <div>
-                <Route exact path="/" component={Home} />
-            </div>
-        </ConnectedRouter>
-    </Provider>,
-    document.getElementById("root"),
-);
+
+<Provider store={store}>
+    {/* ConnectedRouter will use the store from Provider automatically */}
+    <ConnectedRouter history={history}>
+        <div>
+            <Route exact path="/" component={Home} />
+        </div>
+    </ConnectedRouter>
+</Provider>;
 
 // Now you can dispatch navigation actions from anywhere!
 store.dispatch(push("/foo"));


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.