### PR TITLE
[@types/highland] Add `_.of`/`_.fromError` and modify `_.compact`

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -508,6 +508,8 @@ fooStream.toPromise<Promise<Foo>>(MyPromise);
 // UTILS
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+fooStream = _.fromError(new Error());
+
 bool = _.isNil(x);
 
 bool = _.isStream(x);

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -115,6 +115,8 @@ var barStreamThen: PromiseLike<Highland.Stream<Bar>>;
 var fooIterable: Iterable<Foo>;
 var fooIterator: Iterator<Foo>;
 
+var maybeFooStream: Highland.Stream<Foo | undefined>;
+
 var isBaz: (obj: Foo) => obj is Baz;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -215,6 +217,8 @@ fooArrStream = fooStream.batchWithTimeOrCount(10, 2);
 fooArrStream = fooStream.collect();
 
 fooStream = fooStream.compact();
+
+fooStream = maybeFooStream.compact();
 
 barStream = fooStream.consume(
     (

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -526,6 +526,8 @@ _.log(str, num, foo);
 
 obj = _.nil;
 
+fooStream = _.of(foo);
+
 f = _.wrapCallback(func);
 f = _.wrapCallback(func, num);
 f = _.wrapCallback(func, strArr);

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -141,6 +141,22 @@ interface HighlandStatic {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     /**
+     * Creates a stream that sends a single error then ends.
+     *
+     * @id fromError
+     * @section Utils
+     * @name _.fromError(err)
+     * @param error - the error to send
+     * @returns Stream
+     * @api public
+     *
+     * _.fromError(new Error('Single Error')).toCallback(function (err, result) {
+     *     // err contains Error('Single Error') object
+     * }
+     */
+    fromError<R>(error: unknown): Highland.Stream<R>;
+
+    /**
      * Returns true if `x` is the end of stream marker.
      *
      * @id isNil

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -207,6 +207,20 @@ interface HighlandStatic {
     nil: Highland.Nil;
 
     /**
+     * Creates a stream that sends a single value then ends.
+     *
+     * @id of
+     * @section Utils
+     * @name _.of(x)
+     * @param x - the value to send
+     * @returns Stream
+     * @api public
+     *
+     * _.of(1).toArray(_.log); // => [1]
+     */
+    of<R>(x: R): Highland.Stream<R>;
+
+    /**
      * Wraps a node-style async function which accepts a callback, transforming
      * it to a function which accepts the same arguments minus the callback and
      * returns a Highland Stream instead. The wrapped function keeps its context,

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -601,7 +601,7 @@ declare namespace Highland {
          * @name Stream.compact()
          * @api public
          */
-        compact(): Stream<R>;
+        compact(): Stream<NonNullable<R>>;
 
         /**
          * Consumes values from a Stream (once resumed) and returns a new Stream for

--- a/types/highland/package.json
+++ b/types/highland/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/highland",
-    "version": "2.12.9999",
+    "version": "2.13.9999",
     "projects": [
         "http://highlandjs.org/"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - `_.of`: https://github.com/caolan/highland/blob/18c14bbbc1154ecc9df0115e4e0ecf7d52b25eb3/lib/index.js#L859-L874
  - `_.fromError`: https://github.com/caolan/highland/blob/18c14bbbc1154ecc9df0115e4e0ecf7d52b25eb3/lib/index.js#L876-L896
  - `_.compact`: https://github.com/caolan/highland/blob/18c14bbbc1154ecc9df0115e4e0ecf7d52b25eb3/lib/index.js#L2725-L2742
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - Not fully up to date with latest stable (2.13.5), but may be able to find some time if it is absolutely required for a merge

