### PR TITLE
fix: calling @rdfjs/fetch with URL also with factory usage

### DIFF
--- a/types/rdfjs__fetch/index.d.ts
+++ b/types/rdfjs__fetch/index.d.ts
@@ -1,15 +1,15 @@
-import { DatasetResponse, FactoryInit, FormatsInit, RdfFetchResponse } from "@rdfjs/fetch-lite";
+import { DatasetResponse, FactoryInit, FormatsInit, RdfFetchResponse, default as fetch } from "@rdfjs/fetch-lite";
 import { BaseQuad, DatasetCore, Quad } from "@rdfjs/types";
 
 export { Headers } from "@rdfjs/fetch-lite";
 
-declare function rdfFetch(url: string, options?: Partial<FormatsInit>): Promise<RdfFetchResponse>;
+declare function rdfFetch(url: Parameters<typeof fetch>[0], options?: Partial<FormatsInit>): Promise<RdfFetchResponse>;
 declare function rdfFetch<
     D extends DatasetCore<OutQuad, InQuad>,
     OutQuad extends BaseQuad = Quad,
     InQuad extends BaseQuad = OutQuad,
 >(
-    url: string,
+    url: Parameters<typeof fetch>[0],
     options?: Partial<FactoryInit<D, OutQuad, InQuad>>,
 ): Promise<DatasetResponse<D, OutQuad, InQuad>>;
 

--- a/types/rdfjs__fetch/index.d.ts
+++ b/types/rdfjs__fetch/index.d.ts
@@ -1,4 +1,4 @@
-import { DatasetResponse, FactoryInit, FormatsInit, RdfFetchResponse, default as fetch } from "@rdfjs/fetch-lite";
+import { DatasetResponse, default as fetch, FactoryInit, FormatsInit, RdfFetchResponse } from "@rdfjs/fetch-lite";
 import { BaseQuad, DatasetCore, Quad } from "@rdfjs/types";
 
 export { Headers } from "@rdfjs/fetch-lite";

--- a/types/rdfjs__fetch/rdfjs__fetch-tests.ts
+++ b/types/rdfjs__fetch/rdfjs__fetch-tests.ts
@@ -45,3 +45,14 @@ async function fetchTypedStream(): Promise<Stream<QuadExt>> {
     const response = await fetch("http://example.com", { formats, factory });
     return response.quadStream();
 }
+
+async function fetchURL() {
+    // $ExpectType RdfFetchResponse<Quad>
+    const response = await fetch(new URL("http://example.com"));
+}
+
+async function fetchRequestInfo() {
+    const req: Request = <any> {};
+    // $ExpectType RdfFetchResponse<Quad>
+    const response = await fetch(req);
+}


### PR DESCRIPTION
Similar to #68170, applied downstream

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdfjs-base/fetch/blob/master/index.js#L6>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
