### PR TITLE
[@types/sequelize] Use namespace import for validator

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 // ***************************** IMPORTANT NOTE *****************************
 // These types are for the 4.x branch of Sequelize. As of Sequelize 5.0,
 // types are packaged directly within Sequelize itself. Please target the
@@ -9,7 +10,7 @@ import * as _ from "lodash";
 import Promise = require("bluebird");
 import * as cls from "continuation-local-storage";
 
-import ValidatorJS from "validator";
+import * as ValidatorJS from "validator";
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 

--- a/types/sequelize/package.json
+++ b/types/sequelize/package.json
@@ -10,6 +10,7 @@
         "@types/bluebird": "*",
         "@types/continuation-local-storage": "*",
         "@types/lodash": "*",
+        "@types/node": "*",
         "@types/validator": "*"
     },
     "devDependencies": {

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3,7 +3,7 @@
 import * as Promise from "bluebird";
 import * as _ from "lodash";
 
-import ValidatorJS from "validator";
+import * as ValidatorJS from "validator";
 
 declare namespace sequelize {
     //


### PR DESCRIPTION
While researching #68152, I found that the other package where people commonly report this issue is from @types/sequelize. This fixes the namespace import in @types/sequelize to not rely on the global validator namespace

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #68152
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
