### PR TITLE
[@types/node] Crypto: support outputLength on hash.copy()

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -363,7 +363,7 @@ declare module "crypto" {
          * @since v13.1.0
          * @param options `stream.transform` options
          */
-        copy(options?: stream.TransformOptions): Hash;
+        copy(options?: HashOptions): Hash;
         /**
          * Updates the hash content with the given `data`, the encoding of which
          * is given in `inputEncoding`.

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -3,6 +3,11 @@ import assert = require("node:assert");
 import { promisify } from "node:util";
 
 {
+    // crypto hash copy with outputLength
+    const copied: crypto.Hash = crypto.createHash("shake256").copy({ outputLength: 128 });
+}
+
+{
     const copied: crypto.Hash = crypto.createHash("md5").copy().copy({
         encoding: "ascii",
     });

--- a/types/node/ts4.8/crypto.d.ts
+++ b/types/node/ts4.8/crypto.d.ts
@@ -363,7 +363,7 @@ declare module "crypto" {
          * @since v13.1.0
          * @param options `stream.transform` options
          */
-        copy(options?: stream.TransformOptions): Hash;
+        copy(options?: HashOptions): Hash;
         /**
          * Updates the hash content with the given `data`, the encoding of which
          * is given in `inputEncoding`.

--- a/types/node/ts4.8/test/crypto.ts
+++ b/types/node/ts4.8/test/crypto.ts
@@ -3,6 +3,11 @@ import assert = require("node:assert");
 import { promisify } from "node:util";
 
 {
+    // crypto hash copy with outputLength
+    const copied: crypto.Hash = crypto.createHash("shake256").copy({ outputLength: 128 });
+}
+
+{
     const copied: crypto.Hash = crypto.createHash("md5").copy().copy({
         encoding: "ascii",
     });


### PR DESCRIPTION
Related discussion: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68196

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#hashcopyoptions
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~