### PR TITLE
mongodb-queue: remove dependecy on specific mongodb version

### DIFF
--- a/types/mongodb-queue/package.json
+++ b/types/mongodb-queue/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "mongodb": "^4.5.0"
+        "mongodb": "*"
     },
     "devDependencies": {
         "@types/mongodb-queue": "workspace:."


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The package https://github.com/chilts/mongodb-queue is not receiving mongodb versions updates, but many users have created forks at different mongodb versions. The types will be more broadly useful if they don't depend on a specific version of mongodb.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
