### PR TITLE
Bump pnpm to 8.15.0, improving CI partial install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
     },
-    "packageManager": "pnpm@8.10.2",
+    "packageManager": "pnpm@8.15.0",
     "engines": {
         "pnpm": ">=8.9.2",
         "node": ">=7.8.0"


### PR DESCRIPTION
https://github.com/pnpm/pnpm/pull/7563 is now released, which should reduce the likelihood that we need the workaround introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67460. There are still PRs which will OOM and fall back to a full install, but partial installs should succeed more often.