### PR TITLE
[socketcluster-server] Fix reference to ws Server

### DIFF
--- a/types/socketcluster-server/server.d.ts
+++ b/types/socketcluster-server/server.d.ts
@@ -60,7 +60,7 @@ declare class AGServer extends AsyncStreamEmitter<any> {
     };
     pendingClientsCount: number;
 
-    wsServer: WebSocket.Server;
+    wsServer: WebSocket.WebSocketServer;
 
     constructor(options?: AGServer.AGServerOptions);
 
@@ -170,7 +170,7 @@ declare namespace AGServer {
 
         // This can be the name of an npm module or a path to a
         // Node.js module to use as the WebSocket server engine.
-        wsEngine?: string | { Server: WebSocket.Server };
+        wsEngine?: string | { Server: WebSocket.WebSocketServer };
 
         // Custom options to pass to the wsEngine when it is being
         // instantiated.

--- a/types/socketcluster-server/v15/server.d.ts
+++ b/types/socketcluster-server/v15/server.d.ts
@@ -59,7 +59,7 @@ declare class AGServer extends AsyncStreamEmitter<any> {
     };
     pendingClientsCount: number;
 
-    wsServer: WebSocket.Server;
+    wsServer: WebSocket.WebSocketServer;
 
     constructor(options?: AGServer.AGServerOptions);
 
@@ -169,7 +169,7 @@ declare namespace AGServer {
 
         // This can be the name of an npm module or a path to a
         // Node.js module to use as the WebSocket server engine.
-        wsEngine?: string | { Server: WebSocket.Server };
+        wsEngine?: string | { Server: WebSocket.WebSocketServer };
 
         // Custom options to pass to the wsEngine when it is being
         // instantiated.

--- a/types/socketcluster-server/v16/server.d.ts
+++ b/types/socketcluster-server/v16/server.d.ts
@@ -59,7 +59,7 @@ declare class AGServer extends AsyncStreamEmitter<any> {
     };
     pendingClientsCount: number;
 
-    wsServer: WebSocket.Server;
+    wsServer: WebSocket.WebSocketServer;
 
     constructor(options?: AGServer.AGServerOptions);
 
@@ -169,7 +169,7 @@ declare namespace AGServer {
 
         // This can be the name of an npm module or a path to a
         // Node.js module to use as the WebSocket server engine.
-        wsEngine?: string | { Server: WebSocket.Server };
+        wsEngine?: string | { Server: WebSocket.WebSocketServer };
 
         // Custom options to pass to the wsEngine when it is being
         // instantiated.

--- a/types/socketcluster-server/v17/server.d.ts
+++ b/types/socketcluster-server/v17/server.d.ts
@@ -59,7 +59,7 @@ declare class AGServer extends AsyncStreamEmitter<any> {
     };
     pendingClientsCount: number;
 
-    wsServer: WebSocket.Server;
+    wsServer: WebSocket.WebSocketServer;
 
     constructor(options?: AGServer.AGServerOptions);
 
@@ -169,7 +169,7 @@ declare namespace AGServer {
 
         // This can be the name of an npm module or a path to a
         // Node.js module to use as the WebSocket server engine.
-        wsEngine?: string | { Server: WebSocket.Server };
+        wsEngine?: string | { Server: WebSocket.WebSocketServer };
 
         // Custom options to pass to the wsEngine when it is being
         // instantiated.

--- a/types/socketcluster-server/v18/server.d.ts
+++ b/types/socketcluster-server/v18/server.d.ts
@@ -60,7 +60,7 @@ declare class AGServer extends AsyncStreamEmitter<any> {
     };
     pendingClientsCount: number;
 
-    wsServer: WebSocket.Server;
+    wsServer: WebSocket.WebSocketServer;
 
     constructor(options?: AGServer.AGServerOptions);
 
@@ -170,7 +170,7 @@ declare namespace AGServer {
 
         // This can be the name of an npm module or a path to a
         // Node.js module to use as the WebSocket server engine.
-        wsEngine?: string | { Server: WebSocket.Server };
+        wsEngine?: string | { Server: WebSocket.WebSocketServer };
 
         // Custom options to pass to the wsEngine when it is being
         // instantiated.


### PR DESCRIPTION
The ESM version of the ws types does not export the `Server` type, it only exports `WebSocketServer`, which should be synonymous.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ws/index.d.mts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
