### PR TITLE
[sinon] Fix `calledOnceWithMatch` to accept match-like arguments

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1165,7 +1165,7 @@ declare namespace Sinon {
          */
         calledOnceWithMatch<TArgs extends any[]>(
             spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: TArgs
+            ...args: MatchPartialArguments<TArgs>
         ): void;
         /**
          * Passes if spy was always called with matching arguments.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -396,6 +396,7 @@ function testAssert() {
     sinon.assert.calledWithMatch(spy, "a", "b", "c");
     sinon.assert.calledWithMatch(spy.firstCall, "a", "b", "c");
     sinon.assert.calledOnceWithMatch(spy, "a", "b", "c");
+    sinon.assert.calledOnceWithMatch(spy, sinon.match("a"), "b", "c");
     sinon.assert.calledOnceWithMatch(spy.firstCall, "a", "b", "c");
     sinon.assert.alwaysCalledWithMatch(spy, "a", "b", "c");
     sinon.assert.neverCalledWithMatch(spy, "a", "b", "c");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the few signatures above and below it