### PR TITLE
[passport-jwt] Improve typings by adding required parameters, remove non-existant function, add docs, fix Request type

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -1,66 +1,154 @@
 import { Algorithm, VerifyOptions } from "jsonwebtoken";
 import { Strategy as PassportStrategy } from "passport-strategy";
 
+
 export declare class Strategy extends PassportStrategy {
+    /**
+     * Strategy constructor
+     */
     constructor(opt: StrategyOptionsWithoutRequest, verify: VerifyCallback);
+    /**
+     * Strategy constructor
+     */
     constructor(opt: StrategyOptionsWithRequest, verify: VerifyCallbackWithRequest);
     name: string;
 }
 
+/**
+ * Interface for providing the secret or key for verification.
+ */
 export interface SecretOrKeyProvider<T = any> {
+    /**
+     * Callback for secret or key provider.
+     *
+     * @param request - The request object from your framework (e.g., Express.Request)
+     * @param rawJwtToken - The raw JWT token string
+     * @param done - A function with the signature function(err, secret)
+     */
     (request: T, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void): void;
 }
 
 interface BaseStrategyOptions {
+    /**
+     * Function that accepts a request as the only parameter and returns either the JWT as a string or null.
+     * REQUIRED.
+     */
     jwtFromRequest: JwtFromRequestFunction;
+    /**
+     * If defined, the issuer will be verified against this value.
+     */
     issuer?: string | string[] | undefined;
+    /**
+     * If defined, the audience will be verified against this value.
+     */
     audience?: string | string[] | undefined;
+    /**
+     * List of strings with the names of allowed algorithms (e.g., ["HS256", "HS384"]).
+     */
     algorithms?: Algorithm[] | undefined;
+    /**
+     * If true, do not validate the expiration of the token.
+     */
     ignoreExpiration?: boolean | undefined;
+
+    /**
+     * @deprecated
+     * for backwards compatibility, still allowing you to pass
+     * audience / issuer / algorithms / ignoreExpiration
+     * on the options.
+     */
     jsonWebTokenOptions?: VerifyOptions | undefined;
 }
 interface WithSecretOrKeyProvider extends BaseStrategyOptions {
     secretOrKeyProvider: SecretOrKeyProvider;
 }
-
 interface WithSecretOrKey extends BaseStrategyOptions {
     secretOrKey: string | Buffer;
 }
-
 type StrategyOptionsWithSecret = Omit<WithSecretOrKey, 'secretOrKeyProvider'> | Omit<WithSecretOrKeyProvider, 'secretOrKey'>;
-
-export type StrategyOptionsWithRequest = StrategyOptionsWithSecret & {
+type StrategyOptionsWithRequest = StrategyOptionsWithSecret & {
+    /**
+     * If true, the verify callback will be called with args (request, jwt_payload, done_callback).
+     */
     passReqToCallback: true;
 }
-
-export type StrategyOptionsWithoutRequest = StrategyOptionsWithSecret & {
-    passReqToCallback?: false | undefined;
+type StrategyOptionsWithoutRequest = StrategyOptionsWithSecret & {
+    /**
+     * If true, the verify callback will be called with args (request, jwt_payload, done_callback).
+     */
+    passReqToCallback?: false;
 }
 
+/**
+ * Union type for all possible Strategy options.
+ */
 export type StrategyOptions = StrategyOptionsWithRequest | StrategyOptionsWithoutRequest;
 
-export interface VerifyCallback {
-    (payload: any, done: VerifiedCallback): void;
-}
+/**
+ * Callback used to verify the JWT payload.
+ */
+export type VerifyCallback = (payload: any, done: VerifiedCallback) => void;
 
-export interface VerifyCallbackWithRequest<T = any> {
-    (req: T, payload: any, done: VerifiedCallback): void;
-}
 
+/**
+ * Callback used to verify the JWT payload with request.
+ */
+export type VerifyCallbackWithRequest<T = any> = (req: T, payload: any, done: VerifiedCallback) => void;
+
+/**
+ * Callback for the verified result.
+ */
 export interface VerifiedCallback {
     (error: any, user?: unknown | false, info?: any): void;
 }
 
+/**
+ * Function that returns either the JWT as a string or null.
+ */
 export interface JwtFromRequestFunction<T = any> {
     (req: T): string | null;
 }
 
 export declare namespace ExtractJwt {
+    /**
+ * Creates an extractor function to retrieve a token from the request header.
+ *
+ * @param {string} header_name - The name of the header to extract the token from.
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromHeader(header_name: string): JwtFromRequestFunction;
+    /**
+ * Creates an extractor function to retrieve a token from a field in the request body.
+ *
+ * @param {string} field_name - The name of the field to extract the token from.
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromBodyField(field_name: string): JwtFromRequestFunction;
+    /**
+ * Creates an extractor function to retrieve a token from a query parameter in the URL.
+ *
+ * @param {string} param_name - The name of the query parameter to extract the token from.
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromUrlQueryParameter(param_name: string): JwtFromRequestFunction;
+    /**
+ * Creates an extractor function to retrieve a token from the authorization header with a specific scheme.
+ *
+ * @param {string} auth_scheme - The authorization scheme (e.g., 'Bearer').
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromAuthHeaderWithScheme(auth_scheme: string): JwtFromRequestFunction;
-    export function fromAuthHeader(): JwtFromRequestFunction;
+    /**
+ * Creates an extractor function that combines multiple extractor functions.
+ *
+ * @param {JwtFromRequestFunction[]} extractors - An array of extractor functions.
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromExtractors<T = any>(extractors: Array<JwtFromRequestFunction<T>>): JwtFromRequestFunction<T>;
+    /**
+ * Creates an extractor function to retrieve a token from the authorization header as a Bearer token.
+ *
+ * @returns {JwtFromRequestFunction} A function that takes a request object and returns the extracted token.
+ */
     export function fromAuthHeaderAsBearerToken(): JwtFromRequestFunction;
 }

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -45,6 +45,6 @@ export declare namespace ExtractJwt {
     export function fromUrlQueryParameter(param_name: string): JwtFromRequestFunction;
     export function fromAuthHeaderWithScheme(auth_scheme: string): JwtFromRequestFunction;
     export function fromAuthHeader(): JwtFromRequestFunction;
-    export function fromExtractors(extractors: JwtFromRequestFunction[]): JwtFromRequestFunction;
+    export function fromExtractors(extractors: Array<JwtFromRequestFunction<any>>): JwtFromRequestFunction;
     export function fromAuthHeaderAsBearerToken(): JwtFromRequestFunction;
 }

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -1,4 +1,3 @@
-import * as express from "express";
 import { VerifyOptions } from "jsonwebtoken";
 import { Strategy as PassportStrategy } from "passport-strategy";
 
@@ -25,19 +24,19 @@ export interface VerifyCallback {
 }
 
 export interface VerifyCallbackWithRequest {
-    (req: express.Request, payload: any, done: VerifiedCallback): void;
+    (req: Request, payload: any, done: VerifiedCallback): void;
 }
 
 export interface VerifiedCallback {
     (error: any, user?: Express.User | false, info?: any): void;
 }
 
-export interface JwtFromRequestFunction {
-    (req: express.Request): string | null;
+export interface JwtFromRequestFunction<T = Request> {
+    (req: T): string | null;
 }
 
 export interface SecretOrKeyProvider {
-    (request: express.Request, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void): void;
+    (request: Request, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void): void;
 }
 
 export declare namespace ExtractJwt {

--- a/types/passport-jwt/package.json
+++ b/types/passport-jwt/package.json
@@ -11,7 +11,9 @@
     },
     "devDependencies": {
         "@types/passport": "*",
-        "@types/passport-jwt": "workspace:."
+        "@types/passport-jwt": "workspace:.",
+        "@types/express": "*",
+        "fastify": "*"
     },
     "owners": [
         {

--- a/types/passport-jwt/package.json
+++ b/types/passport-jwt/package.json
@@ -6,7 +6,6 @@
         "https://github.com/themikenicholson/passport-jwt"
     ],
     "dependencies": {
-        "@types/express": "*",
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
     },

--- a/types/passport-jwt/package.json
+++ b/types/passport-jwt/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/passport-jwt",
-    "version": "4.0.1",
+    "version": "4.0.9999",
     "projects": [
         "https://github.com/themikenicholson/passport-jwt"
     ],

--- a/types/passport-jwt/package.json
+++ b/types/passport-jwt/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/passport-jwt",
-    "version": "3.0.9999",
+    "version": "4.0.1",
     "projects": [
         "https://github.com/themikenicholson/passport-jwt"
     ],

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -1,7 +1,6 @@
 /// <reference types="passport" />
 "use strict";
 
-import { Request } from "express";
 import * as passport from "passport";
 import { ExtractJwt, Strategy as JwtStrategy, StrategyOptions } from "passport-jwt";
 
@@ -40,7 +39,7 @@ opts.jwtFromRequest = ExtractJwt.fromExtractors([
 ]);
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
 opts.jwtFromRequest = (req: Request) => {
-    return req.query.token as string;
+    return req.headers.get('token') as string;
 };
 opts.secretOrKey = new Buffer("secret");
 opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer("secret"));

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -13,8 +13,8 @@ let opts: StrategyOptions = {
 
 passport.use(
     JwtStrategy.name,
-    new JwtStrategy(opts, function (jwt_payload, done) {
-        findUser({ id: jwt_payload.sub }, function (err, user) {
+    new JwtStrategy(opts, function(jwt_payload, done) {
+        findUser({ id: jwt_payload.sub }, function(err, user) {
             if (err) {
                 return done(err, false);
             }
@@ -25,7 +25,7 @@ passport.use(
                 // or you could create a new account
             }
         });
-    })
+    }),
 );
 
 const jwtFromTokenInRequest: JwtFromRequestFunction<{ token: string }> = (req: { token: string }) => {

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -1,14 +1,18 @@
 /// <reference types="passport" />
 "use strict";
 
+import { Request as ExpressRequest } from "express";
+import { FastifyReply } from 'fastify';
 import * as passport from "passport";
 import { ExtractJwt, JwtFromRequestFunction, Strategy as JwtStrategy, StrategyOptions } from "passport-jwt";
 
+// valid case without request in callback
 let opts: StrategyOptions = {
     jwtFromRequest: ExtractJwt.fromAuthHeader(),
     secretOrKey: "secret",
     issuer: "accounts.example.com",
     audience: "example.org",
+    algorithms: ["RS256"]
 };
 
 passport.use(
@@ -32,6 +36,10 @@ const jwtFromTokenInRequest: JwtFromRequestFunction<{ token: string }> = (req: {
     return req.token;
 };
 
+const jwtFromTokenInRequest2: JwtFromRequestFunction = (req: ExpressRequest) => {
+    return req.body.my_token;
+}
+
 opts.jwtFromRequest = ExtractJwt.fromHeader("x-api-key");
 opts.jwtFromRequest = ExtractJwt.fromBodyField("field_name");
 opts.jwtFromRequest = ExtractJwt.fromUrlQueryParameter("param_name");
@@ -41,21 +49,85 @@ opts.jwtFromRequest = ExtractJwt.fromExtractors([
     ExtractJwt.fromBodyField("field_name"),
     ExtractJwt.fromUrlQueryParameter("param_name"),
     jwtFromTokenInRequest,
+    jwtFromTokenInRequest2,
 ]);
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
-opts.jwtFromRequest = (req: Request) => {
-    return req.headers.get("token") as string;
+opts.jwtFromRequest = (req: ExpressRequest) => {
+    return req.query.token as string;
 };
-opts.secretOrKey = new Buffer("secret");
-opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer("secret"));
+opts.jwtFromRequest = (req: FastifyReply) => {
+    return req.getHeader('token') as string;
+}
+opts.secretOrKey = Buffer.from("secret");
 opts.audience = ["example1.org", "example2.org"];
 
 class UserModel {}
-
-declare global {
-    namespace Express {
-        // eslint-disable-next-line @typescript-eslint/no-empty-interface
-        interface User extends UserModel {}
-    }
-}
 declare function findUser(condition: { id: string }, callback: (error: any, user: UserModel) => void): void;
+
+// Invalid algorithm
+let invalidOptsAlg: StrategyOptions = {
+    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    secretOrKey: 'test',
+    // @ts-expect-error
+    algorithms: ['invalid']
+}
+
+// secretOrKey and secretOrKeyProvider are mutually exclusive
+// https://github.com/mikenicholson/passport-jwt/blob/fed94fa005c5b2dcb7e6d5d5372e3b20cae898f1/lib/strategy.js#L37C106-L37C106
+// @ts-expect-error
+let invalidOpts: StrategyOptions = {
+    secretOrKey: "secret",
+    secretOrKeyProvider: (request, rawJwtToken, done) => done(null, new Buffer("secret")),
+}
+
+// secret or key already defined
+// @ts-expect-error
+opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer("secret"));
+
+// valid case with request in callback
+let opts2: StrategyOptions = {
+    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    secretOrKey: "secret",
+    passReqToCallback: true
+}
+
+passport.use(
+    JwtStrategy.name,
+    new JwtStrategy(opts2, function(req: ExpressRequest, jwt_payload, done) {
+        findUser({ id: req.headers['user'] as string }, function(err, user) {
+            return done(err, user);
+        });
+    })
+);
+
+
+// using request in verify callback, without setting it in opts
+let opts3: StrategyOptions = {
+    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    secretOrKey: "secret",
+}
+passport.use(
+    JwtStrategy.name,
+    //@ts-expect-error
+    new JwtStrategy(opts3, function(request: ExpressRequest, jwt_payload: {sub: string}, done) {
+        findUser({ id: jwt_payload.sub }, function(err, user) {
+            return done(err, user);
+        });
+    })
+);
+
+
+// jwtFromRequest is required
+// https://github.com/mikenicholson/passport-jwt/blob/fed94fa005c5b2dcb7e6d5d5372e3b20cae898f1/lib/strategy.js#L53
+// @ts-expect-error
+let invalid: StrategyOptions = {
+    secretOrKey: "secret",
+}
+
+// secret or key is required
+// https://github.com/mikenicholson/passport-jwt/blob/fed94fa005c5b2dcb7e6d5d5372e3b20cae898f1/lib/strategy.js#L44
+// @ts-expect-error
+let invalid: StrategyOptions = {
+    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+}
+

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -2,7 +2,7 @@
 "use strict";
 
 import * as passport from "passport";
-import { ExtractJwt, Strategy as JwtStrategy, StrategyOptions } from "passport-jwt";
+import { ExtractJwt, JwtFromRequestFunction, Strategy as JwtStrategy, StrategyOptions } from "passport-jwt";
 
 let opts: StrategyOptions = {
     jwtFromRequest: ExtractJwt.fromAuthHeader(),
@@ -13,8 +13,8 @@ let opts: StrategyOptions = {
 
 passport.use(
     JwtStrategy.name,
-    new JwtStrategy(opts, function(jwt_payload, done) {
-        findUser({ id: jwt_payload.sub }, function(err, user) {
+    new JwtStrategy(opts, function (jwt_payload, done) {
+        findUser({ id: jwt_payload.sub }, function (err, user) {
             if (err) {
                 return done(err, false);
             }
@@ -25,8 +25,12 @@ passport.use(
                 // or you could create a new account
             }
         });
-    }),
+    })
 );
+
+const jwtFromTokenInRequest: JwtFromRequestFunction<{ token: string }> = (req: { token: string }) => {
+    return req.token;
+};
 
 opts.jwtFromRequest = ExtractJwt.fromHeader("x-api-key");
 opts.jwtFromRequest = ExtractJwt.fromBodyField("field_name");
@@ -36,10 +40,11 @@ opts.jwtFromRequest = ExtractJwt.fromExtractors([
     ExtractJwt.fromHeader("x-api-key"),
     ExtractJwt.fromBodyField("field_name"),
     ExtractJwt.fromUrlQueryParameter("param_name"),
+    jwtFromTokenInRequest,
 ]);
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
 opts.jwtFromRequest = (req: Request) => {
-    return req.headers.get('token') as string;
+    return req.headers.get("token") as string;
 };
 opts.secretOrKey = new Buffer("secret");
 opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer("secret"));

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -8,7 +8,7 @@ import { ExtractJwt, JwtFromRequestFunction, Strategy as JwtStrategy, StrategyOp
 
 // valid case without request in callback
 let opts: StrategyOptions = {
-    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    jwtFromRequest: ExtractJwt.fromBodyField('jwt'),
     secretOrKey: "secret",
     issuer: "accounts.example.com",
     audience: "example.org",
@@ -66,7 +66,7 @@ declare function findUser(condition: { id: string }, callback: (error: any, user
 
 // Invalid algorithm
 let invalidOptsAlg: StrategyOptions = {
-    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    jwtFromRequest: ExtractJwt. fromAuthHeaderAsBearerToken(),
     secretOrKey: 'test',
     // @ts-expect-error
     algorithms: ['invalid']
@@ -86,7 +86,7 @@ opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer
 
 // valid case with request in callback
 let opts2: StrategyOptions = {
-    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
     secretOrKey: "secret",
     passReqToCallback: true
 }
@@ -103,7 +103,7 @@ passport.use(
 
 // using request in verify callback, without setting it in opts
 let opts3: StrategyOptions = {
-    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
     secretOrKey: "secret",
 }
 passport.use(
@@ -128,6 +128,6 @@ let invalid: StrategyOptions = {
 // https://github.com/mikenicholson/passport-jwt/blob/fed94fa005c5b2dcb7e6d5d5372e3b20cae898f1/lib/strategy.js#L44
 // @ts-expect-error
 let invalid: StrategyOptions = {
-    jwtFromRequest: ExtractJwt.fromAuthHeader(),
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
 }
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/QuentinLemCode/40552804fee8d73a9e2831ae8ed58956
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.





The changes are the following : 
- In the StrategyOptions, it is required to have secretOrKey or secretOrKeyProvider defined (but not both). The types now reflect that.
- In the StrategyOptions, there is a parameter to have request in callback, this now change the type signature of the 'verify' callback function accordingly.
- The Request type, precedently used, is now any. As the lib can be used by multiple type of http server, the user can now define the proper type of Request object to handle.
- In the StrategyOptions, the "algorithms" type is now "Algorithm" from jsonwebtoken library. Reflecting the real usage of the javascript code : https://github.com/mikenicholson/passport-jwt/blob/master/lib/verify_jwt.js
- Added documentation
- Remove ExtractJwt.FromAuthHeader that seems to not exist in the library : https://github.com/mikenicholson/passport-jwt/blob/master/lib/extract_jwt.js

Source : https://github.com/mikenicholson/passport-jwt/tree/master/lib