### PR TITLE
[@types/node-fetch] Improve node-fetch compatibility with NodeNext

### DIFF
--- a/types/node-fetch-cache/index.d.ts
+++ b/types/node-fetch-cache/index.d.ts
@@ -1,13 +1,13 @@
-import fetch, { Response } from "node-fetch";
+import fetch = require("node-fetch");
 
-declare class NFCResponse extends Response {
+declare class NFCResponse extends fetch.Response {
     ejectFromCache(): Promise<void>;
 }
 
 interface Cache {
     get(key: string): Promise<any>;
     remove(key: string): Promise<void>;
-    set(key: string, bodyStream: Response["body"], metaData: any): Promise<any>;
+    set(key: string, bodyStream: fetch.Response["body"], metaData: any): Promise<any>;
 }
 
 interface MemoryCacheOptions {
@@ -18,7 +18,7 @@ export class MemoryCache implements Cache {
     constructor(options?: MemoryCacheOptions);
     get(key: string): Promise<any>;
     remove(key: string): Promise<void>;
-    set(key: string, bodyStream: Response["body"], metaData: any): Promise<any>;
+    set(key: string, bodyStream: fetch.Response["body"], metaData: any): Promise<any>;
 }
 
 interface FileSystemCacheOptions {
@@ -30,7 +30,7 @@ export class FileSystemCache implements Cache {
     constructor(options?: FileSystemCacheOptions);
     get(key: string): Promise<any>;
     remove(key: string): Promise<void>;
-    set(key: string, bodyStream: Response["body"], metaData: any): Promise<any>;
+    set(key: string, bodyStream: fetch.Response["body"], metaData: any): Promise<any>;
 }
 
 type FetchBuilder = (cache: Cache) => FetchCache;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-// Minimum TypeScript Version: 4.7
 
 import { RequestOptions } from "http";
 import { URL, URLSearchParams } from "url";

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import FormData = require("form-data");
 import { RequestOptions } from "http";
 import { URL, URLSearchParams } from "url";
 import { AbortSignal } from "./externals";
@@ -196,7 +197,8 @@ type BodyInit =
     | ArrayBufferView
     | NodeJS.ReadableStream
     | string
-    | URLSearchParams;
+    | URLSearchParams
+    | FormData;
 type RequestInfo = string | URLLike | Request;
 
 declare function fetch(

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -5,211 +5,211 @@ import { RequestOptions } from "http";
 import { URL, URLSearchParams } from "url";
 import { AbortSignal } from "./externals";
 
-export class Request extends Body {
-    constructor(input: RequestInfo, init?: RequestInit);
-    clone(): Request;
-    context: RequestContext;
-    headers: Headers;
-    method: string;
-    redirect: RequestRedirect;
-    referrer: string;
-    url: string;
-
-    // node-fetch extensions to the whatwg/fetch spec
-    agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]);
-    compress: boolean;
-    counter: number;
-    follow: number;
-    hostname: string;
-    port?: number | undefined;
-    protocol: string;
-    size: number;
-    timeout: number;
-}
-
-export interface RequestInit {
-    // whatwg/fetch standard options
-    body?: BodyInit | undefined;
-    headers?: HeadersInit | undefined;
-    method?: string | undefined;
-    redirect?: RequestRedirect | undefined;
-    signal?: AbortSignal | null | undefined;
-
-    // node-fetch extensions
-    agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]); // =null http.Agent instance, allows custom proxy, certificate etc.
-    compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
-    follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
-    size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
-    timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
-
-    // node-fetch does not support mode, cache or credentials options
-}
-
-export type RequestContext =
-    | "audio"
-    | "beacon"
-    | "cspreport"
-    | "download"
-    | "embed"
-    | "eventsource"
-    | "favicon"
-    | "fetch"
-    | "font"
-    | "form"
-    | "frame"
-    | "hyperlink"
-    | "iframe"
-    | "image"
-    | "imageset"
-    | "import"
-    | "internal"
-    | "location"
-    | "manifest"
-    | "object"
-    | "ping"
-    | "plugin"
-    | "prefetch"
-    | "script"
-    | "serviceworker"
-    | "sharedworker"
-    | "style"
-    | "subresource"
-    | "track"
-    | "video"
-    | "worker"
-    | "xmlhttprequest"
-    | "xslt";
-export type RequestMode = "cors" | "no-cors" | "same-origin";
-export type RequestRedirect = "error" | "follow" | "manual";
-export type RequestCredentials = "omit" | "include" | "same-origin";
-
-export type RequestCache =
-    | "default"
-    | "force-cache"
-    | "no-cache"
-    | "no-store"
-    | "only-if-cached"
-    | "reload";
-
-export class Headers implements Iterable<[string, string]> {
-    constructor(init?: HeadersInit);
-    forEach(callback: (value: string, name: string) => void): void;
-    append(name: string, value: string): void;
-    delete(name: string): void;
-    get(name: string): string | null;
-    has(name: string): boolean;
-    raw(): { [k: string]: string[] };
-    set(name: string, value: string): void;
-
-    // Iterable methods
-    entries(): IterableIterator<[string, string]>;
-    keys(): IterableIterator<string>;
-    values(): IterableIterator<string>;
-    [Symbol.iterator](): Iterator<[string, string]>;
-}
-
-type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
-
-interface BlobOptions {
-    type?: string | undefined;
-    endings?: "transparent" | "native" | undefined;
-}
-
-export class Blob {
-    constructor(blobParts?: BlobPart[], options?: BlobOptions);
-    readonly type: string;
-    readonly size: number;
-    slice(start?: number, end?: number): Blob;
-    text(): Promise<string>;
-}
-
-export class Body {
-    constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
-    arrayBuffer(): Promise<ArrayBuffer>;
-    blob(): Promise<Blob>;
-    body: NodeJS.ReadableStream;
-    bodyUsed: boolean;
-    buffer(): Promise<Buffer>;
-    json(): Promise<any>;
-    size: number;
-    text(): Promise<string>;
-    textConverted(): Promise<string>;
-    timeout: number;
-}
-
-interface SystemError extends Error {
-    code?: string | undefined;
-}
-
-export class AbortError extends Error {
-    readonly name: "AbortError";
-    constructor(message: string);
-    readonly type: "aborted";
-}
-
-export class FetchError extends Error {
-    name: "FetchError";
-    constructor(message: string, type: string, systemError?: SystemError);
-    type: string;
-    code?: string | undefined;
-    errno?: string | undefined;
-}
-
-export class Response extends Body {
-    constructor(body?: BodyInit, init?: ResponseInit);
-    static error(): Response;
-    static redirect(url: string, status: number): Response;
-    clone(): Response;
-    headers: Headers;
-    ok: boolean;
-    redirected: boolean;
-    status: number;
-    statusText: string;
-    type: ResponseType;
-    url: string;
-}
-
-export type ResponseType =
-    | "basic"
-    | "cors"
-    | "default"
-    | "error"
-    | "opaque"
-    | "opaqueredirect";
-
-export interface ResponseInit {
-    headers?: HeadersInit | undefined;
-    size?: number | undefined;
-    status?: number | undefined;
-    statusText?: string | undefined;
-    timeout?: number | undefined;
-    url?: string | undefined;
-    counter?: number | undefined;
-}
-
-interface URLLike {
-    href: string;
-}
-
-export type HeadersInit = Headers | string[][] | { [key: string]: string | string[] };
-// HeaderInit is exported to support backwards compatibility. See PR #34382
-export type HeaderInit = HeadersInit;
-export type BodyInit =
-    | ArrayBuffer
-    | ArrayBufferView
-    | NodeJS.ReadableStream
-    | string
-    | URLSearchParams
-    | FormData;
-export type RequestInfo = string | URLLike | Request;
-
 declare function fetch(
-    url: RequestInfo,
-    init?: RequestInit,
-): Promise<Response>;
+    url: fetch.RequestInfo,
+    init?: fetch.RequestInit,
+): Promise<fetch.Response>;
 
 declare namespace fetch {
+    export class Request extends Body {
+        constructor(input: RequestInfo, init?: RequestInit);
+        clone(): Request;
+        context: RequestContext;
+        headers: Headers;
+        method: string;
+        redirect: RequestRedirect;
+        referrer: string;
+        url: string;
+    
+        // node-fetch extensions to the whatwg/fetch spec
+        agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]);
+        compress: boolean;
+        counter: number;
+        follow: number;
+        hostname: string;
+        port?: number | undefined;
+        protocol: string;
+        size: number;
+        timeout: number;
+    }
+    
+    export interface RequestInit {
+        // whatwg/fetch standard options
+        body?: BodyInit | undefined;
+        headers?: HeadersInit | undefined;
+        method?: string | undefined;
+        redirect?: RequestRedirect | undefined;
+        signal?: AbortSignal | null | undefined;
+    
+        // node-fetch extensions
+        agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]); // =null http.Agent instance, allows custom proxy, certificate etc.
+        compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
+        follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
+        size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
+        timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+    
+        // node-fetch does not support mode, cache or credentials options
+    }
+    
+    export type RequestContext =
+        | "audio"
+        | "beacon"
+        | "cspreport"
+        | "download"
+        | "embed"
+        | "eventsource"
+        | "favicon"
+        | "fetch"
+        | "font"
+        | "form"
+        | "frame"
+        | "hyperlink"
+        | "iframe"
+        | "image"
+        | "imageset"
+        | "import"
+        | "internal"
+        | "location"
+        | "manifest"
+        | "object"
+        | "ping"
+        | "plugin"
+        | "prefetch"
+        | "script"
+        | "serviceworker"
+        | "sharedworker"
+        | "style"
+        | "subresource"
+        | "track"
+        | "video"
+        | "worker"
+        | "xmlhttprequest"
+        | "xslt";
+    export type RequestMode = "cors" | "no-cors" | "same-origin";
+    export type RequestRedirect = "error" | "follow" | "manual";
+    export type RequestCredentials = "omit" | "include" | "same-origin";
+    
+    export type RequestCache =
+        | "default"
+        | "force-cache"
+        | "no-cache"
+        | "no-store"
+        | "only-if-cached"
+        | "reload";
+    
+    export class Headers implements Iterable<[string, string]> {
+        constructor(init?: HeadersInit);
+        forEach(callback: (value: string, name: string) => void): void;
+        append(name: string, value: string): void;
+        delete(name: string): void;
+        get(name: string): string | null;
+        has(name: string): boolean;
+        raw(): { [k: string]: string[] };
+        set(name: string, value: string): void;
+    
+        // Iterable methods
+        entries(): IterableIterator<[string, string]>;
+        keys(): IterableIterator<string>;
+        values(): IterableIterator<string>;
+        [Symbol.iterator](): Iterator<[string, string]>;
+    }
+    
+    type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
+    
+    interface BlobOptions {
+        type?: string | undefined;
+        endings?: "transparent" | "native" | undefined;
+    }
+    
+    export class Blob {
+        constructor(blobParts?: BlobPart[], options?: BlobOptions);
+        readonly type: string;
+        readonly size: number;
+        slice(start?: number, end?: number): Blob;
+        text(): Promise<string>;
+    }
+    
+    export class Body {
+        constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
+        arrayBuffer(): Promise<ArrayBuffer>;
+        blob(): Promise<Blob>;
+        body: NodeJS.ReadableStream;
+        bodyUsed: boolean;
+        buffer(): Promise<Buffer>;
+        json(): Promise<any>;
+        size: number;
+        text(): Promise<string>;
+        textConverted(): Promise<string>;
+        timeout: number;
+    }
+    
+    interface SystemError extends Error {
+        code?: string | undefined;
+    }
+    
+    export class AbortError extends Error {
+        readonly name: "AbortError";
+        constructor(message: string);
+        readonly type: "aborted";
+    }
+    
+    export class FetchError extends Error {
+        name: "FetchError";
+        constructor(message: string, type: string, systemError?: SystemError);
+        type: string;
+        code?: string | undefined;
+        errno?: string | undefined;
+    }
+    
+    export class Response extends Body {
+        constructor(body?: BodyInit, init?: ResponseInit);
+        static error(): Response;
+        static redirect(url: string, status: number): Response;
+        clone(): Response;
+        headers: Headers;
+        ok: boolean;
+        redirected: boolean;
+        status: number;
+        statusText: string;
+        type: ResponseType;
+        url: string;
+    }
+    
+    export type ResponseType =
+        | "basic"
+        | "cors"
+        | "default"
+        | "error"
+        | "opaque"
+        | "opaqueredirect";
+    
+    export interface ResponseInit {
+        headers?: HeadersInit | undefined;
+        size?: number | undefined;
+        status?: number | undefined;
+        statusText?: string | undefined;
+        timeout?: number | undefined;
+        url?: string | undefined;
+        counter?: number | undefined;
+    }
+    
+    interface URLLike {
+        href: string;
+    }
+    
+    export type HeadersInit = Headers | string[][] | { [key: string]: string | string[] };
+    // HeaderInit is exported to support backwards compatibility. See PR #34382
+    export type HeaderInit = HeadersInit;
+    export type BodyInit =
+        | ArrayBuffer
+        | ArrayBufferView
+        | NodeJS.ReadableStream
+        | string
+        | URLSearchParams
+        | FormData;
+    export type RequestInfo = string | URLLike | Request;
+
     function isRedirect(code: number): boolean;
 }
 
-export default fetch;
+export = fetch;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -226,7 +226,7 @@ declare namespace fetch {
         Response,
         ResponseInit,
         ResponseType,
-    }
+    };
     export function isRedirect(code: number): boolean;
 
     const _default: typeof fetch;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -231,7 +231,7 @@ declare namespace fetch {
     };
     export function isRedirect(code: number): boolean;
 
-    const _default: typeof fetch;
+    import _default = fetch;
     export { _default as default };
 }
 

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -209,7 +209,11 @@ declare namespace fetch {
         | FormData;
     export type RequestInfo = string | URLLike | Request;
 
-    function isRedirect(code: number): boolean;
+    export function isRedirect(code: number): boolean;
+
+    const _default: typeof fetch;
+
+    export { _default as default };
 }
 
 export = fetch;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -5,213 +5,232 @@ import { RequestOptions } from "http";
 import { URL, URLSearchParams } from "url";
 import { AbortSignal } from "./externals";
 
+declare class Request extends Body {
+    constructor(input: RequestInfo, init?: RequestInit);
+    clone(): Request;
+    context: RequestContext;
+    headers: Headers;
+    method: string;
+    redirect: RequestRedirect;
+    referrer: string;
+    url: string;
+
+    // node-fetch extensions to the whatwg/fetch spec
+    agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]);
+    compress: boolean;
+    counter: number;
+    follow: number;
+    hostname: string;
+    port?: number | undefined;
+    protocol: string;
+    size: number;
+    timeout: number;
+}
+
+interface RequestInit {
+    // whatwg/fetch standard options
+    body?: BodyInit | undefined;
+    headers?: HeadersInit | undefined;
+    method?: string | undefined;
+    redirect?: RequestRedirect | undefined;
+    signal?: AbortSignal | null | undefined;
+
+    // node-fetch extensions
+    agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]); // =null http.Agent instance, allows custom proxy, certificate etc.
+    compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
+    follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
+    size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
+    timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+
+    // node-fetch does not support mode, cache or credentials options
+}
+
+type RequestContext =
+    | "audio"
+    | "beacon"
+    | "cspreport"
+    | "download"
+    | "embed"
+    | "eventsource"
+    | "favicon"
+    | "fetch"
+    | "font"
+    | "form"
+    | "frame"
+    | "hyperlink"
+    | "iframe"
+    | "image"
+    | "imageset"
+    | "import"
+    | "internal"
+    | "location"
+    | "manifest"
+    | "object"
+    | "ping"
+    | "plugin"
+    | "prefetch"
+    | "script"
+    | "serviceworker"
+    | "sharedworker"
+    | "style"
+    | "subresource"
+    | "track"
+    | "video"
+    | "worker"
+    | "xmlhttprequest"
+    | "xslt";
+type RequestMode = "cors" | "no-cors" | "same-origin";
+type RequestRedirect = "error" | "follow" | "manual";
+type RequestCredentials = "omit" | "include" | "same-origin";
+
+type RequestCache =
+    | "default"
+    | "force-cache"
+    | "no-cache"
+    | "no-store"
+    | "only-if-cached"
+    | "reload";
+
+declare class Headers implements Iterable<[string, string]> {
+    constructor(init?: HeadersInit);
+    forEach(callback: (value: string, name: string) => void): void;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    raw(): { [k: string]: string[] };
+    set(name: string, value: string): void;
+
+    // Iterable methods
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): Iterator<[string, string]>;
+}
+
+type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
+
+interface BlobOptions {
+    type?: string | undefined;
+    endings?: "transparent" | "native" | undefined;
+}
+
+declare class Blob {
+    constructor(blobParts?: BlobPart[], options?: BlobOptions);
+    readonly type: string;
+    readonly size: number;
+    slice(start?: number, end?: number): Blob;
+    text(): Promise<string>;
+}
+
+declare class Body {
+    constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    body: NodeJS.ReadableStream;
+    bodyUsed: boolean;
+    buffer(): Promise<Buffer>;
+    json(): Promise<any>;
+    size: number;
+    text(): Promise<string>;
+    textConverted(): Promise<string>;
+    timeout: number;
+}
+
+interface SystemError extends Error {
+    code?: string | undefined;
+}
+
+declare class AbortError extends Error {
+    readonly name: "AbortError";
+    constructor(message: string);
+    readonly type: "aborted";
+}
+
+declare class FetchError extends Error {
+    name: "FetchError";
+    constructor(message: string, type: string, systemError?: SystemError);
+    type: string;
+    code?: string | undefined;
+    errno?: string | undefined;
+}
+
+declare class Response extends Body {
+    constructor(body?: BodyInit, init?: ResponseInit);
+    static error(): Response;
+    static redirect(url: string, status: number): Response;
+    clone(): Response;
+    headers: Headers;
+    ok: boolean;
+    redirected: boolean;
+    status: number;
+    statusText: string;
+    type: ResponseType;
+    url: string;
+}
+
+type ResponseType =
+    | "basic"
+    | "cors"
+    | "default"
+    | "error"
+    | "opaque"
+    | "opaqueredirect";
+
+interface ResponseInit {
+    headers?: HeadersInit | undefined;
+    size?: number | undefined;
+    status?: number | undefined;
+    statusText?: string | undefined;
+    timeout?: number | undefined;
+    url?: string | undefined;
+    counter?: number | undefined;
+}
+
+interface URLLike {
+    href: string;
+}
+
+type HeadersInit = Headers | string[][] | { [key: string]: string | string[] };
+type BodyInit =
+    | ArrayBuffer
+    | ArrayBufferView
+    | NodeJS.ReadableStream
+    | string
+    | URLSearchParams;
+type RequestInfo = string | URLLike | Request;
+
 declare function fetch(
-    url: fetch.RequestInfo,
-    init?: fetch.RequestInit,
-): Promise<fetch.Response>;
+    url: RequestInfo,
+    init?: RequestInit,
+): Promise<Response>;
 
 declare namespace fetch {
-    export class Request extends Body {
-        constructor(input: RequestInfo, init?: RequestInit);
-        clone(): Request;
-        context: RequestContext;
-        headers: Headers;
-        method: string;
-        redirect: RequestRedirect;
-        referrer: string;
-        url: string;
-    
-        // node-fetch extensions to the whatwg/fetch spec
-        agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]);
-        compress: boolean;
-        counter: number;
-        follow: number;
-        hostname: string;
-        port?: number | undefined;
-        protocol: string;
-        size: number;
-        timeout: number;
+    export {
+        AbortError,
+        Blob,
+        Body,
+        BodyInit,
+        FetchError,
+        Headers,
+        HeadersInit,
+        // HeaderInit is exported to support backwards compatibility. See PR #34382
+        HeadersInit as HeaderInit,
+        Request,
+        RequestCache,
+        RequestContext,
+        RequestCredentials,
+        RequestInfo,
+        RequestInit,
+        RequestMode,
+        RequestRedirect,
+        Response,
+        ResponseInit,
+        ResponseType,
     }
-    
-    export interface RequestInit {
-        // whatwg/fetch standard options
-        body?: BodyInit | undefined;
-        headers?: HeadersInit | undefined;
-        method?: string | undefined;
-        redirect?: RequestRedirect | undefined;
-        signal?: AbortSignal | null | undefined;
-    
-        // node-fetch extensions
-        agent?: RequestOptions["agent"] | ((parsedUrl: URL) => RequestOptions["agent"]); // =null http.Agent instance, allows custom proxy, certificate etc.
-        compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
-        follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
-        size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
-        timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
-    
-        // node-fetch does not support mode, cache or credentials options
-    }
-    
-    export type RequestContext =
-        | "audio"
-        | "beacon"
-        | "cspreport"
-        | "download"
-        | "embed"
-        | "eventsource"
-        | "favicon"
-        | "fetch"
-        | "font"
-        | "form"
-        | "frame"
-        | "hyperlink"
-        | "iframe"
-        | "image"
-        | "imageset"
-        | "import"
-        | "internal"
-        | "location"
-        | "manifest"
-        | "object"
-        | "ping"
-        | "plugin"
-        | "prefetch"
-        | "script"
-        | "serviceworker"
-        | "sharedworker"
-        | "style"
-        | "subresource"
-        | "track"
-        | "video"
-        | "worker"
-        | "xmlhttprequest"
-        | "xslt";
-    export type RequestMode = "cors" | "no-cors" | "same-origin";
-    export type RequestRedirect = "error" | "follow" | "manual";
-    export type RequestCredentials = "omit" | "include" | "same-origin";
-    
-    export type RequestCache =
-        | "default"
-        | "force-cache"
-        | "no-cache"
-        | "no-store"
-        | "only-if-cached"
-        | "reload";
-    
-    export class Headers implements Iterable<[string, string]> {
-        constructor(init?: HeadersInit);
-        forEach(callback: (value: string, name: string) => void): void;
-        append(name: string, value: string): void;
-        delete(name: string): void;
-        get(name: string): string | null;
-        has(name: string): boolean;
-        raw(): { [k: string]: string[] };
-        set(name: string, value: string): void;
-    
-        // Iterable methods
-        entries(): IterableIterator<[string, string]>;
-        keys(): IterableIterator<string>;
-        values(): IterableIterator<string>;
-        [Symbol.iterator](): Iterator<[string, string]>;
-    }
-    
-    type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
-    
-    interface BlobOptions {
-        type?: string | undefined;
-        endings?: "transparent" | "native" | undefined;
-    }
-    
-    export class Blob {
-        constructor(blobParts?: BlobPart[], options?: BlobOptions);
-        readonly type: string;
-        readonly size: number;
-        slice(start?: number, end?: number): Blob;
-        text(): Promise<string>;
-    }
-    
-    export class Body {
-        constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
-        arrayBuffer(): Promise<ArrayBuffer>;
-        blob(): Promise<Blob>;
-        body: NodeJS.ReadableStream;
-        bodyUsed: boolean;
-        buffer(): Promise<Buffer>;
-        json(): Promise<any>;
-        size: number;
-        text(): Promise<string>;
-        textConverted(): Promise<string>;
-        timeout: number;
-    }
-    
-    interface SystemError extends Error {
-        code?: string | undefined;
-    }
-    
-    export class AbortError extends Error {
-        readonly name: "AbortError";
-        constructor(message: string);
-        readonly type: "aborted";
-    }
-    
-    export class FetchError extends Error {
-        name: "FetchError";
-        constructor(message: string, type: string, systemError?: SystemError);
-        type: string;
-        code?: string | undefined;
-        errno?: string | undefined;
-    }
-    
-    export class Response extends Body {
-        constructor(body?: BodyInit, init?: ResponseInit);
-        static error(): Response;
-        static redirect(url: string, status: number): Response;
-        clone(): Response;
-        headers: Headers;
-        ok: boolean;
-        redirected: boolean;
-        status: number;
-        statusText: string;
-        type: ResponseType;
-        url: string;
-    }
-    
-    export type ResponseType =
-        | "basic"
-        | "cors"
-        | "default"
-        | "error"
-        | "opaque"
-        | "opaqueredirect";
-    
-    export interface ResponseInit {
-        headers?: HeadersInit | undefined;
-        size?: number | undefined;
-        status?: number | undefined;
-        statusText?: string | undefined;
-        timeout?: number | undefined;
-        url?: string | undefined;
-        counter?: number | undefined;
-    }
-    
-    interface URLLike {
-        href: string;
-    }
-    
-    export type HeadersInit = Headers | string[][] | { [key: string]: string | string[] };
-    // HeaderInit is exported to support backwards compatibility. See PR #34382
-    export type HeaderInit = HeadersInit;
-    export type BodyInit =
-        | ArrayBuffer
-        | ArrayBufferView
-        | NodeJS.ReadableStream
-        | string
-        | URLSearchParams;
-    export type RequestInfo = string | URLLike | Request;
-
     export function isRedirect(code: number): boolean;
 
     const _default: typeof fetch;
-
     export { _default as default };
 }
 

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
+// Minimum TypeScript Version: 4.7
 
-import FormData = require("form-data");
 import { RequestOptions } from "http";
 import { URL, URLSearchParams } from "url";
 import { AbortSignal } from "./externals";
@@ -205,8 +205,7 @@ declare namespace fetch {
         | ArrayBufferView
         | NodeJS.ReadableStream
         | string
-        | URLSearchParams
-        | FormData;
+        | URLSearchParams;
     export type RequestInfo = string | URLLike | Request;
 
     export function isRedirect(code: number): boolean;

--- a/types/node-fetch/node-fetch-tests.mts
+++ b/types/node-fetch/node-fetch-tests.mts
@@ -1,0 +1,359 @@
+import { Agent } from "http";
+import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response, HeaderInit, HeadersInit } from "node-fetch";
+import { URL } from "url";
+import FormData = require("form-data");
+
+function test_AbortError() {
+    const e = new AbortError("message");
+
+    // $ExpectType "aborted"
+    e.type;
+
+    // $ExpectType "AbortError"
+    e.name;
+
+    // $ExpectType string
+    e.message;
+}
+
+function test_fetchUrlWithOptions() {
+    const headers = new Headers();
+    headers.append("Content-Type", "application/json");
+    const requestOptions: RequestInit = {
+        compress: true,
+        follow: 10,
+        headers,
+        method: "POST",
+        redirect: "manual",
+        size: 100,
+        timeout: 5000,
+        agent: false,
+    };
+    handlePromise(
+        fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions),
+    );
+}
+
+function test_headerInit() {
+    const h1: HeaderInit = [["Content-Type", "applicaion/json"]];
+    const h2: HeadersInit = h1;
+}
+
+function test_fetchUrlWithHeadersObject() {
+    const requestOptions: RequestInit = {
+        headers: {
+            "Content-Type": "application/json",
+        },
+        method: "POST",
+    };
+    handlePromise(
+        fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions),
+    );
+}
+
+function test_fetchUrl() {
+    handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"));
+}
+
+function test_fetchUrlArrayBuffer() {
+    handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"), true);
+}
+
+function test_fetchUrlWithRequestObject() {
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        signal: {
+            reason: undefined,
+            aborted: false,
+
+            addEventListener: (
+                type: "abort",
+                listener: (event: any) => any,
+                options?: boolean | {
+                    capture?: boolean | undefined;
+                    once?: boolean | undefined;
+                    passive?: boolean | undefined;
+                },
+            ) => undefined,
+
+            removeEventListener: (
+                type: "abort",
+                listener: (event: any) => any,
+                options?: boolean | {
+                    capture?: boolean | undefined;
+                },
+            ) => undefined,
+
+            dispatchEvent: (event: any) => false,
+            onabort: null,
+            throwIfAborted: () => {},
+        },
+    };
+    const request: Request = new Request(
+        "http://www.andlabs.net/html5/uCOR.php",
+        requestOptions,
+    );
+    const timeout: number = request.timeout;
+    const size: number = request.size;
+    const agent: Agent | ((parsedUrl: URL) => boolean | Agent | undefined) | boolean | undefined = request.agent;
+    const protocol: string = request.protocol;
+
+    handlePromise(fetch(request));
+}
+
+function test_fetchUrlObject() {
+    handlePromise(fetch(new URL("https://example.org")));
+}
+
+async function test_formData() {
+    await fetch(new URL("https://example.org"), { body: new FormData() });
+}
+
+async function test_responseReturnTypes() {
+    const response = await fetch(new URL("https://example.org"));
+
+    // $ExpectType Blob
+    const blob = await response.clone().blob();
+
+    // $ExpectType string
+    const text = await response.clone().text();
+
+    // $ExpectType Buffer
+    const buffer = await response.clone().buffer();
+}
+
+function test_fetchUrlObjectWithRequestObject() {
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        signal: {
+            reason: undefined,
+            aborted: false,
+
+            addEventListener: (
+                type: "abort",
+                listener: (event: any) => any,
+                options?: boolean | {
+                    capture?: boolean | undefined;
+                    once?: boolean | undefined;
+                    passive?: boolean | undefined;
+                },
+            ) => undefined,
+
+            removeEventListener: (
+                type: "abort",
+                listener: (event: any) => any,
+                options?: boolean | {
+                    capture?: boolean | undefined;
+                },
+            ) => undefined,
+
+            dispatchEvent: (event: any) => false,
+            onabort: null,
+            throwIfAborted: () => {},
+        },
+    };
+    const request: Request = new Request(
+        new URL("https://example.org"),
+        requestOptions,
+    );
+    const timeout: number = request.timeout;
+    const size: number = request.size;
+    const agent: Agent | ((parsedUrl: URL) => boolean | Agent | undefined) | boolean | undefined = request.agent;
+    const protocol: string = request.protocol;
+
+    handlePromise(fetch(request));
+}
+
+function test_globalFetchVar() {
+    fetch("http://test.com", {}).then(response => {
+        // for test only
+    });
+}
+
+function handlePromise(
+    promise: Promise<Response>,
+    isArrayBuffer: boolean = false,
+) {
+    promise
+        .then(
+            (response): Promise<string | ArrayBuffer> => {
+                if (response.type === "basic") {
+                    // for test only
+                }
+                if (isArrayBuffer) {
+                    return response.arrayBuffer();
+                } else {
+                    return response.text();
+                }
+            },
+        )
+        .then((text: string | ArrayBuffer) => {
+            console.log(text);
+        });
+}
+
+function test_headers() {
+    const headers = new Headers();
+    const myHeader = "foo";
+    headers.raw()[myHeader]; // $ExpectType string[]
+
+    [...headers]; // $ExpectType [string, string][]
+    [...headers.entries()]; // $ExpectType [string, string][]
+    [...headers.keys()]; // $ExpectType string[]
+    [...headers.values()]; // $ExpectType string[]
+    headers.raw(); // $ExpectType { [k: string]: string[]; }
+}
+
+function test_isRedirect() {
+    fetch.isRedirect(301);
+    fetch.isRedirect(201);
+}
+
+function test_FetchError() {
+    new FetchError("message", "type", {
+        name: "Error",
+        message: "Error message",
+        code: "systemError",
+    });
+    new FetchError("message", "type", {
+        name: "Error",
+        message: "Error without code",
+    });
+    new FetchError("message", "type");
+}
+
+function test_Blob() {
+    new Blob();
+    new Blob(["beep", "boop"]);
+    new Blob(["beep", "boop"], { endings: "native" });
+    new Blob(["beep", "boop"], { type: "text/plain" });
+}
+
+function test_ResponseInit() {
+    fetch("http://test.com", {}).then(response => {
+        new Response(response.body);
+        new Response(response.body, {
+            url: response.url,
+            size: response.size,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            timeout: response.timeout,
+            counter: 5,
+        });
+    });
+}
+
+function test_ResponseInitRawHeaders() {
+    fetch("http://test.com", {}).then(response => {
+        new Response(response.body, {
+            url: response.url,
+            size: response.size,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers.raw(),
+            timeout: response.timeout,
+        });
+    });
+}
+
+async function test_BlobText() {
+    const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
+}
+
+function test_AbortSignal() {
+    let abortSignal: AbortSignal;
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    };
+
+    requestOptions.signal = {
+        reason: undefined,
+        aborted: false,
+        addEventListener: (
+            type: "abort",
+            listener: (event: any) => any,
+            options?: boolean | {
+                capture?: boolean | undefined;
+                once?: boolean | undefined;
+                passive?: boolean | undefined;
+            },
+        ) => undefined,
+
+        removeEventListener: (
+            type: "abort",
+            listener: (event: any) => any,
+            options?: boolean | {
+                capture?: boolean | undefined;
+            },
+        ) => undefined,
+
+        dispatchEvent: (event: any) => false,
+        onabort: (event: any) => "something",
+        throwIfAborted: () => {},
+    };
+    abortSignal = requestOptions.signal;
+
+    requestOptions.signal = {
+        reason: undefined,
+        aborted: false,
+        addEventListener: (
+            type: "abort",
+            listener: (event: any) => any,
+            options?: boolean | {
+                capture?: boolean | undefined;
+                once?: boolean | undefined;
+                passive?: boolean | undefined;
+            },
+        ) => {},
+
+        removeEventListener: (
+            type: "abort",
+            listener: (event: any) => any,
+            options?: boolean | {
+                capture?: boolean | undefined;
+            },
+        ) => {},
+
+        dispatchEvent: (event: any) => true,
+        onabort: (event: any) => false,
+        throwIfAborted: () => {},
+    };
+    abortSignal = requestOptions.signal;
+
+    requestOptions.signal = {
+        reason: undefined,
+        aborted: true,
+        addEventListener: (
+            type: "abort",
+            listener: (event: string) => string,
+            options?: boolean | {
+                capture?: boolean | undefined;
+                once?: boolean | undefined;
+                passive?: boolean | undefined;
+            },
+        ) => undefined,
+
+        removeEventListener: (
+            type: "abort",
+            listener: (event: any) => any,
+            options?: boolean | {
+                capture?: boolean | undefined;
+            },
+        ) => undefined,
+
+        dispatchEvent: (event: any) => false,
+        onabort: null,
+        throwIfAborted: () => {},
+    };
+    abortSignal = requestOptions.signal;
+}

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -1,5 +1,5 @@
 import { Agent } from "http";
-import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response } from "node-fetch";
+import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response, HeaderInit, HeadersInit } from "node-fetch";
 import { URL } from "url";
 import FormData from "form-data";
 
@@ -32,6 +32,11 @@ function test_fetchUrlWithOptions() {
     handlePromise(
         fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions),
     );
+}
+
+function test_headerInit() {
+    const h1: HeaderInit = [["Content-Type", "applicaion/json"]];
+    const h2: HeadersInit = h1;
 }
 
 function test_fetchUrlWithHeadersObject() {

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -1,6 +1,7 @@
 import { Agent } from "http";
 import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response } from "node-fetch";
 import { URL } from "url";
+import FormData from "form-data";
 
 function test_AbortError() {
     const e = new AbortError("message");
@@ -100,6 +101,10 @@ function test_fetchUrlWithRequestObject() {
 
 function test_fetchUrlObject() {
     handlePromise(fetch(new URL("https://example.org")));
+}
+
+async function test_formData() {
+    await fetch(new URL("https://example.org"), { body: new FormData() });
 }
 
 async function test_responseReturnTypes() {

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -1,7 +1,7 @@
 import { Agent } from "http";
 import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response, HeaderInit, HeadersInit } from "node-fetch";
 import { URL } from "url";
-import FormData from "form-data";
+import FormData = require("form-data");
 
 function test_AbortError() {
     const e = new AbortError("message");

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -1,7 +1,14 @@
 import { Agent } from "http";
 import fetch, { AbortError, Blob, FetchError, Headers, Request, RequestInit, Response, HeaderInit, HeadersInit } from "node-fetch";
 import { URL } from "url";
+// eslint-disable-next-line no-duplicate-imports -- test namespace import where import name differs
+import Fetch from "node-fetch";
 import FormData = require("form-data");
+
+function test_FetchNamespace() {
+    // without `import _default = fetch;`, Fetch.HeaderInit errors with "Cannot find namespace 'Fetch'"
+    const h1: Fetch.HeaderInit = [["Content-Type", "applicaion/json"]];
+}
 
 function test_AbortError() {
     const e = new AbortError("message");

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -6,12 +6,13 @@
         "https://github.com/bitinn/node-fetch"
     ],
     "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
+        "@types/node": "*"
     },
     "devDependencies": {
-        "@types/node-fetch": "workspace:."
+        "@types/node-fetch": "workspace:.",
+        "form-data": "^4.0.0"
     },
+    "minimumTypeScriptVersion": "4.7",
     "owners": [
         {
             "name": "Torsten Werner",

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -6,13 +6,12 @@
         "https://github.com/bitinn/node-fetch"
     ],
     "dependencies": {
-        "@types/node": "*"
-    },
-    "devDependencies": {
-        "@types/node-fetch": "workspace:.",
+        "@types/node": "*",
         "form-data": "^4.0.0"
     },
-    "minimumTypeScriptVersion": "4.7",
+    "devDependencies": {
+        "@types/node-fetch": "workspace:."
+    },
     "owners": [
         {
             "name": "Torsten Werner",

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "target": "es6",
         "lib": [
             "es6"

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "Node16",
+        "module": "commonjs",
         "target": "es6",
         "lib": [
             "es6"

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "Node16",
+        "moduleResolution": "Node16",
         "target": "es6",
         "lib": [
             "es6"

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -15,6 +15,7 @@
     },
     "files": [
         "index.d.ts",
-        "node-fetch-tests.ts"
+        "node-fetch-tests.ts",
+        "node-fetch-tests.mts"
     ]
 }

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "module": "Node16",
-        "moduleResolution": "Node16",
         "target": "es6",
         "lib": [
             "es6"

--- a/types/zipkin-instrumentation-fetch/index.d.ts
+++ b/types/zipkin-instrumentation-fetch/index.d.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch = require("node-fetch");
 import { Tracer } from "zipkin";
 
 interface Options {


### PR DESCRIPTION
We have a large TypeScript codebase, which we are attempting to migrate to using the new node16 module mode + ESM. While there is a new major version of node-fetch that exports its own types and is ESM only, upgrading node-fetch while also migrating to ESM creates a much larger testing surface. Therefore, I'm hoping we can tweak node-fetch 2's types to be more compatible with the node16 mode, which gives us a moment to ship the ESM migration first, and then we can upgrade to node-fetch 3 after the migration.

This PR switches this d.ts to use the `export =` syntax to fix compatibility for node16 users. Because `export =` must live on its own, the individual exports were moved into a big export block in the fetch namespace. The end result should result in an equivalent type definition for node-fetch 2 users.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


For everyone's reference, here are what the exports look like in the latest published 2.x package (in each of the CommonJS and ESM files):

CommonJS
```js
fetch.isRedirect = function (code) {
	return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
};

// expose Promise
fetch.Promise = global.Promise;

module.exports = exports = fetch;
Object.defineProperty(exports, "__esModule", { value: true });
exports.default = exports;
exports.Headers = Headers;
exports.Request = Request;
exports.Response = Response;
exports.FetchError = FetchError;
exports.AbortError = AbortError;
```

ESM
```js
fetch.isRedirect = function (code) {
	return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
};

// expose Promise
fetch.Promise = global.Promise;

export default fetch;
export { Headers, Request, Response, FetchError, AbortError };
```