### PR TITLE
[sharedb] make client compatible with ESM imports

### DIFF
--- a/types/sharedb/lib/client/index.d.ts
+++ b/types/sharedb/lib/client/index.d.ts
@@ -1,6 +1,6 @@
-/// <reference path="sharedb.d.ts" />
-import * as ShareDB from "./sharedb";
-import Agent = require("./agent");
+/// <reference path="../sharedb.d.ts" />
+import * as ShareDB from "../sharedb";
+import Agent = require("../agent");
 
 export class Connection extends ShareDB.TypedEmitter<ShareDB.ConnectionEventMap> {
     constructor(ws: ShareDB.Socket);
@@ -99,7 +99,7 @@ export {
     StringDeleteOp,
     StringInsertOp,
     SubtypeOp,
-} from "./sharedb";
+} from "../sharedb";
 
 export const types: ShareDB.Types;
 export const logger: ShareDB.Logger;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -4,6 +4,9 @@ import * as ShareDBClient from "sharedb/lib/client";
 import { Duplex } from "stream";
 import * as WebSocket from "ws";
 import Agent = require("sharedb/lib/agent");
+import * as ClientESM from "sharedb/lib/client/index.js";
+
+ClientESM.Connection;
 
 const { Connection, Doc, Query, types, logger } = ShareDBClient;
 Connection.prototype;


### PR DESCRIPTION
`sharedb/lib/client` actually points to [`lib/client/index.js`][1], which doesn't match the structure of the type definitions.

This causes problems when trying to impor `sharedb/lib/client` in ESM, since ESM forces us to import `sharedb/lib/client/index.js`, which has no matching type definition.

This change just moves the `client.d.ts` to `client/index.d.ts` to match the upstream file structure, which should be compatible with both CJS and ESM imports.

[1]: https://github.com/share/sharedb/blob/d985e90e2b22e0a450cdbad3bfc01ce8e779f797/lib/client/index.js#L1

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
