### PR TITLE
fix(@types/node): extend the ExecException interface from the child_process module

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -894,6 +894,8 @@ declare module "child_process" {
         killed?: boolean | undefined;
         code?: number | undefined;
         signal?: NodeJS.Signals | undefined;
+        stdout?: string;
+        stderr?: string;
     }
     /**
      * Spawns a shell then executes the `command` within that shell, buffering any


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Reason

The type definition for the first parameter of the callback in `exec`, `ExecException`, lacks the `stdout` and `stderr` properties. Generally, this is not an issue; however, when using `util.promisify` to wrap `exec`, the rejected `ExecException` object should include `stdout` and `stderr` properties when the child process exits with a non-zero code.

## Example

I use `depcheck` to identify missing and unused dependencies in some projects in CI/CD environment. By some reason I need to invoke it via a child process. If `depcheck` finds issues, it exits with a code of 255 and outputs messages to `stdout`. When I wrap `exec` with `util.promisify` to utilize async/await patterns, I am unable to access `stdout` or `stderr` on the `ExecException` object in case of an error.

```typescript
try {
  const { stderr, stdout } = await promisify(exec)(`depcheck ${path} --json`)
} catch (error) {
  const err: ExecException = error
  // TypeScript raises an error here because 'stdout' is not known to be a property on 'ExecException'
  console.log(err.stdout)
}
```