### PR TITLE
[@types/braintree] Allow ValidatedResponse.transaction to be undefined

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -119,7 +119,7 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
         amount: "128.00",
     };
     const response = await gateway.transaction.sale(transactionRequest).catch(console.error);
-    if (!response) return;
+    if (!response || !response.transaction) return;
     const {
         additionalProcessorResponse,
         amount,

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -197,7 +197,7 @@ declare namespace braintree {
         paymentMethodNonce: T extends PaymentMethodNonce ? PaymentMethodNonce : never;
         settlementBatchSumary: T extends SettlementBatchSummary ? SettlementBatchSummary : never;
         subscription: T extends Subscription ? Subscription : never;
-        transaction: T extends Transaction ? Transaction : never;
+        transaction?: T extends Transaction ? Transaction : never;
         clientToken: T extends ClientToken ? string : never;
         credentials: T extends OAuthToken ? OAuthToken : never;
     }

--- a/types/braintree/package.json
+++ b/types/braintree/package.json
@@ -19,10 +19,6 @@
         {
             "name": "Aaron Rose",
             "githubUsername": "acdr"
-        },
-        {
-            "name": "Sanders DeNardi",
-            "githubUsername": "sedenardi"
         }
     ]
 }


### PR DESCRIPTION
Relevant quote from the [Braintree Docs](https://developer.paypal.com/braintree/docs/reference/response/transaction/node#validation-errors)

> When receiving a validation error, a Transaction object will not be present on the Result object.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.paypal.com/braintree/docs/reference/response/transaction/node#validation-errors - `When receiving a validation error, a Transaction object will not be present on the Result object.`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
