### PR TITLE
Matter.js: Make pairs parameter optional in Collision.collides. The current definition does not match the API implementation

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -4003,7 +4003,7 @@ declare namespace Matter {
          * @param {pairs} [Pairs] Optionally reuse collision records from existing pairs.
          * @returns {collision|null} A collision record if detected, otherwise null
          */
-        static collides(bodyA: Body, bodyB: Body, pairs: Pairs): Collision | null;
+        static collides(bodyA: Body, bodyB: Body, pairs?: Pairs): Collision | null;
 
         /**
          * A reference to the pair using this collision record, if there is one.


### PR DESCRIPTION
I got a lint error complaining about using Collision.collides without passing "pairs":
```
Expected 3 arguments, but got 2.ts(2554)
index.d.ts(4006, 51): An argument for 'pairs' was not provided.
```

So, I passed an empty array to make the error go away. However, this caused a `Cannot read properties of undefined` error to be thrown in matter.js itself. The library expects `undefined` if the pairs array should not be used. This pull request updates the type definitions to match this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. *I don't think any changes are needed*
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://brm.io/matter-js/docs/classes/Collision.html#method_collides. These docs declare the pairs field as optional.