### PR TITLE
[react-google-recaptcha]: Adds missing isolated property to component props

### DIFF
--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -120,4 +120,10 @@ export interface ReCAPTCHAProps
      * @default "bottomright"
      */
     badge?: Badge | undefined;
+    /**
+     * Optional. For plugin owners to not interfere with existing reCAPTCHA installations on a page.
+     * If true, this reCAPTCHA instance will be part of a separate ID space.
+     * @default false
+     */
+    isolated?: boolean | undefined;
 }

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -42,5 +42,14 @@ const isolatedReacaptcha2: React.FC = () => {
         }
     };
 
-    return <ReCAPTCHA2 ref={recaptchaRef} sitekey="xxx" size="normal" grecaptcha={{}} className="mockclass" isolated={true}/>;
+    return (
+        <ReCAPTCHA2
+            ref={recaptchaRef}
+            sitekey="xxx"
+            size="normal"
+            grecaptcha={{}}
+            className="mockclass"
+            isolated={true}
+        />
+    );
 };

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -20,7 +20,7 @@ const invisibleRecaptcha: React.FC = () => {
     );
 };
 
-const basicRecapchta2 = <ReCAPTCHA2 ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" />;
+const basicRecapchta2 = <ReCAPTCHA2 ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" isolated={true} />;
 const invisibleRecaptcha2: React.FC = () => {
     const recaptchaRef = React.createRef<ReCAPTCHA2>();
 

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -20,7 +20,15 @@ const invisibleRecaptcha: React.FC = () => {
     );
 };
 
-const basicRecapchta2 = <ReCAPTCHA2 ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" isolated={true} />;
+const basicRecapchta2 = (
+    <ReCAPTCHA2
+        ref={handleRef}
+        sitekey="xxx"
+        onChange={a => a}
+        className="mockclass"
+        isolated={true}
+    />
+);
 const invisibleRecaptcha2: React.FC = () => {
     const recaptchaRef = React.createRef<ReCAPTCHA2>();
 

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -20,15 +20,7 @@ const invisibleRecaptcha: React.FC = () => {
     );
 };
 
-const basicRecapchta2 = (
-    <ReCAPTCHA2
-        ref={handleRef}
-        sitekey="xxx"
-        onChange={a => a}
-        className="mockclass"
-        isolated={true}
-    />
-);
+const basicRecapchta2 = <ReCAPTCHA2 ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" />;
 const invisibleRecaptcha2: React.FC = () => {
     const recaptchaRef = React.createRef<ReCAPTCHA2>();
 

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -40,3 +40,15 @@ const invisibleRecaptcha2: React.FC = () => {
 
     return <ReCAPTCHA2 ref={recaptchaRef} sitekey="xxx" size="invisible" grecaptcha={{}} className="mockclass" />;
 };
+
+const isolatedReacaptcha2: React.FC = () => {
+    const recaptchaRef = React.createRef<ReCAPTCHA2>();
+
+    const handleOnSubmit = async () => {
+        if (recaptchaRef.current) {
+            const token = await recaptchaRef.current.executeAsync();
+        }
+    };
+
+    return <ReCAPTCHA2 ref={recaptchaRef} sitekey="xxx" size="normal" grecaptcha={{}} className="mockclass" isolated={true}/>;
+};

--- a/types/react-google-recaptcha/v0/index.d.ts
+++ b/types/react-google-recaptcha/v0/index.d.ts
@@ -75,4 +75,10 @@ export interface ReCAPTCHAProps {
      * @default "bottomright"
      */
     badge?: Badge | undefined;
+    /**
+     * Optional. For plugin owners to not interfere with existing reCAPTCHA installations on a page.
+     * If true, this reCAPTCHA instance will be part of a separate ID space.
+     * @default false
+     */
+    isolated?: boolean | undefined;
 }

--- a/types/react-google-recaptcha/v0/index.d.ts
+++ b/types/react-google-recaptcha/v0/index.d.ts
@@ -75,10 +75,4 @@ export interface ReCAPTCHAProps {
      * @default "bottomright"
      */
     badge?: Badge | undefined;
-    /**
-     * Optional. For plugin owners to not interfere with existing reCAPTCHA installations on a page.
-     * If true, this reCAPTCHA instance will be part of a separate ID space.
-     * @default false
-     */
-    isolated?: boolean | undefined;
 }


### PR DESCRIPTION
There's an optional property `isolated` in the documentation for `react-google-recaptcha` but it's missing from the types. Closes #68246

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-google-recaptcha#component-props
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
