### PR TITLE
Guess username renames using GitHub redirects in ghostbuster

### DIFF
--- a/.github/workflows/ghostbuster.yml
+++ b/.github/workflows/ghostbuster.yml
@@ -34,7 +34,7 @@ jobs:
           run_install: |
             - args: [--filter, ., --filter, '{./scripts}...']
 
-      - run: node ./scripts/ghostbuster.js
+      - run: node ./scripts/ghostbuster.js > comment.md
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_API_READ }}
 
@@ -61,7 +61,4 @@ jobs:
           branch-suffix: short-commit-hash
           delete-branch: true
           title: Remove contributors with deleted accounts
-          body: |
-            Generated from [.github/workflows/ghostbuster.yml](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/workflows/ghostbuster.yml)
-
-            Some of these users may have simply changed their usernames; you may want do a bit of searching and ping them to see if they still want to be owners.
+          body-path: comment.md

--- a/scripts/ghostbuster.js
+++ b/scripts/ghostbuster.js
@@ -34,24 +34,14 @@ void 0;
  * @param {string} packageJsonPath
  * @param {PackageInfo} info
  * @param {Set<string>} ghosts
- * @param {Map<string, string>} renames
  */
-function bust(packageJsonPath, info, ghosts, renames) {
-    /** @type {(c: Owner) => c is Owner & { githubUsername: string }} */
-    const isGhost = c => !!c.githubUsername && ghosts.has(c.githubUsername.toLowerCase());
+function bust(packageJsonPath, info, ghosts) {
+    /** @param {Owner} c */
+    const isGhost = c => c.githubUsername && ghosts.has(c.githubUsername.toLowerCase());
     if (info.owners.some(isGhost)) {
-        console.log(`Found one or more deleted accounts in ${packageJsonPath}. Patching...`);
+        console.error(`Found one or more deleted accounts in ${packageJsonPath}. Patching...`);
         const parsed = JSON.parse(info.raw);
-        parsed.owners = info.owners.map(c => {
-            if (isGhost(c)) {
-                const newName = renames.get(c.githubUsername.toLowerCase());
-                if (!newName) {
-                    return undefined;
-                }
-                c.githubUsername = newName;
-            }
-            return c;
-        }).filter(c => c);
+        parsed.owners = info.owners.filter(c => !isGhost(c));
         const newContent = JSON.stringify(parsed, undefined, 4);
         writeFileSync(packageJsonPath, newContent + "\n", "utf-8");
     }
@@ -75,7 +65,7 @@ function recurse(dir, fn) {
 function getAllPackageJsons() {
     /** @type {Record<string, PackageInfo>} */
     const headers = {};
-    console.log("Reading headers...");
+    console.error("Reading headers...");
     recurse(new URL("../types/", import.meta.url), subpath => {
         const index = new URL("package.json", subpath);
         if (existsSync(index)) {
@@ -96,9 +86,9 @@ function getAllPackageJsons() {
  * @param {Set<string>} users
  */
 async function fetchGhosts(users) {
-    console.log("Checking for deleted accounts...");
+    console.error("Checking for deleted accounts...");
     const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
-    const maxPageSize = 2000;
+    const maxPageSize = 500;
     const pages = Math.ceil(users.size / maxPageSize);
     const userArray = Array.from(users);
     /** @type string[] */
@@ -164,19 +154,18 @@ process.on("unhandledRejection", err => {
     );
     const ghosts = await fetchGhosts(users);
     if (!ghosts.size) {
-        console.log("No ghosts found");
+        console.error("No ghosts found");
         return;
     }
 
-    /** @type {Map<string, string>} */
-    const renames = new Map();
+    const renames = [];
     for (const oldName of ghosts) {
         try {
             const result = await fetch(`https://github.com/${oldName}/DefinitelyTyped`, { method: "HEAD" });
             const url = new URL(result.url);
             const newName = url.pathname.split("/")[1].toLowerCase();
             if (newName !== oldName) {
-                renames.set(oldName, newName);
+                renames.push(`@${newName}`);
             }
         } catch {
             // ignore
@@ -184,6 +173,23 @@ process.on("unhandledRejection", err => {
     }
 
     for (const indexPath in packageJsons) {
-        bust(indexPath, packageJsons[indexPath], ghosts, renames);
+        bust(indexPath, packageJsons[indexPath], ghosts);
+    }
+
+    console.log(
+        "Generated from [.github/workflows/ghostbuster.yml](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/workflows/ghostbuster.yml)",
+    );
+    console.log();
+    console.log(
+        "Some of these users may have simply changed their usernames; you may want do a bit of searching and ping them to see if they still want to be owners.",
+    );
+
+    if (renames.length) {
+        console.log();
+        console.log(
+            `Hey ${
+                renames.join(", ")
+            }, if you'd still like to be an owner for these types, please feel free (but no pressure) to add your new account name back to \`package.json\`. Thanks!`,
+        );
     }
 })();


### PR DESCRIPTION
We already manually try and figure out renames via googling people's GitHub profile URLs and trying to find repos that redirect.

If we assume that users will have probably forked DefinitelyTyped itself at some point, we can `fetch` that URL and see if it redirects. If it does, we have the new username.

I'm not totally sure if this is a good idea to do automatically; I know some people may change their usernames for personal reasons and would rather not directly have this rename visible, but we already manually ping people so it's theoretically no worse.