### PR TITLE
[node] Update types to v20.11

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -564,7 +564,7 @@ declare module "buffer" {
              *
              * The `Buffer` module pre-allocates an internal `Buffer` instance of
              * size `Buffer.poolSize` that is used as a pool for the fast allocation of new`Buffer` instances created using `Buffer.allocUnsafe()`, `Buffer.from(array)`,
-             * and `Buffer.concat()` only when `size` is less than or equal to`Buffer.poolSize >> 1` (floor of `Buffer.poolSize` divided by two).
+             * and `Buffer.concat()` only when `size` is less than`Buffer.poolSize >>> 1` (floor of `Buffer.poolSize` divided by two).
              *
              * Use of this pre-allocated internal memory pool is a key difference between
              * calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -638,9 +638,10 @@ declare module "crypto" {
         export(options?: KeyExportOptions<"der">): Buffer;
         export(options?: JwkKeyExportOptions): JsonWebKey;
         /**
-         * Returns `true` or `false` depending on whether the keys have exactly the same type, value, and parameters.
-         * This method is not [constant time](https://en.wikipedia.org/wiki/Timing_attack).
-         * @since v16.15.0
+         * Returns `true` or `false` depending on whether the keys have exactly the same
+         * type, value, and parameters. This method is not [constant time](https://en.wikipedia.org/wiki/Timing_attack).
+         * @since v17.7.0, v16.15.0
+         * @param otherKeyObject A `KeyObject` with which to compare `keyObject`.
          */
         equals(otherKeyObject: KeyObject): boolean;
         /**

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -228,13 +228,13 @@ declare module "dgram" {
          */
         getSendBufferSize(): number;
         /**
-         * @since v18.8.0,v16.19.0
-         * @return the number of bytes queued for sending.
+         * @since v18.8.0, v16.19.0
+         * @return Number of bytes queued for sending.
          */
         getSendQueueSize(): number;
         /**
-         * @since v18.8.0,v16.19.0
-         * @return the number of send requests currently in the queue awaiting to be processed.
+         * @since v18.8.0, v16.19.0
+         * @return Number of send requests currently in the queue awaiting to be processed.
          */
         getSendQueueCount(): number;
         /**

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -9,12 +9,12 @@
  *
  * HTTP message headers are represented by an object like this:
  *
- * ```js
- * { 'content-length': '123',
- *   'content-type': 'text/plain',
- *   'connection': 'keep-alive',
- *   'host': 'example.com',
- *   'accept': '*' }
+ * ```json
+ * { "content-length": "123",
+ *   "content-type": "text/plain",
+ *   "connection": "keep-alive",
+ *   "host": "example.com",
+ *   "accept": "*" }
  * ```
  *
  * Keys are lowercased. Values are not modified.
@@ -1814,7 +1814,6 @@ declare module "http" {
      *
      * It is not necessary to use this method before passing headers to an HTTP request
      * or response. The HTTP module will automatically validate such headers.
-     * Examples:
      *
      * Example:
      *

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -276,6 +276,20 @@ declare module "module" {
     }
     global {
         interface ImportMeta {
+            /**
+             * The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.
+             * **Caveat:** only present on `file:` modules.
+             */
+            dirname?: string;
+            /**
+             * The full absolute path and filename of the current module, with symlinks resolved.
+             * This is the same as the `url.fileURLToPath()` of the `import.meta.url`.
+             * **Caveat:** only local modules support this property. Modules not using the `file:` protocol will not provide it.
+             */
+            filename?: string;
+            /**
+             * The absolute `file:` URL of the module.
+             */
             url: string;
             /**
              * Provides a module-relative resolution function scoped to each module, returning

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.10.9999",
+    "version": "20.11.9999",
     "nonNpm": true,
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -314,13 +314,15 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 81.465639,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   },
          *    *   PerformanceEntry {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 81.860064,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -355,7 +357,8 @@ declare module "perf_hooks" {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 98.545991,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -368,7 +371,8 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 63.518931,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -404,13 +408,15 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 55.897834,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   },
          *    *   PerformanceEntry {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 56.350146,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -903,9 +903,14 @@ declare module "process" {
                  */
                 readonly sourceMapsEnabled: boolean;
                 /**
-                 * This function enables or disables the Source Map v3 support for stack traces.
-                 * It provides same features as launching Node.js process with commandline options --enable-source-maps.
-                 * @since v16.6.0
+                 * This function enables or disables the [Source Map v3](https://sourcemaps.info/spec.html) support for
+                 * stack traces.
+                 *
+                 * It provides same features as launching Node.js process with commandline options`--enable-source-maps`.
+                 *
+                 * Only source maps in JavaScript files that are loaded after source maps has been
+                 * enabled will be parsed and loaded.
+                 * @since v16.6.0, v14.18.0
                  * @experimental
                  */
                 setSourceMapsEnabled(value: boolean): void;

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -74,10 +74,10 @@ declare module "querystring" {
      *
      * For example, the query string `'foo=bar&#x26;abc=xyz&#x26;abc=123'` is parsed into:
      *
-     * ```js
+     * ```json
      * {
-     *   foo: 'bar',
-     *   abc: ['xyz', '123']
+     *   "foo": "bar",
+     *   "abc": ["xyz", "123"]
      * }
      * ```
      *

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "node:stream";
 import { after, afterEach, before, beforeEach, describe, it, Mock, mock, only, run, skip, test, todo } from "node:test";
-import { dot, junit, spec, tap, TestEvent } from "node:test/reporters";
+import { dot, junit, spec, tap, lcov, TestEvent } from "node:test/reporters";
 
 // run without options
 // $ExpectType TestsStream
@@ -657,6 +657,8 @@ new spec();
 junit();
 // $ExpectType AsyncGenerator<string, void, unknown>
 junit("" as any);
+// $ExpectType Lcov
+new lcov();
 
 describe("Mock Timers Test Suite", () => {
     it((t) => {

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -564,7 +564,7 @@ declare module "buffer" {
              *
              * The `Buffer` module pre-allocates an internal `Buffer` instance of
              * size `Buffer.poolSize` that is used as a pool for the fast allocation of new`Buffer` instances created using `Buffer.allocUnsafe()`, `Buffer.from(array)`,
-             * and `Buffer.concat()` only when `size` is less than or equal to`Buffer.poolSize >> 1` (floor of `Buffer.poolSize` divided by two).
+             * and `Buffer.concat()` only when `size` is less than`Buffer.poolSize >>> 1` (floor of `Buffer.poolSize` divided by two).
              *
              * Use of this pre-allocated internal memory pool is a key difference between
              * calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.

--- a/types/node/ts4.8/crypto.d.ts
+++ b/types/node/ts4.8/crypto.d.ts
@@ -638,9 +638,10 @@ declare module "crypto" {
         export(options?: KeyExportOptions<"der">): Buffer;
         export(options?: JwkKeyExportOptions): JsonWebKey;
         /**
-         * Returns `true` or `false` depending on whether the keys have exactly the same type, value, and parameters.
-         * This method is not [constant time](https://en.wikipedia.org/wiki/Timing_attack).
-         * @since v16.15.0
+         * Returns `true` or `false` depending on whether the keys have exactly the same
+         * type, value, and parameters. This method is not [constant time](https://en.wikipedia.org/wiki/Timing_attack).
+         * @since v17.7.0, v16.15.0
+         * @param otherKeyObject A `KeyObject` with which to compare `keyObject`.
          */
         equals(otherKeyObject: KeyObject): boolean;
         /**

--- a/types/node/ts4.8/dgram.d.ts
+++ b/types/node/ts4.8/dgram.d.ts
@@ -228,13 +228,13 @@ declare module "dgram" {
          */
         getSendBufferSize(): number;
         /**
-         * @since v18.8.0,v16.19.0
-         * @return the number of bytes queued for sending.
+         * @since v18.8.0, v16.19.0
+         * @return Number of bytes queued for sending.
          */
         getSendQueueSize(): number;
         /**
-         * @since v18.8.0,v16.19.0
-         * @return the number of send requests currently in the queue awaiting to be processed.
+         * @since v18.8.0, v16.19.0
+         * @return Number of send requests currently in the queue awaiting to be processed.
          */
         getSendQueueCount(): number;
         /**

--- a/types/node/ts4.8/http.d.ts
+++ b/types/node/ts4.8/http.d.ts
@@ -9,12 +9,12 @@
  *
  * HTTP message headers are represented by an object like this:
  *
- * ```js
- * { 'content-length': '123',
- *   'content-type': 'text/plain',
- *   'connection': 'keep-alive',
- *   'host': 'example.com',
- *   'accept': '*' }
+ * ```json
+ * { "content-length": "123",
+ *   "content-type": "text/plain",
+ *   "connection": "keep-alive",
+ *   "host": "example.com",
+ *   "accept": "*" }
  * ```
  *
  * Keys are lowercased. Values are not modified.
@@ -1814,7 +1814,6 @@ declare module "http" {
      *
      * It is not necessary to use this method before passing headers to an HTTP request
      * or response. The HTTP module will automatically validate such headers.
-     * Examples:
      *
      * Example:
      *

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -276,6 +276,20 @@ declare module "module" {
     }
     global {
         interface ImportMeta {
+            /**
+             * The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.
+             * **Caveat:** only present on `file:` modules.
+             */
+            dirname?: string;
+            /**
+             * The full absolute path and filename of the current module, with symlinks resolved.
+             * This is the same as the `url.fileURLToPath()` of the `import.meta.url`.
+             * **Caveat:** only local modules support this property. Modules not using the `file:` protocol will not provide it.
+             */
+            filename?: string;
+            /**
+             * The absolute `file:` URL of the module.
+             */
             url: string;
             /**
              * Provides a module-relative resolution function scoped to each module, returning

--- a/types/node/ts4.8/perf_hooks.d.ts
+++ b/types/node/ts4.8/perf_hooks.d.ts
@@ -31,7 +31,7 @@
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
-    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http";
+    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http" | "dns" | "net";
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies
@@ -314,13 +314,15 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 81.465639,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   },
          *    *   PerformanceEntry {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 81.860064,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -355,7 +357,8 @@ declare module "perf_hooks" {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 98.545991,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -368,7 +371,8 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 63.518931,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *
@@ -404,13 +408,15 @@ declare module "perf_hooks" {
          *    *     name: 'test',
          *    *     entryType: 'mark',
          *    *     startTime: 55.897834,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   },
          *    *   PerformanceEntry {
          *    *     name: 'meow',
          *    *     entryType: 'mark',
          *    *     startTime: 56.350146,
-         *    *     duration: 0
+         *    *     duration: 0,
+         *    *     detail: null
          *    *   }
          *    * ]
          *

--- a/types/node/ts4.8/process.d.ts
+++ b/types/node/ts4.8/process.d.ts
@@ -903,9 +903,14 @@ declare module "process" {
                  */
                 readonly sourceMapsEnabled: boolean;
                 /**
-                 * This function enables or disables the Source Map v3 support for stack traces.
-                 * It provides same features as launching Node.js process with commandline options --enable-source-maps.
-                 * @since v16.6.0
+                 * This function enables or disables the [Source Map v3](https://sourcemaps.info/spec.html) support for
+                 * stack traces.
+                 *
+                 * It provides same features as launching Node.js process with commandline options`--enable-source-maps`.
+                 *
+                 * Only source maps in JavaScript files that are loaded after source maps has been
+                 * enabled will be parsed and loaded.
+                 * @since v16.6.0, v14.18.0
                  * @experimental
                  */
                 setSourceMapsEnabled(value: boolean): void;

--- a/types/node/ts4.8/querystring.d.ts
+++ b/types/node/ts4.8/querystring.d.ts
@@ -74,10 +74,10 @@ declare module "querystring" {
      *
      * For example, the query string `'foo=bar&#x26;abc=xyz&#x26;abc=123'` is parsed into:
      *
-     * ```js
+     * ```json
      * {
-     *   foo: 'bar',
-     *   abc: ['xyz', '123']
+     *   "foo": "bar",
+     *   "abc": ["xyz", "123"]
      * }
      * ```
      *

--- a/types/node/ts4.8/wasi.d.ts
+++ b/types/node/ts4.8/wasi.d.ts
@@ -1,6 +1,11 @@
 /**
- * The WASI API provides an implementation of the [WebAssembly System Interface](https://wasi.dev/) specification. WASI gives sandboxed WebAssembly applications access to the
- * underlying operating system via a collection of POSIX-like functions.
+ * **The `node:wasi` module does not currently provide the**
+ * **comprehensive file system security properties provided by some WASI runtimes.**
+ * **Full support for secure file system sandboxing may or may not be implemented in**
+ * **future. In the mean time, do not rely on it to run untrusted code.**
+ *
+ * The WASI API provides an implementation of the [WebAssembly System Interface](https://wasi.dev/) specification. WASI gives WebAssembly applications access to the underlying
+ * operating system via a collection of POSIX-like functions.
  *
  * ```js
  * import { readFile } from 'node:fs/promises';
@@ -12,7 +17,7 @@
  *   args: argv,
  *   env,
  *   preopens: {
- *     '/sandbox': '/some/real/path/that/wasm/can/access',
+ *     '/local': '/some/real/path/that/wasm/can/access',
  *   },
  * });
  *
@@ -117,8 +122,7 @@ declare module "wasi" {
     /**
      * The `WASI` class provides the WASI system call API and additional convenience
      * methods for working with WASI-based applications. Each `WASI` instance
-     * represents a distinct sandbox environment. For security purposes, each `WASI`instance must have its command-line arguments, environment variables, and
-     * sandbox directory structure configured explicitly.
+     * represents a distinct environment.
      * @since v13.3.0, v12.16.0
      */
     class WASI {

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -1,6 +1,11 @@
 /**
- * The WASI API provides an implementation of the [WebAssembly System Interface](https://wasi.dev/) specification. WASI gives sandboxed WebAssembly applications access to the
- * underlying operating system via a collection of POSIX-like functions.
+ * **The `node:wasi` module does not currently provide the**
+ * **comprehensive file system security properties provided by some WASI runtimes.**
+ * **Full support for secure file system sandboxing may or may not be implemented in**
+ * **future. In the mean time, do not rely on it to run untrusted code.**
+ *
+ * The WASI API provides an implementation of the [WebAssembly System Interface](https://wasi.dev/) specification. WASI gives WebAssembly applications access to the underlying
+ * operating system via a collection of POSIX-like functions.
  *
  * ```js
  * import { readFile } from 'node:fs/promises';
@@ -12,7 +17,7 @@
  *   args: argv,
  *   env,
  *   preopens: {
- *     '/sandbox': '/some/real/path/that/wasm/can/access',
+ *     '/local': '/some/real/path/that/wasm/can/access',
  *   },
  * });
  *
@@ -117,8 +122,7 @@ declare module "wasi" {
     /**
      * The `WASI` class provides the WASI system call API and additional convenience
      * methods for working with WASI-based applications. Each `WASI` instance
-     * represents a distinct sandbox environment. For security purposes, each `WASI`instance must have its command-line arguments, environment variables, and
-     * sandbox directory structure configured explicitly.
+     * represents a distinct environment.
      * @since v13.3.0, v12.16.0
      */
     class WASI {


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.11.0

- esm: add `import.meta.dirname` and `import.meta.filename`
- test_runner: adds built in `lcov` reporter

