### PR TITLE
[ssh2] Adjust FileEntity types for input vs output

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1364,6 +1364,10 @@ export interface Stats extends Attributes {
 export interface FileEntry {
     filename: string;
     longname: string;
+    attrs: Attributes;
+}
+
+export interface FileEntryWithStats extends Omit<FileEntry, "attrs"> {
     attrs: Stats;
 }
 
@@ -1548,7 +1552,7 @@ export interface SFTPWrapper extends EventEmitter {
      * (Client-only)
      * Retrieves a directory listing.
      */
-    readdir(location: string | Buffer, callback: (err: Error | undefined, list: FileEntry[]) => void): void;
+    readdir(location: string | Buffer, callback: (err: Error | undefined, list: FileEntryWithStats[]) => void): void;
 
     /**
      * (Client-only)

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -134,7 +134,7 @@ conn.on("ready", () => {
     console.log("Client :: ready");
     conn.sftp((err: Error, sftp: ssh2.SFTPWrapper) => {
         if (err) throw err;
-        sftp.readdir("foo", (err: Error | undefined, list: ssh2.FileEntry[]) => {
+        sftp.readdir("foo", (err, list) => {
             if (err) throw err;
             console.dir(list);
             for (const item of list) {


### PR DESCRIPTION
The ssh2 library decorates FileEntities that are returned by `readdir` with a few helper functions. The `FileEntity` type was recently improved to reflect those helpers in the type signature.

FileEntity objects passed to `name` do NOT need those helper functions defined, and so using the same type in both places resulted in an unnecessary constraint for that use case.  Developers would have had to either spoof those helper functions or override the type assignment.

This change removes that constraint for `name` while keeping the type signaling for `readdir`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/67360 and https://github.com/PermanentOrg/sftp-service/pull/330#issuecomment-1899619986