### PR TITLE
mapbox-gl - add raster source setTiles and setUrl methods

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1355,6 +1355,24 @@ declare namespace mapboxgl {
         | RasterDemSource
         | CustomSourceInterface<HTMLImageElement | ImageData | ImageBitmap>;
 
+    interface RasterSourceImpl extends RasterSource {
+        /**
+         * Sets the source `tiles` property and re-renders the map.
+         *
+         * @param {string[]} tiles An array of one or more tile source URLs, as in the TileJSON spec.
+         * @returns {RasterTileSource} this
+         */
+        setTiles(tiles: readonly string[]): RasterSourceImpl;
+
+        /**
+         * Sets the source `url` property and re-renders the map.
+         *
+         * @param {string} url A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
+         * @returns {RasterTileSource} this
+         */
+        setUrl(url: string): RasterSourceImpl;
+    }
+
     interface VectorSourceImpl extends VectorSource {
         /**
          * Sets the source `tiles` property and re-renders the map.
@@ -1379,7 +1397,7 @@ declare namespace mapboxgl {
         | ImageSource
         | CanvasSource
         | VectorSourceImpl
-        | RasterSource
+        | RasterSourceImpl
         | RasterDemSource
         | CustomSource<HTMLImageElement | ImageData | ImageBitmap>;
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -418,6 +418,15 @@ map.addSource("some id", videoSourceObj); // add
 map.removeSource("some id"); // remove
 
 /**
+ * Raster Source
+ */
+const rasterSource = map.getSource("tile-source") as mapboxgl.RasterSourceImpl;
+// $ExpectType RasterSourceImpl
+rasterSource.setTiles(["a", "b"]);
+// $ExpectType RasterSourceImpl
+rasterSource.setUrl("https://github.com");
+
+/**
  * Vector Source
  */
 const vectorSource = map.getSource("tile-source") as mapboxgl.VectorSourceImpl;


### PR DESCRIPTION
In version `2.13.0` raster source was updated to have `setTiles` and `setUrl` methods to dynamically update tiles.
CHANGELOG: https://github.com/mapbox/mapbox-gl-js/blob/main/CHANGELOG.md#2130
PR: https://github.com/mapbox/mapbox-gl-js/pull/12352

This PR adds those new methods to `AnySourceImpl` type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-gl-js/pull/12352
