### PR TITLE
Fix mapboxgl-spidererifier

### DIFF
--- a/types/mapboxgl-spiderifier/index.d.ts
+++ b/types/mapboxgl-spiderifier/index.d.ts
@@ -5,17 +5,17 @@ export function popupOffsetForSpiderLeg(spiderLeg: SpiderLeg, offset?: number): 
 
 export interface SpiderLegOffsets {
     top: SpiderLegOffset;
-    "top-left": SpiderlegOffset;
-    "top-right": SpiderlegOffset;
-    bottom: SpiderlegOffset;
-    "bottom-left": SpiderlegOffset;
-    "bottom-right": SpiderlegOffset;
-    left: SpiderlegOffset;
-    right: SpiderlegOffset;
+    "top-left": SpiderLegOffset;
+    "top-right": SpiderLegOffset;
+    bottom: SpiderLegOffset;
+    "bottom-left": SpiderLegOffset;
+    "bottom-right": SpiderLegOffset;
+    left: SpiderLegOffset;
+    right: SpiderLegOffset;
 }
 export type SpiderLegOffset = [number, number];
 
-class MapboxglSpiderifier {
+declare class MapboxglSpiderifier {
     constructor(map: Map, options: Options);
 
     each: (spiderLeg: SpiderLeg) => void;
@@ -33,6 +33,8 @@ export interface Options {
     /**
      * number of markers till which the spider will be circular and beyond this threshold,
      * it will spider in spiral.
+     *
+     * 0 -> always spiral; Infinity -> always circle
      * Default: 9
      */
     circleSpiralSwitchover?: number;
@@ -40,9 +42,6 @@ export interface Options {
     initializeLeg?: (spiderLeg: SpiderLeg) => void;
     onClick?: (event: MouseEvent, spiderLeg: SpiderLeg) => void;
     // --- <SPIDER TUNING Params>
-    // circleSpiralSwitchover: show spiral instead of circle from this marker count upwards
-    //                        0 -> always spiral; Infinity -> always circle
-    circleSpiralSwitchover?: number; // Default: 9,
     circleFootSeparation?: number; // Default: 25, // related to circumference of circle
     spiralFootSeparation?: number; // Default: 28, // related to size of spiral (experiment!)
     spiralLengthStart?: number; // Default: 15, // ditto

--- a/types/mapboxgl-spiderifier/package.json
+++ b/types/mapboxgl-spiderifier/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/bewithjonam/mapboxgl-spiderifier"
     ],
+    "dependencies": {
+        "@types/mapbox-gl": "*"
+    },
     "devDependencies": {
         "@types/mapboxgl-spiderifier": "workspace:."
     },


### PR DESCRIPTION
Tests incorrectly failed to issue errors on #67917 back in December and CI hasn't run since then, so it didn't get the bug fixes in the dt-tools framework.

1. Add mapbox-gl to dependencies.
2. Fix spelling of SpiderLegOffset.
3. Remove duplicate declaration of circleSpiralSwitcher.
4. Add 'declare' keyword required by the DT lint rules.