### PR TITLE
[node] esm: make import.meta.dirname and import.meta.filename non-optional

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -280,13 +280,13 @@ declare module "module" {
              * The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.
              * **Caveat:** only present on `file:` modules.
              */
-            dirname?: string;
+            dirname: string;
             /**
              * The full absolute path and filename of the current module, with symlinks resolved.
              * This is the same as the `url.fileURLToPath()` of the `import.meta.url`.
              * **Caveat:** only local modules support this property. Modules not using the `file:` protocol will not provide it.
              */
-            filename?: string;
+            filename: string;
             /**
              * The absolute `file:` URL of the module.
              */

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -52,6 +52,8 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 // global
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
+    importmeta.dirname; // $ExpectType string
+    importmeta.filename; // $ExpectType string
     importmeta.url; // $ExpectType string
     importmeta.resolve("local"); // $ExpectType string
     importmeta.resolve("local", "/parent"); // $ExpectType string

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -280,13 +280,13 @@ declare module "module" {
              * The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.
              * **Caveat:** only present on `file:` modules.
              */
-            dirname?: string;
+            dirname: string;
             /**
              * The full absolute path and filename of the current module, with symlinks resolved.
              * This is the same as the `url.fileURLToPath()` of the `import.meta.url`.
              * **Caveat:** only local modules support this property. Modules not using the `file:` protocol will not provide it.
              */
-            filename?: string;
+            filename: string;
             /**
              * The absolute `file:` URL of the module.
              */

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -52,6 +52,8 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
 // global
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
+    importmeta.dirname; // $ExpectType string
+    importmeta.filename; // $ExpectType string
     importmeta.url; // $ExpectType string
     importmeta.resolve("local"); // $ExpectType string
     importmeta.resolve("local", "/parent"); // $ExpectType string


### PR DESCRIPTION
`dirname` and `filename` are defined for most real code. So better to make them non-optional.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68157#issuecomment-1889883013