### PR TITLE
Extend AgentOptions from https for tunnel

### DIFF
--- a/types/tunnel/index.d.ts
+++ b/types/tunnel/index.d.ts
@@ -1,24 +1,27 @@
 /// <reference types="node" />
-import { Agent } from "http";
-import { Agent as HttpsAgent, AgentOptions } from "https";
+import { Agent, AgentOptions as HttpAgentOptions } from "http";
+import { Agent as HttpsAgent, AgentOptions as HttpsAgentOptions } from "https";
 
 export function httpOverHttp(options?: HttpOptions): Agent;
 export function httpsOverHttp(options?: HttpsOverHttpOptions): Agent;
 export function httpOverHttps(options?: HttpOverHttpsOptions): HttpsAgent;
 export function httpsOverHttps(options?: HttpsOverHttpsOptions): HttpsAgent;
 
-export interface HttpOptions {
-    maxSockets?: number | undefined;
+export interface HttpOptions extends HttpAgentOptions {
     proxy?: ProxyOptions | undefined;
 }
 
-export interface HttpsOverHttpOptions extends HttpOptions {
+export interface HttpsOptions extends HttpsAgentOptions {
+    proxy?: ProxyOptions | undefined;
+}
+
+export interface HttpsOverHttpOptions extends HttpsOptions {
     ca?: Buffer[] | undefined;
     key?: Buffer | undefined;
     cert?: Buffer | undefined;
 }
 
-export interface HttpOverHttpsOptions extends HttpOptions, AgentOptions {
+export interface HttpOverHttpsOptions extends HttpOptions {
     proxy?: HttpsProxyOptions | undefined;
 }
 

--- a/types/tunnel/index.d.ts
+++ b/types/tunnel/index.d.ts
@@ -7,7 +7,7 @@ export function httpsOverHttp(options?: HttpsOverHttpOptions): Agent;
 export function httpOverHttps(options?: HttpOverHttpsOptions): HttpsAgent;
 export function httpsOverHttps(options?: HttpsOverHttpsOptions): HttpsAgent;
 
-export interface HttpOptions extends AgentOptions {
+export interface HttpOptions {
     maxSockets?: number | undefined;
     proxy?: ProxyOptions | undefined;
 }
@@ -18,7 +18,7 @@ export interface HttpsOverHttpOptions extends HttpOptions {
     cert?: Buffer | undefined;
 }
 
-export interface HttpOverHttpsOptions extends HttpOptions {
+export interface HttpOverHttpsOptions extends HttpOptions, AgentOptions {
     proxy?: HttpsProxyOptions | undefined;
 }
 

--- a/types/tunnel/index.d.ts
+++ b/types/tunnel/index.d.ts
@@ -1,13 +1,13 @@
 /// <reference types="node" />
 import { Agent } from "http";
-import { Agent as HttpsAgent } from "https";
+import { Agent as HttpsAgent, AgentOptions } from "https";
 
 export function httpOverHttp(options?: HttpOptions): Agent;
 export function httpsOverHttp(options?: HttpsOverHttpOptions): Agent;
 export function httpOverHttps(options?: HttpOverHttpsOptions): HttpsAgent;
 export function httpsOverHttps(options?: HttpsOverHttpsOptions): HttpsAgent;
 
-export interface HttpOptions {
+export interface HttpOptions extends AgentOptions {
     maxSockets?: number | undefined;
     proxy?: ProxyOptions | undefined;
 }

--- a/types/tunnel/tunnel-tests.ts
+++ b/types/tunnel/tunnel-tests.ts
@@ -145,3 +145,32 @@ const localAddress = "1.2.3.4";
         agent: tunnelingAgent,
     });
 })();
+
+(() => {
+    const tunnelingAgent = tunnel.httpsOverHttp({
+        maxSockets: poolSize, // Defaults to http.Agent.defaultMaxSockets
+
+        proxy: { // Proxy settings
+            host: proxyHost, // Defaults to 'localhost'
+            port: proxyPort, // Defaults to 80
+            localAddress, // Local interface if necessary
+
+            // Basic authorization for proxy server if necessary
+            proxyAuth: "user:password",
+
+            // Header fields for proxy server if necessary
+            headers: {
+                "User-Agent": "Node",
+            },
+        },
+
+        // Make sure rejectUnauthorized (of AgentOptions) is available for use
+        rejectUnauthorized: false,
+    });
+
+    const req = https.request({
+        host: "example.com",
+        port: 443,
+        agent: tunnelingAgent,
+    });
+})();


### PR DESCRIPTION
This is so that developers could add `AgentOptions` from `https`, such as `rejectUnauthorized`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/https.html#new-agentoptions
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
