### PR TITLE
net: Support lookup of one address in `net.LookupFunction` (`autoSelectFamily: false`)

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -18,8 +18,8 @@ declare module "net" {
     import * as dns from "node:dns";
     type LookupFunction = (
         hostname: string,
-        options: dns.LookupAllOptions,
-        callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void,
+        options: dns.LookupOptions,
+        callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void,
     ) => void;
     interface AddressInfo {
         address: string;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -673,6 +673,11 @@ import * as url from "node:url";
             cb(null, [{ address: "", family: 1 }]);
         },
     });
+    http.request({
+        lookup: (hostname, options, cb) => {
+            cb(null, "", 1);
+        },
+    });
 }
 
 {

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -604,4 +604,9 @@ import * as url from "node:url";
             cb(null, [{ address: "", family: 1 }]);
         },
     });
+    https.request({
+        lookup: (hostname, options, cb) => {
+            cb(null, "", 1);
+        },
+    });
 }

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -1,5 +1,5 @@
 import { Socket } from "node:dgram";
-import { LookupAddress, LookupAllOptions } from "node:dns";
+import { LookupAddress, LookupOptions } from "node:dns";
 import * as net from "node:net";
 
 {
@@ -71,6 +71,30 @@ import * as net from "node:net";
 }
 
 {
+    // lookup callback can be either an array of LookupAddress or a single address and family
+    const tcpConnectLookupAllOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+        ): void => {
+            callback(null, [{ address: "", family: 1 }]);
+        },
+        port: 80,
+    };
+    const tcpConnectLookupOneOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        ): void => {
+            callback(null, "", 1);
+        },
+        port: 80,
+    };
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -109,7 +133,7 @@ import * as net from "node:net";
         localPort: 1234,
         lookup: (
             _hostname: string,
-            _options: LookupAllOptions,
+            _options: LookupOptions,
             _callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
         ): void => {
             // nothing

--- a/types/node/ts4.8/net.d.ts
+++ b/types/node/ts4.8/net.d.ts
@@ -18,8 +18,8 @@ declare module "net" {
     import * as dns from "node:dns";
     type LookupFunction = (
         hostname: string,
-        options: dns.LookupAllOptions,
-        callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void,
+        options: dns.LookupOptions,
+        callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void,
     ) => void;
     interface AddressInfo {
         address: string;

--- a/types/node/ts4.8/test/http.ts
+++ b/types/node/ts4.8/test/http.ts
@@ -646,6 +646,11 @@ import * as url from "node:url";
             cb(null, [{ address: "", family: 1 }]);
         },
     });
+    http.request({
+        lookup: (hostname, options, cb) => {
+            cb(null, "", 1);
+        },
+    });
 }
 
 {

--- a/types/node/ts4.8/test/https.ts
+++ b/types/node/ts4.8/test/https.ts
@@ -604,4 +604,9 @@ import * as url from "node:url";
             cb(null, [{ address: "", family: 1 }]);
         },
     });
+    https.request({
+        lookup: (hostname, options, cb) => {
+            cb(null, "", 1);
+        },
+    });
 }

--- a/types/node/ts4.8/test/net.ts
+++ b/types/node/ts4.8/test/net.ts
@@ -1,5 +1,5 @@
 import { Socket } from "node:dgram";
-import { LookupAddress, LookupAllOptions } from "node:dns";
+import { LookupAddress, LookupOptions } from "node:dns";
 import * as net from "node:net";
 
 {
@@ -71,6 +71,30 @@ import * as net from "node:net";
 }
 
 {
+    // lookup callback can be either an array of LookupAddress or a single address and family
+    const tcpConnectLookupAllOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+        ): void => {
+            callback(null, [{ address: "", family: 1 }]);
+        },
+        port: 80,
+    };
+    const tcpConnectLookupOneOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        ): void => {
+            callback(null, "", 1);
+        },
+        port: 80,
+    };
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -109,7 +133,7 @@ import * as net from "node:net";
         localPort: 1234,
         lookup: (
             _hostname: string,
-            _options: LookupAllOptions,
+            _options: LookupOptions,
             _callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
         ): void => {
             // nothing

--- a/types/node/v18/net.d.ts
+++ b/types/node/v18/net.d.ts
@@ -18,8 +18,8 @@ declare module "net" {
     import * as dns from "node:dns";
     type LookupFunction = (
         hostname: string,
-        options: dns.LookupOneOptions,
-        callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        options: dns.LookupOptions,
+        callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void,
     ) => void;
     interface AddressInfo {
         address: string;

--- a/types/node/v18/test/net.ts
+++ b/types/node/v18/test/net.ts
@@ -1,5 +1,5 @@
 import { Socket } from "node:dgram";
-import { LookupOneOptions } from "node:dns";
+import { LookupAddress, LookupOptions } from "node:dns";
 import * as net from "node:net";
 
 {
@@ -71,6 +71,30 @@ import * as net from "node:net";
 }
 
 {
+    // lookup callback can be either an array of LookupAddress or a single address and family
+    const tcpConnectLookupAllOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+        ): void => {
+            callback(null, [{ address: "", family: 1 }]);
+        },
+        port: 80,
+    };
+    const tcpConnectLookupOneOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        ): void => {
+            callback(null, "", 1);
+        },
+        port: 80,
+    };
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -109,7 +133,7 @@ import * as net from "node:net";
         localPort: 1234,
         lookup: (
             _hostname: string,
-            _options: LookupOneOptions,
+            _options: LookupOptions,
             _callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
         ): void => {
             // nothing

--- a/types/node/v18/ts4.8/net.d.ts
+++ b/types/node/v18/ts4.8/net.d.ts
@@ -18,8 +18,8 @@ declare module "net" {
     import * as dns from "node:dns";
     type LookupFunction = (
         hostname: string,
-        options: dns.LookupOneOptions,
-        callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        options: dns.LookupOptions,
+        callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void,
     ) => void;
     interface AddressInfo {
         address: string;

--- a/types/node/v18/ts4.8/test/net.ts
+++ b/types/node/v18/ts4.8/test/net.ts
@@ -1,5 +1,5 @@
 import { Socket } from "node:dgram";
-import { LookupOneOptions } from "node:dns";
+import { LookupAddress, LookupOptions } from "node:dns";
 import * as net from "node:net";
 
 {
@@ -71,6 +71,30 @@ import * as net from "node:net";
 }
 
 {
+    // lookup callback can be either an array of LookupAddress or a single address and family
+    const tcpConnectLookupAllOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+        ): void => {
+            callback(null, [{ address: "", family: 1 }]);
+        },
+        port: 80,
+    };
+    const tcpConnectLookupOneOpts: net.TcpSocketConnectOpts = {
+        lookup: (
+            _hostname: string,
+            _options: LookupOptions,
+            callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+        ): void => {
+            callback(null, "", 1);
+        },
+        port: 80,
+    };
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -109,7 +133,7 @@ import * as net from "node:net";
         localPort: 1234,
         lookup: (
             _hostname: string,
-            _options: LookupOneOptions,
+            _options: LookupOptions,
             _callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
         ): void => {
             // nothing


### PR DESCRIPTION
This PR updates the `net.LookupFunction` to accept lookup of a single address on Node 18+.

The `net.LookupFunction` was updated to only accept `dns.LookupAllOptions` options instead of `dns.LookupOneOptions` and a callback signature expecting an array of `dns.LookupAddress`:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66031

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/53a5da9c02796ac3d30d05162fd614658b7e1dad/types/node/net.d.ts#L21-L22

**However even though the default `autoSelectFamily` was changed, the node implementation still supports the lookup of a single address with [`autoSelectFamily: false`](https://nodejs.org/api/net.html#socketconnect) or globally with [`net.setDefaultAutoSelectFamily(false)`](https://nodejs.org/api/net.html#netsetdefaultautoselectfamilyvalue)**

 `net.LookupFunction` diverges from the `dns.lookup` one (which [is typed to support both](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f38e980ff8bc44ccc3f77e061ab6a7042d80f851/types/node/dns.d.ts#L118-L141)). This does not compile but should:

```ts
net.createConnection({
  autoSelectFamily: false, // expects callback with a single address
  port: 80,
  lookup: (hostname, options, callback) => {
    callback(null, '127.0.0.1', 4) // this should be accepted
  },
})
```


<details>
  <summary>Node code to lookup a single address with `dns.lookup`</summary>

```js
const net = require('net')
const dns = require('dns')

var socket = net.createConnection({
  host: 'google.com',
  port: 80,
  autoSelectFamily: false, // or net.setDefaultAutoSelectFamily(false)
  lookup: (hostname, options, callback) => {
    console.log('lookup options', options)
    dns.lookup(hostname, options, (...args) => {
      console.warn('lookup callback', args)
      callback(...args)
    })
  },
})
socket.on('connect', () => socket.write("GET / HTTP/1.0\r\n\r\n"))
```

```
lookup options { family: undefined, hints: 1024 } // ← all: true is not set
lookup callback [ null, '172.217.20.174', 4 ]     // ← callback with a single address and family
```

</details>

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - **[`net.lookupAndConnect`: looking up a single address](https://github.com/nodejs/node/blob/258e9e767e3d048dae69658d4019a93906522a42/lib/net.js#L1342-L1373)**
    The `emitLookup` callback expects a single `ip` and `addressType`
  - [`net.lookupAndConnect`: looking up multiple addresses](https://github.com/nodejs/node/blob/258e9e767e3d048dae69658d4019a93906522a42/lib/net.js#L1320-L1337)
  - Support for `autoSelectFamily` introduced in Node 18: https://github.com/nodejs/node/pull/44731