### PR TITLE
fix(cloudflare): DNSRecord types have `id`

### DIFF
--- a/types/cloudflare/cloudflare-tests.ts
+++ b/types/cloudflare/cloudflare-tests.ts
@@ -76,6 +76,13 @@ cf.dnsRecords.browse("123", {
     content: "irrelevant",
 });
 
+cf.dnsRecords.browse("123").then((response) => {
+    if (response.result !== null) {
+        // $ExpectType string
+        response.result[0].id;
+    }
+});
+
 cf.dnsRecords.browse("123", {
     // @ts-expect-error
     invalid: "invalid",

--- a/types/cloudflare/index.d.ts
+++ b/types/cloudflare/index.d.ts
@@ -61,10 +61,12 @@ declare namespace Cloudflare {
     }
 
     type DnsRecord = DnsRecordWithPriority | DnsRecordWithoutPriority | SrvDnsRecord;
-    type DnsRecordByType<RecordType extends RecordTypes> = RecordType extends "MX" | "URI" ? DnsRecordWithPriority
-        : RecordType extends "SRV" ? SrvDnsRecord
-        : RecordType extends Exclude<RecordTypes, "MX" | "SRV" | "URI"> ? DnsRecordWithoutPriority
-        : DnsRecord;
+    type ExistingDnsRecordByType<RecordType extends RecordTypes> =
+        & (RecordType extends "MX" | "URI" ? DnsRecordWithPriority
+            : RecordType extends "SRV" ? SrvDnsRecord
+            : RecordType extends Exclude<RecordTypes, "MX" | "SRV" | "URI"> ? DnsRecordWithoutPriority
+            : DnsRecord)
+        & { id: string };
 
     interface DNSRecords {
         edit(zone_id: string, id: string, record: DnsRecord): ResponseObjectPromise;
@@ -95,7 +97,7 @@ declare namespace Cloudflare {
     }
 
     interface DnsRecordsBrowseResponse<RecordType extends RecordTypes> {
-        result: Array<DnsRecordByType<RecordType>> | null;
+        result: Array<ExistingDnsRecordByType<RecordType>> | null;
         result_info: {
             page: number;
             per_page: number;


### PR DESCRIPTION
- `id` field for DNSRecord types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-list-dns-records>