### PR TITLE
[@types/webxr] Fix type used by XRHand

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -687,7 +687,12 @@ interface XRFrame {
         | undefined;
 }
 
-// Hand Tracking
+/**
+ * The XRHand interface is pair iterator (an ordered map) with the key being the hand
+ * joints ({@link XRHandJoint}) and the value being an {@link XRJointSpace}.
+ *
+ * @see https://immersive-web.github.io/webxr-hand-input/#xrhand-interface
+ */
 type XRHandJoint =
     | "wrist"
     | "thumb-metacarpal"
@@ -715,6 +720,12 @@ type XRHandJoint =
     | "pinky-finger-phalanx-distal"
     | "pinky-finger-tip";
 
+/**
+ * The XRJointSpace interface is an {@link XRSpace} and represents the position and
+ * orientation of an {@link XRHand} joint.
+ *
+ * @see https://immersive-web.github.io/webxr-hand-input/#xrjointspace-interface
+ */
 interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
@@ -727,6 +738,12 @@ interface XRJointPose extends XRPose {
 
 declare abstract class XRJointPose implements XRJointPose {}
 
+/**
+ * The XRHand interface is pair iterator (an ordered map) with the key being the hand
+ * joints ({@link XRHandJoint}) and the value being an {@link XRJointSpace}.
+ *
+ * @see https://immersive-web.github.io/webxr-hand-input/#xrhand-interface
+ */
 interface XRHand extends Map<XRHandJoint, XRJointSpace> {
     readonly WRIST: number;
 

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -727,7 +727,7 @@ interface XRJointPose extends XRPose {
 
 declare abstract class XRJointPose implements XRJointPose {}
 
-interface XRHand extends Map<number, XRJointSpace> {
+interface XRHand extends Map<XRHandJoint, XRJointSpace> {
     readonly WRIST: number;
 
     readonly THUMB_METACARPAL: number;


### PR DESCRIPTION
Calling `get` on XRHand needed a string but was defined as a number. The strings are limited to the definition of XRHandJoint. The type is already defined but was not used in this case.

Documentation is added for related types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://immersive-web.github.io/webxr-hand-input/#xrhand-interface
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
