### PR TITLE
[Luxon] Swap true/false types for invalid reason and explanation

### DIFF
--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -479,12 +479,12 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
     /**
      * Returns an error code if this Duration became invalid, or null if the Duration is valid
      */
-    get invalidReason(): IfValid<string, null, IsValid>;
+    get invalidReason(): IfValid<null, string, IsValid>;
 
     /**
      * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
      */
-    get invalidExplanation(): IfValid<string | null, null, IsValid>;
+    get invalidExplanation(): IfValid<null, string | null, IsValid>;
 
     /**
      * Equality check

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -108,12 +108,12 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
     /**
      * Returns an error code if this Interval is invalid, or null if the Interval is valid
      */
-    get invalidReason(): IfValid<string, null, IsValid>;
+    get invalidReason(): IfValid<null, string, IsValid>;
 
     /**
      * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
      */
-    get invalidExplanation(): IfValid<string | null, null, IsValid>;
+    get invalidExplanation(): IfValid<null, string | null, IsValid>;
 
     /**
      * Returns the length of the Interval in the specified unit.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -297,8 +297,8 @@ i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<true> | Interval<f
 i.mapEndpoints(d => d); // $ExpectType Interval<true> | Interval<false>
 i.intersection(i); // $ExpectType Interval<boolean> | null
 
-i.invalidReason; // $ExpectType null
-i.invalidExplanation; // $ExpectType null
+i.invalidReason; // $ExpectType string | null
+i.invalidExplanation; // $ExpectType string | null
 
 i.toISO(); // $ExpectType string
 i.toISODate(); // $ExpectType string

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -241,6 +241,10 @@ if (DateTime.isDateTime(anything)) {
 
 const { input, result, zone } = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
 
+const invalidDateTime = DateTime.invalid("some reason", "some explanation");
+invalidDateTime.invalidReason; // $ExpectType string
+invalidDateTime.invalidExplanation; // $ExpectType string | null
+
 /* Duration */
 const dur = Duration.fromObject({ hours: 2, minutes: 7 }); // $ExpectType Duration<true>
 Duration.fromObject({ hour: 2, minute: 7 }); // $ExpectType Duration<true>
@@ -278,7 +282,9 @@ if (Duration.isDuration(anything)) {
 }
 // @ts-expect-error
 Duration.invalid();
-Duration.invalid("code", "because I said so"); // $ExpectType Duration<false>
+const invalidDuration = Duration.invalid("code", "because I said so"); // $ExpectType Duration<false>
+invalidDuration.invalidReason; // $ExpectType string
+invalidDuration.invalidExplanation; // $ExpectType string | null
 Duration.isDuration(0 as unknown); // $ExpectType boolean
 
 /* Interval */
@@ -312,7 +318,9 @@ if (Interval.isInterval(anything)) {
 new Interval(now, later);
 // @ts-expect-error
 Interval.invalid();
-Interval.invalid("code", "because I said so"); // $ExpectType Interval<false>
+const invalidInterval = Interval.invalid("code", "because I said so"); // $ExpectType Interval<false>
+invalidInterval.invalidReason; // $ExpectType string
+invalidInterval.invalidExplanation; // $ExpectType string | null
 Interval.isInterval(0 as unknown); // $ExpectType boolean
 
 /* Info */

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -297,8 +297,8 @@ i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<true> | Interval<f
 i.mapEndpoints(d => d); // $ExpectType Interval<true> | Interval<false>
 i.intersection(i); // $ExpectType Interval<boolean> | null
 
-i.invalidReason; // $ExpectType string | null
-i.invalidExplanation; // $ExpectType string | null
+i.invalidReason; // $ExpectType null
+i.invalidExplanation; // $ExpectType null
 
 i.toISO(); // $ExpectType string
 i.toISODate(); // $ExpectType string
@@ -526,8 +526,8 @@ dur.reconfigure({ conversionAccuracy: "longterm" }); // $ExpectType Duration<tru
 start.until(end); // $ExpectType Interval<true> | DateTime<false> || DateTime<false> | Interval<true>
 i.toDuration(["years", "months", "days"]); // $ExpectType Duration<true> | Duration<false>
 
-dur.invalidReason; // $ExpectType string
-dur.invalidExplanation; // $ExpectType string | null
+dur.invalidReason; // $ExpectType null
+dur.invalidExplanation; // $ExpectType null
 
 /* Sample Zone Implementation */
 class SampleZone extends Zone {


### PR DESCRIPTION
Bringing type signatures for `invalidReason` and `invalidExplanation` inline with `DateTime` for `Interval` and `Duration`.  When the object is invalid, we expect a value to be present for `reason`. `explanation` is optional so can still be null.

This was raised in moment/luxon#1419

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/master/src/interval.js#L211-L221
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

