### PR TITLE
Remove private capacitor property from graphql-upload

### DIFF
--- a/types/graphql-upload/graphql-upload-tests.ts
+++ b/types/graphql-upload/graphql-upload-tests.ts
@@ -1,10 +1,12 @@
 import express from "express";
+import { WriteStream } from "fs-capacitor";
 import graphqlUploadExpress from "graphql-upload/graphqlUploadExpress.mjs";
 import graphqlUploadKoa from "graphql-upload/graphqlUploadKoa.mjs";
 import { FileUpload } from "graphql-upload/processRequest.mjs";
 import Upload from "graphql-upload/Upload.mjs";
 import Koa from "koa";
 import { createWriteStream, unlink } from "node:fs";
+import Stream from "node:stream";
 
 express()
     .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
@@ -36,4 +38,18 @@ export const storeUpload = async (fileUpload: Promise<FileUpload>) => {
     });
 
     return filename;
+};
+
+export const fileUploadMock: FileUpload = {
+    filename: "Test file.pdf",
+    encoding: "utf8",
+    // No need to define the capacitor property.
+    mimetype: "application/pdf",
+    createReadStream: () => {
+        const readableStream = new Stream.Readable();
+        readableStream.push(null);
+        const writeStream = new WriteStream();
+        readableStream.pipe(writeStream);
+        return writeStream.createReadStream();
+    },
 };

--- a/types/graphql-upload/processRequest.d.mts
+++ b/types/graphql-upload/processRequest.d.mts
@@ -1,4 +1,4 @@
-import { ReadStreamOptions, WriteStream } from "fs-capacitor";
+import { ReadStreamOptions } from "fs-capacitor";
 import { GraphQLScalarType } from "graphql";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
@@ -38,7 +38,7 @@ export interface FileUpload {
     filename: string;
     mimetype: string;
     encoding: string;
-    capacitor: WriteStream;
+    // We omit the capacitor property because it's a private implementation detail that shouldn't be used outside.
     createReadStream: FileUploadCreateReadStream;
 }
 


### PR DESCRIPTION
- Although the `capacitor` prop is part of the `FileUpload` type, we can omit it since [the author explains](https://github.com/jaydenseric/graphql-upload/blob/master/processRequest.mjs#L357-L359) that it's a private implementation detail that should not be used outside. This also helps by avoiding breaking changes like [this one](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67864#issuecomment-1875061139).
- This property was added [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67864) because we generated the types from the JSDocs types defined in the library, but since it's causing issues and is not needed, we can remove it.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67864#issuecomment-1875061139
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
