### PR TITLE
[gatsbyjs__reach-router] Stop testing react-dom

### DIFF
--- a/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
+++ b/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
@@ -10,7 +10,6 @@ import {
     useParams,
 } from "@gatsbyjs/reach-router";
 import * as React from "react";
-import { render } from "react-dom";
 
 interface DashParams {
     id: string;
@@ -49,7 +48,6 @@ const UseParamsCheck = (props: RouteComponentProps) => {
     return <div>{params.value}</div>;
 };
 
-render(
     <Router className="my-class">
         <Router component="div">
             <Home path="/" />
@@ -81,19 +79,17 @@ render(
                 </>
             )}
         </LocationProvider>
-    </Router>,
-    document.getElementById("app-root"),
-);
+    </Router>;
 
 const handleRef = (el: HTMLAnchorElement) => {
     el.focus();
 };
 
-render(<Link innerRef={handleRef} to="./foo"></Link>, document.getElementById("app-root"));
-render(<Link ref={handleRef} to="./foo"></Link>, document.getElementById("app-root"));
+<Link innerRef={handleRef} to="./foo"></Link>;
+<Link ref={handleRef} to="./foo"></Link>;
 
 const refObject: React.RefObject<HTMLAnchorElement> = { current: null };
-render(<Link innerRef={refObject} to="./foo"></Link>, document.getElementById("app-root"));
-render(<Link ref={refObject} to="./foo"></Link>, document.getElementById("app-root"));
+<Link innerRef={refObject} to="./foo"></Link>;
+<Link ref={refObject} to="./foo"></Link>;
 
 const elem: React.JSX.Element = <Link<number> state={5} to="./foo">Click me!</Link>;

--- a/types/gatsbyjs__reach-router/package.json
+++ b/types/gatsbyjs__reach-router/package.json
@@ -10,8 +10,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/gatsbyjs__reach-router": "workspace:.",
-        "@types/react-dom": "*"
+        "@types/gatsbyjs__reach-router": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Usage of `react-dom` in this package was not actually testing integration between this package and `react-dom` but `react` and `react-dom`. This adds considerable overhead to making changes to react-dom so I just removed these redundant tests.