### PR TITLE
[three-dat.gui] Remove reference to THREE.Vector

### DIFF
--- a/types/three-dat.gui/index.d.ts
+++ b/types/three-dat.gui/index.d.ts
@@ -15,7 +15,11 @@ declare module "dat.gui" {
             stepRotation?: number | undefined;
             stepScale?: number | undefined;
         }): GUI;
-        addVector(name: string, vector: THREE.Vector2 | THREE.Vector3 | THREE.Vector4 | THREE.Euler, options?: { step?: number | undefined }): GUI;
+        addVector(
+            name: string,
+            vector: THREE.Vector2 | THREE.Vector3 | THREE.Vector4 | THREE.Euler,
+            options?: { step?: number | undefined },
+        ): GUI;
     }
 }
 

--- a/types/three-dat.gui/index.d.ts
+++ b/types/three-dat.gui/index.d.ts
@@ -15,7 +15,7 @@ declare module "dat.gui" {
             stepRotation?: number | undefined;
             stepScale?: number | undefined;
         }): GUI;
-        addVector(name: string, vector: THREE.Vector | THREE.Euler, options?: { step?: number | undefined }): GUI;
+        addVector(name: string, vector: THREE.Vector2 | THREE.Vector3 | THREE.Vector4 | THREE.Euler, options?: { step?: number | undefined }): GUI;
     }
 }
 


### PR DESCRIPTION
`THREE.Vector` [will be removed](https://github.com/three-types/three-ts-types/pull/727) in an upcoming version of @types/three because it was not type-safe and is better replaced by type unions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/three-types/three-ts-types/pull/727
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
