### PR TITLE
Disable new no-type-only-packages rule in packages which fail

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "@definitelytyped/no-type-only-packages": "off"
-    }
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/angular-agility/.eslintrc.json
+++ b/types/angular-agility/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/angular-bootstrap-lightbox/.eslintrc.json
+++ b/types/angular-bootstrap-lightbox/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/angular-clipboard/.eslintrc.json
+++ b/types/angular-clipboard/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/dt-header": "off"
+        "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/angular-environment/.eslintrc.json
+++ b/types/angular-environment/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/dt-header": "off"
+        "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/angular-file-upload/.eslintrc.json
+++ b/types/angular-file-upload/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/angular-modal/.eslintrc.json
+++ b/types/angular-modal/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/no-unnecessary-generics": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/ban-types": "off"

--- a/types/angular-spinner/.eslintrc.json
+++ b/types/angular-spinner/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/angular-strap/.eslintrc.json
+++ b/types/angular-strap/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/naming-convention": "off"
+        "@definitelytyped/no-type-only-packages": "off",
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/angular-toasty/.eslintrc.json
+++ b/types/angular-toasty/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/angular-ui-tree/.eslintrc.json
+++ b/types/angular-ui-tree/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/angularfire/.eslintrc.json
+++ b/types/angularfire/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/ban-types": "off"
     }

--- a/types/annyang/.eslintrc.json
+++ b/types/annyang/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/apple-music-api/.eslintrc.json
+++ b/types/apple-music-api/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/arcgis-rest-api/.eslintrc.json
+++ b/types/arcgis-rest-api/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/artillery/.eslintrc.json
+++ b/types/artillery/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/aws-cloudfront-function/.eslintrc.json
+++ b/types/aws-cloudfront-function/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/babel__plugin-transform-runtime/.eslintrc.json
+++ b/types/babel__plugin-transform-runtime/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/babel__preset-env/.eslintrc.json
+++ b/types/babel__preset-env/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/bgiframe/.eslintrc.json
+++ b/types/bgiframe/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/blip-sdk/.eslintrc.json
+++ b/types/blip-sdk/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/cookieconsent/.eslintrc.json
+++ b/types/cookieconsent/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/cyclonedx/.eslintrc.json
+++ b/types/cyclonedx/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-    "ignorePatterns": ["cyclonedx-tests.json"]
+    "ignorePatterns": [
+        "cyclonedx-tests.json"
+    ],
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
 }

--- a/types/d3-indirections/.eslintrc.json
+++ b/types/d3-indirections/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/dadata-api/.eslintrc.json
+++ b/types/dadata-api/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/edtr-io__mathquill/.eslintrc.json
+++ b/types/edtr-io__mathquill/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/elm/.eslintrc.json
+++ b/types/elm/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-interface": "off"

--- a/types/estree/.eslintrc.json
+++ b/types/estree/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/express-serve-static-core/.eslintrc.json
+++ b/types/express-serve-static-core/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/naming-convention": "off"
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/eyevinn-iaf/.eslintrc.json
+++ b/types/eyevinn-iaf/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/feflow__cli/.eslintrc.json
+++ b/types/feflow__cli/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/flowdoc/.eslintrc.json
+++ b/types/flowdoc/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/fontoxml/.eslintrc.json
+++ b/types/fontoxml/.eslintrc.json
@@ -1,8 +1,9 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
+        "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/freedom/.eslintrc.json
+++ b/types/freedom/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/adjacent-overload-signatures": "off",
         "@typescript-eslint/ban-types": "off"
     }

--- a/types/gandi-livedns/.eslintrc.json
+++ b/types/gandi-livedns/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/gatsby-transformer-remark/.eslintrc.json
+++ b/types/gatsby-transformer-remark/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/google.fonts/.eslintrc.json
+++ b/types/google.fonts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/har-format/.eslintrc.json
+++ b/types/har-format/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/hast/.eslintrc.json
+++ b/types/hast/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/hast/v2/.eslintrc.json
+++ b/types/hast/v2/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/highcharts-ng/.eslintrc.json
+++ b/types/highcharts-ng/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/dt-header": "off"
+        "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/history.js/.eslintrc.json
+++ b/types/history.js/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/hyper-function-component/.eslintrc.json
+++ b/types/hyper-function-component/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/hypertext-application-language/.eslintrc.json
+++ b/types/hypertext-application-language/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/imgur-rest-api/.eslintrc.json
+++ b/types/imgur-rest-api/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/jquery.elang/.eslintrc.json
+++ b/types/jquery.elang/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/naming-convention": "off"

--- a/types/js-git/.eslintrc.json
+++ b/types/js-git/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/jui-grid/.eslintrc.json
+++ b/types/jui-grid/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/no-any-union": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/jui/.eslintrc.json
+++ b/types/jui/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/no-any-union": "off"
+        "@definitelytyped/no-any-union": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/kap-plugin/.eslintrc.json
+++ b/types/kap-plugin/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/keystonejs__session/.eslintrc.json
+++ b/types/keystonejs__session/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/lint-staged/.eslintrc.json
+++ b/types/lint-staged/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/mdast/.eslintrc.json
+++ b/types/mdast/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/mdast/v3/.eslintrc.json
+++ b/types/mdast/v3/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/mimos/.eslintrc.json
+++ b/types/mimos/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/ng-i18next/.eslintrc.json
+++ b/types/ng-i18next/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/ng-notify/.eslintrc.json
+++ b/types/ng-notify/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/ng-stomp/.eslintrc.json
+++ b/types/ng-stomp/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/ngkookies/.eslintrc.json
+++ b/types/ngkookies/.eslintrc.json
@@ -1,8 +1,9 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/no-unnecessary-generics": "off",
-        "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/consistent-type-definitions": "off"
+        "@typescript-eslint/consistent-type-definitions": "off",
+        "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/ngprogress/.eslintrc.json
+++ b/types/ngprogress/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/naming-convention": "off"
     }

--- a/types/ngreact/.eslintrc.json
+++ b/types/ngreact/.eslintrc.json
@@ -3,6 +3,7 @@
         "@definitelytyped/dt-header": "off",
         "@definitelytyped/no-declare-current-package": "off",
         "@definitelytyped/no-single-declare-module": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/ngstorage/.eslintrc.json
+++ b/types/ngstorage/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/no-unnecessary-generics": "off"
     }
 }

--- a/types/ngtoaster/.eslintrc.json
+++ b/types/ngtoaster/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/export-just-namespace": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/ngwysiwyg/.eslintrc.json
+++ b/types/ngwysiwyg/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/nlcst/.eslintrc.json
+++ b/types/nlcst/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-interface": "off"

--- a/types/nlcst/v1/.eslintrc.json
+++ b/types/nlcst/v1/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/node-red/v0/.eslintrc.json
+++ b/types/node-red/v0/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/pgwmodal/.eslintrc.json
+++ b/types/pgwmodal/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/phantomcss/.eslintrc.json
+++ b/types/phantomcss/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/dt-header": "off"
+        "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/plaid-link/.eslintrc.json
+++ b/types/plaid-link/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/protractor-console-plugin/.eslintrc.json
+++ b/types/protractor-console-plugin/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/qlik-engineapi/.eslintrc.json
+++ b/types/qlik-engineapi/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/naming-convention": "off"
+        "@definitelytyped/no-type-only-packages": "off",
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/restangular/.eslintrc.json
+++ b/types/restangular/.eslintrc.json
@@ -2,10 +2,11 @@
     "rules": {
         "@definitelytyped/dt-header": "off",
         "@definitelytyped/export-just-namespace": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/no-unnecessary-generics": "off",
         "@typescript-eslint/adjacent-overload-signatures": "off",
         "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/triple-slash-reference": "off",
-        "@typescript-eslint/naming-convention": "off"
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/triple-slash-reference": "off"
     }
 }

--- a/types/riot-games-api/.eslintrc.json
+++ b/types/riot-games-api/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/rx-core/.eslintrc.json
+++ b/types/rx-core/.eslintrc.json
@@ -1,9 +1,10 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
-        "@definitelytyped/no-unnecessary-generics": "off",
         "@definitelytyped/no-declare-current-package": "off",
         "@definitelytyped/no-single-declare-module": "off",
+        "@definitelytyped/no-type-only-packages": "off",
+        "@definitelytyped/no-unnecessary-generics": "off",
         "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/sarif/.eslintrc.json
+++ b/types/sarif/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/scaleway-functions/.eslintrc.json
+++ b/types/scaleway-functions/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/serverless-step-functions/.eslintrc.json
+++ b/types/serverless-step-functions/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/shexj/.eslintrc.json
+++ b/types/shexj/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/sketchapp/.eslintrc.json
+++ b/types/sketchapp/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/solution-center-communicator/.eslintrc.json
+++ b/types/solution-center-communicator/.eslintrc.json
@@ -2,6 +2,7 @@
     "rules": {
         "@definitelytyped/dt-header": "off",
         "@definitelytyped/no-declare-current-package": "off",
-        "@definitelytyped/no-single-declare-module": "off"
+        "@definitelytyped/no-single-declare-module": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/spotify-api/.eslintrc.json
+++ b/types/spotify-api/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/stripejs/.eslintrc.json
+++ b/types/stripejs/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/no-single-element-tuple-type": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/svg-maps__common/.eslintrc.json
+++ b/types/svg-maps__common/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/svgjs.draggable/.eslintrc.json
+++ b/types/svgjs.draggable/.eslintrc.json
@@ -1,8 +1,9 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
+        "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/prefer-namespace": "off"
     }

--- a/types/svgjs.resize/.eslintrc.json
+++ b/types/svgjs.resize/.eslintrc.json
@@ -1,8 +1,9 @@
 {
     "rules": {
         "@definitelytyped/dt-header": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
+        "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/ban-types": "off"
     }
 }

--- a/types/swagger-schema-official/.eslintrc.json
+++ b/types/swagger-schema-official/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@typescript-eslint/consistent-type-definitions": "off"
     }
 }

--- a/types/ui-grid/.eslintrc.json
+++ b/types/ui-grid/.eslintrc.json
@@ -3,10 +3,11 @@
         "@definitelytyped/dt-header": "off",
         "@definitelytyped/export-just-namespace": "off",
         "@definitelytyped/no-any-union": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/naming-convention": "off",
         "@typescript-eslint/prefer-namespace": "off",
-        "@typescript-eslint/triple-slash-reference": "off",
-        "@typescript-eslint/naming-convention": "off"
+        "@typescript-eslint/triple-slash-reference": "off"
     }
 }

--- a/types/underscore-ko/.eslintrc.json
+++ b/types/underscore-ko/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/no-unnecessary-generics": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
-        "@definitelytyped/npm-naming": "off"
+        "@definitelytyped/npm-naming": "off",
+        "@definitelytyped/strict-export-declare-modifiers": "off"
     }
 }

--- a/types/unist/.eslintrc.json
+++ b/types/unist/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/unist/v2/.eslintrc.json
+++ b/types/unist/v2/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/valdr-message/.eslintrc.json
+++ b/types/valdr-message/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/valdr/.eslintrc.json
+++ b/types/valdr/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/dt-header": "off"
+        "@definitelytyped/dt-header": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/wallabyjs/.eslintrc.json
+++ b/types/wallabyjs/.eslintrc.json
@@ -2,10 +2,11 @@
     "rules": {
         "@definitelytyped/dt-header": "off",
         "@definitelytyped/no-declare-current-package": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
         "@definitelytyped/no-single-declare-module": "off",
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
-        "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/explicit-member-accessibility": "off"
+        "@definitelytyped/strict-export-declare-modifiers": "off",
+        "@typescript-eslint/explicit-member-accessibility": "off",
+        "@typescript-eslint/naming-convention": "off"
     }
 }

--- a/types/web-app-manifest/.eslintrc.json
+++ b/types/web-app-manifest/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/wistia-player-browser/.eslintrc.json
+++ b/types/wistia-player-browser/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/xast/.eslintrc.json
+++ b/types/xast/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }

--- a/types/xast/v1/.eslintrc.json
+++ b/types/xast/v1/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@definitelytyped/no-type-only-packages": "off",
         "@definitelytyped/npm-naming": "off"
     }
 }

--- a/types/xmlhttprequest/.eslintrc.json
+++ b/types/xmlhttprequest/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}

--- a/types/zrender/.eslintrc.json
+++ b/types/zrender/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "@definitelytyped/no-declare-current-package": "off",
-        "@definitelytyped/no-single-declare-module": "off"
+        "@definitelytyped/no-single-declare-module": "off",
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/DefinitelyTyped-tools/pull/865 adds a new lint rule which errors when a package does not contain any declarations in value space (or augment other packages/globals) and therefore do not describe actual JS code that can be imported or referenced.

We prefer that these kinds of packages are not added to the repo without some sort of clear rationale, per https://github.com/DefinitelyTyped/DefinitelyTyped#what-about-type-definitions-with-no-matching-package.

Only 100 packages fail this rule today; this PR exempts them.