### PR TITLE
@types/eslint allow non-ESTree AST for parsers in flat configs

### DIFF
--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1179,6 +1179,18 @@ export namespace Linter {
         messages: LintMessage[];
     }
 
+    // Temporarily loosen type for just flat config files (see #68232)
+    type FlatConfigParserModule =
+        & Omit<ParserModule, "parseForESLint">
+        & ({
+            parse(text: string, options?: any): unknown;
+        } | {
+            parseForESLint(text: string, options?: any): Omit<ESLintParseResult, "ast" | "scopeManager"> & {
+                ast: unknown;
+                scopeManager?: unknown;
+            };
+        });
+
     type ParserModule =
         & ESLint.ObjectMetaProperties
         & (
@@ -1252,7 +1264,7 @@ export namespace Linter {
              * An object containing a parse() or parseForESLint() method.
              * If not configured, the default ESLint parser (Espree) will be used.
              */
-            parser?: ParserModule;
+            parser?: FlatConfigParserModule;
 
             /**
              * An object specifying additional options that are passed directly to the


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/latest/use/configure/migration-guide#custom-parsers
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

([Original Changes](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/eb3890d3f5d74638cc97e862a273cf94b5bfca71..4153f4919588dfe3c821cc83d86cf07e924c94f1) for reference)

Loosens the types for the parser in a flat config to allow for ones which output a custom AST which does not extend ESTree's AST.

With the new flat config files, it allows for the config, and consequently the parser, to the typechecked. In its current state a compile-time error will occur on most uses of a custom parser.