### PR TITLE
[react-addons-pure-render-mixin] Stop depending on React.Mixin

### DIFF
--- a/types/react-addons-pure-render-mixin/index.d.ts
+++ b/types/react-addons-pure-render-mixin/index.d.ts
@@ -1,6 +1,8 @@
-import { Mixin } from "react";
+import { ComponentLifecycle } from "react";
 
 declare var PureRenderMixin: PureRenderMixin;
 export = PureRenderMixin;
 
-interface PureRenderMixin extends Mixin<any, any> {}
+interface PureRenderMixin {
+    shouldComponentUpdate: NonNullable<ComponentLifecycle<any, any>['shouldComponentUpdate']>
+}


### PR DESCRIPTION
Removes the deprecated `React.Mixin` which no longer has any runtime relevance in React. It's better to concretely type what this mixin does to be forward compatible when other lifecycles or statics get removed from React actual.