### PR TITLE
[@types/react] Render functions should accept ReactNode instead of ReactElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     },
     "packageManager": "pnpm@8.15.1",
     "engines": {
-        "pnpm": ">=8.9.2",
         "node": ">=7.8.0"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "packageManager": "pnpm@8.15.1",
     "engines": {
+        "pnpm": ">=8.9.2",
         "node": ">=7.8.0"
     },
     "scripts": {

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -21,7 +21,7 @@ declare global {
     interface ReadableStream {}
 }
 
-import { ReactElement, ReactNode } from "react";
+import { ReactNode } from "react";
 import { ErrorInfo } from "./client";
 
 export interface RenderToPipeableStreamOptions {
@@ -67,7 +67,7 @@ export function renderToPipeableStream(children: ReactNode, options?: RenderToPi
  * React will preserve it and only attach event handlers, allowing you
  * to have a very performant first-load experience.
  */
-export function renderToString(element: ReactElement, options?: ServerOptions): string;
+export function renderToString(element: ReactNode, options?: ServerOptions): string;
 
 /**
  * Render a React element to its initial HTML. Returns a Readable stream that outputs
@@ -76,7 +76,7 @@ export function renderToString(element: ReactElement, options?: ServerOptions): 
  *
  * @deprecated
  */
-export function renderToNodeStream(element: ReactElement, options?: ServerOptions): NodeJS.ReadableStream;
+export function renderToNodeStream(element: ReactNode, options?: ServerOptions): NodeJS.ReadableStream;
 
 /**
  * Similar to `renderToString`, except this doesn't create extra DOM attributes
@@ -84,14 +84,14 @@ export function renderToNodeStream(element: ReactElement, options?: ServerOption
  * to use React as a simple static page generator, as stripping away the extra
  * attributes can save lots of bytes.
  */
-export function renderToStaticMarkup(element: ReactElement, options?: ServerOptions): string;
+export function renderToStaticMarkup(element: ReactNode, options?: ServerOptions): string;
 
 /**
  * Similar to `renderToNodeStream`, except this doesn't create extra DOM attributes
  * such as `data-reactid`, that React uses internally. The HTML output by this stream
  * is exactly equal to what `ReactDOMServer.renderToStaticMarkup()` would return.
  */
-export function renderToStaticNodeStream(element: ReactElement, options?: ServerOptions): NodeJS.ReadableStream;
+export function renderToStaticNodeStream(element: ReactNode, options?: ServerOptions): NodeJS.ReadableStream;
 
 export interface RenderToReadableStreamOptions {
     identifierPrefix?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/server/renderToPipeableStream
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream
