### PR TITLE
react-color: Fix types of Hue.pointer

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,4 +1,4 @@
-import { ClassAttributes, ReactNode } from "react";
+import { ClassAttributes, ComponentType } from "react";
 import { Classes } from "reactcss";
 
 export interface HSLColor {
@@ -35,7 +35,7 @@ export interface ColorPickerProps<A> extends ClassAttributes<A> {
 
 export interface CustomPickerProps<A> extends ClassAttributes<A> {
     color?: Color | undefined;
-    pointer?: ReactNode | undefined;
+    pointer?: ComponentType<{ direction?: 'vertical' }> | undefined;
     className?: string | undefined;
     styles?: Partial<Classes<any>> | undefined;
     onChange: ColorChangeHandler;

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -35,7 +35,7 @@ export interface ColorPickerProps<A> extends ClassAttributes<A> {
 
 export interface CustomPickerProps<A> extends ClassAttributes<A> {
     color?: Color | undefined;
-    pointer?: ComponentType<{ direction?: 'vertical' }> | undefined;
+    pointer?: ComponentType<{ direction?: "vertical" }> | undefined;
     className?: string | undefined;
     styles?: Partial<Classes<any>> | undefined;
     onChange: ColorChangeHandler;

--- a/types/react-color/react-color-tests.tsx
+++ b/types/react-color/react-color-tests.tsx
@@ -26,9 +26,8 @@ interface CustomProps extends InjectedColorProps {
 }
 
 const CustomComponent: FunctionComponent<CustomProps> = (props: CustomProps) => {
-
     function customPointer({ direction }: { direction?: "vertical" } = {}) {
-        return <div className={`custom-cn ${direction === 'vertical' ? 'custom-cn' : 'custom-cn'}`} />;
+        return <div className={`custom-cn ${direction === "vertical" ? "custom-cn" : "custom-cn"}`} />;
     }
     function onChange(color: ColorResult, event: React.ChangeEvent<HTMLInputElement>) {
         console.log(color, event);

--- a/types/react-color/react-color-tests.tsx
+++ b/types/react-color/react-color-tests.tsx
@@ -26,6 +26,10 @@ interface CustomProps extends InjectedColorProps {
 }
 
 const CustomComponent: FunctionComponent<CustomProps> = (props: CustomProps) => {
+
+    function customPointer({ direction }: { direction?: "vertical" } = {}) {
+        return <div className={`custom-cn ${direction === 'vertical' ? 'custom-cn' : 'custom-cn'}`} />;
+    }
     function onChange(color: ColorResult, event: React.ChangeEvent<HTMLInputElement>) {
         console.log(color, event);
     }
@@ -35,7 +39,7 @@ const CustomComponent: FunctionComponent<CustomProps> = (props: CustomProps) => 
             <Alpha color={props.color} onChange={onChange} />
             <Checkboard size={10} white="transparent" grey="#333" />
             <EditableInput value={props.color} label="Test" onChange={onChange} />
-            <Hue color={props.color} direction="horizontal" onChange={onChange} />
+            <Hue color={props.color} direction="horizontal" onChange={onChange} pointer={customPointer} />
             <Saturation color={props.color} onChange={onChange} />
         </div>
     );


### PR DESCRIPTION
The current type is ReactNode; the actual library accepts a Component instead.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Default pointer type in library](https://github.com/casesandberg/react-color/blob/bc9a0e1dc5d11b06c511a8e02a95bd85c7129f4b/src/components/hue/HuePointer.js#L4), [called pointer](https://github.com/casesandberg/react-color/blob/bc9a0e1dc5d11b06c511a8e02a95bd85c7129f4b/src/components/hue/Hue.js#L47)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
