### PR TITLE
[dockerode] Adding missing properties

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -249,7 +249,12 @@ docker.listContainers({ abortSignal: new AbortController().signal }).then(contai
     return containers.map(container => docker.getContainer(container.Id));
 });
 
-docker.listImages({ all: true, filters: "{\"dangling\":[\"true\"]}", digests: true, abortSignal: new AbortController().signal }).then(images => {
+docker.listImages({
+    all: true,
+    filters: "{\"dangling\":[\"true\"]}",
+    digests: true,
+    abortSignal: new AbortController().signal,
+}).then(images => {
     return images.map(image => docker.getImage(image.Id));
 });
 
@@ -340,7 +345,7 @@ docker.createVolume({ Name: "volumeName" }, (err, volume) => {
         // NOOP
     });
 
-    volume.remove({ abortSignal: new AbortController().signal },(err, data) => {
+    volume.remove({ abortSignal: new AbortController().signal }, (err, data) => {
         // NOOP
     });
 });

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -107,6 +107,9 @@ docker.getEvents().then(stream => {
 });
 
 const container = docker.getContainer("container-id");
+
+container.inspect({ abortSignal: new AbortController().signal });
+
 container.inspect((err, data) => {
     // NOOP
 });
@@ -238,11 +241,15 @@ docker.listContainers((err, containers) => {
     });
 });
 
-docker.listContainers().then(containers => {
+docker.listNetworks({ abortSignal: new AbortController().signal }, (err, response) => {
+    // NOOP
+});
+
+docker.listContainers({ abortSignal: new AbortController().signal }).then(containers => {
     return containers.map(container => docker.getContainer(container.Id));
 });
 
-docker.listImages({ all: true, filters: "{\"dangling\":[\"true\"]}", digests: true }).then(images => {
+docker.listImages({ all: true, filters: "{\"dangling\":[\"true\"]}", digests: true, abortSignal: new AbortController().signal }).then(images => {
     return images.map(image => docker.getImage(image.Id));
 });
 
@@ -319,7 +326,7 @@ docker.createNetwork({ Name: "networkName" }, (err, network) => {
 
 docker.createVolume();
 
-docker.createVolume({ Name: "volumeName" });
+docker.createVolume({ Name: "volumeName", abortSignal: new AbortController().signal });
 
 docker.createVolume({
     Name: "volumeName",
@@ -330,6 +337,10 @@ docker.createVolume({
 
 docker.createVolume({ Name: "volumeName" }, (err, volume) => {
     volume.remove((err, data) => {
+        // NOOP
+    });
+
+    volume.remove({ abortSignal: new AbortController().signal },(err, data) => {
         // NOOP
     });
 });
@@ -399,13 +410,15 @@ docker.listServices({ filters: { name: ["network-name"] } }).then(services => {
 });
 
 const image = docker.getImage("imageName");
-image.remove({ force: true, noprune: false }, (err, response) => {
+image.remove({ force: true, noprune: false, abortSignal: new AbortController().signal }, (err, response) => {
     // NOOP;
 });
 
 image.distribution({}, (err, response) => {
     // NOOP;
 });
+
+image.tag({ abortSignal: new AbortController().signal });
 
 image.distribution((err, response) => {
     // NOOP;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -11,9 +11,9 @@ declare namespace Dockerode {
         modem: any;
         id: string;
 
-        inspect(options: {}, callback: Callback<ContainerInspectInfo>): void;
+        inspect(options: ContainerInspectOptions, callback: Callback<ContainerInspectInfo>): void;
         inspect(callback: Callback<ContainerInspectInfo>): void;
-        inspect(options?: {}): Promise<ContainerInspectInfo>;
+        inspect(options?: ContainerInspectOptions): Promise<ContainerInspectInfo>;
 
         rename(options: {}, callback: Callback<any>): void;
         rename(options: {}): Promise<any>;
@@ -132,9 +132,9 @@ declare namespace Dockerode {
         push(callback: Callback<NodeJS.ReadableStream>): void;
         push(options?: ImagePushOptions): Promise<NodeJS.ReadableStream>;
 
-        tag(options: {}, callback: Callback<any>): void;
+        tag(options: ImageTagOptions, callback: Callback<any>): void;
         tag(callback: Callback<any>): void;
-        tag(options?: {}): Promise<any>;
+        tag(options?: ImageTagOptions): Promise<any>;
 
         remove(options: ImageRemoveOptions, callback: Callback<ImageRemoveInfo>): void;
         remove(callback: Callback<ImageRemoveInfo>): void;
@@ -155,9 +155,9 @@ declare namespace Dockerode {
         inspect(callback: Callback<VolumeInspectInfo>): void;
         inspect(options?: {}): Promise<VolumeInspectInfo>;
 
-        remove(options: {}, callback: Callback<any>): void;
+        remove(options: VolumeRemoveOptions, callback: Callback<any>): void;
         remove(callback: Callback<any>): void;
-        remove(options?: {}): Promise<any>;
+        remove(options?: VolumeRemoveOptions): Promise<any>;
     }
 
     class Service {
@@ -458,6 +458,11 @@ declare namespace Dockerode {
         Driver?: string | undefined;
         DriverOpts?: { [key: string]: string } | undefined;
         Labels?: { [label: string]: string } | undefined;
+        abortSignal?: AbortSignal;
+    }
+
+    interface VolumeRemoveOptions {
+        abortSignal?: AbortSignal;
     }
 
     interface VolumeCreateResponse {
@@ -629,6 +634,10 @@ declare namespace Dockerode {
                 }
                 | undefined;
         };
+    }
+
+    interface NetworkListOptions {
+        abortSignal?: AbortSignal;
     }
 
     interface NetworkStats {
@@ -941,6 +950,10 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
     }
 
+    interface ImageTagOptions {
+        abortSignal?: AbortSignal;
+    }
+
     interface AuthConfig {
         username: string;
         password: string;
@@ -1143,6 +1156,10 @@ declare namespace Dockerode {
                 EndpointsConfig?: EndpointsConfig | undefined;
             }
             | undefined;
+        abortSignal?: AbortSignal;
+    }
+
+    interface ContainerInspectOptions {
         abortSignal?: AbortSignal;
     }
 
@@ -1480,6 +1497,10 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
     }
 
+    interface ContainerListOptions {
+        abortSignal?: AbortSignal;
+    }
+
     interface ServiceListOptions {
         filters?:
             | {
@@ -1744,6 +1765,7 @@ declare namespace Dockerode {
         all?: boolean | undefined;
         filters?: string | undefined;
         digests?: boolean | undefined;
+        abortSignal?: AbortSignal;
     }
 
     interface ImageDistributionPlatformInfo {
@@ -1773,6 +1795,7 @@ declare namespace Dockerode {
     interface ImageRemoveOptions {
         force?: boolean | undefined;
         noprune?: boolean | undefined;
+        abortSignal?: AbortSignal;
     }
 
     interface PruneImagesInfo {
@@ -1925,9 +1948,9 @@ declare class Dockerode {
 
     getConfig(id: string): Dockerode.Config;
 
-    listContainers(options: {}, callback: Callback<Dockerode.ContainerInfo[]>): void;
+    listContainers(options: Dockerode.ContainerListOptions, callback: Callback<Dockerode.ContainerInfo[]>): void;
     listContainers(callback: Callback<Dockerode.ContainerInfo[]>): void;
-    listContainers(options?: {}): Promise<Dockerode.ContainerInfo[]>;
+    listContainers(options?: Dockerode.ContainerListOptions): Promise<Dockerode.ContainerInfo[]>;
 
     listImages(options: Dockerode.ListImagesOptions, callback: Callback<Dockerode.ImageInfo[]>): void;
     listImages(callback: Callback<Dockerode.ImageInfo[]>): void;
@@ -1971,9 +1994,9 @@ declare class Dockerode {
         Warnings: string[];
     }>;
 
-    listNetworks(options: {}, callback: Callback<Dockerode.NetworkInspectInfo[]>): void;
+    listNetworks(options: Dockerode.NetworkListOptions, callback: Callback<Dockerode.NetworkInspectInfo[]>): void;
     listNetworks(callback: Callback<Dockerode.NetworkInspectInfo[]>): void;
-    listNetworks(options?: {}): Promise<Dockerode.NetworkInspectInfo[]>;
+    listNetworks(options?: Dockerode.NetworkListOptions): Promise<Dockerode.NetworkInspectInfo[]>;
 
     listConfigs(options: {}, callback: Callback<Dockerode.ConfigInfo[]>): void;
     listConfigs(callback: Callback<Dockerode.ConfigInfo[]>): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

-  `Dockerode.Container.inspect` [dockerode/lib/container.js#L55](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/container.js#L55)
- `Dockerode.ListImagesOptions` [dockerode/lib/docker.js#L450](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L450)
- `Dockerode.Image.tag` [dockerode/lib/image.js#L210](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/image.js#L210)
- `Dockerode.ImageRemoveOptions` [dockerode/lib/image.js#L249](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/image.js#L249)
- `Dockerode.listNetworks` [dockerode/lib/docker.js#L1208](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1208)
- `Dockerode.listContainers` [dockerode/lib/docker.js#L1132](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1132)
- `Dockerode.VolumeCreateOptions` [dockerode/lib/docker.js#L1045](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1045)
-  `Dockerode.Volume.remove` [dockerode/lib/volume.js#L64](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/volume.js#L64)
