### PR TITLE
[react] Deprecate types related to classic components in favor of types from create-react-class

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -21,7 +21,7 @@ const container: Element = document.createElement("div");
 // Top-Level API
 // --------------------------------------------------------------------------
 
-const ClassicComponent: React.ClassicComponentClass<Props> = createReactClass<Props, State>({
+const ClassicComponent: createReactClass.ClassicComponentClass<Props> = createReactClass<Props, State>({
     childContextTypes: {},
     componentDidCatch(err, errorInfo) {
         const msg: string = err.message;
@@ -53,7 +53,7 @@ const ClassicComponent: React.ClassicComponentClass<Props> = createReactClass<Pr
     },
     mixins: [],
     propTypes: {},
-    shouldComponentUpdate(this: React.ClassicComponent<Props, State>, nextProps, nextState) {
+    shouldComponentUpdate(this: createReactClass.ClassicComponent<Props, State>, nextProps, nextState) {
         const newFoo: string = nextProps.foo;
         const newBar: number = nextState.bar;
         return newFoo !== this.props.foo && newBar !== this.state.bar;
@@ -75,13 +75,15 @@ const ClassicComponent: React.ClassicComponentClass<Props> = createReactClass<Pr
     },
 });
 
-const ClassicComponentNoProps: React.ClassicComponentClass = createReactClass({
+const ClassicComponentNoProps: createReactClass.ClassicComponentClass = createReactClass({
     render() {
         return DOM.div();
     },
 });
 
-const ClassicComponentNoState: React.ClassicComponentClass<{ text: string }> = createReactClass<{ text: string }>({
+const ClassicComponentNoState: createReactClass.ClassicComponentClass<{ text: string }> = createReactClass<
+    { text: string }
+>({
     render() {
         return DOM.div(this.props.text);
     },
@@ -89,17 +91,32 @@ const ClassicComponentNoState: React.ClassicComponentClass<{ text: string }> = c
 
 // React.createFactory
 const classicFactory: React.ClassicFactory<Props> = React.createFactory(ClassicComponent);
-const classicFactoryElement: React.ClassicElement<Props> = classicFactory(props);
+const classicFactoryElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = classicFactory(
+    props,
+);
 
 // React.createElement
-const classicElement: React.ClassicElement<Props> = React.createElement(ClassicComponent, props);
-const classicElementNullProps: React.ClassicElement<{}> = React.createElement(ClassicComponentNoProps, null);
+const classicElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = React.createElement(
+    ClassicComponent,
+    props,
+);
+const classicElementNullProps: React.ComponentElement<{}, InstanceType<typeof ClassicComponentNoProps>> = React
+    .createElement(
+        ClassicComponentNoProps,
+        null,
+    );
 
 // React.cloneElement
-const clonedClassicElement: React.ClassicElement<Props> = React.cloneElement(classicElement, props);
+const clonedClassicElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = React.cloneElement(
+    classicElement,
+    props,
+);
 
 // ReactDOM.render
-const classicComponent: React.ClassicComponent<Props> = ReactDOM.render(classicElement, container);
+const classicComponent: InstanceType<typeof ClassicComponent> = ReactDOM.render(
+    classicElement,
+    container,
+);
 
 //
 // React Components

--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -89,35 +89,6 @@ const ClassicComponentNoState: createReactClass.ClassicComponentClass<{ text: st
     },
 });
 
-// React.createFactory
-const classicFactory: React.ClassicFactory<Props> = React.createFactory(ClassicComponent);
-const classicFactoryElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = classicFactory(
-    props,
-);
-
-// React.createElement
-const classicElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = React.createElement(
-    ClassicComponent,
-    props,
-);
-const classicElementNullProps: React.ComponentElement<{}, InstanceType<typeof ClassicComponentNoProps>> = React
-    .createElement(
-        ClassicComponentNoProps,
-        null,
-    );
-
-// React.cloneElement
-const clonedClassicElement: React.ComponentElement<Props, InstanceType<typeof ClassicComponent>> = React.cloneElement(
-    classicElement,
-    props,
-);
-
-// ReactDOM.render
-const classicComponent: InstanceType<typeof ClassicComponent> = ReactDOM.render(
-    classicElement,
-    container,
-);
-
 //
 // React Components
 // --------------------------------------------------------------------------
@@ -129,6 +100,8 @@ const propTypes: React.ValidationMap<Props> | undefined = ClassicComponent.propT
 //
 // Component API
 // --------------------------------------------------------------------------
+
+const classicComponent = new ClassicComponent({ foo: "bar" });
 
 // classic
 const isMounted: boolean = classicComponent.isMounted();

--- a/types/create-react-class/index.d.ts
+++ b/types/create-react-class/index.d.ts
@@ -1,7 +1,40 @@
-import { ClassicComponentClass, ComponentSpec } from "react";
+import { Component, ComponentClass, ComponentLifecycle, ReactNode, ValidationMap } from "react";
 
-declare namespace createReactClass {}
-declare function createReactClass<P, S = {}>(spec: ComponentSpec<P, S>): ClassicComponentClass<P>;
+declare namespace createReactClass {
+    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+        mixins?: Array<Mixin<P, S>> | undefined;
+        statics?: {
+            [key: string]: any;
+        } | undefined;
+
+        displayName?: string | undefined;
+        propTypes?: ValidationMap<any> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        childContextTypes?: ValidationMap<any> | undefined;
+
+        getDefaultProps?(): P;
+        getInitialState?(): S;
+    }
+
+    interface ComponentSpec<P, S> extends Mixin<P, S> {
+        render(): ReactNode;
+
+        [propertyName: string]: any;
+    }
+    interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
+        replaceState(nextState: S, callback?: () => void): void;
+        isMounted(): boolean;
+        getInitialState?(): S;
+    }
+
+    interface ClassicComponentClass<P = {}> extends Omit<ComponentClass<P>, "new"> {
+        new(props: P, context?: any): ClassicComponent<P, any>;
+        getDefaultProps?(): P;
+    }
+}
+declare function createReactClass<P, S = {}>(
+    spec: createReactClass.ComponentSpec<P, S>,
+): createReactClass.ClassicComponentClass<P>;
 
 export as namespace createReactClass;
 export = createReactClass;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -7,7 +7,11 @@ import * as ReactTestUtils from "react-dom/test-utils";
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 
-class TestComponent extends React.Component<{ x: string }> {}
+class TestComponent extends React.Component<{ x: string }> {
+    someInstanceMethod() {
+        return 42;
+    }
+}
 
 describe("ReactDOM", () => {
     it("render", () => {
@@ -15,6 +19,9 @@ describe("ReactDOM", () => {
         ReactDOM.render(React.createElement("div"), rootElement);
         ReactDOM.render(React.createElement("div"), document.createDocumentFragment());
         ReactDOM.render(React.createElement("div"), document);
+
+        const instance = ReactDOM.render(React.createElement(TestComponent), rootElement);
+        instance.someInstanceMethod();
     });
 
     it("hydrate", () => {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -148,6 +148,9 @@ declare namespace React {
         ref?: LegacyRef<T> | undefined;
     }
 
+    /**
+     * @deprecated Use `ComponentElement<P, ClassicComponent<P, any>>` instead.
+     */
     type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
 
     // string fallback for custom web-components
@@ -269,9 +272,6 @@ declare namespace React {
 
     // Custom components
     function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
-    function createFactory<P>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-    ): CFactory<P, ClassicComponent<P, ComponentState>>;
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
     ): CFactory<P, T>;
@@ -307,11 +307,6 @@ declare namespace React {
         props?: Attributes & P | null,
         ...children: ReactNode[]
     ): FunctionComponentElement<P>;
-    function createElement<P extends {}>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
-        ...children: ReactNode[]
-    ): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
         props?: ClassAttributes<T> & P | null,
@@ -545,6 +540,9 @@ declare namespace React {
 
     class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> {}
 
+    /**
+     * @deprecated Use `ClassicComponent` from `create-react-class`
+     */
     interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;
         isMounted(): boolean;
@@ -612,6 +610,9 @@ declare namespace React {
         displayName?: string | undefined;
     }
 
+    /**
+     * @deprecated Use `ClassicComponentClass` from `create-react-class`
+     */
     interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
         new(props: P, context?: any): ClassicComponent<P, ComponentState>;
         getDefaultProps?(): P;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -261,6 +261,15 @@ const fragmentElementNullProps: React.ReactElement<{}> = React.createElement(Rea
     React.createElement("div"),
     React.createElement("div"),
 ]);
+// $ExpectType CElement<{}, ComponentWithCustomInstanceMethods>
+const myElement = React.createElement(
+    class ComponentWithCustomInstanceMethods extends React.Component {
+        customInstanceMethod = () => "Dave";
+        render() {
+            return null;
+        }
+    },
+);
 
 const customProps: React.HTMLProps<HTMLElement> = props;
 const customDomElement = "my-element";
@@ -278,6 +287,8 @@ const clonedElement: React.CElement<Props, ModernComponent> = React.cloneElement
 
 React.cloneElement(element, {});
 React.cloneElement(element, {}, null);
+// $ExpectType CElement<{}, ComponentWithCustomInstanceMethods>
+React.cloneElement(myElement);
 
 const clonedElement2: React.CElement<Props, ModernComponent> = React.cloneElement(element, {
     ref: c => c && c.reset(),


### PR DESCRIPTION
The "classic component" notion is only relevant for `create-react-class`. Therefore, its types should live there instead of bloating types in `react`. This PR deprecates:
- `React.ClassicElement<Props>` (use `createReactClass.ComponentElement<Props, InstanceType<T>>`
- `React.ClassicComponentClass` (use `createReactClass.ClassicComponentClass`)
- `React.ClassicComponent` (use `createClass.ClassicComponent`)
- moves the deprecated `React.Mixin` and `React.ComponentSpec` into `create-react-class` that actually uses these types. Addons will use `createReactClass.ComponentSpec` going forward instead of the deprecated `React.ComponentSpec`
