### PR TITLE
[README.md] Add note about breaking type changes without major updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,12 +650,10 @@ Also, `/// <reference types=".." />` will not work with path mapping, so depende
 
 #### How do breaking type changes work if type declaration packages closely track the library package's version?
 
-Contributors should make an effort to not ship breaking type changes that break with [semantic versioning](https://semver.org/) guidelines. However, changes to TypeScript can lead to _rare_ exceptions. Here are some examples:
+`@types` packages always type packages of the same version, so `@types/foo@5.4.x` are for `foo@5.4.x`.
+As a consequence, all changes, breaking or not, are published as patch revisions, unless paired with a major/minor bump to change the package version being targeted (coincidentally or not).
 
-* The type declaration package is updated to use new TypeScript features, breaking support for old versions of TypeScript in accordance with this repository's [TypeScript support window](https://github.com/DefinitelyTyped/DefinitelyTyped/#support-window).
-* Support is improved for modern module systems, which results in new (and otherwise unfillable) support gaps for older module systems.
-
-When such rare cases happen, these updates will be released without a major version update, since updating the type declaration's major version would make its version out of step with its library package.
+When it comes to breaking changes, DT maintainers consider the popularity of the package, the upsides of the proposed breaking change, the effort that will be required for users to fix their code, and whether the change could reasonably be delayed until it can be synced with a major bump of the upstream library.
 
 #### How do I write definitions for packages that can be used globally and as a module?
 

--- a/README.md
+++ b/README.md
@@ -648,6 +648,15 @@ Another package may select this version by specifying:
 
 Also, `/// <reference types=".." />` will not work with path mapping, so dependencies must use `import`.
 
+#### How do breaking type changes work if type declaration packages closely track the library package's version?
+
+Contributors should make an effort to not ship breaking type changes that break with [semantic versioning](https://semver.org/) guidelines. However, changes to TypeScript can lead to _rare_ exceptions. Here are some examples:
+
+* The type declaration package is updated to use new TypeScript features, breaking support for old versions of TypeScript in accordance with this repository's [TypeScript support window](https://github.com/DefinitelyTyped/DefinitelyTyped/#support-window).
+* Support is improved for modern module systems, which results in new (and otherwise unfillable) support gaps for older module systems.
+
+When such rare cases happen, these updates will be released without a major version update, since updating the type declaration's major version would make its version out of step with its library package.
+
 #### How do I write definitions for packages that can be used globally and as a module?
 
 The TypeScript handbook contains excellent [general information about writing definitions](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) and also [this example definition file](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) which shows how to create a definition using ES6-style module syntax, while also specifying objects made available to the global scope.  This technique is demonstrated practically in the [definition for `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), which is a library that can be loaded globally via script tag on a web page or imported via require or ES6-style imports.


### PR DESCRIPTION
While frustrating, this can happen sometimes. You can kind of put 2 and 2 together by reading the other parts of the version documentation in the README, but I think it'd be helpful to have a small section that spells out how this can happen.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
