### PR TITLE
Fix[marked-terminal]: Make all exports relative so TS can find types

### DIFF
--- a/types/marked-terminal/package.json
+++ b/types/marked-terminal/package.json
@@ -7,11 +7,13 @@
     ],
     "type": "module",
     "exports": {
-        "node": {
-            "import": "./index.d.ts",
-            "require": "./index.d.cts"
+        ".": {
+            "types": {
+                "import": "./index.d.ts",
+                "default": "./index.d.cts"
+            }
         },
-        "default": "./index.d.ts"
+        "./package.json": "./package.json"
     },
     "dependencies": {
         "@types/cardinal": "^2.1",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I cannot find a URL to support this code change but it appears we cannot mix relative exports with conditional keywords at the same level in package.json exports property? I'm not 💯 on this but the mono-repo of ESM packages where we're using `@types/marked-terminal` refuses to load the marked-terminal types due to the exports field in the package.json. Running a typecheck against the latest version of `@types/marked-terminal@6.1.0` results in:

```shell
 tsc --noEmit
       
src/utils/utils.console.ts:3:30 - error TS7016: Could not find a declaration file for module 'marked-terminal'. '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/marked-terminal/index.js' implicitly has an 'any' type.
There are types at '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@types/marked-terminal/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@types/marked-terminal' library may need to update its package.json or typings.
       
3 import TerminalRenderer from 'marked-terminal';
                                      ~~~~~~~~~~~~~~~~~  
Found 1 error in src/utils/utils.console.ts:3
```

Opening the `@types/marked-terminal/package.json` file in VSCode reveals the issue:

<img width="961" alt="Screenshot 2024-01-24 at 12 22 09" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/73201/853fc8e8-8845-4f8c-800d-f2f6fde1ad80">

If I change the exports to use the `exports["."].types` syntax as this PR is doing the issue is resolved. Additionally the `./package.json` property is being added at build / release time. I believe it's happening in [header-parser here](https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/header-parser/src/index.ts#L380-L395). I wonder if this could be affecting other types packages in this repo?



