### PR TITLE
Fix sequelize's import of validator

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -9,7 +9,7 @@ import * as _ from "lodash";
 import Promise = require("bluebird");
 import * as cls from "continuation-local-storage";
 
-import ValidatorJS from "validator";
+import ValidatorJS = require("validator");
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3,7 +3,7 @@
 import * as Promise from "bluebird";
 import * as _ from "lodash";
 
-import ValidatorJS from "validator";
+import ValidatorJS = require("validator");
 
 declare namespace sequelize {
     //


### PR DESCRIPTION
Changed in #68121. Sequelize was missed because of a bug in the linter's setup code. That is fixed in https://github.com/microsoft/DefinitelyTyped-tools/pull/899