### PR TITLE
@types/marked-terminal: allow marked 10 and 11

### DIFF
--- a/types/marked-terminal/package.json
+++ b/types/marked-terminal/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/marked-terminal",
-    "version": "6.0.9999",
+    "version": "6.1.9999",
     "projects": [
         "https://github.com/mikaelbr/marked-terminal"
     ],

--- a/types/marked-terminal/package.json
+++ b/types/marked-terminal/package.json
@@ -17,7 +17,7 @@
         "@types/cardinal": "^2.1",
         "@types/node": "*",
         "chalk": "^5.3.0",
-        "marked": ">=6.0.0 <10"
+        "marked": ">=6.0.0 <12"
     },
     "devDependencies": {
         "@types/marked-terminal": "workspace:."


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [marked-terminal supports marked >=10](https://github.com/mikaelbr/marked-terminal/pull/253)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


Working in a typescript monorepo I've noticed NPM is pulling down an older version of marked which then causes type conflict errors due to hoisting. The changes in this PR should fix this issue and aligns with the marked-terminal supported versions of marked. I'm not sure if I should change the version of types/marked-terminal/package.json to 6.1.9999 in this PR to [match the updated version of marked-terminal](https://github.com/mikaelbr/marked-terminal/releases/tag/v6.1.0)  (v6.1.0) where support for marked >= 10 was introduced. If so please let me know and I'll update it. 👍 
