### PR TITLE
[react-bootstrap-table2] Stop testing react-dom

### DIFF
--- a/types/react-bootstrap-table2-toolkit/package.json
+++ b/types/react-bootstrap-table2-toolkit/package.json
@@ -11,8 +11,7 @@
     },
     "devDependencies": {
         "@types/react-bootstrap-table2-paginator": "*",
-        "@types/react-bootstrap-table2-toolkit": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/react-bootstrap-table2-toolkit": "workspace:."
     },
     "owners": [
         {

--- a/types/react-bootstrap-table2-toolkit/react-bootstrap-table2-toolkit-tests.tsx
+++ b/types/react-bootstrap-table2-toolkit/react-bootstrap-table2-toolkit-tests.tsx
@@ -7,7 +7,6 @@ import BootstrapTable, {
 } from "react-bootstrap-table-next";
 import paginationFactory from "react-bootstrap-table2-paginator";
 import ToolkitProvider, { CSVExport, InjectedSearchProps, Search } from "react-bootstrap-table2-toolkit";
-import { render } from "react-dom";
 
 interface Product {
     id: number;
@@ -91,17 +90,14 @@ const CustomSearch = (props: InjectedSearchProps) => {
     );
 };
 
-render(
-    <ToolkitProvider data={products} keyField="id" columns={productColumns}>
-        {({ baseProps, searchProps }) => (
-            <>
-                <CustomSearch {...searchProps} />
-                <BootstrapTable {...baseProps} pagination={paginationFactory({ sizePerPage: 10, page: 1 })} />
-            </>
-        )}
-    </ToolkitProvider>,
-    document.getElementById("app"),
-);
+<ToolkitProvider data={products} keyField="id" columns={productColumns}>
+    {({ baseProps, searchProps }) => (
+        <>
+            <CustomSearch {...searchProps} />
+            <BootstrapTable {...baseProps} pagination={paginationFactory({ sizePerPage: 10, page: 1 })} />
+        </>
+    )}
+</ToolkitProvider>;
 
 /**
  * Toolkit CSV export test
@@ -141,31 +137,28 @@ const csvColumns: Array<ColumnDescription<Product>> = [
     },
 ];
 
-render(
-    <ToolkitProvider
-        data={products}
-        keyField="id"
-        exportCSV={{
-            fileName: "custom.csv",
-            separator: "|",
-            ignoreHeader: true,
-            noAutoBOM: false,
-            blobType: "text/plain;charset=utf-8",
-            exportAll: true,
-            onlyExportSelection: true,
-            onlyExportFiltered: true,
-        }}
-        columns={productColumns}
-    >
-        {({ baseProps, searchProps }) => (
-            <>
-                <CustomSearch {...searchProps} />
-                <BootstrapTable {...baseProps} pagination={paginationFactory({ sizePerPage: 10, page: 1 })} />
-            </>
-        )}
-    </ToolkitProvider>,
-    document.getElementById("app"),
-);
+<ToolkitProvider
+    data={products}
+    keyField="id"
+    exportCSV={{
+        fileName: "custom.csv",
+        separator: "|",
+        ignoreHeader: true,
+        noAutoBOM: false,
+        blobType: "text/plain;charset=utf-8",
+        exportAll: true,
+        onlyExportSelection: true,
+        onlyExportFiltered: true,
+    }}
+    columns={productColumns}
+>
+    {({ baseProps, searchProps }) => (
+        <>
+            <CustomSearch {...searchProps} />
+            <BootstrapTable {...baseProps} pagination={paginationFactory({ sizePerPage: 10, page: 1 })} />
+        </>
+    )}
+</ToolkitProvider>;
 
 /**
  * Toolkit Search with ClearSearchButton
@@ -173,18 +166,15 @@ render(
 
 const { SearchBar, ClearSearchButton } = Search;
 
-render(
-    <ToolkitProvider keyField="id" data={products} columns={productColumns} search>
-        {({ baseProps, searchProps }) => (
-            <>
-                <SearchBar {...searchProps} />
-                <ClearSearchButton {...searchProps} />
-                <BootstrapTable {...baseProps} />
-            </>
-        )}
-    </ToolkitProvider>,
-    document.getElementById("app"),
-);
+<ToolkitProvider keyField="id" data={products} columns={productColumns} search>
+    {({ baseProps, searchProps }) => (
+        <>
+            <SearchBar {...searchProps} />
+            <ClearSearchButton {...searchProps} />
+            <BootstrapTable {...baseProps} />
+        </>
+    )}
+</ToolkitProvider>;
 
 /**
  * Toolkit CSVExport with ExportCSVButton
@@ -192,14 +182,11 @@ render(
 
 const { ExportCSVButton } = CSVExport;
 
-render(
-    <ToolkitProvider keyField="id" data={products} columns={productColumns} search>
-        {({ baseProps, csvProps }) => (
-            <>
-                <ExportCSVButton {...csvProps}>Export</ExportCSVButton>
-                <BootstrapTable {...baseProps} />
-            </>
-        )}
-    </ToolkitProvider>,
-    document.getElementById("app"),
-);
+<ToolkitProvider keyField="id" data={products} columns={productColumns} search>
+    {({ baseProps, csvProps }) => (
+        <>
+            <ExportCSVButton {...csvProps}>Export</ExportCSVButton>
+            <BootstrapTable {...baseProps} />
+        </>
+    )}
+</ToolkitProvider>;


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.