### PR TITLE
Move PreloadableConcreteRequest from react-relay to relay-runtime

### DIFF
--- a/types/react-relay/hooks.d.ts
+++ b/types/react-relay/hooks.d.ts
@@ -6,7 +6,6 @@ export {
     IEnvironmentProvider,
     JSResourceReference,
     LoadQueryOptions,
-    PreloadableConcreteRequest,
     PreloadedEntryPoint,
     PreloadedQuery,
     PreloadFetchPolicy,

--- a/types/react-relay/relay-hooks/EntryPointTypes.d.ts
+++ b/types/react-relay/relay-hooks/EntryPointTypes.d.ts
@@ -8,7 +8,7 @@ import {
     IEnvironment,
     Observable,
     OperationType,
-    RequestParameters,
+    PreloadableConcreteRequest,
     VariablesOf,
 } from "relay-runtime";
 import { GetEntryPointComponentFromEntryPoint, GetEntryPointParamsFromEntryPoint } from "./helpers";
@@ -36,14 +36,6 @@ export type LoadQueryOptions = Readonly<{
     networkCacheConfig?: CacheConfig | null | undefined;
     onQueryAstLoadTimeout?: (() => void) | null | undefined;
 }>;
-
-// Note: the phantom type parameter here helps ensures that the
-// $Parameters.js value matches the type param provided to preloadQuery.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type PreloadableConcreteRequest<TQuery extends OperationType> = {
-    kind: "PreloadableConcreteRequest";
-    params: RequestParameters;
-};
 
 export type EnvironmentProviderOptions<T extends Record<string, unknown> = Record<string, unknown>> = T;
 

--- a/types/react-relay/relay-hooks/loadQuery.d.ts
+++ b/types/react-relay/relay-hooks/loadQuery.d.ts
@@ -1,8 +1,7 @@
-import { GraphQLTaggedNode, IEnvironment, OperationType, VariablesOf } from "relay-runtime";
+import { GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
 import {
     EnvironmentProviderOptions,
     LoadQueryOptions,
-    PreloadableConcreteRequest,
     PreloadedQuery,
 } from "./EntryPointTypes";
 

--- a/types/react-relay/relay-hooks/loadQuery.d.ts
+++ b/types/react-relay/relay-hooks/loadQuery.d.ts
@@ -1,9 +1,5 @@
 import { GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
-import {
-    EnvironmentProviderOptions,
-    LoadQueryOptions,
-    PreloadedQuery,
-} from "./EntryPointTypes";
+import { EnvironmentProviderOptions, LoadQueryOptions, PreloadedQuery } from "./EntryPointTypes";
 
 export function loadQuery<
     TQuery extends OperationType,

--- a/types/react-relay/relay-hooks/useQueryLoader.d.ts
+++ b/types/react-relay/relay-hooks/useQueryLoader.d.ts
@@ -1,5 +1,5 @@
-import { DisposeFn, GraphQLTaggedNode, IEnvironment, OperationType, VariablesOf } from "relay-runtime";
-import { LoadQueryOptions, PreloadableConcreteRequest, PreloadedQuery } from "./EntryPointTypes";
+import { DisposeFn, GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
+import { LoadQueryOptions, PreloadedQuery } from "./EntryPointTypes";
 
 export type useQueryLoaderHookType<TQuery extends OperationType> = [
     PreloadedQuery<TQuery> | null | undefined,

--- a/types/react-relay/relay-hooks/useQueryLoader.d.ts
+++ b/types/react-relay/relay-hooks/useQueryLoader.d.ts
@@ -1,4 +1,11 @@
-import { DisposeFn, GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
+import {
+    DisposeFn,
+    GraphQLTaggedNode,
+    IEnvironment,
+    OperationType,
+    PreloadableConcreteRequest,
+    VariablesOf,
+} from "relay-runtime";
 import { LoadQueryOptions, PreloadedQuery } from "./EntryPointTypes";
 
 export type useQueryLoaderHookType<TQuery extends OperationType> = [

--- a/types/react-relay/v7/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/EntryPointTypes.d.ts
@@ -7,7 +7,7 @@ import {
     IEnvironment,
     Observable,
     OperationType,
-    RequestParameters,
+    PreloadableConcreteRequest,
     VariablesOf,
 } from "relay-runtime";
 import { GetEntryPointComponentFromEntryPoint, GetEntryPointParamsFromEntryPoint } from "./helpers";
@@ -35,14 +35,6 @@ export type LoadQueryOptions = Readonly<{
     networkCacheConfig?: CacheConfig | null | undefined;
     onQueryAstLoadTimeout?: (() => void) | null | undefined;
 }>;
-
-// Note: the phantom type parameter here helps ensures that the
-// $Parameters.js value matches the type param provided to preloadQuery.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type PreloadableConcreteRequest<TQuery extends OperationType> = {
-    kind: "PreloadableConcreteRequest";
-    params: RequestParameters;
-};
 
 export type EnvironmentProviderOptions<T extends Record<string, unknown> = Record<string, unknown>> = T;
 

--- a/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
@@ -1,8 +1,7 @@
-import { GraphQLTaggedNode, IEnvironment, OperationType, VariablesOf } from "relay-runtime";
+import { GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
 import {
     EnvironmentProviderOptions,
     LoadQueryOptions,
-    PreloadableConcreteRequest,
     PreloadedQuery,
 } from "./EntryPointTypes";
 

--- a/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
@@ -1,9 +1,5 @@
 import { GraphQLTaggedNode, IEnvironment, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
-import {
-    EnvironmentProviderOptions,
-    LoadQueryOptions,
-    PreloadedQuery,
-} from "./EntryPointTypes";
+import { EnvironmentProviderOptions, LoadQueryOptions, PreloadedQuery } from "./EntryPointTypes";
 
 export function loadQuery<
     TQuery extends OperationType,

--- a/types/react-relay/v7/lib/relay-experimental/useQueryLoader.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/useQueryLoader.d.ts
@@ -1,5 +1,5 @@
-import { DisposeFn, GraphQLTaggedNode, OperationType, VariablesOf } from "relay-runtime";
-import { LoadQueryOptions, PreloadableConcreteRequest, PreloadedQuery } from "./EntryPointTypes";
+import { DisposeFn, GraphQLTaggedNode, OperationType, PreloadableConcreteRequest, VariablesOf } from "relay-runtime";
+import { LoadQueryOptions, PreloadedQuery } from "./EntryPointTypes";
 
 export type useQueryLoaderHookType<TQuery extends OperationType> = [
     PreloadedQuery<TQuery> | null | undefined,

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -134,6 +134,7 @@ export {
     ConcreteRequest,
     ConcreteUpdatableQuery,
     GeneratedNode,
+    PreloadableConcreteRequest,
     RequestParameters,
 } from "./lib/util/RelayConcreteNode";
 export { RelayReplaySubject as ReplaySubject } from "./lib/util/RelayReplaySubject";

--- a/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
+++ b/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
@@ -1,5 +1,6 @@
 import { NormalizationOperation, NormalizationSplitOperation } from "./NormalizationNode";
 import { ReaderFragment, ReaderInlineDataFragment } from "./ReaderNode";
+import { OperationType } from "./RelayRuntimeTypes";
 
 /**
  * Represents a common GraphQL request that can be executed, an `operation`
@@ -11,6 +12,17 @@ export interface ConcreteRequest {
     readonly kind: string; // 'Request';
     readonly fragment: ReaderFragment;
     readonly operation: NormalizationOperation;
+    readonly params: RequestParameters;
+}
+
+/**
+ * Represents the minimal information necessary to identify and execute
+ * a particular GraphQL request.
+ */
+// Note: the phantom type parameter here helps ensures that the
+// $Parameters.js value matches the type param provided to preloadQuery.
+export interface PreloadableConcreteRequest<TQuery extends OperationType> {
+    readonly kind: string; // 'PreloadableConcreteRequest';
     readonly params: RequestParameters;
 }
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -16,6 +16,7 @@ import {
     graphql,
     isPromise,
     Network,
+    PreloadableConcreteRequest,
     QueryResponseCache,
     ReaderFragment,
     ReaderInlineDataFragment,
@@ -297,6 +298,33 @@ commitLocalUpdate(environment, store => {
     const root = store.get(ROOT_ID);
     root!.setValue("foo", "localKey");
 });
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// PreloadableConcreteRequest
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+type FooQuery$variables = Record<PropertyKey, never>;
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type FooQuery$data = {
+    readonly foo: string | null | undefined;
+};
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type FooQuery = {
+    response: FooQuery$data;
+    variables: FooQuery$variables;
+};
+
+const preloadableNode: PreloadableConcreteRequest<FooQuery> = {
+    kind: "PreloadableConcreteRequest",
+    params: {
+        operationKind: "query",
+        name: "FooQuery",
+        id: null,
+        cacheID: "2e5967148a8303de3c58059c0eaa87c6",
+        text: "query FooQuery {\n  foo\n}\n",
+        metadata: {},
+    },
+};
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // ConcreteRequest


### PR DESCRIPTION
This is another attempt at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67321.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/pull/4515
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.