### PR TITLE
Corrected `chrome-webstore-upload` `Item` interface

### DIFF
--- a/types/chrome-webstore-upload/index.d.ts
+++ b/types/chrome-webstore-upload/index.d.ts
@@ -15,7 +15,7 @@ export interface Item {
     itemError: {
         error_code: string;
         error_detail: string;
-    };
+    }[];
 }
 
 export type PublishStatus =


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Additional context
I noticed that the return type of `itemError` is an array:
```yaml
[
  {
    error_code: 'ITEM_NOT_UPDATABLE',
    error_detail: 'The item cannot be updated now because it is in pending review, ready to publish, or deleted status.'
  }
]
```