### PR TITLE
[@types/meteor] Change user `services` to empty interface

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -43,13 +43,19 @@ declare namespace Meteor {
      * record's profile field)
      */
     interface UserProfile {}
+
+    /**
+     * UserServices is left intentionally underspecified to allow overriding in your application.
+     */
+    interface UserServices {}
+
     interface User {
         _id: string;
         username?: string | undefined;
         emails?: UserEmail[] | undefined;
         createdAt?: Date | undefined;
         profile?: UserProfile;
-        services?: any;
+        services?: UserServices;
     }
 
     function user(options?: { fields?: Mongo.FieldSpecifier | undefined }): User | null;

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -48,13 +48,19 @@ declare module 'meteor/meteor' {
          * record's profile field)
          */
         interface UserProfile {}
+
+        /**
+         * UserServices is left intentionally underspecified to allow overriding in your application.
+         */
+        interface UserServices {}
+
         interface User {
             _id: string;
             username?: string | undefined;
             emails?: UserEmail[] | undefined;
             createdAt?: Date | undefined;
             profile?: UserProfile;
-            services?: any;
+            services?: UserServices;
         }
 
         function user(options?: { fields?: Mongo.FieldSpecifier | undefined }): User | null;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -19,6 +19,11 @@ declare namespace Meteor {
     interface UserProfile {
         name?: string | undefined;
     }
+    interface UserServices {
+        google?: {
+            email: string;
+        }
+    }
 }
 
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
@@ -1091,7 +1096,7 @@ namespace MeteorTests {
         return '<h1>Some html here</h1>';
     };
     Accounts.emailTemplates.enrollAccount.from = function (user: Meteor.User) {
-        return 'asdf@asdf.com';
+        return user.services?.google?.email || 'asdf@asdf.com';
     };
     Accounts.emailTemplates.enrollAccount.text = function (user: Meteor.User, url: string) {
         return (

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -35,6 +35,12 @@ declare module 'meteor/meteor' {
         interface UserProfile {
             name?: string | undefined;
         }
+
+        interface UserServices {
+            google?: {
+                email: string;
+            }
+        }
     }
 }
 
@@ -1108,7 +1114,7 @@ namespace MeteorTests {
         return '<h1>Some html here</h1>';
     };
     Accounts.emailTemplates.enrollAccount.from = function (user: Meteor.User) {
-        return 'asdf@asdf.com';
+        return user.services?.google?.email || 'asdf@asdf.com';
     };
     Accounts.emailTemplates.enrollAccount.text = function (user: Meteor.User, url: string) {
         return (


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/68254

this is similar to the `UserProfile` override fix [(Link to discussion)](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58366)
<div type='discussions-op-text'>


### Problem:
Previously, the `services` field on `Meteor.User` was declared as `any`, making it impossible to declare a more specific type for the services object. Throws error - `Subsequent property
declarations must have the same type. Property 'profile' must be of type 'any' ...`.

### Solution
Instead, create a new empty `UserServices` interface that will be used for `User.services`. This allows customization of the `User.services` type.

Note: This is a breaking change.  It will cause accesses to fields under `user.services` to display type errors (instead of `any`), where they would previously now show errors.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Context is not app specific
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (N/A)
