### PR TITLE
[react-addons-linked-state-mixin] Use `Mixin` from `create-react-class`

### DIFF
--- a/types/react-addons-linked-state-mixin/index.d.ts
+++ b/types/react-addons-linked-state-mixin/index.d.ts
@@ -1,4 +1,4 @@
-import { Mixin } from "react";
+import { Mixin } from "create-react-class";
 
 declare var LinkedStateMixin: LinkedStateMixin.LinkedStateMixin;
 type LinkedStateMixin = LinkedStateMixin.LinkedStateMixin;

--- a/types/react-addons-linked-state-mixin/package.json
+++ b/types/react-addons-linked-state-mixin/package.json
@@ -6,10 +6,9 @@
         "http://facebook.github.io/react/"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/create-react-class": "*"
     },
     "devDependencies": {
-        "@types/create-react-class": "*",
         "@types/react-dom-factories": "*",
         "@types/react-addons-linked-state-mixin": "workspace:."
     },

--- a/types/react-addons-linked-state-mixin/package.json
+++ b/types/react-addons-linked-state-mixin/package.json
@@ -6,6 +6,7 @@
         "http://facebook.github.io/react/"
     ],
     "dependencies": {
+        "@types/react": "*",
         "@types/create-react-class": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Stacked on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68091

React hasn't had an API to use mixins for a while. `create-react-class` still has though so it makes more sense to depend on its types. 

`React.Mixin` is already deprecated and will be removed soon.