### PR TITLE
[react-mixin] Use `Mixin` from `create-react-class`

### DIFF
--- a/types/react-mixin/index.d.ts
+++ b/types/react-mixin/index.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react" />
 
+import { Mixin } from "create-react-class";
 import * as React from "react";
 
 declare namespace reactMixin {
@@ -9,9 +10,9 @@ declare namespace reactMixin {
     }
 
     interface ReactMixin {
-        decorate(mixin: React.Mixin<any, any>): ClassDecorator;
-        onClass<S>(clazz: any, mixin: React.Mixin<any, any>): React.ComponentClass<S>;
-        <S>(clazz: any, mixin: React.Mixin<any, any>): React.ComponentClass<S>;
+        decorate(mixin: Mixin<any, any>): ClassDecorator;
+        onClass<S>(clazz: any, mixin: Mixin<any, any>): React.ComponentClass<S>;
+        <S>(clazz: any, mixin: Mixin<any, any>): React.ComponentClass<S>;
     }
 }
 

--- a/types/react-mixin/package.json
+++ b/types/react-mixin/package.json
@@ -6,7 +6,8 @@
         "https://github.com/brigand/react-mixin"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "*",
+        "@types/create-react-class": "*"
     },
     "devDependencies": {
         "@types/react-mixin": "workspace:."

--- a/types/react-mixin/react-mixin-tests.tsx
+++ b/types/react-mixin/react-mixin-tests.tsx
@@ -1,8 +1,9 @@
+import { Mixin } from "create-react-class";
 import reactMixin = require("react-mixin");
 import * as React from "react";
 
-var someMixin: React.Mixin<any, any>;
-var someOtherMixin: React.Mixin<any, any>;
+var someMixin: Mixin<any, any>;
+var someOtherMixin: Mixin<any, any>;
 
 class Foo extends React.Component {
     render(): React.JSX.Element {
@@ -13,7 +14,7 @@ class Foo extends React.Component {
 reactMixin(Foo.prototype, someMixin);
 reactMixin(Foo.prototype, someOtherMixin);
 
-var mixin: React.Mixin<any, any> = {
+var mixin: Mixin<any, any> = {
     getDefaultProps: function(): any {
         return { b: 2 };
     },
@@ -35,7 +36,7 @@ reactMixin.onClass(Foo2, mixin);
 class Foo3 extends React.Component {
 }
 
-function autobind(methodNames: string[]): React.Mixin<any, any> {
+function autobind(methodNames: string[]): Mixin<any, any> {
     return {
         componentWillMount: function(): void {
             methodNames.forEach((name) => {


### PR DESCRIPTION
Stacked on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68091

React hasn't had an API to use mixins for a while. `create-react-class` still has though so it makes more sense to depend on its types. 

`React.Mixin` is already deprecated and will be removed soon.