### PR TITLE
[@wordpress/block-editor] Fix: type for store descriptor object for core/block-editor store.

### DIFF
--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -13,7 +13,7 @@ declare module "@wordpress/data" {
 }
 
 export interface BlockEditorStoreDescriptor extends StoreDescriptor {
-  name: "core/block-editor";
+    name: "core/block-editor";
 }
 
 export const store: BlockEditorStoreDescriptor;

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -1,5 +1,5 @@
 import { BlockIconNormalized } from "@wordpress/blocks";
-import { dispatch, select } from "@wordpress/data";
+import { dispatch, select, StoreDescriptor } from "@wordpress/data";
 
 export * from "./components";
 export * from "./hooks";
@@ -12,7 +12,11 @@ declare module "@wordpress/data" {
     function select(key: "core/block-editor"): typeof import("./store/selectors");
 }
 
-export const store: any;
+export interface BlockEditorStoreDescriptor extends StoreDescriptor {
+  name: "core/block-editor";
+}
+
+export const store: BlockEditorStoreDescriptor;
 
 export type EditorBlockMode = "html" | "visual";
 export type EditorMode = "text" | "visual";

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -417,7 +417,7 @@ be.transformStyles(STYLES, ".foobar");
 // Store
 // ============================================================================
 
-// $ExpectType any
+// $ExpectType BlockEditorStoreDescriptor
 be.store;
 
 // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - The concept for new type is inherited from @types/wordpress__edit-post package [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c7c3b75eeed5fd5edc16914acb1e011769f9a643/types/wordpress__edit-post/index.d.ts#L8C1-L12C45)
  - Library implementation - https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/index.js#L28C1-L36C5
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
